### PR TITLE
[WIP] Backport to ARMv7-A

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ On a Skylake processor, the parsing speeds (in GB/s) of various processors on th
 - A processor with 
   - AVX2 (i.e., Intel processors starting with the Haswell microarchitecture released 2013 and AMD processors starting with the Zen microarchitecture released 2017), 
   - or SSE 4.2 and CLMUL (i.e., Intel processors going back to Westmere released in 2010 or AMD processors starting with the Jaguar used in the PS4 and XBox One)
-  - or a 64-bit ARM processor (ARMv8-A): this covers a wide range of mobile processors, including all Apple processors currently available for sale, going as far back as the iPhone 5s (2013).
+  - or ARM NEON (ARMv7-A, ARMv8-A), supported on all iOS devices except the original iPhone, all 64-bit ARM chips, and almost all 32-bit Androids.
 - A recent C++ compiler (e.g., GNU GCC or LLVM CLANG or Visual Studio 2017), we assume C++17. GNU GCC 7 or better or LLVM's clang 6 or better.
 - Some benchmark scripts assume bash and other common utilities, but they are optional.
 
@@ -190,8 +190,13 @@ The code automatically detects the feature set of your processor and switches to
 sometimes called runtime dispatch).
 
 
-We also support 64-bit ARM. We assume NEON support, and if the cryptographic extension is available, we leverage it, at compile-time.
+We also support ARM NEON, and if the cryptographic extension is available, we leverage it, at compile-time.
+
+The paths, namespaces, and macros reference ARM64, but ARMv7-A NEON is also supported with a polyfill.
+
 There is no runtime dispatch on ARM.
+
+
 
 ## Thread safety
 

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -79,7 +79,7 @@ static inline int8x16_t vqtbl1q_s8(int8x16_t t, uint8x16_t idx) {
 }
 
 # undef vpaddq_u8
-// Emulate vpqddq_u8 with two vpadd_u8 instructions.
+// Emulate vpaddq_u8 with two vpadd_u8 instructions.
 static inline uint8x16_t vpaddq_u8(uint8x16_t a, uint8x16_t b) {
   return vcombine_u8(
     vpadd_u8(vget_low_u8(a), vget_high_u8(a)),

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -61,7 +61,7 @@
 // vtbl2({[A][B], [C][D]}, [0][3]) -> [A][D]
 // vcombine([B][C], [A][D]) -> [B][C][A][D]
 static inline uint8x16_t vqtbl1q_u8(uint8x16_t t, uint8x16_t idx) {
-  // Because Q regisrers are unions of D-registers on ARMv7-A, this
+  // Because Q-registers are unions of D-registers on ARMv7-A, this
   // cast is well-defined.
   // Don't try this on aarch64, though, as its registers are different.
   // Trying to split manually here causes scalarization on GCC.
@@ -71,7 +71,6 @@ static inline uint8x16_t vqtbl1q_u8(uint8x16_t t, uint8x16_t idx) {
     vtbl2_u8(split, vget_high_u8(idx))
   );
 }
-
 
 #  undef vqtbl1q_s8
 // Don't reinvent the wheel for s8, the instructions are literally the same.

--- a/src/arm64/simdutf8check.h
+++ b/src/arm64/simdutf8check.h
@@ -5,7 +5,7 @@
 #define SIMDJSON_ARM64_SIMDUTF8CHECK_H
 
 // TODO this is different from IS_ARM64 in portability.h, which we use in other places ...
-#if defined(_ARM_NEON) || defined(__aarch64__) ||                              \
+#if defined(_ARM_NEON) || defined(__ARM_NEON) || defined(__aarch64__) ||                              \
     (defined(_MSC_VER) && defined(_M_ARM64))
 
 #include "simdjson/simdjson.h"


### PR DESCRIPTION
With some small polyfills for the new Q-form instructions, we can easily support ARMv7-A. 

Makefile needs to be updated, and I am not sure if we should change the paths/namespaces.

Tests seem to be passing on a Snapdragon 835 in 32-bit mode.