### PR TITLE
Wrap backslash processing in a branch

### DIFF
--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -83,7 +83,7 @@ struct option_struct {
   bool stage1_only = false;
 
   int32_t iterations = 200;
-  int32_t iteration_step = 50;
+  int32_t iteration_step = -1;
 
   bool verbose = false;
   bool tabbed_output = false;
@@ -149,17 +149,18 @@ struct option_struct {
       }
     }
 
+    if (iteration_step == -1) {
+      iteration_step = iterations / 50;
+      if (iteration_step < 200) { iteration_step = 200; }
+      if (iteration_step > iterations) { iteration_step = iterations; }
+    }
+
     // All remaining arguments are considered to be files
     for (int i=optind; i<argc; i++) {
       files.push_back(argv[i]);
     }
     if (files.empty()) {
       exit_usage("No files specified");
-    }
-
-    // Keeps the numbers the same for CI (old ./parse didn't have a two-stage loop)
-    if (files.size() == 1) {
-      iteration_step = iterations;
     }
   }
 };

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -77,6 +77,15 @@ really_inline simd8<bool> must_be_continuation(simd8<uint8_t> prev1, simd8<uint8
 #include "generic/stage1/json_string_scanner.h"
 #include "generic/stage1/json_scanner.h"
 
+namespace stage1 {
+really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+  // On ARM, we don't short-circuit this if there are no backslashes, because the branch gives us no
+  // benefit and therefore makes things worse.
+  // if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
+  return find_escaped_branchless(backslash);
+}
+}
+
 #include "generic/stage1/json_minifier.h"
 WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept {
   return arm64::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);

--- a/src/generic/stage1/json_string_scanner.h
+++ b/src/generic/stage1/json_string_scanner.h
@@ -40,7 +40,9 @@ public:
   really_inline bool in_unclosed_string() { return prev_in_string; }
 
 private:
+  // Intended to be defined by the implementation
   really_inline uint64_t find_escaped(uint64_t escape);
+  really_inline uint64_t find_escaped_branchless(uint64_t escape);
 
   // Whether the last iteration was still inside a string (all 1's = true, all 0's = false).
   uint64_t prev_in_string = 0ULL;
@@ -75,9 +77,7 @@ private:
 // desired        |   x  | x x  x x  x x  x  x  |
 // text           |  \\\ | \\\"\\\" \\\" \\"\\" |
 //
-really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
-  if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
-
+really_inline uint64_t json_string_scanner::find_escaped_branchless(uint64_t backslash) {
   // If there was overflow, pretend the first character isn't a backslash
   backslash &= ~prev_escaped;
   uint64_t follows_escape = backslash << 1 | prev_escaped;

--- a/src/generic/stage1/json_string_scanner.h
+++ b/src/generic/stage1/json_string_scanner.h
@@ -13,6 +13,8 @@ struct json_string_block {
   really_inline uint64_t string_start() const { return _quote & ~_in_string; }
   // Only characters inside the string (not including the quotes)
   really_inline uint64_t string_content() const { return _in_string & ~_quote; }
+  // Whether the entire block is strings, or not
+  really_inline bool all_string() { return _in_string == 0xFFFFFFFFFFFFFFFFULL; }
   // Return a mask of whether the given characters are inside a string (only works on non-quotes)
   really_inline uint64_t non_quote_inside_string(uint64_t mask) const { return mask & _in_string; }
   // Return a mask of whether the given characters are inside a string (only works on non-quotes)
@@ -35,6 +37,7 @@ class json_string_scanner {
 public:
   really_inline json_string_block next(const simd::simd8x64<uint8_t> in);
   really_inline error_code finish(bool streaming);
+  really_inline bool in_unclosed_string() { return prev_in_string; }
 
 private:
   really_inline uint64_t find_escaped(uint64_t escape);
@@ -73,6 +76,8 @@ private:
 // text           |  \\\ | \\\"\\\" \\\" \\"\\" |
 //
 really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+  if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
+
   // If there was overflow, pretend the first character isn't a backslash
   backslash &= ~prev_escaped;
   uint64_t follows_escape = backslash << 1 | prev_escaped;
@@ -101,13 +106,23 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
   const uint64_t backslash = in.eq('\\');
   const uint64_t escaped = find_escaped(backslash);
   const uint64_t quote = in.eq('"') & ~escaped;
+
+  //
   // prefix_xor flips on bits inside the string (and flips off the end quote).
+  //
   // Then we xor with prev_in_string: if we were in a string already, its effect is flipped
   // (characters inside strings are outside, and characters outside strings are inside).
+  //
   const uint64_t in_string = prefix_xor(quote) ^ prev_in_string;
+
+  //
+  // Check if we're still in a string at the end of the box so the next block will know
+  //
   // right shift of a signed value expected to be well-defined and standard
   // compliant as of C++20, John Regher from Utah U. says this is fine code
+  //
   prev_in_string = uint64_t(static_cast<int64_t>(in_string) >> 63);
+
   // Use ^ to turn the beginning quote off, and the end quote on.
   return {
     backslash,
@@ -118,7 +133,7 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
 }
 
 really_inline error_code json_string_scanner::finish(bool streaming) {
-  if (prev_in_string and (not streaming)) {
+  if (in_unclosed_string() and (not streaming)) {
     return UNCLOSED_STRING;
   }
   return SUCCESS;

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -65,6 +65,13 @@ really_inline simd8<bool> must_be_continuation(simd8<uint8_t> prev1, simd8<uint8
 #include "generic/stage1/json_string_scanner.h"
 #include "generic/stage1/json_scanner.h"
 
+namespace stage1 {
+really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+  if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
+  return find_escaped_branchless(backslash);
+}
+}
+
 #include "generic/stage1/json_minifier.h"
 WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept {
   return haswell::stage1::json_minifier::minify<128>(buf, len, dst, dst_len);

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -66,6 +66,13 @@ really_inline simd8<bool> must_be_continuation(simd8<uint8_t> prev1, simd8<uint8
 #include "generic/stage1/json_string_scanner.h"
 #include "generic/stage1/json_scanner.h"
 
+namespace stage1 {
+really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+  if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
+  return find_escaped_branchless(backslash);
+}
+}
+
 #include "generic/stage1/json_minifier.h"
 WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept {
   return westmere::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);


### PR DESCRIPTION
This wraps `find_escaped` in `if (backslash || prev_escape)`, short-circuiting roughly 9 instructions per loop iteration. I did not add an `if` for quote processing, because it'll only skip the clmul and strings are ridiculously common (I feel like it'll be rare for 64-bytes to *ever* lack a string, except in cases of > 64 byte strings).

I know this is all about branch-free, but ... backslashes just aren't that common. And in files where they happen a reasonable amount, they are going to be on the edge of predictable: like, they'll happen basically everywhere (multiline strings that use \n's all over), in runs (small spurts of strings that have weird characters), or in repeated patterns (because they are all objects of the same type.

This should be a discussion; you know a *lot* more about the impact of branches than I do, but this was striking enough that I felt the need to bring it up.

Here are the numbers I got on this machine, for stage 1, which improves it by 5-10% across the board:

| File | master GB/s stage 1| `if(backslash)` GB/s stage 1 |
|---|---|---|
| apache_builds | 6.526923 | 6.993132 |
| canada | 5.698863 | 6.097105 |
| citm_catalog | 7.272438 | 7.883177 |
| github_events | 6.714639 | 7.236889 |
| gsoc-2018 | 7.793515 | 8.407860 |
| instruments | 6.461760 | 6.779877 |
| marine_ik | 4.962518 | 5.217674 |
| mesh | 5.428335 | 5.761123 |
| mesh.pretty | 6.939520 | 7.500490 |
| numbers | 6.307731 | 6.701964 |
| random | 4.366775 | 4.493627 |
| twitter | 5.991603 | 6.037428 |
| twitterescaped | 6.340564 | 6.449633 |
| update-center | 5.917625 | 6.072642 |

This is only on one type of machine (Kady Lake R). The least affected file is (interestingly) `twitter.json`, and even that got a close to 1% improvement (overall, that's basically a wash).