### PR TITLE
Possible workaround for libc++ (issue 578)

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -263,7 +263,7 @@ struct benchmarker {
     : filename(_filename), collector(_collector), stats(NULL) {
     verbose() << "[verbose] loading " << filename << endl;
     simdjson::error_code error;
-    padded_string::load(filename).tie(this->json, error);
+    std::tie(this->json, error) = padded_string::load(filename).mov(); // mov: workaround for libc++
     if (error) {
       exit_error(string("Could not load the file ") + filename);
     }

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -158,18 +158,18 @@ struct simdjson_move_result : std::pair<T, error_code> {
   * because libc++ expects exactly either an std::pair or std::tuple,
   * and excludes derived classes/struct. It will happily accept
   * a reference to std::pair pair which this function provides.
-  * So you can do std::tie(a,b) = x.ref() where x is of type
+  * So you can do std::tie(a,b) = x.mov() where x is of type
   * simdjson_move_result in a portable manner (including libc++).
   * The alternative is to do std::tie(a,b) =
-  * static_cast<std::pair<T, error_code>&>(x) which is obviously
+  * static_cast<std::pair<T, error_code>&&>(x) which is obviously
   * undesirable.
   * Note that libc++ is the default standard library under macOS/Xcode.
   * We have to worry about this, but users who do not need to
   * support libc++ can omit the ref call.
   * See https://github.com/simdjson/simdjson/issues/578
   */
-  std::pair<T, error_code>& ref() {
-    return static_cast<std::pair<T, error_code>&>(*this);
+  std::pair<T, error_code>&& mov() {
+    return static_cast<std::pair<T, error_code>&&>(*this);
   }
 
   /**

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -77,15 +77,26 @@ private:
  */
 template<typename T>
 struct simdjson_result : public std::pair<T, error_code> {
+
   /**
-   * Move the value and the error to the provided variables.
-   */
-  void tie(T& t, error_code & e) {
-    // on the clang compiler that comes with current macOS (Apple clang version 11.0.0),
-    // tie(width, error) = size["w"].as_uint64_t();
-    // fails with "error: no viable overloaded '='""
-    t = std::move(this->first);
-    e = std::move(this->second);
+  * Returns a reference to the base class (std::pair). This is
+  * syntaxic sugar to implement a workaround for libc++,
+  * where std:tie(a,b) = simdjson_result instance does not work
+  * because libc++ expects exactly either an std::pair or std::tuple,
+  * and excludes derived classes/struct. It will happily accept
+  * a reference to std::pair pair which this function provides.
+  * So you can do std::tie(a,b) = x.ref() where x is of type
+  * simdjson_result in a portable manner (including libc++).
+  * The alternative is to do std::tie(a,b) =
+  * static_cast<std::pair<T, error_code>&>(x) which is obviously
+  * undesirable.
+  * Note that libc++ is the default standard library under macOS/Xcode.
+  * We have to worry about this, but users who do not need to
+  * support libc++ can omit the ref call.
+  * See https://github.com/simdjson/simdjson/issues/578
+  */
+  std::pair<T, error_code>& ref() {
+    return static_cast<std::pair<T, error_code>&>(*this);
   }
 
   /**
@@ -139,15 +150,26 @@ struct simdjson_result : public std::pair<T, error_code> {
  */
 template<typename T>
 struct simdjson_move_result : std::pair<T, error_code> {
+
   /**
-   * Move the value and the error to the provided variables.
-   */
-  void tie(T& t, error_code & e) {
-    // on the clang compiler that comes with current macOS (Apple clang version 11.0.0),
-    // std::tie(this->json, error) = padded_string::load(filename);
-    // fails with "benchmark/benchmarker.h:266:33: error: no viable overloaded '='""
-    t = std::move(this->first);
-    e = std::move(this->second);
+  * Returns a reference to the base class (std::pair). This is
+  * syntaxic sugar to implement a workaround for libc++,
+  * where std:tie(a,b) = simdjson_result instance does not work
+  * because libc++ expects exactly either an std::pair or std::tuple,
+  * and excludes derived classes/struct. It will happily accept
+  * a reference to std::pair pair which this function provides.
+  * So you can do std::tie(a,b) = x.ref() where x is of type
+  * simdjson_move_result in a portable manner (including libc++).
+  * The alternative is to do std::tie(a,b) =
+  * static_cast<std::pair<T, error_code>&>(x) which is obviously
+  * undesirable.
+  * Note that libc++ is the default standard library under macOS/Xcode.
+  * We have to worry about this, but users who do not need to
+  * support libc++ can omit the ref call.
+  * See https://github.com/simdjson/simdjson/issues/578
+  */
+  std::pair<T, error_code>& ref() {
+    return static_cast<std::pair<T, error_code>&>(*this);
   }
 
   /**

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -892,8 +892,7 @@ namespace dom_api {
     if (doc["a"].as_uint64_t().first != 1) { cerr << "Expected uint64_t(doc[\"a\"]) to be 1, was " << doc["a"].first << endl; return false; }
 
     UNUSED document::element val;
-    // tie(val, error) = doc["d"]; fails with "no viable overloaded '='" on Apple clang version 11.0.0
-    doc["d"].tie(val, error);
+    tie(val, error) = doc["d"].ref();  // ref: workaround for libc++
     if (error != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(doc[\"d\"]), got " << error << endl; return false; }
     return true;
   }
@@ -907,11 +906,11 @@ namespace dom_api {
     if (doc["obj"]["a"].as_uint64_t().first != 1) { cerr << "Expected uint64_t(doc[\"obj\"][\"a\"]) to be 1, was " << doc["obj"]["a"].first << endl; return false; }
 
     document::object obj;
-    doc.as_object().tie(obj, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+    tie(obj, error) = doc.as_object().ref();  // ref: workaround for libc++
     if (error) { cerr << "Error: " << error << endl; return false; }
     if (obj["obj"]["a"].as_uint64_t().first != 1) { cerr << "Expected uint64_t(doc[\"obj\"][\"a\"]) to be 1, was " << doc["obj"]["a"].first << endl; return false; }
 
-    obj["obj"].as_object().tie(obj, error);  //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+    tie(obj, error) = obj["obj"].as_object().ref();
     if (obj["a"].as_uint64_t().first != 1) { cerr << "Expected uint64_t(obj[\"a\"]) to be 1, was " << obj["a"].first << endl; return false; }
     if (obj["b"].as_uint64_t().first != 2) { cerr << "Expected uint64_t(obj[\"b\"]) to be 2, was " << obj["b"].first << endl; return false; }
     if (obj["c"].as_uint64_t().first != 3) { cerr << "Expected uint64_t(obj[\"c\"]) to be 3, was " << obj["c"].first << endl; return false; }
@@ -921,7 +920,7 @@ namespace dom_api {
     if (obj["a"].as_uint64_t().first != 1) { cerr << "Expected uint64_t(obj[\"a\"]) to be 1, was " << obj["a"].first << endl; return false; }
 
     UNUSED document::element val;
-    doc["d"].tie(val, error);  //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+    tie(val, error) = doc["d"].ref();  // ref: workaround for libc++
     if (error != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(obj[\"d\"]), got " << error << endl; return false; }
     return true;
   }
@@ -945,14 +944,14 @@ namespace dom_api {
     if (error) { cerr << "Error: " << error << endl; return false; }
     for (auto tweet : tweets) {
       document::object user;
-      tweet["user"].as_object().tie(user, error);  //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+      tie(user, error) = tweet["user"].as_object().ref(); // ref: workaround for libc++
       if (error) { cerr << "Error: " << error << endl; return false; }
       bool default_profile;
-      user["default_profile"].as_bool().tie(default_profile, error);  //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+      tie(default_profile, error) = user["default_profile"].as_bool().ref();
       if (error) { cerr << "Error: " << error << endl; return false; }
       if (default_profile) {
         std::string_view screen_name;
-        user["screen_name"].as_string().tie(screen_name, error);  //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+        tie(screen_name, error) = user["screen_name"].as_string().ref();
         if (error) { cerr << "Error: " << error << endl; return false; }
         default_users.insert(screen_name);
       }
@@ -973,13 +972,13 @@ namespace dom_api {
       if (!not_found) {
         for (auto image : media) {
           document::object sizes;
-          image["sizes"].as_object().tie(sizes, error);  //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+          tie(sizes, error) = image["sizes"].as_object().ref();  // ref: workaround for libc++
           if (error) { cerr << "Error: " << error << endl; return false; }
           for (auto [key, size] : sizes) {
             uint64_t width, height;
-            size["w"].as_uint64_t().tie(width, error);  //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+            tie(width, error) = size["w"].as_uint64_t().ref();
             if (error) { cerr << "Error: " << error << endl; return false; }
-            size["h"].as_uint64_t().tie(height, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+            tie(height, error) = size["h"].as_uint64_t().ref();
             if (error) { cerr << "Error: " << error << endl; return false; }
             image_sizes.insert(make_pair(width, height));
           }


### PR DESCRIPTION
I think that this makes the code *worse* than what we have in master. It certainly makes it more verbose.

I like the syntax:

```
doc["fsdfd"].tie(x.b)
```

It is short and sweet. But I have the feeling that @jkeiser might be highly motivated to write

```
std::tie(x,b) = doc["fsdfd"]
```

Well. That cannot be portable right now since libc++ won't allow it. So we can do...

```
std::tie(x,b) = doc["fsdfd"].ref()
```

(I also introduced "mov" for the case where we need to do a move.)

This is for discussion.

I don't think dropping support for libc++ is good. It means dropping macos and maybe other systems. I think libc++ is in wide use at many important places besides Apple.