### PR TITLE
Fix typos.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ In particular, the following contributions are invited:
 
 - The library is focused on performance. Well-documented performance optimization are invited.
 - Fixes to known or newly discovered bugs are always welcome. Typically, a bug fix should come with a test demonstrating that the bug has been fixed.
-- The simdjson library is advanced software and maintanability and flexibility are always a concern. Specific contributions to improve maintanability and flexibility are invited.
+- The simdjson library is advanced software and maintainability and flexibility are always a concern. Specific contributions to improve maintainability and flexibility are invited.
 
 
 
@@ -28,5 +28,5 @@ Contributors are encouraged to
 
 
 
-Though we do not have a formal code of conduct, we will not tolerate bullying, bigotery or intimidation. Everyone is welcome to contribute.
+Though we do not have a formal code of conduct, we will not tolerate bullying, bigotry or intimidation. Everyone is welcome to contribute.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This library is part of the [Awesome Modern C++](https://awesomecpp.com) list.
 simdjson is easily consumable with a single .h and .cpp file.
 
 0. Prerequisites: `g++` or `clang++`.
-1. Pull [simdjson.h](singleheader/simdjson.h) and [simdjson.cpp](singleheader/simdjson.h) into a directory, along with the sample file [twitter.json](jsonexamples/twitter.json).
+1. Pull [simdjson.h](singleheader/simdjson.h) and [simdjson.cpp](singleheader/simdjson.cpp) into a directory, along with the sample file [twitter.json](jsonexamples/twitter.json).
    ```
    wget https://raw.githubusercontent.com/simdjson/simdjson/master/singleheader/simdjson.h https://raw.githubusercontent.com/simdjson/simdjson/master/singleheader/simdjson.cpp https://raw.githubusercontent.com/simdjson/simdjson/master/jsonexamples/twitter.json
    ```
@@ -138,7 +138,7 @@ be concerned with computed gotos.
 
 ## Thread safety
 
-The simdjson library is mostly single-threaded. Thread safety is the responsability of the caller: it is unsafe to reuse a document::parser object between different threads.
+The simdjson library is mostly single-threaded. Thread safety is the responsibility of the caller: it is unsafe to reuse a document::parser object between different threads.
 
 If you are on an x64 processor, the runtime dispatching assigns the right code path the first time that parsing is attempted. The runtime dispatching is thread-safe.
 
@@ -491,7 +491,7 @@ You then have access to the following methods on the resulting `simdjson::docume
 * `bool move_to_key(const char *key, uint32_t length)`: as above except that the target can contain NULL characters
 * `void move_to_value()`: when at a key location within an object, this moves to the accompanying, value (located next to it).  This is equivalent but much faster than calling `next()`.
 * `bool move_to_index(uint32_t index)`: when at `[`, go one level deep, and advance to the given index, if successful, we are left pointing at the value,i f not, we are still pointing at the array
-* `bool move_to(const char *pointer, uint32_t length)`: Moves the iterator to the value correspoding to the json pointer. Always search from the root of the document. If successful, we are left pointing at the value, if not, we are still pointing the same value we were pointing before the call. The json pointer follows the rfc6901 standard's syntax: https://tools.ietf.org/html/rfc6901
+* `bool move_to(const char *pointer, uint32_t length)`: Moves the iterator to the value corresponding to the json pointer. Always search from the root of the document. If successful, we are left pointing at the value, if not, we are still pointing the same value we were pointing before the call. The json pointer follows the rfc6901 standard's syntax: https://tools.ietf.org/html/rfc6901
 * `bool move_to(const std::string &pointer) `: same as above but with a std::string parameter
 * `bool next()`:   Within a given scope (series of nodes at the same depth within either an array or an object), we move forward. Thus, given [true, null, {"a":1}, [1,2]], we would visit true, null, { and [. At the object ({) or at the array ([), you can issue a "down" to visit their content. valid if we're not at the end of a scope (returns true).
 * `bool prev()`:  Within a given scope (series of nodes at the same depth within either an
@@ -595,7 +595,7 @@ make allparsingcompetition
 ```
 
 Both the `parsingcompetition` and `allparsingcompetition` tools take a `-t` flag which produces
-a table-oriented output that can be conventiently parsed by other tools.
+a table-oriented output that can be conveniently parsed by other tools.
 
 
 ## Docker

--- a/doc/tape.md
+++ b/doc/tape.md
@@ -84,12 +84,12 @@ Simple JSON nodes are represented with one tape element:
 ## Integer and Double values
 
 Integer values are represented as two 64-bit tape elements:
-- The 64-bit value `('l' << 56)` followed by the 64-bit integer value litterally. Integer values are assumed to be signed 64-bit values, using two's complement notation.
-- The 64-bit value `('u' << 56)` followed by the 64-bit integer value litterally. Integer values are assumed to be unsigned 64-bit values.
+- The 64-bit value `('l' << 56)` followed by the 64-bit integer value literally. Integer values are assumed to be signed 64-bit values, using two's complement notation.
+- The 64-bit value `('u' << 56)` followed by the 64-bit integer value literally. Integer values are assumed to be unsigned 64-bit values.
 
 
 Float values are represented as two 64-bit tape elements:
-- The 64-bit value `('d' << 56)` followed by the 64-bit double value litterally in standard IEEE 754 notation.
+- The 64-bit value `('d' << 56)` followed by the 64-bit double value literally in standard IEEE 754 notation.
 
 Performance consideration: We store numbers of the main tape because we believe that locality of reference is helpful for performance. 
 

--- a/include/simdjson/document_iterator.h
+++ b/include/simdjson/document_iterator.h
@@ -24,10 +24,10 @@ public:
 
   inline bool is_ok() const;
 
-  // useful for debuging purposes
+  // useful for debugging purposes
   inline size_t get_tape_location() const;
 
-  // useful for debuging purposes
+  // useful for debugging purposes
   inline size_t get_tape_length() const;
 
   // returns the current depth (start at 1 with 0 reserved for the fictitious
@@ -165,7 +165,7 @@ public:
   // if not, we are still pointing at the array ([)
   inline bool move_to_index(uint32_t index);
 
-  // Moves the iterator to the value correspoding to the json pointer.
+  // Moves the iterator to the value corresponding to the json pointer.
   // Always search from the root of the document.
   // if successful, we are left pointing at the value,
   // if not, we are still pointing the same value we were pointing before the
@@ -177,7 +177,7 @@ public:
   // jsonpointer string ('pointer').
   bool move_to(const char *pointer, uint32_t length);
 
-  // Moves the iterator to the value correspoding to the json pointer.
+  // Moves the iterator to the value corresponding to the json pointer.
   // Always search from the root of the document.
   // if successful, we are left pointing at the value,
   // if not, we are still pointing the same value we were pointing before the
@@ -191,7 +191,7 @@ public:
   }
 
   private:
-  // Almost the same as move_to(), except it searchs from the current
+  // Almost the same as move_to(), except it searches from the current
   // position. The pointer's syntax is identical, though that case is not
   // handled by the rfc6901 standard. The '/' is still required at the
   // beginning. However, contrary to move_to(), the URI Fragment Identifier

--- a/include/simdjson/inline/document_iterator.h
+++ b/include/simdjson/inline/document_iterator.h
@@ -12,13 +12,13 @@ WARN_UNUSED bool document_iterator<max_depth>::is_ok() const {
   return location < tape_length;
 }
 
-// useful for debuging purposes
+// useful for debugging purposes
 template <size_t max_depth>
 size_t document_iterator<max_depth>::get_tape_location() const {
   return location;
 }
 
-// useful for debuging purposes
+// useful for debugging purposes
 template <size_t max_depth>
 size_t document_iterator<max_depth>::get_tape_length() const {
   return tape_length;

--- a/include/simdjson/jsonstream.h
+++ b/include/simdjson/jsonstream.h
@@ -35,7 +35,7 @@ namespace simdjson {
  * to a char* and to the number of bytes respectively.
  * The simdjson parser may read up to SIMDJSON_PADDING bytes beyond the end
  * of the string, so if you do not use a padded_string container,
- * you have the responsability to overallocated. If you fail to
+ * you have the responsibility to overallocated. If you fail to
  * do so, your software may crash if you cross a page boundary,
  * and you should expect memory checkers to object.
  * Most users should use a simdjson::padded_string.

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -2846,10 +2846,10 @@ public:
 
   inline bool is_ok() const;
 
-  // useful for debuging purposes
+  // useful for debugging purposes
   inline size_t get_tape_location() const;
 
-  // useful for debuging purposes
+  // useful for debugging purposes
   inline size_t get_tape_length() const;
 
   // returns the current depth (start at 1 with 0 reserved for the fictitious
@@ -2987,7 +2987,7 @@ public:
   // if not, we are still pointing at the array ([)
   inline bool move_to_index(uint32_t index);
 
-  // Moves the iterator to the value correspoding to the json pointer.
+  // Moves the iterator to the value corresponding to the json pointer.
   // Always search from the root of the document.
   // if successful, we are left pointing at the value,
   // if not, we are still pointing the same value we were pointing before the
@@ -2999,7 +2999,7 @@ public:
   // jsonpointer string ('pointer').
   bool move_to(const char *pointer, uint32_t length);
 
-  // Moves the iterator to the value correspoding to the json pointer.
+  // Moves the iterator to the value corresponding to the json pointer.
   // Always search from the root of the document.
   // if successful, we are left pointing at the value,
   // if not, we are still pointing the same value we were pointing before the
@@ -3013,7 +3013,7 @@ public:
   }
 
   private:
-  // Almost the same as move_to(), except it searchs from the current
+  // Almost the same as move_to(), except it searches from the current
   // position. The pointer's syntax is identical, though that case is not
   // handled by the rfc6901 standard. The '/' is still required at the
   // beginning. However, contrary to move_to(), the URI Fragment Identifier
@@ -3222,7 +3222,7 @@ namespace simdjson {
  * to a char* and to the number of bytes respectively.
  * The simdjson parser may read up to SIMDJSON_PADDING bytes beyond the end
  * of the string, so if you do not use a padded_string container,
- * you have the responsability to overallocated. If you fail to
+ * you have the responsibility to overallocated. If you fail to
  * do so, your software may crash if you cross a page boundary,
  * and you should expect memory checkers to object.
  * Most users should use a simdjson::padded_string.
@@ -4350,13 +4350,13 @@ WARN_UNUSED bool document_iterator<max_depth>::is_ok() const {
   return location < tape_length;
 }
 
-// useful for debuging purposes
+// useful for debugging purposes
 template <size_t max_depth>
 size_t document_iterator<max_depth>::get_tape_location() const {
   return location;
 }
 
-// useful for debuging purposes
+// useful for debugging purposes
 template <size_t max_depth>
 size_t document_iterator<max_depth>::get_tape_length() const {
   return tape_length;


### PR DESCRIPTION
The most important of these is the fix for the file link for `simdjson.cpp` in the README.