### PR TITLE
Update jsonpointer tool to use new API

### DIFF
--- a/tools/jsonpointer.cpp
+++ b/tools/jsonpointer.cpp
@@ -50,35 +50,26 @@ int main(int argc, char *argv[]) {
               << std::endl;
     exit(1);
   }
+
   const char *filename = argv[1];
-  auto [p, error] = simdjson::padded_string::load(filename);
-  if (error) {
-    std::cerr << "Could not load the file " << filename << std::endl;
-    return EXIT_FAILURE;
-  }
-  simdjson::ParsedJson pj;
-  int res =
-      simdjson::json_parse(p, pj); // do the parsing, return false on error
-  if (res) {
-    std::cerr << " Parsing failed with error " << simdjson::error_message(res)
-              << std::endl;
-    return EXIT_FAILURE;
-  }
+  auto [doc, error] = simdjson::document::load(filename);
+  if (error) { std::cerr << "Error parsing " << filename << ": " << error << std::endl; }
+
   std::cout << "[" << std::endl;
   for (int idx = 2; idx < argc; idx++) {
-    const char *jsonpath = argv[idx];
-    simdjson::ParsedJson::Iterator it(pj.doc);
-    if (it.move_to(std::string(jsonpath))) {
-      std::cout << "{\"jsonpath\": \"" << jsonpath << "\"," << std::endl;
-      std::cout << "\"value\":";
-      compute_dump(it);
-      std::cout << "}" << std::endl;
+    const char *json_pointer = argv[idx];
+    auto [value, pointer_error] = doc[json_pointer];
+    std::cout << "{\"jsonpath\": \"" << json_pointer << "\"";
+    if (pointer_error) {
+      std::cout << ",\"error\":\"" << pointer_error << "\"";
     } else {
-      std::cout << "null" << std::endl;
+      std::cout << ",\"value\":" << value;
     }
+    std::cout << "}";
     if (idx + 1 < argc) {
-      std::cout << "," << std::endl;
+      std::cout << ",";
     }
+    std::cout << std::endl;
   }
   std::cout << "]" << std::endl;
   return EXIT_SUCCESS;


### PR DESCRIPTION
Fixes #599. Also shows the error when it can't find something.

When running `./jsonpointer jsonexamples/small/demo.json /Image/Width /Image/Height /Image/IDs/2 /Image/IDs/10`:

### New output

```json
[
{"jsonpath": "/Image/Width","value":800},
{"jsonpath": "/Image/Height","value":600},
{"jsonpath": "/Image/IDs/2","value":234},
{"jsonpath": "/Image/IDs/10","error":"Attempted to access an element of a JSON array that is beyond its length."}
]
```

### Old output

```json
[
{"jsonpath": "/Image/Width",
"value":800}
,
{"jsonpath": "/Image/Height",
"value":600}
,
{"jsonpath": "/Image/IDs/2",
"value":234}
,
null
]
```