### PR TITLE
Remove backslash unescaping from JSON pointer implementation

### DIFF
--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -1110,6 +1110,7 @@ private:
  /** The result of a JSON navigation that may fail. */
 class document::element_result : public simdjson_result<document::element> {
 public:
+  really_inline element_result() noexcept;
   really_inline element_result(element value) noexcept;
   really_inline element_result(error_code error) noexcept;
 
@@ -1146,6 +1147,7 @@ public:
 /** The result of a JSON conversion that may fail. */
 class document::array_result : public simdjson_result<document::array> {
 public:
+  really_inline array_result() noexcept;
   really_inline array_result(array value) noexcept;
   really_inline array_result(error_code error) noexcept;
 
@@ -1163,6 +1165,7 @@ public:
 /** The result of a JSON conversion that may fail. */
 class document::object_result : public simdjson_result<document::object> {
 public:
+  really_inline object_result() noexcept;
   really_inline object_result(object value) noexcept;
   really_inline object_result(error_code error) noexcept;
 

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -119,6 +119,11 @@ struct simdjson_result : public std::pair<T, error_code> {
 #endif // SIMDJSON_EXCEPTIONS
 
   /**
+   * Create a new empty result with error = UNINITIALIZED.
+   */
+  simdjson_result() noexcept : simdjson_result(UNINITIALIZED) {}
+
+  /**
    * Create a new error result.
    */
   simdjson_result(error_code _error) noexcept : std::pair<T, error_code>({}, _error) {}
@@ -179,6 +184,11 @@ struct simdjson_move_result : std::pair<T, error_code> {
   operator T() noexcept(false) { return move(); }
 
 #endif
+
+  /**
+   * Create a new empty result with error = UNINITIALIZED.
+   */
+  simdjson_move_result() noexcept : simdjson_move_result(UNINITIALIZED) {}
 
   /**
    * Create a new error result.

--- a/tests/pointercheck.cpp
+++ b/tests/pointercheck.cpp
@@ -60,9 +60,9 @@ bool json_pointer_failure_test(const char *json_pointer, error_code expected_fai
 
 int main() {
   if (
-    json_pointer_success_test(R"(/~1~001abc/1/\\\" 0/0)", "value0") &&
-    json_pointer_success_test(R"(/~1~001abc/1/\\\" 0/1)", "value1") &&
-    json_pointer_failure_test(R"(/~1~001abc/1/\\\" 0/2)", INDEX_OUT_OF_BOUNDS) && // index actually out of bounds
+    json_pointer_success_test("/~1~001abc/1/\\\" 0/0", "value0") &&
+    json_pointer_success_test("/~1~001abc/1/\\\" 0/1", "value1") &&
+    json_pointer_failure_test("/~1~001abc/1/\\\" 0/2", INDEX_OUT_OF_BOUNDS) && // index actually out of bounds
     json_pointer_success_test("/arr") && // get array
     json_pointer_failure_test("/arr/0", INDEX_OUT_OF_BOUNDS) && // array index 0 out of bounds on empty array
     json_pointer_success_test("/~1~001abc") && // get object


### PR DESCRIPTION
Since it's not a part of JSON pointer.

Also speed up non-escaped key lookup by not copying keys unless there is an escape character.

Fixes #604 and #610.