### PR TITLE
Deprecate json_parse() and build_parsed_json()

### DIFF
--- a/include/simdjson/jsonparser.h
+++ b/include/simdjson/jsonparser.h
@@ -13,6 +13,7 @@ namespace simdjson {
 // C API (json_parse and build_parsed_json) declarations
 //
 
+[[deprecated("Use document::parser.parse() instead")]]
 inline int json_parse(const uint8_t *buf, size_t len, document::parser &parser, bool realloc_if_needed = true) noexcept {
   error_code code = parser.parse(buf, len, realloc_if_needed).error();
   // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
@@ -23,29 +24,87 @@ inline int json_parse(const uint8_t *buf, size_t len, document::parser &parser, 
   parser.error = code;
   return code;
 }
+[[deprecated("Use document::parser.parse() instead")]]
 inline int json_parse(const char *buf, size_t len, document::parser &parser, bool realloc_if_needed = true) noexcept {
-  return json_parse(reinterpret_cast<const uint8_t *>(buf), len, parser, realloc_if_needed);
+  error_code code = parser.parse(buf, len, realloc_if_needed).error();
+  // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
+  // bits in the parser instead of heeding the result code. The normal parser unsets those in
+  // anticipation of making the error code ephemeral.
+  // Here we put the code back into the parser, until we've removed this method.
+  parser.valid = code == SUCCESS;
+  parser.error = code;
+  return code;
 }
+[[deprecated("Use document::parser.parse() instead")]]
 inline int json_parse(const std::string &s, document::parser &parser, bool realloc_if_needed = true) noexcept {
-  return json_parse(s.data(), s.length(), parser, realloc_if_needed);
+  error_code code = parser.parse(s.data(), s.length(), realloc_if_needed).error();
+  // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
+  // bits in the parser instead of heeding the result code. The normal parser unsets those in
+  // anticipation of making the error code ephemeral.
+  // Here we put the code back into the parser, until we've removed this method.
+  parser.valid = code == SUCCESS;
+  parser.error = code;
+  return code;
 }
+[[deprecated("Use document::parser.parse() instead")]]
 inline int json_parse(const padded_string &s, document::parser &parser) noexcept {
-  return json_parse(s.data(), s.length(), parser, false);
+  error_code code = parser.parse(s).error();
+  // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
+  // bits in the parser instead of heeding the result code. The normal parser unsets those in
+  // anticipation of making the error code ephemeral.
+  // Here we put the code back into the parser, until we've removed this method.
+  parser.valid = code == SUCCESS;
+  parser.error = code;
+  return code;
 }
 
-WARN_UNUSED static document::parser build_parsed_json(const uint8_t *buf, size_t len, bool realloc_if_needed = true) noexcept {
+[[deprecated("Use document::parser.parse() instead")]]
+WARN_UNUSED inline document::parser build_parsed_json(const uint8_t *buf, size_t len, bool realloc_if_needed = true) noexcept {
   document::parser parser;
-  json_parse(buf, len, parser, realloc_if_needed);
+  error_code code = parser.parse(buf, len, realloc_if_needed).error();
+  // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
+  // bits in the parser instead of heeding the result code. The normal parser unsets those in
+  // anticipation of making the error code ephemeral.
+  // Here we put the code back into the parser, until we've removed this method.
+  parser.valid = code == SUCCESS;
+  parser.error = code;
   return parser;
 }
+[[deprecated("Use document::parser.parse() instead")]]
 WARN_UNUSED inline document::parser build_parsed_json(const char *buf, size_t len, bool realloc_if_needed = true) noexcept {
-  return build_parsed_json(reinterpret_cast<const uint8_t *>(buf), len, realloc_if_needed);
+  document::parser parser;
+  error_code code = parser.parse(buf, len, realloc_if_needed).error();
+  // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
+  // bits in the parser instead of heeding the result code. The normal parser unsets those in
+  // anticipation of making the error code ephemeral.
+  // Here we put the code back into the parser, until we've removed this method.
+  parser.valid = code == SUCCESS;
+  parser.error = code;
+  return parser;
 }
+[[deprecated("Use document::parser.parse() instead")]]
 WARN_UNUSED inline document::parser build_parsed_json(const std::string &s, bool realloc_if_needed = true) noexcept {
-  return build_parsed_json(s.data(), s.length(), realloc_if_needed);
+  document::parser parser;
+  error_code code = parser.parse(s.data(), s.length(), realloc_if_needed).error();
+  // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
+  // bits in the parser instead of heeding the result code. The normal parser unsets those in
+  // anticipation of making the error code ephemeral.
+  // Here we put the code back into the parser, until we've removed this method.
+  parser.valid = code == SUCCESS;
+  parser.error = code;
+  return parser;
 }
+[[deprecated("Use document::parser.parse() instead")]]
 WARN_UNUSED inline document::parser build_parsed_json(const padded_string &s) noexcept {
-  return build_parsed_json(s.data(), s.length(), false);
+  document::parser parser;
+  error_code code = parser.parse(s).error();
+  // The deprecated json_parse API is a signal that the user plans to *use* the error code / valid
+  // bits in the parser instead of heeding the result code. The normal parser unsets those in
+  // anticipation of making the error code ephemeral.
+  // Here we put the code back into the parser, until we've removed this method.
+  parser.valid = code == SUCCESS;
+  parser.error = code;
+  return parser;
 }
 
 // We do not want to allow implicit conversion from C string to std::string.


### PR DESCRIPTION
This deprecates these methods. It does not deprecate the name `JsonParser`, mainly because doing that caused me lots of warnings last time I did it. But json_parse and build_parsed_json should be enough to warn existing users off.