### PR TITLE
Remove document::parse and document::load

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -16,7 +16,8 @@ const padded_string EMPTY_ARRAY("[]", 2);
 
 static void twitter_count(State& state) {
   // Prints the number of results in twitter.json
-  document doc = document::load(JSON_TEST_PATH);
+  document::parser parser;
+  document &doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     uint64_t result_count = doc["search_metadata"]["count"];
     if (result_count != 100) { return; }
@@ -43,7 +44,8 @@ BENCHMARK(iterator_twitter_count);
 
 static void twitter_default_profile(State& state) {
   // Count unique users with a default profile.
-  document doc = document::load(JSON_TEST_PATH);
+  document::parser parser;
+  document &doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<string_view> default_users;
     for (document::object tweet : doc["statuses"].as_array()) {
@@ -59,7 +61,8 @@ BENCHMARK(twitter_default_profile);
 
 static void twitter_image_sizes(State& state) {
   // Count unique image sizes
-  document doc = document::load(JSON_TEST_PATH);
+  document::parser parser;
+  document &doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<tuple<uint64_t, uint64_t>> image_sizes;
     for (document::object tweet : doc["statuses"].as_array()) {
@@ -81,7 +84,8 @@ BENCHMARK(twitter_image_sizes);
 
 static void error_code_twitter_count(State& state) noexcept {
   // Prints the number of results in twitter.json
-  document doc = document::load(JSON_TEST_PATH);
+  document::parser parser;
+  document &doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     auto [value, error] = doc["search_metadata"]["count"].as_uint64_t();
     if (error) { return; }
@@ -92,7 +96,8 @@ BENCHMARK(error_code_twitter_count);
 
 static void error_code_twitter_default_profile(State& state) noexcept {
   // Count unique users with a default profile.
-  document doc = document::load(JSON_TEST_PATH);
+  document::parser parser;
+  document &doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<string_view> default_users;
 
@@ -155,7 +160,8 @@ BENCHMARK(iterator_twitter_default_profile);
 
 static void error_code_twitter_image_sizes(State& state) noexcept {
   // Count unique image sizes
-  document doc = document::load(JSON_TEST_PATH);
+  document::parser parser;
+  document &doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<tuple<uint64_t, uint64_t>> image_sizes;
     auto [statuses, error] = doc["statuses"].as_array();

--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -46,7 +46,8 @@ static void build_parsed_json(State& state) {
 BENCHMARK(build_parsed_json);
 static void document_parse_error_code(State& state) {
   for (auto _ : state) {
-    auto [doc, error] = document::parse(EMPTY_ARRAY);
+    document::parser parser;
+    auto [doc, error] = parser.parse(EMPTY_ARRAY);
     if (error) { return; }
   }
 }
@@ -54,7 +55,8 @@ BENCHMARK(document_parse_error_code);
 static void document_parse_exception(State& state) {
   for (auto _ : state) {
     try {
-      UNUSED document doc = document::parse(EMPTY_ARRAY);
+      document::parser parser;
+      UNUSED document &doc = parser.parse(EMPTY_ARRAY);
     } catch(simdjson_error &j) {
       return;
     }

--- a/benchmark/distinctuseridcompetition.cpp
+++ b/benchmark/distinctuseridcompetition.cpp
@@ -114,7 +114,8 @@ simdjson_compute_stats(const simdjson::padded_string &p) {
 
 __attribute__((noinline)) bool
 simdjson_just_parse(const simdjson::padded_string &p) {
-  return simdjson::document::parse(p).error() == simdjson::SUCCESS;
+  simdjson::document::parser parser;
+  return parser.parse(p).error() != simdjson::SUCCESS;
 }
 
 void sajson_traverse(std::vector<int64_t> &answer, const sajson::value &node) {
@@ -368,7 +369,7 @@ int main(int argc, char *argv[]) {
             volume, !just_data);
   simdjson::document::parser parser;
   simdjson::document &doc = parser.parse(p);
-  BEST_TIME("simdjson (just dom)", simdjson_just_dom(doc).size(), size,
+  BEST_TIME("simdjson (just dom)  ", simdjson_just_dom(doc).size(), size,
             , repeat, volume, !just_data);
   char *buffer = (char *)malloc(p.size() + 1);
   buffer[p.size()] = '\0';

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -43,7 +43,8 @@ enum error_code {
 /**
  * Get the error message for the given error code.
  *
- *   auto [doc, error] = document::parse("foo");
+ *   document::parser parser;
+ *   auto [doc, error] = parser.parse("foo");
  *   if (error) { printf("Error: %s\n", error_message(error)); }
  *
  * @return The error message.

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -238,27 +238,6 @@ inline document::element_result document::operator[](const char *json_pointer) c
 }
 
 
-inline document::doc_move_result document::load(const std::string &path) noexcept {
-  document::parser parser;
-  auto [doc, error] = parser.load(path);
-  return doc_move_result((document &&)doc, error);
-}
-
-inline document::doc_move_result document::parse(const uint8_t *buf, size_t len, bool realloc_if_needed) noexcept {
-  document::parser parser;
-  auto [doc, error] = parser.parse(buf, len, realloc_if_needed);
-  return doc_move_result((document &&)doc, error);
-}
-really_inline document::doc_move_result document::parse(const char *buf, size_t len, bool realloc_if_needed) noexcept {
-  return parse((const uint8_t *)buf, len, realloc_if_needed);
-}
-really_inline document::doc_move_result document::parse(const std::string &s) noexcept {
-  return parse(s.data(), s.length(), s.capacity() - s.length() < SIMDJSON_PADDING);
-}
-really_inline document::doc_move_result document::parse(const padded_string &s) noexcept {
-  return parse(s.data(), s.length(), false);
-}
-
 WARN_UNUSED
 inline error_code document::set_capacity(size_t capacity) noexcept {
   if (capacity == 0) {
@@ -408,46 +387,6 @@ inline document::element_result document::doc_result::at_key(std::string_view ke
   return first.at_key(key);
 }
 inline document::element_result document::doc_result::at_key(const char *key) const noexcept {
-  if (error()) { return error(); }
-  return first.at_key(key);
-}
-
-//
-// doc_move_result inline implementation
-//
-inline document::doc_move_result::doc_move_result(document &&doc, error_code error) noexcept : simdjson_move_result<document>(std::move(doc), error) { }
-inline document::doc_move_result::doc_move_result(document &&doc) noexcept : simdjson_move_result<document>(std::move(doc)) { }
-inline document::doc_move_result::doc_move_result(error_code error) noexcept : simdjson_move_result<document>(error) { }
-
-inline document::array_result document::doc_move_result::as_array() const noexcept {
-  if (error()) { return error(); }
-  return first.root().as_array();
-}
-inline document::object_result document::doc_move_result::as_object() const noexcept {
-  if (error()) { return error(); }
-  return first.root().as_object();
-}
-
-inline document::element_result document::doc_move_result::operator[](std::string_view key) const noexcept {
-  if (error()) { return error(); }
-  return first[key];
-}
-inline document::element_result document::doc_move_result::operator[](const char *json_pointer) const noexcept {
-  return (*this)[std::string_view(json_pointer)];
-}
-inline document::element_result document::doc_move_result::at(std::string_view key) const noexcept {
-  if (error()) { return error(); }
-  return first.at(key);
-}
-inline document::element_result document::doc_move_result::at(size_t index) const noexcept {
-  if (error()) { return error(); }
-  return first.at(index);
-}
-inline document::element_result document::doc_move_result::at_key(std::string_view key) const noexcept {
-  if (error()) { return error(); }
-  return first.at_key(key);
-}
-inline document::element_result document::doc_move_result::at_key(const char *key) const noexcept {
   if (error()) { return error(); }
   return first.at_key(key);
 }
@@ -1226,11 +1165,6 @@ inline std::ostream& minify<document::key_value_pair>::print(std::ostream& out) 
 
 #if SIMDJSON_EXCEPTIONS
 
-template<>
-inline std::ostream& minify<document::doc_move_result>::print(std::ostream& out) {
-  if (value.error()) { throw simdjson_error(value.error()); }
-  return out << minify<document>(value.first);
-}
 template<>
 inline std::ostream& minify<document::doc_result>::print(std::ostream& out) {
   if (value.error()) { throw simdjson_error(value.error()); }

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -385,7 +385,8 @@ namespace document_tests {
     for(size_t i = 0; i < 200; i++) {
       input += "]";
     }
-    auto [doc, error] = simdjson::document::parse(input);
+    simdjson::document::parser parser;
+    auto [doc, error] = parser.parse(input);
     if (error) { std::cerr << "Error: " << simdjson::error_message(error) << std::endl; return false; }
     return true;
   }
@@ -680,13 +681,6 @@ namespace parse_api_tests {
   const padded_string BASIC_NDJSON = string("[1,2,3]\n[4,5,6]");
   // const padded_string EMPTY_NDJSON = string("");
 
-  bool document_parse() {
-    std::cout << "Running " << __func__ << std::endl;
-    auto [doc, error] = document::parse(BASIC_JSON);
-    if (error) { cerr << error << endl; return false; }
-    if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
-    return true;
-  }
   bool parser_parse() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
@@ -719,13 +713,6 @@ namespace parse_api_tests {
   //   return true;
   // }
 
-  bool document_load() {
-    std::cout << "Running " << __func__ << std::endl;
-    auto [doc, error] = document::load(JSON_TEST_PATH);
-    if (error) { cerr << error << endl; return false; }
-    if (!doc.root().is_object()) { cerr << "Document did not parse as an object" << endl; return false; }
-    return true;
-  }
   bool parser_load() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
@@ -749,12 +736,6 @@ namespace parse_api_tests {
 
 #if SIMDJSON_EXCEPTIONS
 
-  bool document_parse_exception() {
-    std::cout << "Running " << __func__ << std::endl;
-    document doc = document::parse(BASIC_JSON);
-    if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
-    return true;
-  }
   bool parser_parse_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
@@ -774,12 +755,6 @@ namespace parse_api_tests {
     return true;
   }
 
-  bool document_load_exception() {
-    std::cout << "Running " << __func__ << std::endl;
-    document doc = document::load(JSON_TEST_PATH);
-    if (!doc.root().is_object()) { cerr << "Document did not parse as an object" << endl; return false; }
-    return true;
-  }
   bool parser_load_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
@@ -801,18 +776,14 @@ namespace parse_api_tests {
 #endif
 
   bool run() {
-    return document_parse() &&
-           parser_parse() &&
+    return parser_parse() &&
            parser_parse_many() &&
 //           parser_parse_many_empty() &&
-           document_load() &&
            parser_load() &&
            parser_load_many() &&
 #if SIMDJSON_EXCEPTIONS
-           document_parse_exception() &&
            parser_parse_exception() &&
            parser_parse_many_exception() &&
-           document_load_exception() &&
            parser_load_exception() &&
            parser_load_many_exception() &&
 #endif
@@ -1185,7 +1156,8 @@ namespace dom_api_tests {
     uint64_t expected_value[] = { 1, 2, 3 };
     int i = 0;
 
-    document doc = document::parse(json);
+    document::parser parser;
+    document &doc = parser.parse(json);
     for (auto [key, value] : doc.as_object()) {
       if (key != expected_key[i] || uint64_t(value) != expected_value[i]) { cerr << "Expected " << expected_key[i] << " = " << expected_value[i] << ", got " << key << "=" << uint64_t(value) << endl; return false; }
       i++;
@@ -1200,7 +1172,8 @@ namespace dom_api_tests {
     uint64_t expected_value[] = { 1, 10, 100 };
     int i=0;
 
-    document doc = document::parse(json);
+    document::parser parser;
+    document &doc = parser.parse(json);
     for (uint64_t value : doc.as_array()) {
       if (value != expected_value[i]) { cerr << "Expected " << expected_value[i] << ", got " << value << endl; return false; }
       i++;
@@ -1273,7 +1246,8 @@ namespace dom_api_tests {
   bool document_object_index_exception() {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "a": 1, "b": 2, "c": 3})");
-    document doc = document::parse(json);
+    document::parser parser;
+    document &doc = parser.parse(json);
     if (uint64_t(doc["a"]) != 1) { cerr << "Expected uint64_t(doc[\"a\"]) to be 1, was " << uint64_t(doc["a"]) << endl; return false; }
     return true;
   }
@@ -1290,7 +1264,8 @@ namespace dom_api_tests {
   bool twitter_count_exception() {
     std::cout << "Running " << __func__ << std::endl;
     // Prints the number of results in twitter.json
-    document doc = document::load(JSON_TEST_PATH);
+    document::parser parser;
+    document &doc = parser.load(JSON_TEST_PATH);
     uint64_t result_count = doc["search_metadata"]["count"];
     if (result_count != 100) { cerr << "Expected twitter.json[metadata_count][count] = 100, got " << result_count << endl; return false; }
     return true;
@@ -1300,7 +1275,8 @@ namespace dom_api_tests {
     std::cout << "Running " << __func__ << std::endl;
     // Print users with a default profile.
     set<string_view> default_users;
-    document doc = document::load(JSON_TEST_PATH);
+    document::parser parser;
+    document &doc = parser.load(JSON_TEST_PATH);
     for (document::object tweet : doc["statuses"].as_array()) {
       document::object user = tweet["user"];
       if (user["default_profile"]) {
@@ -1315,7 +1291,8 @@ namespace dom_api_tests {
     std::cout << "Running " << __func__ << std::endl;
     // Print image names and sizes
     set<pair<uint64_t, uint64_t>> image_sizes;
-    document doc = document::load(JSON_TEST_PATH);
+    document::parser parser;
+    document &doc = parser.load(JSON_TEST_PATH);
     for (document::object tweet : doc["statuses"].as_array()) {
       auto [media, not_found] = tweet["entities"]["media"];
       if (!not_found) {
@@ -1376,23 +1353,6 @@ namespace format_tests {
       return false;
     }
     return true;
-  }
-
-  bool print_document_parse() {
-    std::cout << "Running " << __func__ << std::endl;
-    auto [doc, error] = document::parse(DOCUMENT);
-    if (error) { cerr << error << endl; return false; }
-    ostringstream s;
-    s << doc;
-    return assert_minified(s);
-  }
-  bool print_minify_document_parse() {
-    std::cout << "Running " << __func__ << std::endl;
-    auto [doc, error] = document::parse(DOCUMENT);
-    if (error) { cerr << error << endl; return false; }
-    ostringstream s;
-    s << minify(doc);
-    return assert_minified(s);
   }
 
   bool print_parser_parse() {
@@ -1467,19 +1427,6 @@ namespace format_tests {
 
 #if SIMDJSON_EXCEPTIONS
 
-  bool print_document_parse_exception() {
-    std::cout << "Running " << __func__ << std::endl;
-    ostringstream s;
-    s << document::parse(DOCUMENT);
-    return assert_minified(s);
-  }
-  bool print_minify_document_parse_exception() {
-    std::cout << "Running " << __func__ << std::endl;
-    ostringstream s;
-    s << minify(document::parse(DOCUMENT));
-    return assert_minified(s);
-  }
-
   bool print_parser_parse_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
@@ -1499,14 +1446,16 @@ namespace format_tests {
 
   bool print_element_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << doc["foo"];
     return assert_minified(s, "1");
   }
   bool print_minify_element_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << minify(doc["foo"]);
     return assert_minified(s, "1");
@@ -1514,7 +1463,8 @@ namespace format_tests {
 
   bool print_element_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     document::element value = doc["foo"];
     ostringstream s;
     s << value;
@@ -1522,7 +1472,8 @@ namespace format_tests {
   }
   bool print_minify_element_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     document::element value = doc["foo"];
     ostringstream s;
     s << minify(value);
@@ -1531,14 +1482,16 @@ namespace format_tests {
 
   bool print_array_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << doc["bar"].as_array();
     return assert_minified(s, "[1,2,3]");
   }
   bool print_minify_array_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << minify(doc["bar"].as_array());
     return assert_minified(s, "[1,2,3]");
@@ -1546,14 +1499,16 @@ namespace format_tests {
 
   bool print_object_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << doc["baz"].as_object();
     return assert_minified(s, R"({"a":1,"b":2,"c":3})");
   }
   bool print_minify_object_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << minify(doc["baz"].as_object());
     return assert_minified(s, R"({"a":1,"b":2,"c":3})");
@@ -1561,7 +1516,8 @@ namespace format_tests {
 
   bool print_array_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     document::array value = doc["bar"];
     ostringstream s;
     s << value;
@@ -1569,7 +1525,8 @@ namespace format_tests {
   }
   bool print_minify_array_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     document::array value = doc["bar"];
     ostringstream s;
     s << minify(value);
@@ -1578,7 +1535,8 @@ namespace format_tests {
 
   bool print_object_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     document::object value = doc["baz"];
     ostringstream s;
     s << value;
@@ -1586,7 +1544,8 @@ namespace format_tests {
   }
   bool print_minify_object_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    const document &doc = document::parse(DOCUMENT);
+    document::parser parser;
+    document &doc = parser.parse(DOCUMENT);
     document::object value = doc["baz"];
     ostringstream s;
     s << minify(value);
@@ -1595,13 +1554,11 @@ namespace format_tests {
 #endif // SIMDJSON_EXCEPTIONS
 
   bool run() {
-    return print_document_parse() && print_minify_document_parse() &&
-           print_parser_parse() && print_minify_parser_parse() &&
+    return print_parser_parse() && print_minify_parser_parse() &&
            print_element() && print_minify_element() &&
            print_array() && print_minify_array() &&
            print_object() && print_minify_object() &&
 #if SIMDJSON_EXCEPTIONS
-           print_document_parse_exception() && print_minify_document_parse_exception() &&
            print_parser_parse_exception() && print_minify_parser_parse_exception() &&
            print_element_result_exception() && print_minify_element_result_exception() &&
            print_array_result_exception() && print_minify_array_result_exception() &&

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -41,12 +41,6 @@ namespace parser_load {
     TEST_FAIL("No documents returned");
   }
 
-  bool document_load_nonexistent() {
-    TEST_START();
-    auto [doc, error] = document::load(NONEXISTENT_FILE);
-    ASSERT_ERROR(error, IO_ERROR);
-    TEST_SUCCEED();
-  }
   bool parser_load_nonexistent() {
     TEST_START();
     document::parser parser;
@@ -70,12 +64,6 @@ namespace parser_load {
     TEST_SUCCEED();
   }
 
-  bool document_load_chain() {
-    TEST_START();
-    auto [val, error] = document::load(NONEXISTENT_FILE)["foo"].as_uint64_t();
-    ASSERT_ERROR(error, IO_ERROR);
-    TEST_SUCCEED();
-  }
   bool parser_load_chain() {
     TEST_START();
     document::parser parser;
@@ -95,8 +83,8 @@ namespace parser_load {
   }
   bool run() {
     return parser_load_capacity() && parser_load_many_capacity()
-        && parser_load_nonexistent() && parser_load_many_nonexistent() && document_load_nonexistent() && padded_string_load_nonexistent()
-        && document_load_chain() && parser_load_chain() && parser_load_many_chain();
+        && parser_load_nonexistent() && parser_load_many_nonexistent() && padded_string_load_nonexistent()
+        && parser_load_chain() && parser_load_many_chain();
   }
 }
 

--- a/tests/pointercheck.cpp
+++ b/tests/pointercheck.cpp
@@ -34,8 +34,8 @@ const padded_string TEST_JSON = R"(
 
 bool json_pointer_success_test(const char *json_pointer, std::string_view expected_value) {
   std::cout << "Running successful JSON pointer test '" << json_pointer << "' ..." << std::endl;
-  auto doc = document::parse(TEST_JSON);
-  auto [value, error] = doc[json_pointer].as_string();
+  document::parser parser;
+  auto [value, error] = parser.parse(TEST_JSON)[json_pointer].as_string();
   if (error) { std::cerr << "Unexpected Error: " << error << std::endl; return false; }
   ASSERT(value == expected_value);
   return true;
@@ -43,8 +43,8 @@ bool json_pointer_success_test(const char *json_pointer, std::string_view expect
 
 bool json_pointer_success_test(const char *json_pointer) {
   std::cout << "Running successful JSON pointer test '" << json_pointer << "' ..." << std::endl;
-  auto doc = document::parse(TEST_JSON);
-  auto [value, error] = doc[json_pointer];
+  document::parser parser;
+  auto [value, error] = parser.parse(TEST_JSON)[json_pointer];
   if (error) { std::cerr << "Unexpected Error: " << error << std::endl; return false; }
   return true;
 }
@@ -52,8 +52,8 @@ bool json_pointer_success_test(const char *json_pointer) {
 
 bool json_pointer_failure_test(const char *json_pointer, error_code expected_failure_test) {
   std::cout << "Running invalid JSON pointer test '" << json_pointer << "' ..." << std::endl;
-  auto doc = document::parse(TEST_JSON);
-  auto [value, error] = doc[json_pointer];
+  document::parser parser;
+  auto [value, error] = parser.parse(TEST_JSON)[json_pointer];
   ASSERT(error == expected_failure_test);
   return true;
 }

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -3,14 +3,6 @@
 using namespace std;
 using namespace simdjson;
 
-void document_parse_error_code() {
-  cout << __func__ << endl;
-
-  auto [doc, error] = document::parse("[ 1, 2, 3 ]"_padded);
-  if (error) { cerr << "Error: " << error << endl; exit(1); }
-  cout << doc << endl;
-}
-
 void parser_parse_error_code() {
   cout << __func__ << endl;
 
@@ -71,30 +63,20 @@ void parser_parse_fixed_capacity() {
 
 #if SIMDJSON_EXCEPTIONS
 
-void document_parse_exception() {
-  cout << __func__ << endl;
-
-  cout << document::parse("[ 1, 2, 3 ]"_padded) << endl;
-}
-
-void document_parse_padded_string() {
+void parser_parse_padded_string() {
   cout << __func__ << endl;
 
   auto json = "[ 1, 2, 3 ]"_padded;
-  cout << document::parse(json) << endl;
+  document::parser parser;
+  cout << parser.parse(json) << endl;
 }
 
-void document_parse_get_corpus() {
+void parser_parse_get_corpus() {
   cout << __func__ << endl;
 
   auto json = get_corpus("jsonexamples/small/demo.json");
-  cout << document::parse(json) << endl;
-}
-
-void document_load() {
-  cout << __func__ << endl;
-
-  cout << document::load("jsonexamples/small/demo.json") << endl;
+  document::parser parser;
+  cout << parser.parse(json) << endl;
 }
 
 void parser_parse_exception() {
@@ -126,18 +108,15 @@ void parser_parse_many_exception() {
 
 int main() {
   cout << "Running examples." << endl;
-  document_parse_error_code();
   parser_parse_error_code();
   parser_parse_many_error_code();
   parser_parse_max_capacity();
   parser_parse_fixed_capacity();
 #if SIMDJSON_EXCEPTIONS
-  document_parse_exception();
   parser_parse_exception();
   parser_parse_many_exception();
-  document_parse_padded_string();
-  document_parse_get_corpus();
-  document_load();
+  parser_parse_padded_string();
+  parser_parse_get_corpus();
 #endif // SIMDJSON_EXCEPTIONS
   cout << "Ran to completion!" << endl;
   return 0;

--- a/tools/jsonpointer.cpp
+++ b/tools/jsonpointer.cpp
@@ -52,7 +52,8 @@ int main(int argc, char *argv[]) {
   }
 
   const char *filename = argv[1];
-  auto [doc, error] = simdjson::document::load(filename);
+  simdjson::document::parser parser;
+  auto [doc, error] = parser.load(filename);
   if (error) { std::cerr << "Error parsing " << filename << ": " << error << std::endl; }
 
   std::cout << "[" << std::endl;


### PR DESCRIPTION
We've talked about this elsewhere but I don't believe we came to a conclusion. Now that it's easier to create and use a parser, I think we should remove `document::load()` and `document::parse()` and leave the `parser` interface as the only way to do it:

```c++
document::parser parser;
parser.load(...)
```

* **Con -- More lines:** document::parse() is one line instead of two. (On the other hand, it's a pretty simple extra line.)
* **Pro -- It makes the default way the right way:** When you grow out of a simple use case, you're going to want to keep the parser around. But if your original use case uses `document::parse()`, the least friction is to copy/paste `document::parse()` all over the place. People tend to do whatever the least friction is.
* **Pro -- Easier to reason about lifetime.** parser.parse() never returns an owned thing, and the clearest way to write is to put the parser in a variable. Thus, the only owned memory lives in a variable and is easier to reason about.
* **Pro -- Fewer choices:** This is our entry point API. If we have documentation and examples strewn all over the place doing different things, we aren't sending a clear signal to the user.
* **Pro -- Clarity about memory model:** document::parse() returns owned documents, parser.parse() returns references, which one was I using again? If there's only parser.parse(), there are only ever document references, unless you *explicitly* declare a `document` variable.