### PR TITLE
Remove simdjson_move_result

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,11 @@ executors:
       - image: gcc:7
         environment:
           CXX: g++
+  gcc8:
+    docker:
+      - image: gcc:8
+        environment:
+          CXX: g++
   gcc9:
     docker:
       - image: gcc:9
@@ -25,6 +30,18 @@ commands:
       - run: apt-get update -qq
       - run: apt-get install -y clang build-essential git
   make_test:
+    steps:
+      - checkout
+      - run: make
+      - run: make amalgamate
+      - run: ARCHFLAGS=-march=haswell make amalgamate # some users do this: https://github.com/lemire/simdjson/issues/444
+      - run: make test
+      - run: make checkperf
+      - run: make clean
+      - run: ARCHFLAGS=-march=haswell make test # this breaks runtime dispatch, but see https://github.com/lemire/simdjson/issues/444... this is a code robustness test
+      - run: make clean
+      - run: EXTRAFLAGS=-DSIMDJSON_NO_COMPUTED_GOTO=true make test # this should run tests with computed gotos disabled
+   make_test_strict:
     steps:
       - checkout
       - run: EXTRAFLAGS=-Werror make
@@ -73,7 +90,11 @@ jobs:
   gcc9-avx:
     description: Build, run tests and check performance on GCC 9 and AVX 2
     executor: gcc9
-    steps: [ make_test ]
+    steps: [ make_test_strict ]
+  gcc8-avx:
+    description: Build, run tests and check performance on GCC 8 and AVX 2
+    executor: gcc9
+    steps: [ make_test_strict ]
   gcc-avx:
     description: Build, run tests and check performance on GCC 7 and AVX 2
     executor: gcc7
@@ -170,8 +191,9 @@ workflows:
   version: 2.1
   build_and_test:
     jobs:
-      - gcc-avx
       - gcc9-avx
+      - gcc8-avx
+      - gcc-avx
       - gcc-avx-dynamic
       - gcc-avx-static
       - gcc-avx-google-benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,14 +45,13 @@ commands:
     steps:
       - checkout
       - run: EXTRAFLAGS=-Werror make
-      - run: make amalgamate
+      - run: EXTRAFLAGS=-Werror make amalgamate
       - run: ARCHFLAGS=-march=haswell make amalgamate # some users do this: https://github.com/lemire/simdjson/issues/444
-      - run: make test
-      - run: make checkperf
+      - run: EXTRAFLAGS=-Werror make test
+      - run: EXTRAFLAGS=-Werror make checkperf
       - run: make clean
       - run: ARCHFLAGS=-march=haswell make test # this breaks runtime dispatch, but see https://github.com/lemire/simdjson/issues/444... this is a code robustness test
       - run: make clean
-      - run: EXTRAFLAGS=-DSIMDJSON_NO_COMPUTED_GOTO=true make test # this should run tests with computed gotos disabled
   
   cmake_test:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,10 +47,7 @@ commands:
       - run: EXTRAFLAGS=-Werror make
       - run: EXTRAFLAGS=-Werror make amalgamate
       - run: ARCHFLAGS=-march=haswell make amalgamate # some users do this: https://github.com/lemire/simdjson/issues/444
-      - run: EXTRAFLAGS=-Werror make test
-      - run: EXTRAFLAGS=-Werror make checkperf
-      - run: make clean
-      - run: ARCHFLAGS=-march=haswell make test # this breaks runtime dispatch, but see https://github.com/lemire/simdjson/issues/444... this is a code robustness test
+      - run: EXTRAFLAGS=-Werror make quicktest
       - run: make clean
   
   cmake_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
       - run: ARCHFLAGS=-march=haswell make test # this breaks runtime dispatch, but see https://github.com/lemire/simdjson/issues/444... this is a code robustness test
       - run: make clean
       - run: EXTRAFLAGS=-DSIMDJSON_NO_COMPUTED_GOTO=true make test # this should run tests with computed gotos disabled
-   make_test_strict:
+  make_test_strict:
     steps:
       - checkout
       - run: EXTRAFLAGS=-Werror make

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
       - run: EXTRAFLAGS=-Werror make
       - run: EXTRAFLAGS=-Werror make amalgamate
       - run: ARCHFLAGS=-march=haswell make amalgamate # some users do this: https://github.com/lemire/simdjson/issues/444
-      - run: EXTRAFLAGS=-Werror make quicktest
+      - run: EXTRAFLAGS=-Werror make quicktests
       - run: make clean
   
   cmake_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,11 @@ executors:
       - image: gcc:7
         environment:
           CXX: g++
+  gcc9:
+    docker:
+      - image: gcc:9
+        environment:
+          CXX: g++
   clang6:
     docker:
       - image: ubuntu:18.04
@@ -22,7 +27,7 @@ commands:
   make_test:
     steps:
       - checkout
-      - run: make
+      - run: EXTRAFLAGS=-Werror make
       - run: make amalgamate
       - run: ARCHFLAGS=-march=haswell make amalgamate # some users do this: https://github.com/lemire/simdjson/issues/444
       - run: make test
@@ -65,6 +70,10 @@ jobs:
     environment: { CMAKE_TEST_FLAGS: -DSIMDJSON_ENABLE_THREADS=ON }
     steps: [ init_clang6, cmake_test ]
 
+  gcc9-avx:
+    description: Build, run tests and check performance on GCC 9 and AVX 2
+    executor: gcc9
+    steps: [ make_test ]
   gcc-avx:
     description: Build, run tests and check performance on GCC 7 and AVX 2
     executor: gcc7
@@ -162,6 +171,7 @@ workflows:
   build_and_test:
     jobs:
       - gcc-avx
+      - gcc9-avx
       - gcc-avx-dynamic
       - gcc-avx-static
       - gcc-avx-google-benchmarks

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -73,8 +73,12 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 #define unlikely(x) x
 #endif
 
+#define SIMDJSON_PUSH_DISABLE_WARNINGS __pragma(warning( push ))
+#define SIMDJSON_DISABLE_VS_WARNING(WARNING_NUMBER) __pragma(warning( disable : WARNING_NUMBER ))
+#define SIMDJSON_DISABLE_DEPRECATED_WARNING SIMDJSON_DISABLE_VS_WARNING(4996)
+#define SIMDJSON_POP_DISABLE_WARNINGS __pragma(warning( pop ))
 
-#else
+#else // MSC_VER
 
 
 #define really_inline inline __attribute__((always_inline, unused))
@@ -89,6 +93,12 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 #ifndef unlikely
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #endif
+
+#define SIMDJSON_PUSH_DISABLE_WARNINGS _Pragma("GCC diagnostic push")
+#define SIMDJSON_PRAGMA(P) _Pragma(#P)
+#define SIMDJSON_DISABLE_GCC_WARNING(WARNING) SIMDJSON_PRAGMA(GCC diagnostic ignored #WARNING)
+#define SIMDJSON_DISABLE_DEPRECATED_WARNING SIMDJSON_DISABLE_GCC_WARNING(-Wdeprecated-declarations)
+#define SIMDJSON_POP_DISABLE_WARNINGS _Pragma("GCC diagnostic pop")
 
 #endif // MSC_VER
 

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -413,6 +413,11 @@ public:
   really_inline bool is_number() const noexcept;
   /** Whether this is a JSON integer (e.g. 1 or -1, but *not* 1.0 or 1e2) */
   really_inline bool is_integer() const noexcept;
+  /** Whether this is a JSON integer in [9223372036854775808, 18446744073709551616)
+   * that is, a value too large for a signed 64-bit integer, but that still fits
+   * in a 64-bit word. Note that is_integer() is true when is_unsigned_integer()
+   * is true.*/
+  really_inline bool is_unsigned_integer() const noexcept;
   /** Whether this is a JSON number but not an integer */
   really_inline bool is_float() const noexcept;
   /** Whether this is a JSON string (e.g. "abc") */
@@ -889,16 +894,32 @@ public:
   /**
    * Get the value associated with the given key.
    *
-   * Note: The key will be matched against **unescaped** JSON:
-   *
-   *   document::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })")["a\n"].as_uint64_t().value == 1
-   *   parser.parse(R"({ "a\n": 1 })")["a\\n"].as_uint64_t().error == NO_SUCH_FIELD
+   * Note: The key will be matched against **unescaped** JSON.
    *
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
   inline element_result at_key(const char *s) const noexcept;
+
+  /**
+   * Get the value associated with the given key, the provided key is
+   * considered to have length characters.
+   *
+   * Note: The key will be matched against **unescaped** JSON.
+   *
+   * @return The value associated with this field, or:
+   *         - NO_SUCH_FIELD if the field does not exist in the object
+   */
+  inline element_result at_key(const char *s, size_t length) const noexcept;
+  /**
+   * Get the value associated with the given key in a case-insensitive manner.
+   *
+   * Note: The key will be matched against **unescaped** JSON.
+   *
+   * @return The value associated with this field, or:
+   *         - NO_SUCH_FIELD if the field does not exist in the object
+   */
+  inline element_result at_key_case_insensitive(const char *s) const noexcept;
 
 private:
   really_inline object(const document *_doc, size_t _json_index) noexcept;

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -180,20 +180,6 @@ public:
    */
   inline element_result at_key(std::string_view s) const noexcept;
 
-  /**
-   * Get the value associated with the given key.
-   *
-   * Note: The key will be matched against **unescaped** JSON:
-   *
-   *   document::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })")["a\n"].as_uint64_t().value == 1
-   *   parser.parse(R"({ "a\n": 1 })")["a\\n"].as_uint64_t().error == NO_SUCH_FIELD
-   *
-   * @return The value associated with this field, or:
-   *         - NO_SUCH_FIELD if the field does not exist in the object
-   */
-  inline element_result at_key(const char *s) const noexcept;
-
   std::unique_ptr<uint64_t[]> tape;
   std::unique_ptr<uint8_t[]> string_buf;// should be at least byte_capacity
 
@@ -255,6 +241,11 @@ public:
    *         - UNEXPECTED_TYPE if the JSON document is not an array
    */
   inline array_result as_array() const noexcept;
+
+  /**
+   * Get the root element of this document.
+   */
+  inline element_result root() const noexcept;
 
   /**
    * Get the value associated with the given JSON pointer.
@@ -644,18 +635,14 @@ public:
   inline element_result at_key(std::string_view s) const noexcept;
 
   /**
-   * Get the value associated with the given key.
+   * Get the value associated with the given key in a case-insensitive manner.
    *
-   * Note: The key will be matched against **unescaped** JSON:
-   *
-   *   document::parser parser;
-   *   parser.parse(R"({ "a\n": 1 })")["a\n"].as_uint64_t().value == 1
-   *   parser.parse(R"({ "a\n": 1 })")["a\\n"].as_uint64_t().error == NO_SUCH_FIELD
+   * Note: The key will be matched against **unescaped** JSON.
    *
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key(const char *s) const noexcept;
+  inline element_result at_key_case_insensitive(std::string_view s) const noexcept;
 
 private:
   really_inline element(const document *_doc, size_t _json_index) noexcept;
@@ -889,7 +876,7 @@ public:
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key(std::string_view s) const noexcept;
+  inline element_result at_key(std::string_view key) const noexcept;
 
   /**
    * Get the value associated with the given key.
@@ -899,18 +886,8 @@ public:
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key(const char *s) const noexcept;
+  inline element_result at_key(const char *key) const noexcept;
 
-  /**
-   * Get the value associated with the given key, the provided key is
-   * considered to have length characters.
-   *
-   * Note: The key will be matched against **unescaped** JSON.
-   *
-   * @return The value associated with this field, or:
-   *         - NO_SUCH_FIELD if the field does not exist in the object
-   */
-  inline element_result at_key(const char *s, size_t length) const noexcept;
   /**
    * Get the value associated with the given key in a case-insensitive manner.
    *
@@ -919,7 +896,17 @@ public:
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key_case_insensitive(const char *s) const noexcept;
+  inline element_result at_key_case_insensitive(std::string_view key) const noexcept;
+
+  /**
+   * Get the value associated with the given key in a case-insensitive manner.
+   *
+   * Note: The key will be matched against **unescaped** JSON.
+   *
+   * @return The value associated with this field, or:
+   *         - NO_SUCH_FIELD if the field does not exist in the object
+   */
+  inline element_result at_key_case_insensitive(const char *key) const noexcept;
 
 private:
   really_inline object(const document *_doc, size_t _json_index) noexcept;
@@ -967,6 +954,8 @@ public:
   inline element_result at(size_t index) const noexcept;
   inline element_result at_key(std::string_view key) const noexcept;
   inline element_result at_key(const char *key) const noexcept;
+  inline element_result at_key_case_insensitive(std::string_view key) const noexcept;
+  inline element_result at_key_case_insensitive(const char *key) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   inline operator bool() const noexcept(false);
@@ -1009,7 +998,7 @@ public:
   inline element_result operator[](const char *json_pointer) const noexcept;
   inline element_result at(std::string_view json_pointer) const noexcept;
   inline element_result at_key(std::string_view key) const noexcept;
-  inline element_result at_key(const char *key) const noexcept;
+  inline element_result at_key_case_insensitive(std::string_view key) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   inline object::iterator begin() const noexcept(false);

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -926,7 +926,7 @@ private:
 class document::element_result : public simdjson_result<document::element> {
 public:
   really_inline element_result() noexcept;
-  really_inline element_result(element value) noexcept;
+  really_inline element_result(element &&value) noexcept;
   really_inline element_result(error_code error) noexcept;
 
   /** Whether this is a JSON `null` */

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -180,6 +180,20 @@ public:
    */
   inline element_result at_key(std::string_view s) const noexcept;
 
+  /**
+   * Get the value associated with the given key.
+   *
+   * Note: The key will be matched against **unescaped** JSON:
+   *
+   *   document::parser parser;
+   *   parser.parse(R"({ "a\n": 1 })")["a\n"].as_uint64_t().value == 1
+   *   parser.parse(R"({ "a\n": 1 })")["a\\n"].as_uint64_t().error == NO_SUCH_FIELD
+   *
+   * @return The value associated with this field, or:
+   *         - NO_SUCH_FIELD if the field does not exist in the object
+   */
+  inline element_result at_key(const char *s) const noexcept;
+
   std::unique_ptr<uint64_t[]> tape;
   std::unique_ptr<uint8_t[]> string_buf;// should be at least byte_capacity
 
@@ -635,14 +649,18 @@ public:
   inline element_result at_key(std::string_view s) const noexcept;
 
   /**
-   * Get the value associated with the given key in a case-insensitive manner.
+   * Get the value associated with the given key.
    *
-   * Note: The key will be matched against **unescaped** JSON.
+   * Note: The key will be matched against **unescaped** JSON:
+   *
+   *   document::parser parser;
+   *   parser.parse(R"({ "a\n": 1 })")["a\n"].as_uint64_t().value == 1
+   *   parser.parse(R"({ "a\n": 1 })")["a\\n"].as_uint64_t().error == NO_SUCH_FIELD
    *
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key_case_insensitive(std::string_view s) const noexcept;
+  inline element_result at_key(const char *s) const noexcept;
 
 private:
   really_inline element(const document *_doc, size_t _json_index) noexcept;
@@ -876,7 +894,7 @@ public:
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key(std::string_view key) const noexcept;
+  inline element_result at_key(std::string_view s) const noexcept;
 
   /**
    * Get the value associated with the given key.
@@ -886,8 +904,18 @@ public:
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key(const char *key) const noexcept;
+  inline element_result at_key(const char *s) const noexcept;
 
+  /**
+   * Get the value associated with the given key, the provided key is
+   * considered to have length characters.
+   *
+   * Note: The key will be matched against **unescaped** JSON.
+   *
+   * @return The value associated with this field, or:
+   *         - NO_SUCH_FIELD if the field does not exist in the object
+   */
+  inline element_result at_key(const char *s, size_t length) const noexcept;
   /**
    * Get the value associated with the given key in a case-insensitive manner.
    *
@@ -896,17 +924,7 @@ public:
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
-  inline element_result at_key_case_insensitive(std::string_view key) const noexcept;
-
-  /**
-   * Get the value associated with the given key in a case-insensitive manner.
-   *
-   * Note: The key will be matched against **unescaped** JSON.
-   *
-   * @return The value associated with this field, or:
-   *         - NO_SUCH_FIELD if the field does not exist in the object
-   */
-  inline element_result at_key_case_insensitive(const char *key) const noexcept;
+  inline element_result at_key_case_insensitive(const char *s) const noexcept;
 
 private:
   really_inline object(const document *_doc, size_t _json_index) noexcept;
@@ -954,8 +972,6 @@ public:
   inline element_result at(size_t index) const noexcept;
   inline element_result at_key(std::string_view key) const noexcept;
   inline element_result at_key(const char *key) const noexcept;
-  inline element_result at_key_case_insensitive(std::string_view key) const noexcept;
-  inline element_result at_key_case_insensitive(const char *key) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   inline operator bool() const noexcept(false);
@@ -998,7 +1014,7 @@ public:
   inline element_result operator[](const char *json_pointer) const noexcept;
   inline element_result at(std::string_view json_pointer) const noexcept;
   inline element_result at_key(std::string_view key) const noexcept;
-  inline element_result at_key_case_insensitive(std::string_view key) const noexcept;
+  inline element_result at_key(const char *key) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   inline object::iterator begin() const noexcept(false);

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -783,6 +783,16 @@ inline document::element_result document::object::at(std::string_view json_point
 
   return child;
 }
+inline document::element_result document::object::at_key(const char *key, size_t length) const noexcept {
+  iterator end_field = end();
+  for (iterator field = begin(); field != end_field; ++field) {
+    std::string_view v{field.key()};
+    if ((v.size() == length) && (!memcmp(v.data(), key, length))) {
+      return field.value();
+    }
+  }
+  return NO_SUCH_FIELD;
+}
 inline document::element_result document::object::at_key(std::string_view key) const noexcept {
   iterator end_field = end();
   for (iterator field = begin(); field != end_field; ++field) {
@@ -801,7 +811,18 @@ inline document::element_result document::object::at_key(const char *key) const 
   }
   return NO_SUCH_FIELD;
 }
-
+// In case you wonder why we need this, please see
+// https://github.com/simdjson/simdjson/issues/323
+// People do seek keys in a case-insensitive manner.
+inline document::element_result document::object::at_key_case_insensitive(const char *key) const noexcept {
+  iterator end_field = end();
+  for (iterator field = begin(); field != end_field; ++field) {
+    if (!simdjson_strcasecmp(key, field.key_c_str())) {
+      return field.value();
+    }
+  }
+  return NO_SUCH_FIELD;
+}
 //
 // document::object::iterator inline implementation
 //
@@ -858,6 +879,9 @@ really_inline bool document::element::is_float() const noexcept {
 }
 really_inline bool document::element::is_integer() const noexcept {
   return type() == internal::tape_type::UINT64 || type() == internal::tape_type::INT64;
+}
+really_inline bool document::element::is_unsigned_integer() const noexcept {
+  return type() == internal::tape_type::UINT64;
 }
 really_inline bool document::element::is_string() const noexcept {
   return type() == internal::tape_type::STRING;

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -951,7 +951,7 @@ inline simdjson_result<double> document::element::as_double() const noexcept {
       if (result < 0) {
         return NUMBER_OUT_OF_RANGE;
       }
-      return result;
+      return double(result);
     }
     case internal::tape_type::DOUBLE:
       return next_tape_value<double>();

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -75,9 +75,9 @@ inline document::element_result document::element_result::at_key(std::string_vie
   if (error()) { return *this; }
   return first.at_key(key);
 }
-inline document::element_result document::element_result::at_key(const char *key) const noexcept {
+inline document::element_result document::element_result::at_key_case_insensitive(std::string_view key) const noexcept {
   if (error()) { return *this; }
-  return first.at_key(key);
+  return first.at_key_case_insensitive(key);
 }
 
 #if SIMDJSON_EXCEPTIONS
@@ -167,9 +167,9 @@ inline document::element_result document::object_result::at_key(std::string_view
   if (error()) { return error(); }
   return first.at_key(key);
 }
-inline document::element_result document::object_result::at_key(const char *key) const noexcept {
+inline document::element_result document::object_result::at_key_case_insensitive(std::string_view key) const noexcept {
   if (error()) { return error(); }
-  return first.at_key(key);
+  return first.at_key_case_insensitive(key);
 }
 
 #if SIMDJSON_EXCEPTIONS
@@ -225,9 +225,6 @@ inline document::element_result document::at(size_t index) const noexcept {
   return as_array().at(index);
 }
 inline document::element_result document::at_key(std::string_view key) const noexcept {
-  return as_object().at_key(key);
-}
-inline document::element_result document::at_key(const char *key) const noexcept {
   return as_object().at_key(key);
 }
 inline document::element_result document::operator[](std::string_view json_pointer) const noexcept {
@@ -359,12 +356,14 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
 inline document::doc_result::doc_result(document &doc, error_code error) noexcept : simdjson_result<document&>(doc, error) { }
 
 inline document::array_result document::doc_result::as_array() const noexcept {
-  if (error()) { return error(); }
-  return first.root().as_array();
+  return root().as_array();
 }
 inline document::object_result document::doc_result::as_object() const noexcept {
+  return root().as_object();
+}
+inline document::element_result document::doc_result::root() const noexcept {
   if (error()) { return error(); }
-  return first.root().as_object();
+  return first.root();
 }
 
 inline document::element_result document::doc_result::operator[](std::string_view key) const noexcept {
@@ -783,16 +782,6 @@ inline document::element_result document::object::at(std::string_view json_point
 
   return child;
 }
-inline document::element_result document::object::at_key(const char *key, size_t length) const noexcept {
-  iterator end_field = end();
-  for (iterator field = begin(); field != end_field; ++field) {
-    std::string_view v{field.key()};
-    if ((v.size() == length) && (!memcmp(v.data(), key, length))) {
-      return field.value();
-    }
-  }
-  return NO_SUCH_FIELD;
-}
 inline document::element_result document::object::at_key(std::string_view key) const noexcept {
   iterator end_field = end();
   for (iterator field = begin(); field != end_field; ++field) {
@@ -802,27 +791,21 @@ inline document::element_result document::object::at_key(std::string_view key) c
   }
   return NO_SUCH_FIELD;
 }
-inline document::element_result document::object::at_key(const char *key) const noexcept {
-  iterator end_field = end();
-  for (iterator field = begin(); field != end_field; ++field) {
-    if (!strcmp(key, field.key_c_str())) {
-      return field.value();
-    }
-  }
-  return NO_SUCH_FIELD;
-}
 // In case you wonder why we need this, please see
 // https://github.com/simdjson/simdjson/issues/323
 // People do seek keys in a case-insensitive manner.
-inline document::element_result document::object::at_key_case_insensitive(const char *key) const noexcept {
+inline document::element_result document::object::at_key_case_insensitive(std::string_view key) const noexcept {
   iterator end_field = end();
   for (iterator field = begin(); field != end_field; ++field) {
-    if (!simdjson_strcasecmp(key, field.key_c_str())) {
+    if (std::equal(key.begin(), key.end(), field.key().begin(), [](char a, char b) {
+      return std::tolower(a) == std::tolower(b);
+    })) {
       return field.value();
     }
   }
   return NO_SUCH_FIELD;
 }
+
 //
 // document::object::iterator inline implementation
 //
@@ -1021,8 +1004,8 @@ inline document::element_result document::element::at(size_t index) const noexce
 inline document::element_result document::element::at_key(std::string_view key) const noexcept {
   return as_object().at_key(key);
 }
-inline document::element_result document::element::at_key(const char *key) const noexcept {
-  return as_object().at_key(key);
+inline document::element_result document::element::at_key_case_insensitive(std::string_view key) const noexcept {
+  return as_object().at_key_case_insensitive(key);
 }
 
 //

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -17,7 +17,7 @@ namespace simdjson {
 // element_result inline implementation
 //
 really_inline document::element_result::element_result() noexcept : simdjson_result<element>() {}
-really_inline document::element_result::element_result(element value) noexcept : simdjson_result<element>(value) {}
+really_inline document::element_result::element_result(element &&value) noexcept : simdjson_result<element>((element&&)value) {}
 really_inline document::element_result::element_result(error_code error) noexcept : simdjson_result<element>(error) {}
 inline simdjson_result<bool> document::element_result::is_null() const noexcept {
   if (error()) { return error(); }
@@ -113,7 +113,7 @@ inline document::element_result::operator document::object() const noexcept(fals
 // array_result inline implementation
 //
 really_inline document::array_result::array_result() noexcept : simdjson_result<array>() {}
-really_inline document::array_result::array_result(array value) noexcept : simdjson_result<array>(value) {}
+really_inline document::array_result::array_result(array value) noexcept : simdjson_result<array>((array&&)value) {}
 really_inline document::array_result::array_result(error_code error) noexcept : simdjson_result<array>(error) {}
 
 #if SIMDJSON_EXCEPTIONS
@@ -149,7 +149,7 @@ inline document::element_result document::array_result::at(size_t index) const n
 // object_result inline implementation
 //
 really_inline document::object_result::object_result() noexcept : simdjson_result<object>() {}
-really_inline document::object_result::object_result(object value) noexcept : simdjson_result<object>(value) {}
+really_inline document::object_result::object_result(object value) noexcept : simdjson_result<object>((object&&)value) {}
 really_inline document::object_result::object_result(error_code error) noexcept : simdjson_result<object>(error) {}
 
 inline document::element_result document::object_result::operator[](std::string_view json_pointer) const noexcept {

--- a/include/simdjson/inline/padded_string.h
+++ b/include/simdjson/inline/padded_string.h
@@ -98,7 +98,7 @@ inline const char *padded_string::data() const noexcept { return data_ptr; }
 
 inline char *padded_string::data() noexcept { return data_ptr; }
 
-inline padded_string::operator std::string() const { return std::string(data(), length()); }
+inline padded_string::operator std::string_view() const { return std::string_view(data(), length()); }
 
 inline simdjson_result<padded_string> padded_string::load(const std::string &filename) noexcept {
   // Open the file

--- a/include/simdjson/inline/padded_string.h
+++ b/include/simdjson/inline/padded_string.h
@@ -98,6 +98,8 @@ inline const char *padded_string::data() const noexcept { return data_ptr; }
 
 inline char *padded_string::data() noexcept { return data_ptr; }
 
+inline padded_string::operator std::string() const { return std::string(data(), length()); }
+
 inline simdjson_result<padded_string> padded_string::load(const std::string &filename) noexcept {
   // Open the file
   std::FILE *fp = std::fopen(filename.c_str(), "rb");

--- a/include/simdjson/inline/padded_string.h
+++ b/include/simdjson/inline/padded_string.h
@@ -98,7 +98,7 @@ inline const char *padded_string::data() const noexcept { return data_ptr; }
 
 inline char *padded_string::data() noexcept { return data_ptr; }
 
-inline simdjson_move_result<padded_string> padded_string::load(const std::string &filename) noexcept {
+inline simdjson_result<padded_string> padded_string::load(const std::string &filename) noexcept {
   // Open the file
   std::FILE *fp = std::fopen(filename.c_str(), "rb");
   if (fp == nullptr) {
@@ -131,7 +131,7 @@ inline simdjson_move_result<padded_string> padded_string::load(const std::string
     return IO_ERROR;
   }
 
-  return std::move(s);
+  return s;
 }
 
 } // namespace simdjson

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -94,7 +94,7 @@ struct padded_string final {
    *
    * @param path the path to the file.
    **/
-  inline static simdjson_move_result<padded_string> load(const std::string &path) noexcept;
+  inline static simdjson_result<padded_string> load(const std::string &path) noexcept;
 
 private:
   padded_string &operator=(const padded_string &o) = delete;

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -90,6 +90,11 @@ struct padded_string final {
   char *data() noexcept;
 
   /**
+   * Create a new std::string with the same content.
+   */
+  operator std::string() const;
+
+  /**
    * Load this padded string from a file.
    *
    * @param path the path to the file.

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -90,9 +90,9 @@ struct padded_string final {
   char *data() noexcept;
 
   /**
-   * Create a new std::string with the same content.
+   * Create a std::string_view with the same content.
    */
-  operator std::string() const;
+  operator std::string_view() const;
 
   /**
    * Load this padded string from a file.

--- a/scripts/testjson2json.sh
+++ b/scripts/testjson2json.sh
@@ -2,10 +2,8 @@
 
 TMPDIR1=$(mktemp -d -t simdjsonXXXXXXXX)
 TMPDIR2=$(mktemp -d -t simdjsonXXXXXXXX)
-TMPDIR3=$(mktemp -d -t simdjsonXXXXXXXX)
-TMPDIR4=$(mktemp -d -t simdjsonXXXXXXXX)
 trap "exit 1"         HUP INT PIPE QUIT TERM
-trap "rm -rf $TMPDIR1 $TMPDIR2 $TMPDIR3 $TMPDIR4" EXIT
+trap "rm -rf $TMPDIR1 $TMPDIR2" EXIT
 
 function founderror() {
   echo "code is wrong"
@@ -16,29 +14,15 @@ make minify json2json
 for i in `cd jsonexamples && ls -1 *.json`; do
   echo $i
   ./json2json jsonexamples/$i > $TMPDIR1/$i
-  ./json2json -a jsonexamples/$i > $TMPDIR3/$i
   ./json2json $TMPDIR1/$i > $TMPDIR2/$i
-  ./json2json -a $TMPDIR3/$i > $TMPDIR4/$i
   cmp $TMPDIR1/$i $TMPDIR2/$i
-  retVal=$?
-  if [ $retVal -ne 0 ]; then
-    founderror
-  fi
-  cmp $TMPDIR3/$i $TMPDIR4/$i
   retVal=$?
   if [ $retVal -ne 0 ]; then
     founderror
   fi
   ./minify $TMPDIR1/$i > $TMPDIR1/minify$i
   ./minify $TMPDIR2/$i > $TMPDIR2/minify$i
-  ./minify $TMPDIR3/$i > $TMPDIR3/minify$i
-  ./minify $TMPDIR4/$i > $TMPDIR4/minify$i
   cmp $TMPDIR1/minify$i $TMPDIR2/minify$i
-  retVal=$?
-  if [ $retVal -ne 0 ]; then
-    founderror
-  fi
-  cmp $TMPDIR3/minify$i $TMPDIR4/minify$i
   retVal=$?
   if [ $retVal -ne 0 ]; then
     founderror
@@ -54,35 +38,20 @@ done
 for i in `cd jsonchecker && ls -1 pass*.json`; do
   echo $i
   ./json2json jsonchecker/$i > $TMPDIR1/$i
-  ./json2json -a jsonchecker/$i > $TMPDIR3/$i
   ./json2json $TMPDIR1/$i > $TMPDIR2/$i
-  ./json2json -a $TMPDIR3/$i > $TMPDIR4/$i
   cmp $TMPDIR1/$i $TMPDIR2/$i
   retVal=$?
   if [ $retVal -ne 0 ]; then
     echo "reg failure"
     founderror
   fi
-  cmp $TMPDIR3/$i $TMPDIR4/$i
-  retVal=$?
-  if [ $retVal -ne 0 ]; then
-    echo "-a failure"
-    founderror
-  fi
+
   ./minify $TMPDIR1/$i > $TMPDIR1/minify$i
   ./minify $TMPDIR2/$i > $TMPDIR2/minify$i
-  ./minify $TMPDIR3/$i > $TMPDIR3/minify$i
-  ./minify $TMPDIR4/$i > $TMPDIR4/minify$i
   cmp $TMPDIR1/minify$i $TMPDIR2/minify$i
   retVal=$?
   if [ $retVal -ne 0 ]; then
     echo "reg failure, step 2"
-    founderror
-  fi
-  cmp $TMPDIR3/minify$i $TMPDIR4/minify$i
-  retVal=$?
-  if [ $retVal -ne 0 ]; then
-    echo "-a failure, step 2"
     founderror
   fi
   ./json2json $TMPDIR1/minify$i > $TMPDIR2/bisminify$i

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -212,7 +212,6 @@ namespace number_tests {
   bool powers_of_ten() {
     std::cout << __func__ << std::endl;
     char buf[1024];
-    simdjson::ParsedJson pj;
     for (int i = -1000000; i <= 308; ++i) {// large negative values should be zero.
       auto n = sprintf(buf,"1e%d", i);
       buf[n] = '\0';

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -567,7 +567,7 @@ namespace parse_api_tests {
   }
 }
 
-namespace deprecated_tests {
+namespace dom_api_tests {
   using namespace std;
   using namespace simdjson;
 
@@ -674,22 +674,11 @@ namespace deprecated_tests {
     }
     return true;
   }
-
   SIMDJSON_POP_DISABLE_WARNINGS
-
-  bool run() {
-    return ParsedJson_Iterator_test() &&
-           true;
-  }
-}
-
-namespace dom_api_tests {
-  using namespace std;
-  using namespace simdjson;
 
   bool object_iterator() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "a": 1, "b": 2, "c": 3 })"_padded;
+    string json(R"({ "a": 1, "b": 2, "c": 3 })");
     const char* expected_key[] = { "a", "b", "c" };
     uint64_t expected_value[] = { 1, 2, 3 };
     int i = 0;
@@ -707,7 +696,7 @@ namespace dom_api_tests {
 
   bool array_iterator() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ 1, 10, 100 ])"_padded;
+    string json(R"([ 1, 10, 100 ])");
     uint64_t expected_value[] = { 1, 10, 100 };
     int i=0;
 
@@ -724,7 +713,7 @@ namespace dom_api_tests {
 
   bool object_iterator_empty() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({})"_padded;
+    string json(R"({})");
     int i = 0;
 
     document::parser parser;
@@ -740,7 +729,7 @@ namespace dom_api_tests {
 
   bool array_iterator_empty() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([])"_padded;
+    string json(R"([])");
     int i=0;
 
     document::parser parser;
@@ -754,108 +743,9 @@ namespace dom_api_tests {
     return true;
   }
 
-  bool array_at() {
-    std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ 1, 10, 100 ])"_padded;
-    uint64_t expected[] = { 1, 10, 100 };
-
-    document::parser parser;
-    auto [array, error] = parser.parse(json).as_array();
-    uint64_t actual;
-    {
-      int i = 2;
-      array.at(i).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected[i]) { cerr << "Got [" << i << "] = " << actual << ", expected " << expected[i] << endl; return false; }
-    }
-    {
-      int i = 0;
-      array.at(i).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected[i]) { cerr << "Got [" << i << "] = " << actual << ", expected " << expected[i] << endl; return false; }
-    }
-    {
-      int i = 1;
-      array.at(i).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected[i]) { cerr << "Got [" << i << "] = " << actual << ", expected " << expected[i] << endl; return false; }
-    }
-    {
-      int i = 3;
-      array.at(i).as_uint64_t().tie(actual, error);
-      if (!error) { cerr << "Expected error accessing [" << i << "], got " << actual << " instead!" << endl; return false; }
-    }
-    return true;
-  }
-
-  bool object_at_key() {
-    std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "foo": 1, "bar": 2 })"_padded;
-
-    document::parser parser;
-    auto [object, error] = parser.parse(json).as_object();
-    uint64_t actual;
-    {
-      string key = "bar";
-      uint64_t expected = 2;
-      object.at_key(key).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected) { cerr << "Got " << key << " = " << actual << ", expected " << expected << endl; return false; }
-    }
-    {
-      string key = "foo";
-      uint64_t expected = 1;
-      object.at_key(key).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected) { cerr << "Got " << key << " = " << actual << ", expected " << expected << endl; return false; }
-    }
-    {
-      string key = "baz";
-      object.at_key(key).as_uint64_t().tie(actual, error);
-      if (!error) { cerr << "Expected error accessing " << key << ", got " << actual << " instead!" << endl; return false; }
-    }
-    return true;
-  }
-
-  bool object_at_key_case_insensitive() {
-    std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "foo": 1, "Bar": 2 })"_padded;
-
-    document::parser parser;
-    auto [object, error] = parser.parse(json).as_object();
-    uint64_t actual;
-    {
-      string key = "bar";
-      uint64_t expected = 2;
-      object.at_key_case_insensitive(key).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected) { cerr << "Got " << key << " = " << actual << ", expected " << expected << endl; return false; }
-    }
-    {
-      string key = "BAR";
-      uint64_t expected = 2;
-      object.at_key_case_insensitive(key).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected) { cerr << "Got " << key << " = " << actual << ", expected " << expected << endl; return false; }
-    }
-    {
-      string key = "Bar";
-      uint64_t expected = 2;
-      object.at_key_case_insensitive(key).as_uint64_t().tie(actual, error);
-      if (error) { cerr << error << endl; return false; }
-      if (actual != expected) { cerr << "Got " << key << " = " << actual << ", expected " << expected << endl; return false; }
-    }
-    {
-      string key = "baz";
-      object.at_key_case_insensitive(key).as_uint64_t().tie(actual, error);
-      if (!error) { cerr << "Expected error accessing " << key << ", got " << actual << " instead!" << endl; return false; }
-    }
-    return true;
-  }
-
   bool string_value() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ "hi", "has backslash\\" ])"_padded;
+    string json(R"([ "hi", "has backslash\\" ])");
     document::parser parser;
     auto [array, error] = parser.parse(json).as_array();
     if (error) { cerr << "Error: " << error << endl; return false; }
@@ -869,7 +759,7 @@ namespace dom_api_tests {
 
   bool numeric_values() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ 0, 1, -1, 1.1 ])"_padded;
+    string json(R"([ 0, 1, -1, 1.1 ])");
     document::parser parser;
     auto [array, error] = parser.parse(json).as_array();
     if (error) { cerr << "Error: " << error << endl; return false; }
@@ -892,7 +782,7 @@ namespace dom_api_tests {
 
   bool boolean_values() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ true, false ])"_padded;
+    string json(R"([ true, false ])");
     document::parser parser;
     auto [array, error] = parser.parse(json).as_array();
     if (error) { cerr << "Error: " << error << endl; return false; }
@@ -906,7 +796,7 @@ namespace dom_api_tests {
 
   bool null_value() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ null ])"_padded;
+    string json(R"([ null ])");
     document::parser parser;
     auto [array, error] = parser.parse(json).as_array();
     if (error) { cerr << "Error: " << error << endl; return false; }
@@ -917,7 +807,7 @@ namespace dom_api_tests {
 
   bool document_object_index() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "a": 1, "b": 2, "c": 3})"_padded;
+    string json(R"({ "a": 1, "b": 2, "c": 3})");
     document::parser parser;
     auto [doc, error] = parser.parse(json);
     if (doc["a"].as_uint64_t().first != 1) { cerr << "Expected uint64_t(doc[\"a\"]) to be 1, was " << doc["a"].first << endl; return false; }
@@ -937,7 +827,7 @@ namespace dom_api_tests {
 
   bool object_index() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "obj": { "a": 1, "b": 2, "c": 3 } })"_padded;
+    string json(R"({ "obj": { "a": 1, "b": 2, "c": 3 } })");
     document::parser parser;
     auto [doc, error] = parser.parse(json);
     if (error) { cerr << "Error: " << error << endl; return false; }
@@ -1031,7 +921,7 @@ namespace dom_api_tests {
 
   bool object_iterator_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "a": 1, "b": 2, "c": 3 })"_padded;
+    string json(R"({ "a": 1, "b": 2, "c": 3 })");
     const char* expected_key[] = { "a", "b", "c" };
     uint64_t expected_value[] = { 1, 2, 3 };
     int i = 0;
@@ -1048,7 +938,7 @@ namespace dom_api_tests {
 
   bool array_iterator_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ 1, 10, 100 ])"_padded;
+    string json(R"([ 1, 10, 100 ])");
     uint64_t expected_value[] = { 1, 10, 100 };
     int i=0;
 
@@ -1064,7 +954,7 @@ namespace dom_api_tests {
 
   bool string_value_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ "hi", "has backslash\\" ])"_padded;
+    string json(R"([ "hi", "has backslash\\" ])");
     document::parser parser;
     document::array array = parser.parse(json).as_array();
     auto val = array.begin();
@@ -1079,7 +969,7 @@ namespace dom_api_tests {
 
   bool numeric_values_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ 0, 1, -1, 1.1 ])"_padded;
+    string json(R"([ 0, 1, -1, 1.1 ])");
     document::parser parser;
     document::array array = parser.parse(json).as_array();
     auto val = array.begin();
@@ -1101,7 +991,7 @@ namespace dom_api_tests {
 
   bool boolean_values_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ true, false ])"_padded;
+    string json(R"([ true, false ])");
     document::parser parser;
     document::array array = parser.parse(json).as_array();
     auto val = array.begin();
@@ -1114,7 +1004,7 @@ namespace dom_api_tests {
 
   bool null_value_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"([ null ])"_padded;
+    string json(R"([ null ])");
     document::parser parser;
     document::array array = parser.parse(json).as_array();
     auto val = array.begin();
@@ -1125,7 +1015,7 @@ namespace dom_api_tests {
 
   bool document_object_index_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "a": 1, "b": 2, "c": 3})"_padded;
+    string json(R"({ "a": 1, "b": 2, "c": 3})");
     document::parser parser;
     document &doc = parser.parse(json);
     if (uint64_t(doc["a"]) != 1) { cerr << "Expected uint64_t(doc[\"a\"]) to be 1, was " << uint64_t(doc["a"]) << endl; return false; }
@@ -1134,7 +1024,7 @@ namespace dom_api_tests {
 
   bool object_index_exception() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = R"({ "obj": { "a": 1, "b": 2, "c": 3 } })"_padded;
+    string json(R"({ "obj": { "a": 1, "b": 2, "c": 3 } })");
     document::parser parser;
     document::object obj = parser.parse(json)["obj"];
     if (uint64_t(obj["a"]) != 1) { cerr << "Expected uint64_t(doc[\"a\"]) to be 1, was " << uint64_t(obj["a"]) << endl; return false; }
@@ -1190,13 +1080,11 @@ namespace dom_api_tests {
 #endif
 
   bool run() {
-    return object_iterator() &&
+    return ParsedJson_Iterator_test() &&
+           object_iterator() &&
            array_iterator() &&
            object_iterator_empty() &&
            array_iterator_empty() &&
-           array_at() &&
-           object_at_key() &&
-           object_at_key_case_insensitive() &&
            string_value() &&
            numeric_values() &&
            boolean_values() &&
@@ -1506,10 +1394,8 @@ int main(int argc, char *argv[]) {
       format_tests::run() &&
       document_tests::run() &&
       number_tests::run() &&
-      error_messages_in_correct_order() &&
-      deprecated_tests::run() &&
       document_stream_tests::run() &&
-      true
+      error_messages_in_correct_order()
   ) {
     std::cout << "Basic tests are ok." << std::endl;
     return EXIT_SUCCESS;

--- a/tests/integer_tests.cpp
+++ b/tests/integer_tests.cpp
@@ -32,19 +32,21 @@ template <typename T>
 static void parse_and_validate(const std::string src, T expected) {
   std::cout << "src: " << src << ", ";
   const padded_string pstr{src};
-  auto json = build_parsed_json(pstr);
+  simdjson::document::parser parser;
+  auto [pj, error] = parser.parse(pstr);
+  if(error) {
+    printf("could not parse\n");
+    abort();
+  }
+  
 
-  ASSERT(json.is_valid());
-  ParsedJson::Iterator it{json};
-  ASSERT(it.down());
-  ASSERT(it.next());
   bool result;
   if constexpr (std::is_same<int64_t, T>::value) {
-    const auto actual = it.get_integer();
-    result = expected == actual;
+    int64_t actual = pj.root().as_object()["key"].as_int64_t();
+    result = (expected == actual);
   } else {
-    const auto actual = it.get_unsigned_integer();
-    result = expected == actual;
+    uint64_t actual = pj.root().as_object()["key"].as_uint64_t();
+    result = (expected == actual);
   }
   std::cout << std::boolalpha << "test: " << result << std::endl;
   if(!result) {
@@ -56,25 +58,28 @@ static void parse_and_validate(const std::string src, T expected) {
 static bool parse_and_check_signed(const std::string src) {
   std::cout << "src: " << src << ", expecting signed" << std::endl;
   const padded_string pstr{src};
-  auto json = build_parsed_json(pstr);
-
-  ASSERT(json.is_valid());
-  ParsedJson::Iterator it{json};
-  ASSERT(it.down());
-  ASSERT(it.next());
-  return it.is_integer() && it.is_number();
+  simdjson::document::parser parser;
+  auto [pj, error] = parser.parse(pstr);
+  if(error) {
+    printf("could not parse\n");
+    abort();
+  }
+  auto [v,e] = pj.root().as_object()["key"];
+  return v.is_integer() && v.is_number();
 }
 
-static bool parse_and_check_unsigned(const std::string src) {
-  std::cout << "src: " << src << ", expecting unsigned" << std::endl;
-  const padded_string pstr{src};
-  auto json = build_parsed_json(pstr);
 
-  ASSERT(json.is_valid());
-  ParsedJson::Iterator it{json};
-  ASSERT(it.down());
-  ASSERT(it.next());
-  return it.is_unsigned_integer() && it.is_number();
+static bool parse_and_check_unsigned(const std::string src) {
+  std::cout << "src: " << src << ", expecting signed" << std::endl;
+  const padded_string pstr{src};
+  simdjson::document::parser parser;
+  auto [pj, error] = parser.parse(pstr);
+  if(error) {
+    printf("could not parse\n");
+    abort();
+  }
+  auto [v,e] = pj.root().as_object()["key"];
+  return v.is_unsigned_integer() && v.is_number();
 }
 
 

--- a/tests/integer_tests.cpp
+++ b/tests/integer_tests.cpp
@@ -33,19 +33,15 @@ static void parse_and_validate(const std::string src, T expected) {
   std::cout << "src: " << src << ", ";
   const padded_string pstr{src};
   simdjson::document::parser parser;
-  auto [pj, error] = parser.parse(pstr);
-  if(error) {
-    printf("could not parse\n");
-    abort();
-  }
-  
 
   bool result;
   if constexpr (std::is_same<int64_t, T>::value) {
-    int64_t actual = pj.root().as_object()["key"].as_int64_t();
+    auto [actual, error] = parser.parse(pstr).as_object()["key"].as_int64_t();
+    if (error) { std::cerr << error << std::endl; abort(); }
     result = (expected == actual);
   } else {
-    uint64_t actual = pj.root().as_object()["key"].as_uint64_t();
+    auto [actual, error] = parser.parse(pstr).as_object()["key"].as_uint64_t();
+    if (error) { std::cerr << error << std::endl; abort(); }
     result = (expected == actual);
   }
   std::cout << std::boolalpha << "test: " << result << std::endl;
@@ -59,30 +55,19 @@ static bool parse_and_check_signed(const std::string src) {
   std::cout << "src: " << src << ", expecting signed" << std::endl;
   const padded_string pstr{src};
   simdjson::document::parser parser;
-  auto [pj, error] = parser.parse(pstr);
-  if(error) {
-    printf("could not parse\n");
-    abort();
-  }
-  auto [v,e] = pj.root().as_object()["key"];
-  return v.is_integer() && v.is_number();
+  auto [value, error] = parser.parse(pstr).as_object()["key"];
+  if (error) { std::cerr << error << std::endl; abort(); }
+  return value.is_integer() && value.is_number();
 }
-
 
 static bool parse_and_check_unsigned(const std::string src) {
   std::cout << "src: " << src << ", expecting signed" << std::endl;
   const padded_string pstr{src};
   simdjson::document::parser parser;
-  auto [pj, error] = parser.parse(pstr);
-  if(error) {
-    printf("could not parse\n");
-    abort();
-  }
-  auto [v,e] = pj.root().as_object()["key"];
-  return v.is_unsigned_integer() && v.is_number();
+  auto [value, error] = parser.parse(pstr).as_object()["key"];
+  if (error) { std::cerr << error << std::endl; abort(); }
+  return value.is_unsigned_integer() && value.is_number();
 }
-
-
 
 int main() {
   using std::numeric_limits;

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -70,7 +70,7 @@ bool validate(const char *dirname) {
         return EXIT_FAILURE;
       }
       simdjson::document::parser parser;
-      auto [pj, errorcode] = parser.parse(p);
+      auto [doc, errorcode] = parser.parse(p);
       ++how_many;
       printf("%s\n", errorcode == simdjson::error_code::SUCCESS ? "ok" : "invalid");
       if (contains("EXCLUDE", name)) {

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -69,20 +69,20 @@ bool validate(const char *dirname) {
         std::cerr << "Could not load the file " << fullpath << std::endl;
         return EXIT_FAILURE;
       }
-      simdjson::ParsedJson pj;
+      simdjson::document::parser parser;
+      auto [pj, errorcode] = parser.parse(p);
       ++how_many;
-      const int parse_res = json_parse(p, pj);
-      printf("%s\n", parse_res == 0 ? "ok" : "invalid");
+      printf("%s\n", errorcode == simdjson::error_code::SUCCESS ? "ok" : "invalid");
       if (contains("EXCLUDE", name)) {
         // skipping
         how_many--;
-      } else if (starts_with("pass", name) && parse_res != 0) {
+      } else if (starts_with("pass", name) && errorcode != simdjson::error_code::SUCCESS) {
         is_file_as_expected[i] = false;
         printf("warning: file %s should pass but it fails. Error is: %s\n",
-               name, simdjson::error_message(parse_res).data());
+               name, simdjson::error_message(errorcode));
         printf("size of file in bytes: %zu \n", p.size());
         everything_fine = false;
-      } else if (starts_with("fail", name) && parse_res == 0) {
+      } else if (starts_with("fail", name) && errorcode == simdjson::error_code::SUCCESS) {
         is_file_as_expected[i] = false;
         printf("warning: file %s should fail but it passes.\n", name);
         printf("size of file in bytes: %zu \n", p.size());

--- a/tests/numberparsingcheck.cpp
+++ b/tests/numberparsingcheck.cpp
@@ -174,12 +174,13 @@ bool validate(const char *dirname) {
         return EXIT_FAILURE;
       }
       // terrible hack but just to get it working
-      simdjson::ParsedJson pj;
       float_count = 0;
       int_count = 0;
       invalid_count = 0;
       total_count += float_count + int_count + invalid_count;
-      bool isok = json_parse(p, pj);
+      simdjson::document::parser parser;
+      auto [pj, err] = parser.parse(p);
+      bool isok = (err == simdjson::error_code::SUCCESS);
       if (int_count + float_count + invalid_count > 0) {
         printf("File %40s %s --- integers: %10zu floats: %10zu invalid: %10zu "
                "total numbers: %10zu \n",

--- a/tests/numberparsingcheck.cpp
+++ b/tests/numberparsingcheck.cpp
@@ -179,7 +179,7 @@ bool validate(const char *dirname) {
       invalid_count = 0;
       total_count += float_count + int_count + invalid_count;
       simdjson::document::parser parser;
-      auto [pj, err] = parser.parse(p);
+      auto [doc, err] = parser.parse(p);
       bool isok = (err == simdjson::error_code::SUCCESS);
       if (int_count + float_count + invalid_count > 0) {
         printf("File %40s %s --- integers: %10zu floats: %10zu invalid: %10zu "

--- a/tests/singleheadertest.cpp
+++ b/tests/singleheadertest.cpp
@@ -1,3 +1,4 @@
+// This file is not part of our main, regular tests.
 #include "../singleheader/simdjson.h"
 #include <iostream>
 
@@ -6,13 +7,13 @@ using namespace simdjson;
 int main() {
   const char *filename = JSON_TEST_PATH;
   padded_string p = get_corpus(filename);
-  ParsedJson pj = build_parsed_json(p); // do the parsing
-  if (!pj.is_valid()) {
+  document::parser parser;
+  auto [pj, errorcode] = parser.parse(p);
+  if(errorcode != error_code::SUCCESS) {
+    std::cerr << error_message(errorcode) << std::endl;
     return EXIT_FAILURE;
   }
-  const int res = json_parse(p, pj);
-  if (res) {
-    std::cerr << error_message(res) << std::endl;
+  if(!pj.is_valid()) {
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/tests/singleheadertest.cpp
+++ b/tests/singleheadertest.cpp
@@ -8,12 +8,9 @@ int main() {
   const char *filename = JSON_TEST_PATH;
   padded_string p = get_corpus(filename);
   document::parser parser;
-  auto [pj, errorcode] = parser.parse(p);
-  if(errorcode != error_code::SUCCESS) {
-    std::cerr << error_message(errorcode) << std::endl;
-    return EXIT_FAILURE;
-  }
-  if(!pj.is_valid()) {
+  auto [doc, error] = parser.parse(p);
+  if(error) {
+    std::cerr << error << std::endl;
     return EXIT_FAILURE;
   }
   return EXIT_SUCCESS;

--- a/tests/stringparsingcheck.cpp
+++ b/tests/stringparsingcheck.cpp
@@ -348,7 +348,7 @@ bool validate(const char *dirname) {
       total_string_length = 0;
       empty_string = 0;
       simdjson::document::parser parser;
-      auto [pj, err] = parser.parse(p);
+      auto [doc, err] = parser.parse(p);
       bool isok = (err == simdjson::error_code::SUCCESS);
       free(big_buffer);
       if (good_string > 0) {

--- a/tests/stringparsingcheck.cpp
+++ b/tests/stringparsingcheck.cpp
@@ -338,7 +338,6 @@ bool validate(const char *dirname) {
         std::cerr << "Could not load the file " << fullpath << std::endl;
         return EXIT_FAILURE;
       }
-      simdjson::ParsedJson pj;
       big_buffer = (char *)malloc(p.size());
       if (big_buffer == NULL) {
         std::cerr << "can't allocate memory" << std::endl;
@@ -348,7 +347,9 @@ bool validate(const char *dirname) {
       good_string = 0;
       total_string_length = 0;
       empty_string = 0;
-      bool isok = json_parse(p, pj);
+      simdjson::document::parser parser;
+      auto [pj, err] = parser.parse(p);
+      bool isok = (err == simdjson::error_code::SUCCESS);
       free(big_buffer);
       if (good_string > 0) {
         printf("File %40s %s --- bad strings: %10zu \tgood strings: %10zu\t "

--- a/tools/jsonpointer.cpp
+++ b/tools/jsonpointer.cpp
@@ -1,39 +1,6 @@
 #include "simdjson.h"
 #include <iostream>
 
-void compute_dump(simdjson::ParsedJson::Iterator &pjh) {
-  if (pjh.is_object()) {
-    std::cout << "{";
-    if (pjh.down()) {
-      pjh.print(std::cout); // must be a string
-      std::cout << ":";
-      pjh.next();
-      compute_dump(pjh); // let us recurse
-      while (pjh.next()) {
-        std::cout << ",";
-        pjh.print(std::cout);
-        std::cout << ":";
-        pjh.next();
-        compute_dump(pjh); // let us recurse
-      }
-      pjh.up();
-    }
-    std::cout << "}";
-  } else if (pjh.is_array()) {
-    std::cout << "[";
-    if (pjh.down()) {
-      compute_dump(pjh); // let us recurse
-      while (pjh.next()) {
-        std::cout << ",";
-        compute_dump(pjh); // let us recurse
-      }
-      pjh.up();
-    }
-    std::cout << "]";
-  } else {
-    pjh.print(std::cout); // just print the lone value
-  }
-}
 
 int main(int argc, char *argv[]) {
   if (argc < 3) {


### PR DESCRIPTION
This uses the C++ lvalue operator to enforce moves in and out of simdjson_result, allowing us to use a single class for owned and non-owned things. We never call std::move() anymore, instead relying on `forward` to figure out whether to copy (in the case of references) or move (in the case of values).

Specifically:
* `tie()` can only be done on an rvalue now (i.e. once you tie() you have to throw away the simdjson_result).
* `operator T` is changed to `operator T&&` and requires the simdjson_result to be an rvalue.
* The constructor always takes `T&&`, requiring the input to be an rvalue.

With that, we now use simdjson_result<padded_string> for load() and can remove simdjson_move_result<T> entirely.

Fixes https://github.com/simdjson/simdjson/issues/622