### PR TITLE
Return document::element from parser.parse()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The simdjson library is easily consumable with a single .h and .cpp file.
    #include "simdjson.h"
    int main(void) {
      simdjson::document::parser parser;
-     simdjson::document& tweets = parser.load("twitter.json");
+     simdjson::document::element tweets = parser.load("twitter.json");
      std::cout << tweets["search_metadata"]["count"] << " results." << std::endl;
    }
    ```

--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -17,7 +17,7 @@ const padded_string EMPTY_ARRAY("[]", 2);
 static void twitter_count(State& state) {
   // Prints the number of results in twitter.json
   document::parser parser;
-  document &doc = parser.load(JSON_TEST_PATH);
+  document::element doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     uint64_t result_count = doc["search_metadata"]["count"];
     if (result_count != 100) { return; }
@@ -45,7 +45,7 @@ BENCHMARK(iterator_twitter_count);
 static void twitter_default_profile(State& state) {
   // Count unique users with a default profile.
   document::parser parser;
-  document &doc = parser.load(JSON_TEST_PATH);
+  document::element doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<string_view> default_users;
     for (document::object tweet : doc["statuses"].as_array()) {
@@ -62,7 +62,7 @@ BENCHMARK(twitter_default_profile);
 static void twitter_image_sizes(State& state) {
   // Count unique image sizes
   document::parser parser;
-  document &doc = parser.load(JSON_TEST_PATH);
+  document::element doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<tuple<uint64_t, uint64_t>> image_sizes;
     for (document::object tweet : doc["statuses"].as_array()) {
@@ -85,7 +85,7 @@ BENCHMARK(twitter_image_sizes);
 static void error_code_twitter_count(State& state) noexcept {
   // Prints the number of results in twitter.json
   document::parser parser;
-  document &doc = parser.load(JSON_TEST_PATH);
+  document::element doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     auto [value, error] = doc["search_metadata"]["count"].as_uint64_t();
     if (error) { return; }
@@ -97,7 +97,7 @@ BENCHMARK(error_code_twitter_count);
 static void error_code_twitter_default_profile(State& state) noexcept {
   // Count unique users with a default profile.
   document::parser parser;
-  document &doc = parser.load(JSON_TEST_PATH);
+  document::element doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<string_view> default_users;
 
@@ -161,7 +161,7 @@ BENCHMARK(iterator_twitter_default_profile);
 static void error_code_twitter_image_sizes(State& state) noexcept {
   // Count unique image sizes
   document::parser parser;
-  document &doc = parser.load(JSON_TEST_PATH);
+  document::element doc = parser.load(JSON_TEST_PATH);
   for (auto _ : state) {
     set<tuple<uint64_t, uint64_t>> image_sizes;
     auto [statuses, error] = doc["statuses"].as_array();

--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -29,7 +29,7 @@ static void parser_parse_exception(State& state) {
   if (parser.set_capacity(EMPTY_ARRAY.length())) { return; }
   for (auto _ : state) {
     try {
-      UNUSED document &doc = parser.parse(EMPTY_ARRAY);
+      UNUSED document::element doc = parser.parse(EMPTY_ARRAY);
     } catch(simdjson_error &j) {
       return;
     }
@@ -56,7 +56,7 @@ static void document_parse_exception(State& state) {
   for (auto _ : state) {
     try {
       document::parser parser;
-      UNUSED document &doc = parser.parse(EMPTY_ARRAY);
+      UNUSED document::element doc = parser.parse(EMPTY_ARRAY);
     } catch(simdjson_error &j) {
       return;
     }

--- a/benchmark/distinctuseridcompetition.cpp
+++ b/benchmark/distinctuseridcompetition.cpp
@@ -95,9 +95,9 @@ void simdjson_recurse(std::vector<int64_t> & v, simdjson::document::element elem
 }
 
 __attribute__((noinline)) std::vector<int64_t>
-simdjson_just_dom(simdjson::document &doc) {
+simdjson_just_dom(simdjson::document::element doc) {
   std::vector<int64_t> answer;
-  simdjson_recurse(answer, doc.root());
+  simdjson_recurse(answer, doc);
   remove_duplicates(answer);
   return answer;
 }
@@ -106,8 +106,8 @@ __attribute__((noinline)) std::vector<int64_t>
 simdjson_compute_stats(const simdjson::padded_string &p) {
   std::vector<int64_t> answer;
   simdjson::document::parser parser;
-  simdjson::document &doc = parser.parse(p);
-  simdjson_recurse(answer, doc.root());
+  simdjson::document::element doc = parser.parse(p);
+  simdjson_recurse(answer, doc);
   remove_duplicates(answer);
   return answer;
 }
@@ -368,7 +368,7 @@ int main(int argc, char *argv[]) {
   BEST_TIME("sasjon (just parse) ", sasjon_just_parse(p), false, , repeat,
             volume, !just_data);
   simdjson::document::parser parser;
-  simdjson::document &doc = parser.parse(p);
+  simdjson::document::element doc = parser.parse(p);
   BEST_TIME("simdjson (just dom)  ", simdjson_just_dom(doc).size(), size,
             , repeat, volume, !just_data);
   char *buffer = (char *)malloc(p.size() + 1);

--- a/benchmark/parseandstatcompetition.cpp
+++ b/benchmark/parseandstatcompetition.cpp
@@ -95,7 +95,7 @@ simdjson_compute_stats(const simdjson::padded_string &p) {
     return s;
   }
   s.valid = true;
-  simdjson_recurse(s, doc.root());
+  simdjson_recurse(s, doc);
   return s;
 }
 

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -104,7 +104,7 @@ stat_t simdjson_compute_stats(const simdjson::padded_string &p) {
       reinterpret_cast<const uint8_t *>(p.data()), p.size());
   answer.byte_count = p.size();
   answer.structural_indexes_count = parser.n_structural_indexes;
-  simdjson_recurse(answer, doc.root());
+  simdjson_recurse(answer, doc);
   return answer;
 }
 

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -38,7 +38,7 @@ The simdjson library offers a simple DOM tree API, which you can access by creat
 
 ```c++
 document::parser parser;
-document &doc = parser.load(filename); // load and parse a file
+document::element doc = parser.load(filename); // load and parse a file
 ```
 
 Or by creating a padded string (for efficiency reasons, simdjson requires a string with
@@ -46,16 +46,14 @@ SIMDJSON_PADDING bytes at the end) and calling `parse()`:
 
 ```c++
 document::parser parser;
-document &doc = parser.parse("[1,2,3]"_padded); // parse a string
+document::element doc = parser.parse("[1,2,3]"_padded); // parse a string
 ```
 
 Using the Parsed JSON
 ---------------------
 
-Once you have a document, you can navigate it with idiomatic C++ iterators, operators and casts.
+Once you have an element, you can navigate it with idiomatic C++ iterators, operators and casts.
 
-* **Document Root:** To get the top level JSON element, get `doc.root()`. Many of the
-  methods below will work on the document object itself, as well.
 * **Extracting Values:** You can cast a JSON element to a native type: `double(element)` or
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
   document::object and document::array. You can also use is_*typename*()` to test if it is a
@@ -112,7 +110,7 @@ auto cars_json = R"( [
   { "make": "Toyota", "model": "Tercel", "year": 1999, "tire_pressure": [ 29.8, 30.0, 30.2, 30.5 ] }
 ] )"_padded;
 document::parser parser;
-document &cars = parser.parse(cars_json);
+document::element cars = parser.parse(cars_json);
 cout << cars["/0/tire_pressure/1"] << endl; // Prints 39.9
 ```
 
@@ -123,7 +121,7 @@ All simdjson APIs that can fail return `simdjson_result<T>`, which is a &lt;valu
 pair. The error codes and values can be accessed directly, reading the error like so:
 
 ```c++
-auto [doc, error] = parser.parse(json); // doc is a document&
+auto [doc, error] = parser.parse(json); // doc is a document::element
 if (error) { cerr << error << endl; exit(1); }
 // Use document here now that we've checked for the error
 ```
@@ -138,7 +136,7 @@ behavior.
 > circumvent this, you can use this instead:
 > 
 > ```c++
-> document &doc;
+> document::element doc;
 > error_code error;
 > parser.parse(json).tie(doc, error); // <-- Assigns to doc and error just like "auto [doc, error]"
 > ```
@@ -199,7 +197,7 @@ for (document::element car_element : cars) {
 Users more comfortable with an exception flow may choose to directly cast the `simdjson_result<T>` to the desired type:
 
 ```c++
-document &doc = parser.parse(json); // Throws an exception if there was an error!
+document::element doc = parser.parse(json); // Throws an exception if there was an error!
 ```
 
 When used this way, a `simdjson_error` exception will be thrown if an error occurs, preventing the
@@ -219,7 +217,7 @@ auto ndjson = R"(
 { "foo": 3 }
 )"_padded;
 document::parser parser;
-for (document &doc : parser.load_many(filename)) {
+for (document::element doc : parser.load_many(filename)) {
   cout << doc["foo"] << endl;
 }
 // Prints 1 2 3

--- a/include/simdjson/document_stream.h
+++ b/include/simdjson/document_stream.h
@@ -24,7 +24,7 @@ public:
     /**
      * Get the current document (or error).
      */
-    really_inline doc_result operator*() noexcept;
+    really_inline element_result operator*() noexcept;
     /**
      * Advance to the next document.
      */

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -127,8 +127,10 @@ really_inline document::stream::iterator::iterator(stream& stream, bool _is_end)
   : _stream{stream}, finished{_is_end} {
 }
 
-really_inline document::doc_result document::stream::iterator::operator*() noexcept {
-  return doc_result(_stream.parser.doc, _stream.error == SUCCESS_AND_HAS_MORE ? SUCCESS : _stream.error);
+really_inline document::element_result document::stream::iterator::operator*() noexcept {
+  error_code error = _stream.error == SUCCESS_AND_HAS_MORE ? SUCCESS : _stream.error;
+  if (error) { return error; }
+  return _stream.parser.doc.root();
 }
 
 really_inline document::stream::iterator& document::stream::iterator::operator++() noexcept {

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1526,7 +1526,7 @@ public:
    * Load a JSON document from a file and return a reference to it.
    *
    *   document::parser parser;
-   *   const document &doc = parser.load("jsonexamples/twitter.json");
+   *   const document::element doc = parser.load("jsonexamples/twitter.json");
    *
    * ### IMPORTANT: Document Lifetime
    *

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -49,7 +49,7 @@ namespace number_tests {
         buf[n] = '\0';
         fflush(NULL);
 
-        auto [actual, error] = parser.parse(buf, n).root().as_int64_t();
+        auto [actual, error] = parser.parse(buf, n).as_int64_t();
         if (error) { std::cerr << error << std::endl; return false; }
         if (actual != i) {
           std::cerr << "JSON '" << buf << " parsed to " << actual << " instead of " << i << std::endl;
@@ -57,10 +57,8 @@ namespace number_tests {
         }
       } 
     }
-    printf("Small integers can be parsed.\n");
     return true;
   }
-
 
   bool powers_of_two() {
     std::cout << __func__ << std::endl;
@@ -72,8 +70,7 @@ namespace number_tests {
       auto n = sprintf(buf, "%.*e", std::numeric_limits<double>::max_digits10 - 1, expected);
       buf[n] = '\0';
       fflush(NULL);
-
-      auto [actual, error] = parser.parse(buf, n).root().as_double();
+      auto [actual, error] = parser.parse(buf, n).as_double();
       if (error) { std::cerr << error << std::endl; return false; }
       int ulp = f64_ulp_dist(actual,expected);  
       if(ulp > maxulp) maxulp = ulp;
@@ -82,7 +79,6 @@ namespace number_tests {
         return false;
       }
     }
-    printf("Powers of 2 can be parsed, maxulp = %d.\n", maxulp);
     return true;
   }
 
@@ -168,7 +164,7 @@ namespace number_tests {
       buf[n] = '\0';
       fflush(NULL);
 
-      auto [actual, error] = parser.parse(buf, n).root().as_double();
+      auto [actual, error] = parser.parse(buf, n).as_double();
       if (error) { std::cerr << error << std::endl; return false; }
       double expected = ((i >= -307) ? testing_power_of_ten[i + 307]: std::pow(10, i));
       int ulp = (int) f64_ulp_dist(actual, expected);
@@ -462,7 +458,7 @@ namespace parse_api_tests {
     document::parser parser;
     auto [doc, error] = parser.parse(BASIC_JSON);
     if (error) { cerr << error << endl; return false; }
-    if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
+    if (!doc.is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
     return true;
   }
   bool parser_parse_many() {
@@ -471,7 +467,7 @@ namespace parse_api_tests {
     int count = 0;
     for (auto [doc, error] : parser.parse_many(BASIC_NDJSON)) {
       if (error) { cerr << error << endl; return false; }
-      if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
+      if (!doc.is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
       count++;
     }
     if (count != 2) { cerr << "parse_many returned " << count << " documents, expected 2" << endl; return false; }
@@ -494,7 +490,7 @@ namespace parse_api_tests {
     document::parser parser;
     auto [doc, error] = parser.load(JSON_TEST_PATH);
     if (error) { cerr << error << endl; return false; }
-    if (!doc.root().is_object()) { cerr << "Document did not parse as an object" << endl; return false; }
+    if (!doc.is_object()) { cerr << "Document did not parse as an object" << endl; return false; }
     return true;
   }
   bool parser_load_many() {
@@ -503,7 +499,7 @@ namespace parse_api_tests {
     int count = 0;
     for (auto [doc, error] : parser.load_many(NDJSON_TEST_PATH)) {
       if (error) { cerr << error << endl; return false; }
-      if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
+      if (!doc.is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
       count++;
     }
     if (count != 793) { cerr << "Expected 793 documents, but load_many loaded " << count << " documents." << endl; return false; }
@@ -515,16 +511,16 @@ namespace parse_api_tests {
   bool parser_parse_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    const document& doc = parser.parse(BASIC_JSON);
-    if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
+    document::element doc = parser.parse(BASIC_JSON);
+    if (!doc.is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
     return true;
   }
   bool parser_parse_many_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
     int count = 0;
-    for (const document &doc : parser.parse_many(BASIC_NDJSON)) {
-      if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
+    for (const document::element doc : parser.parse_many(BASIC_NDJSON)) {
+      if (!doc.is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
       count++;
     }
     if (count != 2) { cerr << "parse_many returned " << count << " documents, expected 2" << endl; return false; }
@@ -534,16 +530,16 @@ namespace parse_api_tests {
   bool parser_load_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    const document &doc = parser.load(JSON_TEST_PATH);
-    if (!doc.root().is_object()) { cerr << "Document did not parse as an object" << endl; return false; }
+    const document::element doc = parser.load(JSON_TEST_PATH);
+    if (!doc.is_object()) { cerr << "Document did not parse as an object" << endl; return false; }
     return true;
   }
   bool parser_load_many_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
     int count = 0;
-    for (const document &doc : parser.load_many(NDJSON_TEST_PATH)) {
-      if (!doc.root().is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
+    for (const document::element doc : parser.load_many(NDJSON_TEST_PATH)) {
+      if (!doc.is_array()) { cerr << "Document did not parse as an array" << endl; return false; }
       count++;
     }
     if (count != 793) { cerr << "Expected 1 document, but load_many loaded " << count << " documents." << endl; return false; }
@@ -927,7 +923,7 @@ namespace dom_api_tests {
     int i = 0;
 
     document::parser parser;
-    document &doc = parser.parse(json);
+    document::element doc = parser.parse(json);
     for (auto [key, value] : doc.as_object()) {
       if (key != expected_key[i] || uint64_t(value) != expected_value[i]) { cerr << "Expected " << expected_key[i] << " = " << expected_value[i] << ", got " << key << "=" << uint64_t(value) << endl; return false; }
       i++;
@@ -943,7 +939,7 @@ namespace dom_api_tests {
     int i=0;
 
     document::parser parser;
-    document &doc = parser.parse(json);
+    document::element doc = parser.parse(json);
     for (uint64_t value : doc.as_array()) {
       if (value != expected_value[i]) { cerr << "Expected " << expected_value[i] << ", got " << value << endl; return false; }
       i++;
@@ -1017,7 +1013,7 @@ namespace dom_api_tests {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "a": 1, "b": 2, "c": 3})");
     document::parser parser;
-    document &doc = parser.parse(json);
+    document::element doc = parser.parse(json);
     if (uint64_t(doc["a"]) != 1) { cerr << "Expected uint64_t(doc[\"a\"]) to be 1, was " << uint64_t(doc["a"]) << endl; return false; }
     return true;
   }
@@ -1035,7 +1031,7 @@ namespace dom_api_tests {
     std::cout << "Running " << __func__ << std::endl;
     // Prints the number of results in twitter.json
     document::parser parser;
-    document &doc = parser.load(JSON_TEST_PATH);
+    document::element doc = parser.load(JSON_TEST_PATH);
     uint64_t result_count = doc["search_metadata"]["count"];
     if (result_count != 100) { cerr << "Expected twitter.json[metadata_count][count] = 100, got " << result_count << endl; return false; }
     return true;
@@ -1046,7 +1042,7 @@ namespace dom_api_tests {
     // Print users with a default profile.
     set<string_view> default_users;
     document::parser parser;
-    document &doc = parser.load(JSON_TEST_PATH);
+    document::element doc = parser.load(JSON_TEST_PATH);
     for (document::object tweet : doc["statuses"].as_array()) {
       document::object user = tweet["user"];
       if (user["default_profile"]) {
@@ -1062,7 +1058,7 @@ namespace dom_api_tests {
     // Print image names and sizes
     set<pair<uint64_t, uint64_t>> image_sizes;
     document::parser parser;
-    document &doc = parser.load(JSON_TEST_PATH);
+    document::element doc = parser.load(JSON_TEST_PATH);
     for (document::object tweet : doc["statuses"].as_array()) {
       auto [media, not_found] = tweet["entities"]["media"];
       if (!not_found) {
@@ -1217,7 +1213,7 @@ namespace format_tests {
   bool print_element_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << doc["foo"];
     return assert_minified(s, "1");
@@ -1225,7 +1221,7 @@ namespace format_tests {
   bool print_minify_element_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << minify(doc["foo"]);
     return assert_minified(s, "1");
@@ -1234,7 +1230,7 @@ namespace format_tests {
   bool print_element_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     document::element value = doc["foo"];
     ostringstream s;
     s << value;
@@ -1243,7 +1239,7 @@ namespace format_tests {
   bool print_minify_element_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     document::element value = doc["foo"];
     ostringstream s;
     s << minify(value);
@@ -1253,7 +1249,7 @@ namespace format_tests {
   bool print_array_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << doc["bar"].as_array();
     return assert_minified(s, "[1,2,3]");
@@ -1261,7 +1257,7 @@ namespace format_tests {
   bool print_minify_array_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << minify(doc["bar"].as_array());
     return assert_minified(s, "[1,2,3]");
@@ -1270,7 +1266,7 @@ namespace format_tests {
   bool print_object_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << doc["baz"].as_object();
     return assert_minified(s, R"({"a":1,"b":2,"c":3})");
@@ -1278,7 +1274,7 @@ namespace format_tests {
   bool print_minify_object_result_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     ostringstream s;
     s << minify(doc["baz"].as_object());
     return assert_minified(s, R"({"a":1,"b":2,"c":3})");
@@ -1287,7 +1283,7 @@ namespace format_tests {
   bool print_array_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     document::array value = doc["bar"];
     ostringstream s;
     s << value;
@@ -1296,7 +1292,7 @@ namespace format_tests {
   bool print_minify_array_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     document::array value = doc["bar"];
     ostringstream s;
     s << minify(value);
@@ -1306,7 +1302,7 @@ namespace format_tests {
   bool print_object_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     document::object value = doc["baz"];
     ostringstream s;
     s << value;
@@ -1315,7 +1311,7 @@ namespace format_tests {
   bool print_minify_object_exception() {
     std::cout << "Running " << __func__ << std::endl;
     document::parser parser;
-    document &doc = parser.parse(DOCUMENT);
+    document::element doc = parser.parse(DOCUMENT);
     document::object value = doc["baz"];
     ostringstream s;
     s << minify(value);

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -74,8 +74,8 @@ namespace parser_load {
   bool parser_load_many_chain() {
     TEST_START();
     document::parser parser;
-    for (auto doc_result : parser.load_many(NONEXISTENT_FILE)) {
-      auto [val, error] = doc_result["foo"].as_uint64_t();
+    for (auto doc : parser.load_many(NONEXISTENT_FILE)) {
+      auto [val, error] = doc["foo"].as_uint64_t();
       ASSERT_ERROR(error, IO_ERROR);
       TEST_SUCCEED();
     }

--- a/tests/pointercheck.cpp
+++ b/tests/pointercheck.cpp
@@ -60,23 +60,29 @@ bool json_pointer_failure_test(const char *json_pointer, error_code expected_fai
 
 int main() {
   if (
-    json_pointer_success_test("/~1~001abc/1/\\\" 0/0", "value0") &&
-    json_pointer_success_test("/~1~001abc/1/\\\" 0/1", "value1") &&
-    json_pointer_failure_test("/~1~001abc/1/\\\" 0/2", INDEX_OUT_OF_BOUNDS) && // index actually out of bounds
-    json_pointer_success_test("/arr") && // get array
-    json_pointer_failure_test("/arr/0", INDEX_OUT_OF_BOUNDS) && // array index 0 out of bounds on empty array
-    json_pointer_success_test("/~1~001abc") && // get object
-    json_pointer_success_test("/0", "0 ok") && // object index with integer-ish key
-    json_pointer_success_test("/01", "01 ok") && // object index with key that would be an invalid integer
-    json_pointer_success_test("/", "empty ok") && // object index with empty key
-    json_pointer_failure_test("/~01abc", NO_SUCH_FIELD) && // Test that we don't try to compare the literal key
-    json_pointer_failure_test("/~1~001abc/01", INVALID_JSON_POINTER) && // Leading 0 in integer index
-    json_pointer_failure_test("/~1~001abc/", INVALID_JSON_POINTER) && // Empty index to array
-    json_pointer_failure_test("/~1~001abc/-", INDEX_OUT_OF_BOUNDS) && // End index is always out of bounds
+    json_pointer_success_test("") &&
+    json_pointer_success_test("~1~001abc") &&
+    json_pointer_success_test("~1~001abc/1") &&
+    json_pointer_success_test("~1~001abc/1/\\\" 0") &&
+    json_pointer_success_test("~1~001abc/1/\\\" 0/0", "value0") &&
+    json_pointer_success_test("~1~001abc/1/\\\" 0/1", "value1") &&
+    json_pointer_failure_test("~1~001abc/1/\\\" 0/2", INDEX_OUT_OF_BOUNDS) && // index actually out of bounds
+    json_pointer_success_test("arr") && // get array
+    json_pointer_failure_test("arr/0", INDEX_OUT_OF_BOUNDS) && // array index 0 out of bounds on empty array
+    json_pointer_success_test("~1~001abc") && // get object
+    json_pointer_success_test("0", "0 ok") && // object index with integer-ish key
+    json_pointer_success_test("01", "01 ok") && // object index with key that would be an invalid integer
+    json_pointer_success_test("", "empty ok") && // object index with empty key
+    json_pointer_failure_test("~01abc", NO_SUCH_FIELD) && // Test that we don't try to compare the literal key
+    json_pointer_failure_test("~1~001abc/01", INVALID_JSON_POINTER) && // Leading 0 in integer index
+    json_pointer_failure_test("~1~001abc/", INVALID_JSON_POINTER) && // Empty index to array
+    json_pointer_failure_test("~1~001abc/-", INDEX_OUT_OF_BOUNDS) && // End index is always out of bounds
     true
   ) {
     std::cout << "Success!" << std::endl;
+    return 0;
   } else {
     std::cerr << "Failed!" << std::endl;
+    return 1;
   }
 }

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -99,7 +99,7 @@ void parser_parse_many_exception() {
   auto json = "[1, 2, 3] true [ true, false ]"_padded;
   cout << "Parsing " << json.data() << " ..." << endl;
   document::parser parser;
-  for (const document &doc : parser.parse_many(json)) {
+  for (const document::element doc : parser.parse_many(json)) {
     cout << doc << endl;
   }
 }

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -141,7 +141,7 @@ stat_t simdjson_compute_stats(const simdjson::padded_string &p) {
   s.structural_indexes_count = parser.n_structural_indexes;
 
   //  simdjson::document::iterator iter(doc);
-  recurse(doc.root(), s, 0);
+  recurse(doc, s, 0);
   return s;
 }
 


### PR DESCRIPTION
Returns document::element from parser.parse(), load(), load_many() and parse_many(). Also removes the doc_result type and navigation methods on document, as they are no longer used.

This greatly simplifies user experience and explanation. It means the result of these functions can be used immediately without the extra call to root(). Further, it means there are fewer concepts to grok before using simdjson. It's elements all the way down.

On the **con** side, this patch removes the ability to take or copy the document, so you can no longer keep the document longer than the parser. This wasn't an ability we had before, so I don't feel terrible about it. It also encourages people to convert things to a form that's better for them if they need to keep it around--keeping things around as a JSON tape isn't really the best idea in the first place.

Still, it's a loss! I think we can bring it back by offering functionality to copy a given element, but that is a significant amount of code and testing, and is better done separately. I also don't personally think it's a blocker for 0.3.