### PR TITLE
Deprecate error/valid methods on parser

### DIFF
--- a/benchmark/distinctuseridcompetition.cpp
+++ b/benchmark/distinctuseridcompetition.cpp
@@ -4,6 +4,9 @@
 #include <vector>
 
 #include "benchmark.h"
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
+
 // #define RAPIDJSON_SSE2 // bad for performance
 // #define RAPIDJSON_SSE42 // bad for performance
 #include "rapidjson/document.h"
@@ -12,6 +15,8 @@
 #include "rapidjson/writer.h"
 
 #include "sajson.h"
+
+SIMDJSON_POP_DISABLE_WARNINGS
 
 using namespace rapidjson;
 

--- a/benchmark/minifiercompetition.cpp
+++ b/benchmark/minifiercompetition.cpp
@@ -4,6 +4,8 @@
 #include "benchmark.h"
 #include "simdjson.h"
 
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
+
 // #define RAPIDJSON_SSE2 // bad
 // #define RAPIDJSON_SSE42 // bad
 #include "rapidjson/document.h"
@@ -12,8 +14,10 @@
 #include "rapidjson/writer.h"
 #include "sajson.h"
 
-using namespace simdjson;
+SIMDJSON_POP_DISABLE_WARNINGS
+
 using namespace rapidjson;
+using namespace simdjson;
 
 std::string rapid_stringme_insitu(char *json) {
   Document d;
@@ -40,6 +44,7 @@ std::string rapid_stringme(char *json) {
   d.Accept(writer);
   return buffer.GetString();
 }
+
 
 int main(int argc, char *argv[]) {
   int c;
@@ -101,7 +106,7 @@ int main(int argc, char *argv[]) {
   size_t outlength;
   uint8_t *cbuffer = (uint8_t *)buffer;
   for (auto imple : simdjson::available_implementations) {
-    BEST_TIME((std::string("simdjson->minify+")+imple->name()).c_str(), (imple->minify(cbuffer, p.size(), cbuffer, outlength), outlength),
+    BEST_TIME((std::string("simdjson->minify+")+imple->name()).c_str(), (imple->minify(cbuffer, p.size(), cbuffer, outlength) ? outlength : -1),
             outlength, memcpy(buffer, p.data(), p.size()), repeat, volume,
             !just_data);
   }
@@ -120,8 +125,9 @@ int main(int argc, char *argv[]) {
 
   char *mini_buffer = simdjson::internal::allocate_padded_buffer(p.size() + 1);
   size_t minisize;
-  simdjson::active_implementation->minify((const uint8_t *)p.data(), p.size(),
-                                          (uint8_t *)mini_buffer, minisize);
+  auto minierror = simdjson::active_implementation->minify((const uint8_t *)p.data(), p.size(),
+                                                           (uint8_t *)mini_buffer, minisize);
+  if (!minierror) { std::cerr << minierror << std::endl; exit(1); }
   mini_buffer[minisize] = '\0';
 
   BEST_TIME("RapidJSON Insitu despaced", d.ParseInsitu(buffer).HasParseError(),

--- a/benchmark/parseandstatcompetition.cpp
+++ b/benchmark/parseandstatcompetition.cpp
@@ -2,6 +2,9 @@
 #include <unistd.h>
 
 #include "benchmark.h"
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
+
 // #define RAPIDJSON_SSE2 // bad for performance
 // #define RAPIDJSON_SSE42 // bad for performance
 #include "rapidjson/document.h"
@@ -10,6 +13,8 @@
 #include "rapidjson/writer.h"
 
 #include "sajson.h"
+
+SIMDJSON_POP_DISABLE_WARNINGS
 
 using namespace rapidjson;
 using namespace simdjson;

--- a/benchmark/parsingcompetition.cpp
+++ b/benchmark/parsingcompetition.cpp
@@ -1,4 +1,5 @@
 #include "simdjson.h"
+
 #ifndef _MSC_VER
 #include "linux-perf-events.h"
 #include <unistd.h>
@@ -10,6 +11,8 @@
 #include <memory>
 
 #include "benchmark.h"
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 
 // #define RAPIDJSON_SSE2 // bad for performance
 // #define RAPIDJSON_SSE42 // bad for performance
@@ -43,6 +46,8 @@ extern "C" {
 #include "json/json.h"
 
 #endif
+
+SIMDJSON_POP_DISABLE_WARNINGS
 
 using namespace rapidjson;
 
@@ -104,7 +109,7 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
   }
 
   if (!just_data)
-    BEST_TIME("simdjson (dynamic mem) ", simdjson::build_parsed_json(p).is_valid(), true,
+    BEST_TIME("simdjson (dynamic mem) ", !simdjson::document::parser().parse(p).error(), true,
               , repeat, volume, !just_data);
   // (static alloc)
   simdjson::document::parser parser;
@@ -161,6 +166,8 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
                     sajson::mutable_string_view(p.size(), buffer))
           .is_valid(),
       true, memcpy(buffer, p.data(), p.size()), repeat, volume, !just_data);
+
+
   size_t expected = json::parse(p.data(), p.data() + p.size()).size();
   BEST_TIME("nlohmann-json", json::parse(buffer, buffer + p.size()).size(),
             expected, memcpy(buffer, p.data(), p.size()), repeat, volume,
@@ -291,6 +298,7 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
            stats[2] * 1.0 / repeat, stats[3] * 1.0 / repeat,
            stats[4] * 1.0 / repeat, volume * repeat * 1.0 / stats[2],
            stats[1] * 1.0 / stats[0], stats[1] * 1.0 / (volume * repeat));
+
   }
 #endif //  __linux__
 

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -74,6 +74,7 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 #endif
 
 #define SIMDJSON_PUSH_DISABLE_WARNINGS __pragma(warning( push ))
+#define SIMDJSON_PUSH_DISABLE_ALL_WARNINGS __pragma(warning( push, 0 ))
 #define SIMDJSON_DISABLE_VS_WARNING(WARNING_NUMBER) __pragma(warning( disable : WARNING_NUMBER ))
 #define SIMDJSON_DISABLE_DEPRECATED_WARNING SIMDJSON_DISABLE_VS_WARNING(4996)
 #define SIMDJSON_POP_DISABLE_WARNINGS __pragma(warning( pop ))
@@ -95,6 +96,13 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 #endif
 
 #define SIMDJSON_PUSH_DISABLE_WARNINGS _Pragma("GCC diagnostic push")
+// gcc doesn't seem to disable all warnings with all and extra, add warnings here as necessary
+#define SIMDJSON_PUSH_DISABLE_ALL_WARNINGS SIMDJSON_PUSH_DISABLE_WARNINGS \
+  SIMDJSON_DISABLE_GCC_WARNING(-Wall) \
+  SIMDJSON_DISABLE_GCC_WARNING(-Wextra) \
+  SIMDJSON_DISABLE_GCC_WARNING(-Wshadow) \
+  SIMDJSON_DISABLE_GCC_WARNING(-Wunused-parameter) \
+  SIMDJSON_DISABLE_GCC_WARNING(-Wimplicit-fallthrough)
 #define SIMDJSON_PRAGMA(P) _Pragma(#P)
 #define SIMDJSON_DISABLE_GCC_WARNING(WARNING) SIMDJSON_PRAGMA(GCC diagnostic ignored #WARNING)
 #define SIMDJSON_DISABLE_DEPRECATED_WARNING SIMDJSON_DISABLE_GCC_WARNING(-Wdeprecated-declarations)

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -1633,18 +1633,22 @@ public:
   //
 
   // returns true if the document parsed was valid
+  [[deprecated("Use the result of parser.parse() instead")]]
   inline bool is_valid() const noexcept;
 
   // return an error code corresponding to the last parsing attempt, see
   // simdjson.h will return UNITIALIZED if no parsing was attempted
+  [[deprecated("Use the result of parser.parse() instead")]]
   inline int get_error_code() const noexcept;
 
   // return the string equivalent of "get_error_code"
+  [[deprecated("Use error_message() on the result of parser.parse() instead, or cout << error")]]
   inline std::string get_error_message() const noexcept;
 
   // print the json to std::ostream (should be valid)
   // return false if the tape is likely wrong (e.g., you did not parse a valid
   // JSON).
+  [[deprecated("Use cout << on the result of parser.parse() instead")]]
   inline bool print_json(std::ostream &os) const noexcept;
   inline bool dump_raw_tape(std::ostream &os) const noexcept;
 

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -404,18 +404,18 @@ inline bool document::parser::is_valid() const noexcept { return valid; }
 inline int document::parser::get_error_code() const noexcept { return error; }
 inline std::string document::parser::get_error_message() const noexcept { return error_message(int(error)); }
 inline bool document::parser::print_json(std::ostream &os) const noexcept {
-  if (!is_valid()) { return false; }
+  if (!valid) { return false; }
   os << minify(doc);
   return true;
 }
 inline bool document::parser::dump_raw_tape(std::ostream &os) const noexcept {
-  return is_valid() ? doc.dump_raw_tape(os) : false;
+  return valid ? doc.dump_raw_tape(os) : false;
 }
 
 #if SIMDJSON_EXCEPTIONS
 
 inline const document &document::parser::get_document() const noexcept(false) {
-  if (!is_valid()) {
+  if (!valid) {
     throw simdjson_error(error);
   }
   return doc;

--- a/include/simdjson/inline/parsedjson_iterator.h
+++ b/include/simdjson/inline/parsedjson_iterator.h
@@ -211,7 +211,7 @@ bool ParsedJson::Iterator::next() {
 
 ParsedJson::Iterator::Iterator(const ParsedJson &pj) noexcept(false)
     : doc(pj.doc), depth(0), location(0), tape_length(0) {
-  if (!pj.is_valid()) { throw simdjson_error(pj.error); }
+  if (!pj.valid) { throw simdjson_error(pj.error); }
 
   max_depth = pj.max_depth();
   depth_index = new scopeindex_t[max_depth + 1];

--- a/tests/allparserscheckfile.cpp
+++ b/tests/allparserscheckfile.cpp
@@ -2,6 +2,8 @@
 
 #include "simdjson.h"
 
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
+
 // #define RAPIDJSON_SSE2 // bad
 // #define RAPIDJSON_SSE42 // bad
 #include "fastjson.cpp"
@@ -24,8 +26,10 @@ extern "C" {
 #include "jsoncpp.cpp"
 #include "json/json.h"
 
+SIMDJSON_POP_DISABLE_WARNINGS
+
 // fastjson has a tricky interface
-void on_json_error(void *, const fastjson::ErrorContext &ec) {
+void on_json_error(void *, UNUSED const fastjson::ErrorContext &ec) {
   // std::cerr<<"ERROR: "<<ec.mesg<<std::endl;
 }
 bool fastjson_parse(const char *input) {
@@ -59,9 +63,9 @@ int main(int argc, char *argv[]) {
     exit(1);
   }
   const char *filename = argv[optind];
-  auto [p, error] = simdjson::padded_string::load(filename);
-  if (error) {
-    std::cerr << "Could not load the file " << filename << std::endl;
+  auto [p, loaderr] = simdjson::padded_string::load(filename);
+  if (loaderr) {
+    std::cerr << "Could not load the file " << filename << ": " << loaderr << std::endl;
     return EXIT_FAILURE;
   }
   if (verbose) {

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -193,8 +193,8 @@ namespace document_tests {
     std::cout << __func__ << std::endl;
     simdjson::padded_string badjson = "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"_padded;
     simdjson::document::parser parser;
-    parser.parse(badjson);
-    if(parser.is_valid()) {
+    auto [doc, error] = parser.parse(badjson);
+    if (!error) {
       printf("This json should not be valid %s.\n", badjson.data());
       return false;
     }


### PR DESCRIPTION
We're trying to move to a world where the parser doesn't store error information anymore, it's returned from parse and forgotten, so that there's only one place errors exist. To do that, we have to deprecate these methods. (They won't do what you want unless you're using json_parse and build_parsed_json anyway--we only set them from those methods--but deprecating them makes it harder to accidentally do it.)

This patch also fixes any makes the competitions compile without warnings. At this point `make everything` compiles with no warnings!