### PR TITLE
Let us document the relationship between a parser instance and the parsed document.

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -50,6 +50,8 @@ dom::parser parser;
 dom::element doc = parser.parse("[1,2,3]"_padded); // parse a string
 ```
 
+Note: The parsed document resulting from the `parser.load` and `parser.parse` calls depends on the `parser` instance. Thus the `parser` instance must remain in scope. Furthermore, you must have at most one parsed document in play per `parser` instance. Calling `parse` or `load` a second time invalidates the previous parsed document. If you need access simultaneously to several parsed documents, you need to have several `parser` instances.
+
 Using the Parsed JSON
 ---------------------
 


### PR DESCRIPTION
Currently, I cannot find anything explicit in the MarkDown basic documentation regarding the lifetime relationship between parser and documents. It is in the documentation in the sense that it is in the code and in the doxygen...

Helps to fix https://github.com/simdjson/simdjson/issues/696