### PR TITLE
Providing a size() function to arrays and objects (lazy approach) [MAYBE DO NOT MERGE?]

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -8,7 +8,116 @@ using namespace std;
 
 const padded_string EMPTY_ARRAY("[]", 2);
 
-const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "";
+const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+const char *NUMBERS_JSON = SIMDJSON_BENCHMARK_DATA_DIR "numbers.json";
+
+
+
+static void numbers_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+  if(error) {
+    cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+    return;
+  }
+  for (auto _ : state) {
+    std::vector<double> container;
+    for (auto e : arr) {
+      double x;
+      e.get<double>().tie(x,error);
+      if(error) { cerr << "found a node that is not an number?" << endl; break;}
+      container.push_back(x);
+    }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_scan);
+
+static void numbers_size_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+  if(error) {
+    cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+    return;
+  }
+  for (auto _ : state) {
+    std::vector<double> container;
+    container.resize(arr.size());
+    size_t pos = 0;
+    for (auto e : arr) {
+      double x;
+      e.get<double>().tie(x,error);
+      if(error) { cerr << "found a node that is not an number?" << endl; break;}
+      container[pos++] = x;
+    }
+    if(pos != container.size()) { cerr << "bad count" << endl; }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_size_scan);
+
+
+static void numbers_load_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  for (auto _ : state) {
+    // this may hit the disk, but probably just once
+    parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+    if(error) {
+      cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+      break;
+    }
+    std::vector<double> container;
+    for (auto e : arr) {
+      double x;
+      e.get<double>().tie(x,error);
+      if(error) { cerr << "found a node that is not an number?" << endl; break;}
+      container.push_back(x);
+    }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_load_scan);
+
+static void numbers_load_size_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  for (auto _ : state) {
+    // this may hit the disk, but probably just once
+    parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+    if(error) {
+      cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+      break;
+    }
+    std::vector<double> container;
+    container.resize(arr.size());
+    size_t pos = 0;
+    for (auto e : arr) {
+      double x;
+      e.get<double>().tie(x,error);
+      if(error) { cerr << "found a node that is not an number?" << endl; break;}
+      container[pos++] = x;
+    }
+    if(pos != container.size()) { cerr << "bad count" << endl; }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_load_size_scan);
+
 
 #if SIMDJSON_EXCEPTIONS
 

--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -33,7 +33,7 @@ static void numbers_scan(State& state) {
     }
     benchmark::DoNotOptimize(container.data());
     benchmark::ClobberMemory();
-  }
+  }  
 }
 BENCHMARK(numbers_scan);
 
@@ -60,7 +60,7 @@ static void numbers_size_scan(State& state) {
     if(pos != container.size()) { cerr << "bad count" << endl; }
     benchmark::DoNotOptimize(container.data());
     benchmark::ClobberMemory();
-  }
+  }  
 }
 BENCHMARK(numbers_size_scan);
 
@@ -86,7 +86,7 @@ static void numbers_load_scan(State& state) {
     }
     benchmark::DoNotOptimize(container.data());
     benchmark::ClobberMemory();
-  }
+  }  
 }
 BENCHMARK(numbers_load_scan);
 
@@ -114,12 +114,83 @@ static void numbers_load_size_scan(State& state) {
     if(pos != container.size()) { cerr << "bad count" << endl; }
     benchmark::DoNotOptimize(container.data());
     benchmark::ClobberMemory();
-  }
+  }  
 }
 BENCHMARK(numbers_load_size_scan);
 
 
 #if SIMDJSON_EXCEPTIONS
+
+
+static void numbers_exceptions_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr = parser.load(NUMBERS_JSON);
+  for (auto _ : state) {
+    std::vector<double> container;
+    for (double x : arr) {
+      container.push_back(x);
+    }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }  
+}
+BENCHMARK(numbers_exceptions_scan);
+
+static void numbers_exceptions_size_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr = parser.load(NUMBERS_JSON);
+  for (auto _ : state) {
+    std::vector<double> container;
+    container.resize(arr.size());
+    size_t pos = 0;
+    for (double x : arr) {
+      container[pos++] = x;
+    }
+    if(pos != container.size()) { cerr << "bad count" << endl; }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }  
+}
+BENCHMARK(numbers_exceptions_size_scan);
+
+
+static void numbers_exceptions_load_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  for (auto _ : state) {
+    // this may hit the disk, but probably just once
+    dom::array arr = parser.load(NUMBERS_JSON);
+    std::vector<double> container;
+    for (double x : arr) {
+      container.push_back(x);
+    }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }  
+}
+BENCHMARK(numbers_exceptions_load_scan);
+
+static void numbers_exceptions_load_size_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  for (auto _ : state) {
+    // this may hit the disk, but probably just once
+    dom::array arr = parser.load(NUMBERS_JSON);
+    std::vector<double> container;
+    container.resize(arr.size());
+    size_t pos = 0;
+    for (double x : arr) {
+      container[pos++] = x;
+    }
+    if(pos != container.size()) { cerr << "bad count" << endl; }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }  
+}
+BENCHMARK(numbers_exceptions_load_size_scan);
+
 
 static void twitter_count(State& state) {
   // Prints the number of results in twitter.json

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -145,6 +145,11 @@ public:
   inline iterator end() const noexcept;
   /**
   * Get the size of the array (number of immediate children).
+  * 
+  * The size is evaluated lazily: the first time the function
+  * is called, it is computed (in linear time) and following
+  * calls to the same function on the same instance just
+  * return the precomputed value.
   */
   inline uint32_t size() noexcept;
 
@@ -173,6 +178,7 @@ public:
   inline simdjson_result<element> at(size_t index) const noexcept;
 
 private:
+  size_t lazy_size{SIZE_MAX}; // convention: SIZE_MAX means "unevaluated"
   really_inline array(const document *doc, size_t json_index) noexcept;
   friend class element;
   friend struct simdjson_result<element>;
@@ -219,7 +225,6 @@ public:
      */
     inline element value() const noexcept;
   private:
-    size_t lazy_size{SIZE_MAX};
     really_inline iterator(const document *doc, size_t json_index) noexcept;
     friend class object;
   };
@@ -239,6 +244,11 @@ public:
 
   /**
   * Get the size of the array (number of immediate children).
+  * 
+  * The size is evaluated lazily: the first time the function
+  * is called, it is computed (in linear time) and following
+  * calls to the same function on the same instance just
+  * return the precomputed value.
   */
   inline uint32_t size() noexcept;
   /**
@@ -312,7 +322,7 @@ public:
   inline simdjson_result<element> at_key_case_insensitive(const std::string_view &key) const noexcept;
 
 private:
-  size_t lazy_size{SIZE_MAX};
+  size_t lazy_size{SIZE_MAX}; // convention: SIZE_MAX means "unevaluated"
   really_inline object(const document *doc, size_t json_index) noexcept;
   friend class element;
   friend struct simdjson_result<element>;

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -143,6 +143,10 @@ public:
    * Part of the std::iterable interface.
    */
   inline iterator end() const noexcept;
+  /**
+  * Get the size of the array (number of immediate children).
+  */
+  inline uint32_t size() noexcept;
 
   /**
    * Get the value associated with the given JSON pointer.
@@ -215,6 +219,7 @@ public:
      */
     inline element value() const noexcept;
   private:
+    size_t lazy_size{SIZE_MAX};
     really_inline iterator(const document *doc, size_t json_index) noexcept;
     friend class object;
   };
@@ -232,6 +237,10 @@ public:
    */
   inline iterator end() const noexcept;
 
+  /**
+  * Get the size of the array (number of immediate children).
+  */
+  inline uint32_t size() noexcept;
   /**
    * Get the value associated with the given key.
    *
@@ -303,6 +312,7 @@ public:
   inline simdjson_result<element> at_key_case_insensitive(const std::string_view &key) const noexcept;
 
 private:
+  size_t lazy_size{SIZE_MAX};
   really_inline object(const document *doc, size_t json_index) noexcept;
   friend class element;
   friend struct simdjson_result<element>;

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -548,7 +548,7 @@ inline array::iterator array::end() const noexcept {
 }
 
 inline uint32_t array::size() noexcept {
-  if( lazy_size != SIZE_MAX ) {
+  if(lazy_size != SIZE_MAX) {
     return lazy_size;
   }
   lazy_size = 0;
@@ -621,7 +621,7 @@ inline object::iterator object::end() const noexcept {
   return iterator(doc, after_element() - 1);
 }
 inline uint32_t object::size() noexcept {
-  if( lazy_size != SIZE_MAX ) {
+  if(lazy_size != SIZE_MAX) {
     return lazy_size;
   }
   lazy_size = 0;

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -547,6 +547,16 @@ inline array::iterator array::end() const noexcept {
   return iterator(doc, after_element() - 1);
 }
 
+inline uint32_t array::size() noexcept {
+  if( lazy_size != SIZE_MAX ) {
+    return lazy_size;
+  }
+  lazy_size = 0;
+  for(auto i = begin(); i != end(); ++i) {
+    lazy_size++;
+  }
+  return lazy_size;
+}
 inline simdjson_result<element> array::at(const std::string_view &json_pointer) const noexcept {
   // - means "the append position" or "the element after the end of the array"
   // We don't support this, because we're returning a real element, not a position.
@@ -609,6 +619,16 @@ inline object::iterator object::begin() const noexcept {
 }
 inline object::iterator object::end() const noexcept {
   return iterator(doc, after_element() - 1);
+}
+inline uint32_t object::size() noexcept {
+  if( lazy_size != SIZE_MAX ) {
+    return lazy_size;
+  }
+  lazy_size = 0;
+  for(auto i = begin(); i != end(); ++i) {
+    lazy_size++;
+  }
+  return lazy_size;
 }
 
 inline simdjson_result<element> object::operator[](const std::string_view &key) const noexcept {

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -201,6 +201,36 @@ namespace document_tests {
     }
     return true;
   }
+  bool count_array_example() {
+    std::cout << __func__ << std::endl;
+    simdjson::padded_string smalljson = "[1,2,3]"_padded;
+    simdjson::dom::parser parser;
+    auto [doc, error] = parser.parse(smalljson).get<simdjson::dom::array>();
+    if (error) {
+      printf("This json should  be valid %s.\n", smalljson.data());
+      return false;
+    }
+    if(doc.size() != 3) {
+      printf("This json should  have size three but found %u : %s.\n", doc.size(), smalljson.data());
+      return false;
+    }
+    return true;
+  }
+  bool count_object_example() {
+    std::cout << __func__ << std::endl;
+    simdjson::padded_string smalljson = "{\"1\":1,\"2\":1,\"3\":1}"_padded;
+    simdjson::dom::parser parser;
+    auto [doc, error] = parser.parse(smalljson).get<simdjson::dom::object>();
+    if (error) {
+      printf("This json should  be valid %s.\n", smalljson.data());
+      return false;
+    }
+    if(doc.size() != 3) {
+      printf("This json should  have size three but found %u : %s.\n", doc.size(), smalljson.data());
+      return false;
+    }
+    return true;
+  }
   // returns true if successful
   bool stable_test() {
     std::cout << __func__ << std::endl;
@@ -299,6 +329,8 @@ namespace document_tests {
   }
   bool run() {
     return bad_example() &&
+           count_array_example() &&
+           count_object_example() &&
            stable_test() &&
            skyprophet_test() &&
            lots_of_brackets();


### PR DESCRIPTION
This is an alternative to PR https://github.com/simdjson/simdjson/pull/690

The idea is to compute the size of an array or an object when needed, lazily. Thus if you parse a document and never need to query the size of an array, you are not paying (much) for it. However, if you need it, you incur a price at query time, but only for the arrays or the object where you need the size.

Fixes  https://github.com/simdjson/simdjson/issues/688 and https://github.com/simdjson/simdjson/issues/308