### PR TITLE
Trying to correct the documentation so that it actually describes how the code behaves.

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -57,9 +57,8 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 
 * **Extracting Values:** You can cast a JSON element to a native type: `double(element)` or
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
-  dom::object and dom::array. You can also use is_*typename*()` to test if it is a
-  given type, and as_*typename*() to do the cast and return an error code on failure instead of an
-  exception.
+  dom::object and dom::array. You can also use is<*typename*>()` to test if it is a
+  given type, and get<*typename*>() to get the value (an exception is still thrown if the cast is not possible): casts and get<*typename*>() can be used interchangeably. Note that if you are compiling simdjson without support for exceptions, casts are disabled, and get<*typename*>() returns a pair (result,error code).
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`
@@ -171,7 +170,7 @@ behavior.
 > use it. If your project treats aliased, this means you can't use the same names in `auto [x, error]`
 > without triggering warnings or error (and particularly can't use the word "error" every time). To
 > circumvent this, you can use this instead:
-> 
+>
 > ```c++
 > dom::element doc;
 > simdjson::error_code error;
@@ -341,4 +340,3 @@ The parsed results (`dom::document`, `dom::element`, `array`, `object`) depend o
 
 The CPU detection, which runs the first time parsing is attempted and switches to the fastest
 parser for your CPU, is transparent and thread-safe.
-


### PR DESCRIPTION
Documentation update.

I think that casts and get<type>() are effectively equivalent which brings up the question: why do we bother with  get<type>() at all when exceptions are enabled?


Proof...

```C++

inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
  return get<bool>();
}
inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
  return get<const char *>();
}
inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
  return get<std::string_view>();
}
inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
  return get<uint64_t>();
}
inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
  return get<int64_t>();
}
inline simdjson_result<dom::element>::operator double() const noexcept(false) {
  return get<double>();
}
inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
  return get<dom::array>();
}
inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
  return get<dom::object>();
}
```

See issue https://github.com/simdjson/simdjson/issues/711