### PR TITLE
Trying to correct the documentation so that it actually describes how the code behaves. (Attempt two)

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -58,7 +58,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 * **Extracting Values:** You can cast a JSON element to a native type: `double(element)` or
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
   dom::object and dom::array. You can also use is<*typename*>()` to test if it is a
-  given type, and get<*typename*>() to get the value (an exception is still thrown if the cast is not possible): casts and get<*typename*>() can be used interchangeably. Note that if you are compiling simdjson without support for exceptions, casts are disabled, and get<*typename*>() returns a pair (result,error code).
+  given type, and get<*typename*>() to get the value (an exception is still thrown if the cast is not possible): casts and get<*typename*>() can be used interchangeably. You can use the variant of get<*typename*>() which returns a pair to avoid exceptions: e.g.,  `auto [value,error] = get<double>()`.
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -57,8 +57,21 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 
 * **Extracting Values:** You can cast a JSON element to a native type: `double(element)` or
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
-  dom::object and dom::array. You can also use is<*typename*>()` to test if it is a
-  given type, and get<*typename*>() to get the value (an exception is still thrown if the cast is not possible): casts and get<*typename*>() can be used interchangeably. You can use the variant of get<*typename*>() which returns a pair to avoid exceptions: e.g.,  `auto [value,error] = get<double>()`.
+  dom::object and dom::array. An exception is thrown if the cast is not possible. You can also use is<*typename*>() to test if it is a
+  given type, or use the `type()` method: e.g., `element.type() == dom::element_type::DOUBLE`. Instead of casting, you can use get<*typename*>() to get the value: casts and get<*typename*>() can be used interchangeably. You can use a variant usage of get<*typename*>() with error codes to avoid exceptions: e.g.,  
+  ```c++
+    simdjson::error_code error;
+    double value;
+    result.get<double>().tie(value, error); // no exception, ever
+    /**
+     * If you do not have to support libc++, you can use the simpler syntax:
+     * auto [value, error] = result.get<double>();
+     */
+    if(error) {
+      // error case
+    }
+    ```
+    Other access methods (e.g., is()) can similarly be used with error codes to avoid the generation of exceptions.
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -71,7 +71,6 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
       // error case
     }
     ```
-    Other access methods (e.g., is()) can similarly be used with error codes to avoid the generation of exceptions.
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -60,16 +60,26 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   dom::object and dom::array. An exception is thrown if the cast is not possible. You can also use is<*typename*>() to test if it is a
   given type, or use the `type()` method: e.g., `element.type() == dom::element_type::DOUBLE`. Instead of casting, you can use get<*typename*>() to get the value: casts and get<*typename*>() can be used interchangeably. You can use a variant usage of get<*typename*>() with error codes to avoid exceptions: e.g.,  
   ```c++
-    simdjson::error_code error;
-    double value;
-    result.get<double>().tie(value, error); // no exception, ever
-    /**
-     * If you do not have to support libc++, you can use the simpler syntax:
-     * auto [value, error] = result.get<double>();
-     */
-    if(error) {
-      // error case
-    }
+#include <iostream>
+#include "simdjson.h"
+
+int main() {
+  auto numberstring = "1.2"_padded;
+  simdjson::dom::parser parser;
+  simdjson::error_code error;
+  double value;
+  parser.parse(numberstring).get<double>().tie(value,error);
+  if(error) {
+    std::cerr << "error parsing JSON" << std::endl;
+    return EXIT_FAILURE;
+  }
+  if(value != 1.2) {
+    std::cerr << "bad value" << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
+  return EXIT_SUCCESS;
+}
   ```
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -70,7 +70,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
     if(error) {
       // error case
     }
-    ```
+  ```
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -60,26 +60,13 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   dom::object and dom::array. An exception is thrown if the cast is not possible. You can also use is<*typename*>() to test if it is a
   given type, or use the `type()` method: e.g., `element.type() == dom::element_type::DOUBLE`. Instead of casting, you can use get<*typename*>() to get the value: casts and get<*typename*>() can be used interchangeably. You can use a variant usage of get<*typename*>() with error codes to avoid exceptions: e.g.,  
   ```c++
-#include <iostream>
-#include "simdjson.h"
-
-int main() {
-  auto numberstring = "1.2"_padded;
-  simdjson::dom::parser parser;
   simdjson::error_code error;
-  double value;
+  double value; // variable where we store the value to be parsed
+  simdjson::padded_string numberstring = "1.2"_padded; // our JSON input ("1.2")
+  simdjson::dom::parser parser;
   parser.parse(numberstring).get<double>().tie(value,error);
-  if(error) {
-    std::cerr << "error parsing JSON" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if(value != 1.2) {
-    std::cerr << "bad value" << std::endl;
-    return EXIT_FAILURE;
-  }
+  if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
-  return EXIT_SUCCESS;
-}
   ```
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -57,9 +57,8 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 
 * **Extracting Values:** You can cast a JSON element to a native type: `double(element)` or
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
-  dom::object and dom::array. You can also use is_*typename*()` to test if it is a
-  given type, and as_*typename*() to do the cast and return an error code on failure instead of an
-  exception.
+  dom::object and dom::array. You can also use is<*typename*>()` to test if it is a
+  given type, and get<*typename*>() to get the value (an exception is still thrown if the cast is not possible): casts and get<*typename*>() can be used interchangeably. Note that if you are compiling simdjson without support for exceptions, casts are disabled, and get<*typename*>() returns a pair (result,error code).
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`
@@ -171,7 +170,7 @@ behavior.
 > use it. If your project treats aliased, this means you can't use the same names in `auto [x, error]`
 > without triggering warnings or error (and particularly can't use the word "error" every time). To
 > circumvent this, you can use this instead:
-> 
+>
 > ```c++
 > dom::element doc;
 > simdjson::error_code error;
@@ -341,4 +340,3 @@ The parsed results (`dom::document`, `dom::element`, `array`, `object`) depend o
 
 The CPU detection, which runs the first time parsing is attempted and switches to the fastest
 parser for your CPU, is transparent and thread-safe.
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_cpp_test(integer_tests integer_tests.cpp)
 add_cpp_test(jsoncheck jsoncheck.cpp)
 add_cpp_test(parse_many_test parse_many_test.cpp)
 add_cpp_test(pointercheck pointercheck.cpp quicktests)
+add_cpp_test(extracting_values_example extracting_values_example.cpp quicktests)
 
 set_property(
   TEST basictests errortests integer_tests jsoncheck parse_many_test pointercheck

--- a/tests/extracting_values_example.cpp
+++ b/tests/extracting_values_example.cpp
@@ -2,19 +2,11 @@
 #include "simdjson.h"
 
 int main() {
-  auto numberstring = "1.2"_padded;
-  simdjson::dom::parser parser;
   simdjson::error_code error;
-  double value;
+  double value; // variable where we store the value to be parsed
+  simdjson::padded_string numberstring = "1.2"_padded; // our JSON input ("1.2")
+  simdjson::dom::parser parser;
   parser.parse(numberstring).get<double>().tie(value,error);
-  if(error) {
-    std::cerr << "error parsing JSON" << std::endl;
-    return EXIT_FAILURE;
-  }
-  if(value != 1.2) {
-    std::cerr << "bad value" << std::endl;
-    return EXIT_FAILURE;
-  }
+  if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
-  return EXIT_SUCCESS;
 }

--- a/tests/extracting_values_example.cpp
+++ b/tests/extracting_values_example.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+#include "simdjson.h"
+
+int main() {
+  auto numberstring = "1.2"_padded;
+  simdjson::dom::parser parser;
+  simdjson::error_code error;
+  double value;
+  parser.parse(numberstring).get<double>().tie(value,error);
+  if(error) {
+    std::cerr << "error parsing JSON" << std::endl;
+    return EXIT_FAILURE;
+  }
+  if(value != 1.2) {
+    std::cerr << "bad value" << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Documentation update.

I think that casts and get<type>() are effectively equivalent which brings up the question: why do we bother with  get<type>() at all when exceptions are enabled?


Proof...

```C++

inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
  return get<bool>();
}
inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
  return get<const char *>();
}
inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
  return get<std::string_view>();
}
inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
  return get<uint64_t>();
}
inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
  return get<int64_t>();
}
inline simdjson_result<dom::element>::operator double() const noexcept(false) {
  return get<double>();
}
inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
  return get<dom::array>();
}
inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
  return get<dom::object>();
}
```

See issue https://github.com/simdjson/simdjson/issues/711

This is the second attempt (previously the fuzzer were busted).

Fixes https://github.com/simdjson/simdjson/issues/711