### PR TITLE
Massive performance boost for get<double>.

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -65,6 +65,63 @@ static void numbers_size_scan(State& state) {
 BENCHMARK(numbers_size_scan);
 
 
+static void numbers_type_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+  if(error) {
+    cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+    return;
+  }
+  for (auto _ : state) {
+    std::vector<double> container;
+    for (auto e : arr) {
+      dom::element_type actual_type = e.type();
+      if(actual_type != dom::element_type::DOUBLE) {
+        cerr << "found a node that is not an number?" << endl; break;
+      }
+      double x;
+      e.get<double>().tie(x,error);
+      container.push_back(x);
+    }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_type_scan);
+
+static void numbers_type_size_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+  if(error) {
+    cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+    return;
+  }
+  for (auto _ : state) {
+    std::vector<double> container;
+    container.resize(arr.size());
+    size_t pos = 0;
+    for (auto e : arr) {
+      dom::element_type actual_type = e.type();
+      if(actual_type != dom::element_type::DOUBLE) {
+        cerr << "found a node that is not an number?" << endl; break;
+      }
+      double x;
+      e.get<double>().tie(x,error);
+      container[pos++] = x;
+    }
+    if(pos != container.size()) { cerr << "bad count" << endl; }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_type_size_scan);
+
 static void numbers_load_scan(State& state) {
   // Prints the number of results in twitter.json
   dom::parser parser;

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -71,6 +71,12 @@ public:
   inline size_t after_element() const noexcept;
   really_inline tape_type tape_ref_type() const noexcept;
   really_inline uint64_t tape_value() const noexcept;
+  really_inline bool is_double() const noexcept;
+  really_inline bool is_int64() const noexcept;
+  really_inline bool is_uint64() const noexcept;
+  really_inline bool is_false() const noexcept;
+  really_inline bool is_true() const noexcept;
+  really_inline bool is_null() const noexcept;
   really_inline uint32_t matching_brace_index() const noexcept;
   really_inline uint32_t scope_count() const noexcept;
   template<typename T>

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -76,7 +76,7 @@ public:
   really_inline bool is_uint64() const noexcept;
   really_inline bool is_false() const noexcept;
   really_inline bool is_true() const noexcept;
-  really_inline bool is_null() const noexcept;
+  really_inline bool is_null_on_tape() const noexcept;// different name to avoid clash with is_null.
   really_inline uint32_t matching_brace_index() const noexcept;
   really_inline uint32_t scope_count() const noexcept;
   template<typename T>

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -764,7 +764,7 @@ inline element_type element::type() const noexcept {
   }
 }
 really_inline bool element::is_null() const noexcept {
-  return is_null();
+  return is_null_on_tape();
 }
 
 template<>
@@ -839,7 +839,7 @@ inline simdjson_result<double> element::get<double>() const noexcept {
   if(unlikely(!is_double())) { // branch rarely taken
     if(is_uint64()) {
       return next_tape_value<uint64_t>();
-    } else if(is_uint64()) {
+    } else if(is_int64()) {
       return next_tape_value<int64_t>();
     }
     return INCORRECT_TYPE;
@@ -1140,7 +1140,7 @@ really_inline bool tape_ref::is_true() const noexcept {
   constexpr uint64_t tape_true = static_cast<uint64_t>(tape_type::TRUE_VALUE)<<56;
   return doc->tape[json_index] == tape_true;
 }
-really_inline bool tape_ref::is_null() const noexcept {
+really_inline bool tape_ref::is_null_on_tape() const noexcept {
   constexpr uint64_t tape_null = static_cast<uint64_t>(tape_type::NULL_VALUE)<<56;
   return doc->tape[json_index] == tape_null;
 }


### PR DESCRIPTION
This PR introduces a much faster get<double> function.

Do...

```
mkdir build
cd build
cmake -DSIMDJSON_GOOGLE_BENCHMARKS=ON ..
./benchmark/bench_dom_api 
```

Here are my numbers using master:

```
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
numbers_scan                            28986 ns        28986 ns        24070
numbers_size_scan                       17668 ns        17669 ns        39631
numbers_exceptions_scan                 37095 ns        37095 ns        18891
numbers_exceptions_size_scan            22905 ns        22905 ns        30558
```

Here are my numbers with this PR:

```
-----------------------------------------------------------------------------
Benchmark                                   Time             CPU   Iterations
-----------------------------------------------------------------------------
numbers_scan                            23594 ns        23595 ns        29831
numbers_size_scan                       14255 ns        14255 ns        49109
numbers_exceptions_scan                 28782 ns        28783 ns        24326
numbers_exceptions_size_scan            14246 ns        14246 ns        49116
```

As an aside, observe how the version without exceptions can be, itself, much faster, irrespective of this optimization.


This not 'pretty' code. I just went and wrote straight code with performance in mind without doing any tweaking, any engineering. 


We might consider recommending that people use the exceptionless API for enhanced performance, I will open a separate issue.

