### PR TITLE
This massively improves the performance of tight loops relying on a type() call.

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -65,6 +65,63 @@ static void numbers_size_scan(State& state) {
 BENCHMARK(numbers_size_scan);
 
 
+static void numbers_type_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+  if(error) {
+    cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+    return;
+  }
+  for (auto _ : state) {
+    std::vector<double> container;
+    for (auto e : arr) {
+      dom::element_type actual_type = e.type();
+      if(actual_type != dom::element_type::DOUBLE) {
+        cerr << "found a node that is not an number?" << endl; break;
+      }
+      double x;
+      e.get<double>().tie(x,error);
+      container.push_back(x);
+    }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_type_scan);
+
+static void numbers_type_size_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr;
+  simdjson::error_code error;
+  parser.load(NUMBERS_JSON).get<dom::array>().tie(arr, error);
+  if(error) {
+    cerr << "could not read " << NUMBERS_JSON << " as an array" << endl;
+    return;
+  }
+  for (auto _ : state) {
+    std::vector<double> container;
+    container.resize(arr.size());
+    size_t pos = 0;
+    for (auto e : arr) {
+      dom::element_type actual_type = e.type();
+      if(actual_type != dom::element_type::DOUBLE) {
+        cerr << "found a node that is not an number?" << endl; break;
+      }
+      double x;
+      e.get<double>().tie(x,error);
+      container[pos++] = x;
+    }
+    if(pos != container.size()) { cerr << "bad count" << endl; }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_type_size_scan);
+
 static void numbers_load_scan(State& state) {
   // Prints the number of results in twitter.json
   dom::parser parser;

--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -202,8 +202,8 @@ static void numbers_exceptions_size_scan(State& state) {
     std::vector<double> container;
     container.resize(arr.size());
     size_t pos = 0;
-    for (double x : arr) {
-      container[pos++] = x;
+    for (auto e : arr) {
+      container[pos++] = double(e);
     }
     if(pos != container.size()) { cerr << "bad count" << endl; }
     benchmark::DoNotOptimize(container.data());
@@ -212,6 +212,48 @@ static void numbers_exceptions_size_scan(State& state) {
 }
 BENCHMARK(numbers_exceptions_size_scan);
 
+
+
+static void numbers_type_exceptions_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr = parser.load(NUMBERS_JSON);
+  for (auto _ : state) {
+    std::vector<double> container;
+    for (auto e : arr) {
+      dom::element_type actual_type = e.type();
+      if(actual_type != dom::element_type::DOUBLE) {
+        cerr << "found a node that is not an number?" << endl; break;
+      }
+      container.push_back(double(e));
+    }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_type_exceptions_scan);
+
+static void numbers_type_exceptions_size_scan(State& state) {
+  // Prints the number of results in twitter.json
+  dom::parser parser;
+  dom::array arr = parser.load(NUMBERS_JSON);
+  for (auto _ : state) {
+    std::vector<double> container;
+    container.resize(arr.size());
+    size_t pos = 0;
+    for (auto e : arr) {
+      dom::element_type actual_type = e.type();
+      if(actual_type != dom::element_type::DOUBLE) {
+        cerr << "found a node that is not an number?" << endl; break;
+      }
+      container[pos++] = double(e);
+    }
+    if(pos != container.size()) { cerr << "bad count" << endl; }
+    benchmark::DoNotOptimize(container.data());
+    benchmark::ClobberMemory();
+  }
+}
+BENCHMARK(numbers_type_exceptions_size_scan);
 
 static void numbers_exceptions_load_scan(State& state) {
   // Prints the number of results in twitter.json

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -93,17 +93,15 @@ namespace simdjson::dom {
  * This is the type it is most easily cast to with get<>.
  */
 enum class element_type {
-  ARRAY = 7,     ///< dom::array
-  OBJECT = 11,    ///< dom::object
-  INT64 = 10,     ///< int64_t
-  UINT64 = 5,    ///< uint64_t: any integer that fits in uint64_t but *not* int64_t
-  DOUBLE = 2,    ///< double: Any number with a "." or "e" that fits in double.
-  STRING = 6,    ///< std::string_view
-  BOOL = 4,      ///< bool
-  NULL_VALUE = 12 ///< null
+  ARRAY = '[',     ///< dom::array
+  OBJECT = '{',    ///< dom::object
+  INT64 = 'l',     ///< int64_t
+  UINT64 = 'u',    ///< uint64_t: any integer that fits in uint64_t but *not* int64_t
+  DOUBLE = 'd',    ///< double: Any number with a "." or "e" that fits in double.
+  STRING = '"',    ///< std::string_view
+  BOOL = 't',      ///< bool
+  NULL_VALUE = 'n' ///< null
 };
-
-/* We choose the integers 7, 11, and so forth in element_type so that the matching tape values (", {,..,) are mapped to them using the x -> x % 14 function. */
 
 /**
  * JSON array.

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -44,7 +44,7 @@ constexpr const uint64_t JSON_VALUE_MASK = 0x00FFFFFFFFFFFFFF;
 constexpr const uint32_t JSON_COUNT_MASK = 0xFFFFFF;
 
 /**
- * The possible types in the tape. Internal only.
+ * The possible types in the tape.
  */
 enum class tape_type {
   ROOT = 'r',
@@ -93,15 +93,17 @@ namespace simdjson::dom {
  * This is the type it is most easily cast to with get<>.
  */
 enum class element_type {
-  ARRAY,     ///< dom::array
-  OBJECT,    ///< dom::object
-  INT64,     ///< int64_t
-  UINT64,    ///< uint64_t: any integer that fits in uint64_t but *not* int64_t
-  DOUBLE,    ///< double: Any number with a "." or "e" that fits in double.
-  STRING,    ///< std::string_view
-  BOOL,      ///< bool
-  NULL_VALUE ///< null
+  ARRAY = 7,     ///< dom::array
+  OBJECT = 11,    ///< dom::object
+  INT64 = 10,     ///< int64_t
+  UINT64 = 5,    ///< uint64_t: any integer that fits in uint64_t but *not* int64_t
+  DOUBLE = 2,    ///< double: Any number with a "." or "e" that fits in double.
+  STRING = 6,    ///< std::string_view
+  BOOL = 4,      ///< bool
+  NULL_VALUE = 12 ///< null
 };
+
+/* We choose the integers 7, 11, and so forth in element_type so that the matching tape values (", {,..,) are mapped to them using the x -> x % 14 function. */
 
 /**
  * JSON array.

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -736,47 +736,9 @@ inline key_value_pair::key_value_pair(const std::string_view &_key, element _val
 really_inline element::element() noexcept : internal::tape_ref() {}
 really_inline element::element(const document *_doc, size_t _json_index) noexcept : internal::tape_ref(_doc, _json_index) { }
 
-namespace {
-// fastmod computes (a % 14) quickly
-// uses algorithm from https://arxiv.org/abs/1902.01961
-//  Faster Remainder by Direct Computation
-// 	Software: Practice and Experience 49 (6), 2019
-really_inline uint64_t fastmod14(unsigned int a) {
-  constexpr uint64_t M = 0xFFFFFFFF / 14 + 1;
-  uint64_t lowbits = (M  * a) & 0xFFFFFFFF;
-  return (lowbits * 14) >> 32;
-}
-}
-
 inline element_type element::type() const noexcept {
-  /* The element_type values are chosen so that x -> x % 14 does the correct mapping. We assume
-  that the types are correct, but this is no worse than before where an abort would follow. */
-  return static_cast<element_type>(fastmod14(static_cast<unsigned int>(tape_ref_type())));
-  // this is likely a hot function, so we don't want a switch case?
-  /*switch (tape_ref_type()) {
-    case internal::tape_type::START_ARRAY:
-      return element_type::ARRAY;
-    case internal::tape_type::START_OBJECT:
-      return element_type::OBJECT;
-    case internal::tape_type::INT64:
-      return element_type::INT64;
-    case internal::tape_type::UINT64:
-      return element_type::UINT64;
-    case internal::tape_type::DOUBLE:
-      return element_type::DOUBLE;
-    case internal::tape_type::STRING:
-      return element_type::STRING;
-    case internal::tape_type::TRUE_VALUE:
-    case internal::tape_type::FALSE_VALUE:
-      return element_type::BOOL;
-    case internal::tape_type::NULL_VALUE:
-      return element_type::NULL_VALUE;
-    case internal::tape_type::ROOT:
-    case internal::tape_type::END_ARRAY:
-    case internal::tape_type::END_OBJECT:
-    default:
-      abort();
-  }*/
+  auto tape_type = tape_ref_type();
+  return tape_type == internal::tape_type::FALSE_VALUE ? element_type::BOOL : static_cast<element_type>(tape_type);
 }
 really_inline bool element::is_null() const noexcept {
   return tape_ref_type() == internal::tape_type::NULL_VALUE;


### PR DESCRIPTION


Before:
```
numbers_type_scan                       83977 ns        83978 ns         8325
numbers_type_size_scan                  78568 ns        78570 ns         8910
```

After:

```
numbers_type_scan                       31775 ns        31776 ns        21990
numbers_type_size_scan                  33834 ns        33835 ns        20686
```

The main "trick" is to avoid relying on a switch-case when converting the type read
from the tape (an ascii character value) to a C++ enum class. Instead we do some
branchless arithmetic.

Again, I lack any kind of good metric, so I am going out of instinct and experience. We need instrumented benchmarks where I can see what is going on. Anyhow, for now there are still low-hanging fruits, apparently.

