### PR TITLE
VS2019 compile fixes

### DIFF
--- a/include/simdjson/parsedjson_iterator.h
+++ b/include/simdjson/parsedjson_iterator.h
@@ -16,7 +16,11 @@
 
 namespace simdjson {
 
+#ifndef _MSC_VER // Workaround for VS2019 compiler bug that triggers deprecated error even if deprecated class is unused
 class [[deprecated("Use the new DOM navigation API instead (see doc/usage.md)")]] dom::parser::Iterator {
+#else
+class dom::parser::Iterator {
+#endif
 public:
   inline Iterator(const dom::parser &parser) noexcept(false);
   inline Iterator(const Iterator &o) noexcept;

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -502,7 +502,7 @@ const detect_best_supported_implementation_on_first_use detect_best_supported_im
 
 internal::atomic_ptr<const implementation> active_implementation{&internal::detect_best_supported_implementation_on_first_use_singleton};
 
-constexpr const std::initializer_list<const implementation *> available_implementation_pointers {
+static const std::initializer_list<const implementation *> available_implementation_pointers {
 #if SIMDJSON_IMPLEMENTATION_HASWELL
   &haswell_singleton,
 #endif
@@ -561,6 +561,15 @@ const implementation *available_implementation_list::detect_best_supported() con
 }
 
 const implementation *detect_best_supported_implementation_on_first_use::set_best() const noexcept {
+  char *force_implementation_name = getenv("SIMDJSON_FORCE_IMPLEMENTATION");
+  if (force_implementation_name) {
+    auto force_implementation = available_implementations[force_implementation_name];
+    if (!force_implementation) {
+      fprintf(stderr, "SIMDJSON_FORCE_IMPLEMENTATION environment variable set to '%s', which is not a supported implementation name!\n", force_implementation_name);
+      abort();
+    }
+    return active_implementation = force_implementation;
+  }
   return active_implementation = available_implementations.detect_best_supported();
 }
 
@@ -5759,7 +5768,7 @@ inline size_t codepoint_to_utf8(uint32_t cp, uint8_t *c) {
 // The following code is used in number parsing. It is not
 // properly "char utils" stuff, but we move it here so that
 // it does not get copied multiple times in the binaries (once
-// per instructin set).
+// per instruction set).
 ///
 
 

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -4258,7 +4258,11 @@ inline std::ostream& operator<<(std::ostream& out, const escape_json_string &une
 
 namespace simdjson {
 
+#ifndef _MSC_VER // Workaround for VS2019 compiler bug that triggers deprecated error even if deprecated class is unused
 class [[deprecated("Use the new DOM navigation API instead (see doc/usage.md)")]] dom::parser::Iterator {
+#else
+class dom::parser::Iterator {
+#endif
 public:
   inline Iterator(const dom::parser &parser) noexcept(false);
   inline Iterator(const Iterator &o) noexcept;

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -63,7 +63,7 @@ const detect_best_supported_implementation_on_first_use detect_best_supported_im
 
 internal::atomic_ptr<const implementation> active_implementation{&internal::detect_best_supported_implementation_on_first_use_singleton};
 
-constexpr const std::initializer_list<const implementation *> available_implementation_pointers {
+static const std::initializer_list<const implementation *> available_implementation_pointers {
 #if SIMDJSON_IMPLEMENTATION_HASWELL
   &haswell_singleton,
 #endif


### PR DESCRIPTION
Two errors fixes:

1)  **Workaround for VS2019 compiler bug that triggers deprecated error even if deprecated class is unused**

VS throws compilation error simply from defining inline ctor of the deprecated class. Sample compilation error:
> src\simdjson.h(4829,14): error C4996: 'simdjson::dom::parser::Iterator': Use the new DOM navigation API instead (see doc/usage.md) (compiling source file src\simdjson.cpp)

2) **Change available_implementation_pointers from constexpr to static const**

available_implementation_pointers is a list of non-constexpr objects that use std::string member variables and virtual function. Attempts to create a constexpr variable from pointers to objects that aren't constexpr results in a compilation error in VS2019

And regenerated amalgamated headers