### PR TITLE
[WIP] Fix type conversion warnings on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.9) # CMP0069 NEW
-include(GNUInstallDirs)
 
 message(STATUS "cmake version ${CMAKE_VERSION}")
 if (NOT CMAKE_BUILD_TYPE)
@@ -11,6 +10,8 @@ project(simdjson
   DESCRIPTION "Parsing gigabytes of JSON per second"
   LANGUAGES CXX C
 )
+
+include(GNUInstallDirs)
 
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 3)
@@ -52,7 +53,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 add_library(simdjson-flags INTERFACE)
 if(MSVC)
   target_compile_options(simdjson-flags INTERFACE /nologo /D_CRT_SECURE_NO_WARNINGS)
-  target_compile_options(simdjson-flags INTERFACE /WX /W3 /wd4005 /wd4996 /wd4267 /wd4244 /wd4113)
+  target_compile_options(simdjson-flags INTERFACE /WX /W3 /wd4005 /wd4996 /wd4113)
 else()
   target_compile_options(simdjson-flags INTERFACE -fPIC)
   target_compile_options(simdjson-flags INTERFACE -Werror -Wall -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,8 @@
 cmake_minimum_required(VERSION 3.9) # CMP0069 NEW
-
-message(STATUS "cmake version ${CMAKE_VERSION}")
-if (NOT CMAKE_BUILD_TYPE)
-  message(STATUS "No build type selected, default to Release")
-  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
-endif()
-
 project(simdjson
   DESCRIPTION "Parsing gigabytes of JSON per second"
   LANGUAGES CXX C
 )
-
-include(GNUInstallDirs)
-
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 3)
 set(PROJECT_VERSION_PATCH 1)
@@ -20,107 +10,10 @@ set(SIMDJSON_LIB_VERSION "0.3.1" CACHE STRING "simdjson library version")
 set(SIMDJSON_LIB_SOVERSION "1" CACHE STRING "simdjson library soversion")
 set(SIMDJSON_GITHUB_REPOSITORY https://github.com/simdjson/simdjson)
 
-if(MSVC)
-  option(SIMDJSON_BUILD_STATIC "Build a static library" ON) # turning it on disables the production of a dynamic library
-  option(SIMDJSON_COMPETITION "Compile competitive benchmarks" OFF)
-else()
-  option(SIMDJSON_BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library
-  option(SIMDJSON_COMPETITION "Compile competitive benchmarks" ON)
-endif()
-option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" OFF)
-
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
-
-# We compile tools, tests, etc. with C++ 17. Override yourself if you need on a target.
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
-set(CMAKE_MACOSX_RPATH OFF)
-set(CMAKE_THREAD_PREFER_PTHREAD ON)
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-
-# LTO seems to create all sorts of fun problems. Let us
-# disable temporarily.
-#include(CheckIPOSupported)
-#check_ipo_supported(RESULT ltoresult)
-#if(ltoresult)
-#  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-#endif()
-
 #
-# Flags used by exes and by the simdjson library (project-wide flags)
+# simdjson flags and global options
 #
-add_library(simdjson-flags INTERFACE)
-if(MSVC)
-  target_compile_options(simdjson-flags INTERFACE /nologo /D_CRT_SECURE_NO_WARNINGS)
-  target_compile_options(simdjson-flags INTERFACE /WX /W3 /wd4005 /wd4996 /wd4113)
-else()
-  target_compile_options(simdjson-flags INTERFACE -fPIC)
-  target_compile_options(simdjson-flags INTERFACE -Werror -Wall -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self)
-endif()
-
-# Optional flags
-option(SIMDJSON_IMPLEMENTATION_HASWELL "Include the haswell implementation" ON)
-if(NOT SIMDJSON_IMPLEMENTATION_HASWELL)
-  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_HASWELL=0)
-endif()
-option(SIMDJSON_IMPLEMENTATION_WESTMERE "Include the westmere implementation" ON)
-if(NOT SIMDJSON_IMPLEMENTATION_WESTMERE)
-  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_WESTMERE=0)
-endif()
-option(SIMDJSON_IMPLEMENTATION_ARM64 "Include the arm64 implementation" ON)
-if(NOT SIMDJSON_IMPLEMENTATION_ARM64)
-  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_ARM64=0)
-endif()
-option(SIMDJSON_IMPLEMENTATION_FALLBACK "Include the fallback implementation" ON)
-if(NOT SIMDJSON_IMPLEMENTATION_FALLBACK)
-  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_FALLBACK=0)
-endif()
-
-option(SIMDJSON_EXCEPTIONS "Enable simdjson's exception-throwing interface" ON)
-if(NOT SIMDJSON_EXCEPTIONS)
-  message(STATUS "simdjson exception interface turned off. Code that does not check error codes will not compile.")
-  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_EXCEPTIONS=0)
-endif()
-
-option(SIMDJSON_ENABLE_THREADS "Enable threaded operation" ON)
-if(SIMDJSON_ENABLE_THREADS)
-  find_package(Threads REQUIRED)
-  target_link_libraries(simdjson-flags INTERFACE Threads::Threads)
-endif()
-
-option(SIMDJSON_SANITIZE "Sanitize addresses" OFF)
-if(SIMDJSON_SANITIZE)
-  # Not sure which 
-  target_compile_options(simdjson-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
-  target_link_libraries(simdjson-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
-
-  # Ubuntu bug for GCC 5.0+ (safe for all versions)
-  if (CMAKE_COMPILER_IS_GNUCC)
-    target_link_libraries(simdjson-flags INTERFACE -fuse-ld=gold)
-  endif()
-endif()
-
-# prevent shared libraries from depending on Intel provided libraries
-if(${CMAKE_C_COMPILER_ID} MATCHES "Intel") # icc / icpc
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-intel")
-endif()
-
-# Workaround for https://gitlab.kitware.com/cmake/cmake/issues/15415#note_633938:
-function(export_private_library NAME)
-  install(TARGETS ${NAME}
-    EXPORT ${NAME}-config
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-  )
-  install(EXPORT ${NAME}-config
-    FILE ${NAME}-config.cmake
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simdjson-private
-  )
-endfunction()
-
-export_private_library(simdjson-flags)
+include(simdjson-flags.cmake)
 
 #
 # ${SIMDJSON_USER_CMAKECACHE} contains the *user-specified* simdjson options so you can call cmake on
@@ -140,8 +33,8 @@ if (NOT MSVC)
 endif()
 
 #
-# Create the top level simdjson library (must be done at this level to use both src/ and include/
-# directories) and tools
+# simdjson core library and tools
+
 #
 add_subdirectory(include)
 add_subdirectory(src)

--- a/benchmark/event_counter.h
+++ b/benchmark/event_counter.h
@@ -56,11 +56,11 @@ struct event_count {
 
   double elapsed_sec() const { return duration<double>(elapsed).count(); }
   double elapsed_ns() const { return duration<double, std::nano>(elapsed).count(); }
-  double cycles() const { return event_counts[CPU_CYCLES]; }
-  double instructions() const { return event_counts[INSTRUCTIONS]; }
-  double branch_misses() const { return event_counts[BRANCH_MISSES]; }
-  double cache_references() const { return event_counts[CACHE_REFERENCES]; }
-  double cache_misses() const { return event_counts[CACHE_MISSES]; }
+  double cycles() const { return static_cast<double>(event_counts[CPU_CYCLES]); }
+  double instructions() const { return static_cast<double>(event_counts[INSTRUCTIONS]); }
+  double branch_misses() const { return static_cast<double>(event_counts[BRANCH_MISSES]); }
+  double cache_references() const { return static_cast<double>(event_counts[CACHE_REFERENCES]); }
+  double cache_misses() const { return static_cast<double>(event_counts[CACHE_MISSES]); }
 
   event_count& operator=(const event_count& other) {
     this->elapsed = other.elapsed;

--- a/benchmark/perfdiff.cpp
+++ b/benchmark/perfdiff.cpp
@@ -32,7 +32,7 @@ std::string exec(const char* cmd) {
         std::cerr << "popen() failed!" << std::endl;
         abort();
     }
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
         result += buffer.data();
     }
     return result;
@@ -44,10 +44,10 @@ double readThroughput(std::string parseOutput) {
     double result = 0;
     int numResults = 0;
     while (std::getline(output, line)) {
-        int pos = 0;
-        for (int i=0; i<5; i++) {
+        size_t pos = 0;
+        for (size_t i=0; i<5; i++) {
             pos = line.find('\t', pos);
-            if (pos < 0) {
+            if (pos == std::string::npos) {
                 std::cerr << "Command printed out a line with less than 5 fields in it:\n" << line << std::endl;
             }
             pos++;

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -815,9 +815,9 @@ inline simdjson_result<double> element::get<double>() const noexcept {
   // information. (This could also be solved with profile-guided optimization.)
   if(unlikely(!is_double())) { // branch rarely taken
     if(is_uint64()) {
-      return next_tape_value<uint64_t>();
+      return static_cast<double>(next_tape_value<uint64_t>());
     } else if(is_int64()) {
-      return next_tape_value<int64_t>();
+      return static_cast<double>(next_tape_value<int64_t>());
     }
     return INCORRECT_TYPE;
   }

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -33,7 +33,7 @@ namespace internal {
  * complete
  * document, therefore the last json buffer location is the end of the batch
  * */
-inline size_t find_last_json_buf_idx(const uint8_t *buf, size_t size, const dom::parser &parser) {
+inline uint32_t find_last_json_buf_idx(const uint8_t *buf, size_t size, const dom::parser &parser) {
   // this function can be generally useful
   if (parser.n_structural_indexes == 0)
     return 0;
@@ -172,7 +172,7 @@ inline error_code document_stream::json_parse() noexcept {
       if (stage1_is_ok != simdjson::SUCCESS) {
         return stage1_is_ok;
       }
-      size_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
+      uint32_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
       if (last_index == 0) {
         if (parser.n_structural_indexes == 0) {
           return simdjson::EMPTY;

--- a/include/simdjson/inline/parsedjson_iterator.h
+++ b/include/simdjson/inline/parsedjson_iterator.h
@@ -427,7 +427,7 @@ bool dom::parser::Iterator::relative_move_to(const char *pointer,
 
   bool found = false;
   if (is_object()) {
-    if (move_to_key(key_or_index.c_str(), key_or_index.length())) {
+    if (move_to_key(key_or_index.c_str(), static_cast<uint32_t>(key_or_index.length()))) {
       found = relative_move_to(pointer + offset, length - offset);
     }
   } else if (is_array()) {

--- a/include/simdjson/parsedjson_iterator.h
+++ b/include/simdjson/parsedjson_iterator.h
@@ -187,7 +187,7 @@ public:
   // is referenced is undefined, and evaluation fails". Here we just return
   // the first corresponding value.
   inline bool move_to(const std::string &pointer) {
-      return move_to(pointer.c_str(), pointer.length());
+    return move_to(pointer.c_str(), static_cast<uint32_t>(pointer.length()));
   }
 
   private:

--- a/simdjson-flags.cmake
+++ b/simdjson-flags.cmake
@@ -1,0 +1,113 @@
+#
+# User options
+#
+if(MSVC)
+  option(SIMDJSON_BUILD_STATIC "Build a static library" ON) # turning it on disables the production of a dynamic library
+  option(SIMDJSON_COMPETITION "Compile competitive benchmarks" OFF)
+else()
+  option(SIMDJSON_BUILD_STATIC "Build a static library" OFF) # turning it on disables the production of a dynamic library
+  option(SIMDJSON_COMPETITION "Compile competitive benchmarks" ON)
+endif()
+option(SIMDJSON_ENABLE_THREADS "Enable threaded operation" ON)
+option(SIMDJSON_EXCEPTIONS "Enable simdjson's exception-throwing interface" ON)
+option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" OFF)
+option(SIMDJSON_IMPLEMENTATION_HASWELL "Include the haswell implementation" ON)
+option(SIMDJSON_IMPLEMENTATION_WESTMERE "Include the westmere implementation" ON)
+option(SIMDJSON_IMPLEMENTATION_ARM64 "Include the arm64 implementation" ON)
+option(SIMDJSON_IMPLEMENTATION_FALLBACK "Include the fallback implementation" ON)
+option(SIMDJSON_SANITIZE "Sanitize addresses" OFF)
+
+#
+# Global CMAKE options
+#
+message(STATUS "cmake version ${CMAKE_VERSION}")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_MACOSX_RPATH OFF)
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+if (NOT CMAKE_BUILD_TYPE)
+  message(STATUS "No build type selected, default to Release")
+  set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+endif()
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
+include(GNUInstallDirs)
+
+# Workaround for https://gitlab.kitware.com/cmake/cmake/issues/15415#note_633938:
+function(export_private_library NAME)
+  install(TARGETS ${NAME}
+    EXPORT ${NAME}-config
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  )
+  install(EXPORT ${NAME}-config
+    FILE ${NAME}-config.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simdjson-private
+  )
+endfunction()
+
+#
+# Flags used by exes and by the simdjson library (project-wide flags)
+#
+# We compile tools, tests, etc. with C++ 17. Override yourself if you need on a target.
+
+add_library(simdjson-flags INTERFACE)
+if(MSVC)
+  target_compile_options(simdjson-flags INTERFACE /nologo /D_CRT_SECURE_NO_WARNINGS)
+  target_compile_options(simdjson-flags INTERFACE /WX /W3 /wd4005 /wd4996 /wd4113)
+else()
+  target_compile_options(simdjson-flags INTERFACE -fPIC)
+  target_compile_options(simdjson-flags INTERFACE -Werror -Wall -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self)
+endif()
+
+# Optional flags
+if(NOT SIMDJSON_IMPLEMENTATION_HASWELL)
+  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_HASWELL=0)
+endif()
+if(NOT SIMDJSON_IMPLEMENTATION_WESTMERE)
+  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_WESTMERE=0)
+endif()
+if(NOT SIMDJSON_IMPLEMENTATION_ARM64)
+  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_ARM64=0)
+endif()
+if(NOT SIMDJSON_IMPLEMENTATION_FALLBACK)
+  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_IMPLEMENTATION_FALLBACK=0)
+endif()
+
+if(NOT SIMDJSON_EXCEPTIONS)
+  message(STATUS "simdjson exception interface turned off. Code that does not check error codes will not compile.")
+  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_EXCEPTIONS=0)
+endif()
+
+if(SIMDJSON_ENABLE_THREADS)
+  find_package(Threads REQUIRED)
+  target_link_libraries(simdjson-flags INTERFACE Threads::Threads)
+endif()
+
+if(SIMDJSON_SANITIZE)
+  # Not sure which 
+  target_compile_options(simdjson-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
+  target_link_libraries(simdjson-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
+
+  # Ubuntu bug for GCC 5.0+ (safe for all versions)
+  if (CMAKE_COMPILER_IS_GNUCC)
+    target_link_libraries(simdjson-flags INTERFACE -fuse-ld=gold)
+  endif()
+endif()
+
+# prevent shared libraries from depending on Intel provided libraries
+if(${CMAKE_C_COMPILER_ID} MATCHES "Intel") # icc / icpc
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-intel")
+endif()
+
+# LTO seems to create all sorts of fun problems. Let us
+# disable temporarily.
+#include(CheckIPOSupported)
+#check_ipo_supported(RESULT ltoresult)
+#if(ltoresult)
+#  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+#endif()
+
+export_private_library(simdjson-flags)

--- a/src/arm64/stage1_find_marks.h
+++ b/src/arm64/stage1_find_marks.h
@@ -83,7 +83,7 @@ WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, ui
 #include "generic/utf8_lookup2_algorithm.h"
 #include "generic/json_structural_indexer.h"
 WARN_UNUSED error_code implementation::stage1(const uint8_t *buf, size_t len, parser &parser, bool streaming) const noexcept {
-  return arm64::stage1::json_structural_indexer::index<64>(buf, len, parser, streaming);
+  return arm64::stage1::json_structural_indexer::index<64>(buf, static_cast<uint32_t>(len), parser, streaming);
 }
 
 } // namespace arm64

--- a/src/document_parser_callbacks.h
+++ b/src/document_parser_callbacks.h
@@ -94,7 +94,7 @@ really_inline uint8_t *parser::on_start_string() noexcept {
 }
 
 really_inline bool parser::on_end_string(uint8_t *dst) noexcept {
-  uint32_t str_length = dst - (current_string_buf_loc + sizeof(uint32_t));
+  uint32_t str_length = static_cast<uint32_t>(dst - (current_string_buf_loc + sizeof(uint32_t)));
   // TODO check for overflow in case someone has a crazy string (>=4GB?)
   // But only add the overflow check when the document itself exceeds 4GB
   // Currently unneeded because we refuse to parse docs larger or equal to 4GB.

--- a/src/fallback/stage1_find_marks.h
+++ b/src/fallback/stage1_find_marks.h
@@ -127,7 +127,7 @@ really_inline error_code scan() {
   }
   *next_structural_index = len;
   next_structural_index++;
-  doc_parser.n_structural_indexes = next_structural_index - doc_parser.structural_indexes.get();
+  doc_parser.n_structural_indexes = static_cast<uint32_t>(next_structural_index - doc_parser.structural_indexes.get());
   return error;
 }
 
@@ -148,7 +148,7 @@ WARN_UNUSED error_code implementation::stage1(const uint8_t *buf, size_t len, pa
   if (unlikely(len > parser.capacity())) {
     return CAPACITY;
   }
-  stage1::structural_scanner scanner(buf, len, parser, streaming);
+  stage1::structural_scanner scanner(buf, static_cast<uint32_t>(len), parser, streaming);
   return scanner.scan();
 }
 

--- a/src/generic/atomparsing.h
+++ b/src/generic/atomparsing.h
@@ -16,7 +16,7 @@ really_inline bool is_valid_true_atom(const uint8_t *src) {
 }
 
 WARN_UNUSED
-really_inline bool is_valid_true_atom(const uint8_t *src, size_t len) {
+really_inline bool is_valid_true_atom(const uint8_t *src, uint32_t len) {
   if (len > 4) { return is_valid_true_atom(src); }
   else if (len == 4) { return !str4ncmp(src, "true"); }
   else { return false; }
@@ -28,7 +28,7 @@ really_inline bool is_valid_false_atom(const uint8_t *src) {
 }
 
 WARN_UNUSED
-really_inline bool is_valid_false_atom(const uint8_t *src, size_t len) {
+really_inline bool is_valid_false_atom(const uint8_t *src, uint32_t len) {
   if (len > 5) { return is_valid_false_atom(src); }
   else if (len == 5) { return !str4ncmp(src+1, "alse"); }
   else { return false; }
@@ -40,7 +40,7 @@ really_inline bool is_valid_null_atom(const uint8_t *src) {
 }
 
 WARN_UNUSED
-really_inline bool is_valid_null_atom(const uint8_t *src, size_t len) {
+really_inline bool is_valid_null_atom(const uint8_t *src, uint32_t len) {
   if (len > 4) { return is_valid_null_atom(src); }
   else if (len == 4) { return !str4ncmp(src, "null"); }
   else { return false; }

--- a/src/generic/buf_block_reader.h
+++ b/src/generic/buf_block_reader.h
@@ -1,9 +1,9 @@
 // Walks through a buffer in block-sized increments, loading the last part with spaces
-template<size_t STEP_SIZE>
+template<uint32_t STEP_SIZE>
 struct buf_block_reader {
 public:
-  really_inline buf_block_reader(const uint8_t *_buf, size_t _len) : buf{_buf}, len{_len}, lenminusstep{len < STEP_SIZE ? 0 : len - STEP_SIZE}, idx{0} {}
-  really_inline size_t block_index() { return idx; }
+  really_inline buf_block_reader(const uint8_t *_buf, uint32_t _len) : buf{_buf}, len{_len}, lenminusstep{len < STEP_SIZE ? 0 : len - STEP_SIZE}, idx{0} {}
+  really_inline uint32_t block_index() { return idx; }
   really_inline bool has_full_block() const {
     return idx < lenminusstep;
   }
@@ -22,16 +22,16 @@ public:
   }
 private:
   const uint8_t *buf;
-  const size_t len;
-  const size_t lenminusstep;
-  size_t idx;
+  const uint32_t len;
+  const uint32_t lenminusstep;
+  uint32_t idx;
 };
 
 // Routines to print masks and text for debugging bitmask operations
 UNUSED static char * format_input_text(const simd8x64<uint8_t> in) {
   static char *buf = (char*)malloc(sizeof(simd8x64<uint8_t>) + 1);
   in.store((uint8_t*)buf);
-  for (size_t i=0; i<sizeof(simd8x64<uint8_t>); i++) {
+  for (uint32_t i=0; i<sizeof(simd8x64<uint8_t>); i++) {
     if (buf[i] < ' ') { buf[i] = '_'; }
   }
   buf[sizeof(simd8x64<uint8_t>)] = '\0';
@@ -40,8 +40,8 @@ UNUSED static char * format_input_text(const simd8x64<uint8_t> in) {
 
 UNUSED static char * format_mask(uint64_t mask) {
   static char *buf = (char*)malloc(64 + 1);
-  for (size_t i=0; i<64; i++) {
-    buf[i] = (mask & (size_t(1) << i)) ? 'X' : ' ';
+  for (int i=0; i<64; i++) {
+    buf[i] = (mask & (1ULL << i)) ? 'X' : ' ';
   }
   buf[64] = '\0';
   return buf;

--- a/src/generic/json_minifier.h
+++ b/src/generic/json_minifier.h
@@ -55,7 +55,7 @@ really_inline void json_minifier::step<64>(const uint8_t *block_buf, buf_block_r
 
 template<size_t STEP_SIZE>
 error_code json_minifier::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) noexcept {
-  buf_block_reader<STEP_SIZE> reader(buf, len);
+  buf_block_reader<STEP_SIZE> reader(buf, static_cast<uint32_t>(len));
   json_minifier minifier(dst);
   while (reader.has_full_block()) {
     minifier.step<STEP_SIZE>(reader.full_block(), reader);

--- a/src/generic/numberparsing.h
+++ b/src/generic/numberparsing.h
@@ -16,7 +16,7 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative,
   if (-22 <= power && power <= 22 && i <= 9007199254740991) {
     // convert the integer into a double. This is lossless since
     // 0 <= i <= 2^53 - 1.
-    double d = i;
+    double d = static_cast<double>(i);
     //
     // The general idea is as follows.
     // If 0 <= s < 2^53 and if 10^0 <= p <= 10^22 then
@@ -122,7 +122,7 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative,
   ///////
   uint64_t upperbit = upper >> 63;
   uint64_t mantissa = upper >> (upperbit + 9);
-  lz += 1 ^ upperbit;
+  lz += 1 ^ static_cast<int>(upperbit);
 
   // Here we have mantissa < (1<<54).
 
@@ -455,8 +455,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
     }
     exponent = first_after_period - p;
   }
-  int digit_count =
-      p - start_digits - 1; // used later to guard against overflows
+  int digit_count = static_cast<int>(p - start_digits - 1); // used later to guard against overflows
   int64_t exp_number = 0;   // exponential part
   if (('e' == *p) || ('E' == *p)) {
     is_float = true;
@@ -513,7 +512,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
         start++;
       }
       // we over-decrement by one when there is a '.'
-      digit_count -= (start - start_digits);
+      digit_count -= static_cast<int>(start - start_digits);
       if (digit_count >= 19) {
         // Ok, chances are good that we had an overflow!
         // this is almost never going to get called!!!

--- a/src/generic/stage2_streaming_build_tape.h
+++ b/src/generic/stage2_streaming_build_tape.h
@@ -1,10 +1,10 @@
 namespace stage2 {
 
 struct streaming_structural_parser: structural_parser {
-  really_inline streaming_structural_parser(const uint8_t *_buf, size_t _len, parser &_doc_parser, size_t _i) : structural_parser(_buf, _len, _doc_parser, _i) {}
+  really_inline streaming_structural_parser(const uint8_t *_buf, uint32_t _len, parser &_doc_parser, uint32_t _i) : structural_parser(_buf, _len, _doc_parser, _i) {}
 
   // override to add streaming
-  WARN_UNUSED really_inline error_code start(UNUSED size_t len, ret_address finish_parser) {
+  WARN_UNUSED really_inline error_code start(UNUSED uint32_t len, ret_address finish_parser) {
     doc_parser.init_stage2(); // sets is_valid to false
     // Capacity ain't no thang for streaming, so we don't check it.
     // Advance to the first character as soon as possible
@@ -41,8 +41,8 @@ struct streaming_structural_parser: structural_parser {
  ***********/
 WARN_UNUSED error_code implementation::stage2(const uint8_t *buf, size_t len, parser &doc_parser, size_t &next_json) const noexcept {
   static constexpr stage2::unified_machine_addresses addresses = INIT_ADDRESSES();
-  stage2::streaming_structural_parser parser(buf, len, doc_parser, next_json);
-  error_code result = parser.start(len, addresses.finish);
+  stage2::streaming_structural_parser parser(buf, static_cast<uint32_t>(len), doc_parser, static_cast<uint32_t>(next_json));
+  error_code result = parser.start(static_cast<uint32_t>(len), addresses.finish);
   if (result) { return result; }
   //
   // Read first value

--- a/src/haswell/stage1_find_marks.h
+++ b/src/haswell/stage1_find_marks.h
@@ -72,7 +72,7 @@ WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, ui
 #include "generic/utf8_lookup2_algorithm.h"
 #include "generic/json_structural_indexer.h"
 WARN_UNUSED error_code implementation::stage1(const uint8_t *buf, size_t len, parser &parser, bool streaming) const noexcept {
-  return haswell::stage1::json_structural_indexer::index<128>(buf, len, parser, streaming);
+  return haswell::stage1::json_structural_indexer::index<128>(buf, static_cast<uint32_t>(len), parser, streaming);
 }
 
 } // namespace haswell

--- a/src/westmere/bitmanipulation.h
+++ b/src/westmere/bitmanipulation.h
@@ -44,14 +44,16 @@ really_inline int leading_zeroes(uint64_t input_num) {
 #endif// _MSC_VER
 }
 
-really_inline int count_ones(uint64_t input_num) {
 #ifdef _MSC_VER
+really_inline uint64_t count_ones(uint64_t input_num) {
   // note: we do not support legacy 32-bit Windows
   return __popcnt64(input_num);// Visual Studio wants two underscores
-#else
-  return _popcnt64(input_num);
-#endif
 }
+#else
+really_inline uint64_t count_ones(uint64_t input_num) {
+  return _popcnt64(input_num);
+}
+#endif
 
 really_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                 uint64_t *result) {

--- a/src/westmere/simd.h
+++ b/src/westmere/simd.h
@@ -278,10 +278,10 @@ namespace simd {
     }
 
     really_inline void compress(uint64_t mask, T * output) const {
-      this->chunks[0].compress(mask, output);
-      this->chunks[1].compress(mask >> 16, output + 16 - count_ones(mask & 0xFFFF));
-      this->chunks[2].compress(mask >> 32, output + 32 - count_ones(mask & 0xFFFFFFFF));
-      this->chunks[3].compress(mask >> 48, output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
+      this->chunks[0].compress(static_cast<uint16_t>(mask), output);
+      this->chunks[1].compress(static_cast<uint16_t>(mask >> 16), output + 16 - count_ones(mask & 0xFFFF));
+      this->chunks[2].compress(static_cast<uint16_t>(mask >> 32), output + 32 - count_ones(mask & 0xFFFFFFFF));
+      this->chunks[3].compress(static_cast<uint16_t>(mask >> 48), output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
     }
 
     template <typename F>

--- a/src/westmere/stage1_find_marks.h
+++ b/src/westmere/stage1_find_marks.h
@@ -71,7 +71,7 @@ WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, ui
 #include "generic/utf8_lookup2_algorithm.h"
 #include "generic/json_structural_indexer.h"
 WARN_UNUSED error_code implementation::stage1(const uint8_t *buf, size_t len, parser &parser, bool streaming) const noexcept {
-  return westmere::stage1::json_structural_indexer::index<64>(buf, len, parser, streaming);
+  return westmere::stage1::json_structural_indexer::index<64>(buf, static_cast<uint32_t>(len), parser, streaming);
 }
 
 } // namespace westmere

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -73,7 +73,7 @@ namespace number_tests {
     std::cout << __func__ << std::endl;
     char buf[1024];
     simdjson::dom::parser parser;
-    int maxulp = 0;
+    uint64_t maxulp = 0;
     for (int i = -1075; i < 1024; ++i) {// large negative values should be zero.
       double expected = pow(2, i);
       auto n = sprintf(buf, "%.*e", std::numeric_limits<double>::max_digits10 - 1, expected);
@@ -81,7 +81,7 @@ namespace number_tests {
       fflush(NULL);
       auto [actual, error] = parser.parse(buf, n).get<double>();
       if (error) { std::cerr << error << std::endl; return false; }
-      int ulp = f64_ulp_dist(actual,expected);  
+      uint64_t ulp = f64_ulp_dist(actual,expected);  
       if(ulp > maxulp) maxulp = ulp;
       if(ulp > 0) {
         std::cerr << "JSON '" << buf << " parsed to " << actual << " instead of " << expected << std::endl;
@@ -1563,7 +1563,7 @@ namespace type_tests {
       && (expected_value >= 0 ?
           test_cast<uint64_t>(result, expected_value) :
           test_cast<uint64_t>(result, NUMBER_OUT_OF_RANGE))
-      && test_cast<double>(result, expected_value)
+      && test_cast<double>(result, static_cast<double>(expected_value))
       && test_cast<bool>(result, INCORRECT_TYPE)
       && test_is_null(result, false);
   }
@@ -1582,7 +1582,7 @@ namespace type_tests {
       && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, NUMBER_OUT_OF_RANGE)
       && test_cast<uint64_t>(result, expected_value)
-      && test_cast<double>(result, expected_value)
+      && test_cast<double>(result, static_cast<double>(expected_value))
       && test_cast<bool>(result, INCORRECT_TYPE)
       && test_is_null(result, false);
   }


### PR DESCRIPTION
Paying down the Windows warning debt.

Also moved the flags into simdjson-flags.cmake, something I've wanted to do. The general recommendation for cmake projects is to have the top level cmake mostly include other stuff.