### PR TITLE
This removes the problematic use of the intrinsic _addcarry_u64 for Visual Studio

### DIFF
--- a/src/arm64/bitmanipulation.h
+++ b/src/arm64/bitmanipulation.h
@@ -50,9 +50,8 @@ really_inline int count_ones(uint64_t input_num) {
 
 really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
 #ifdef _MSC_VER
-  // todo: this might fail under visual studio for ARM
-  return _addcarry_u64(0, value1, value2,
-                       reinterpret_cast<unsigned __int64 *>(result));
+  *result = value1 + value2;
+  return *result < value1;
 #else
   return __builtin_uaddll_overflow(value1, value2,
                                    (unsigned long long *)result);


### PR DESCRIPTION


in the ARM 64-bit kernel. This intrinsic does not appear in the documentation
https://docs.microsoft.com/en-us/cpp/intrinsics/arm64-intrinsics?view=vs-2019
and should probably not be used. Note that we expect the compiler to produce
efficient code out of our implementation.