### PR TITLE
Compile with conversion warnings enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,10 +52,10 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 add_library(simdjson-flags INTERFACE)
 if(MSVC)
   target_compile_options(simdjson-flags INTERFACE /nologo /D_CRT_SECURE_NO_WARNINGS)
-  target_compile_options(simdjson-flags INTERFACE /WX /W3 /wd4267 /wd4244)
+  target_compile_options(simdjson-flags INTERFACE /WX /W3)
 else()
   target_compile_options(simdjson-flags INTERFACE -fPIC)
-  target_compile_options(simdjson-flags INTERFACE -Werror -Wall -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self)
+  target_compile_options(simdjson-flags INTERFACE -Werror -Wall -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
 endif()
 
 # Optional flags

--- a/benchmark/benchmark.h
+++ b/benchmark/benchmark.h
@@ -60,7 +60,7 @@ uint64_t global_rdtsc_overhead = (uint64_t)UINT64_MAX;
   do {                                                                         \
     uint64_t cycles_start, cycles_final, cycles_diff;                          \
     uint64_t min_diff = UINT64_MAX;                                            \
-    for (int i = 0; i < repeat; i++) {                                         \
+    for (decltype(repeat) i = 0; i < repeat; i++) {                                         \
       __asm volatile("" ::: /* pretend to clobber */ "memory");                \
       RDTSC_START(cycles_start);                                               \
       test;                                                                    \
@@ -73,7 +73,7 @@ uint64_t global_rdtsc_overhead = (uint64_t)UINT64_MAX;
   } while (0)
 
 double diff(timespec start, timespec end) {
-  return ((end.tv_nsec + 1000000000 * end.tv_sec) -
+  return static_cast<double>((end.tv_nsec + 1000000000 * end.tv_sec) -
           (start.tv_nsec + 1000000000 * start.tv_sec)) /
          1000000000.0;
 }
@@ -100,7 +100,7 @@ double diff(timespec start, timespec end) {
     uint64_t sum_diff = 0;                                                     \
     double sumclockdiff = 0;                                                   \
     struct timespec time1, time2;                                              \
-    for (int i = 0; i < repeat; i++) {                                         \
+    for (decltype(repeat) i = 0; i < repeat; i++) {                                         \
       pre;                                                                     \
       __asm volatile("" ::: /* pretend to clobber */ "memory");                \
       clock_gettime(CLOCK_REALTIME, &time1);                                   \
@@ -121,12 +121,12 @@ double diff(timespec start, timespec end) {
       sum_diff += cycles_diff;                                                 \
     }                                                                          \
     uint64_t S = size;                                                         \
-    float cycle_per_op = (min_diff) / (double)S;                               \
-    float avg_cycle_per_op = (sum_diff) / ((double)S * repeat);                \
+    double cycle_per_op = static_cast<double>(min_diff) / static_cast<double>(S);                               \
+    double avg_cycle_per_op = static_cast<double>(sum_diff) / (static_cast<double>(S) * static_cast<double>(repeat));                \
     double avg_gb_per_s =                                                      \
-        ((double)S * repeat) / ((sumclockdiff)*1000.0 * 1000.0 * 1000.0);      \
+        (static_cast<double>(S) * static_cast<double>(repeat)) / ((sumclockdiff)*1000.0 * 1000.0 * 1000.0);      \
     double max_gb_per_s =                                                      \
-        ((double)S) / ((min_sumclockdiff)*1000.0 * 1000.0 * 1000.0);           \
+        static_cast<double>(S) / (min_sumclockdiff * 1000.0 * 1000.0 * 1000.0);           \
     if (verbose)                                                               \
       printf(" %7.3f %s per input byte (best) ", cycle_per_op, unitname);      \
     if (verbose)                                                               \
@@ -137,7 +137,7 @@ double diff(timespec start, timespec end) {
     if (verbose)                                                               \
       printf(" %13.0f documents/s (best)", 1.0/min_sumclockdiff);             \
     if (verbose)                                                               \
-      printf(" %13.0f documents/s (avg)", 1.0/(sumclockdiff/repeat));         \
+      printf(" %13.0f documents/s (avg)", 1.0/(sumclockdiff/static_cast<double>(repeat)));         \
     if (!verbose)                                                              \
       printf(" %20.3f %20.3f %20.3f %20.3f", cycle_per_op,                     \
              avg_cycle_per_op - cycle_per_op, max_gb_per_s,                    \
@@ -170,8 +170,8 @@ double diff(timespec start, timespec end) {
       sum_diff += cycles_diff;                                                 \
     }                                                                          \
     uint64_t S = size;                                                         \
-    float cycle_per_op = (min_diff) / (double)S;                               \
-    float avg_cycle_per_op = (sum_diff) / ((double)S * repeat);                \
+    double cycle_per_op = static_cast<double>(min_diff) / static_cast<double>(S);                               \
+    double avg_cycle_per_op = static_cast<double>(sum_diff) / (static_cast<double>(S) * static_cast<double>(repeat));                \
     if (verbose)                                                               \
       printf(" %.3f %s per input byte (best) ", cycle_per_op, unitname);       \
     if (verbose)                                                               \

--- a/benchmark/distinctuseridcompetition.cpp
+++ b/benchmark/distinctuseridcompetition.cpp
@@ -366,7 +366,7 @@ int main(int argc, char *argv[]) {
   size_t size = s1.size();
 
   int repeat = 500;
-  int volume = p.size();
+  size_t volume = p.size();
   if (just_data) {
     printf(
         "name cycles_per_byte cycles_per_byte_err  gb_per_s gb_per_s_err \n");

--- a/benchmark/event_counter.h
+++ b/benchmark/event_counter.h
@@ -56,11 +56,11 @@ struct event_count {
 
   double elapsed_sec() const { return duration<double>(elapsed).count(); }
   double elapsed_ns() const { return duration<double, std::nano>(elapsed).count(); }
-  double cycles() const { return event_counts[CPU_CYCLES]; }
-  double instructions() const { return event_counts[INSTRUCTIONS]; }
-  double branch_misses() const { return event_counts[BRANCH_MISSES]; }
-  double cache_references() const { return event_counts[CACHE_REFERENCES]; }
-  double cache_misses() const { return event_counts[CACHE_MISSES]; }
+  double cycles() const { return static_cast<double>(event_counts[CPU_CYCLES]); }
+  double instructions() const { return static_cast<double>(event_counts[INSTRUCTIONS]); }
+  double branch_misses() const { return static_cast<double>(event_counts[BRANCH_MISSES]); }
+  double cache_references() const { return static_cast<double>(event_counts[CACHE_REFERENCES]); }
+  double cache_misses() const { return static_cast<double>(event_counts[CACHE_MISSES]); }
 
   event_count& operator=(const event_count& other) {
     this->elapsed = other.elapsed;

--- a/benchmark/get_corpus_benchmark.cpp
+++ b/benchmark/get_corpus_benchmark.cpp
@@ -12,7 +12,7 @@ double bench(std::string filename, simdjson::padded_string& p) {
   std::chrono::time_point<std::chrono::steady_clock> end_clock =
       std::chrono::steady_clock::now();
   std::chrono::duration<double> elapsed = end_clock - start_clock;
-  return (p.size() / (1024. * 1024 * 1024.)) / elapsed.count();
+  return (static_cast<double>(p.size()) / (1024. * 1024. * 1024.)) / elapsed.count();
 }
 
 int main(int argc, char *argv[]) {
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
   double meanval = 0;
   double maxval = 0;
   double minval = 10000;
-std::cout << "file size: "<<  (p.size() / (1024. * 1024 * 1024.)) << " GB" <<std::endl;
+std::cout << "file size: "<<  (static_cast<double>(p.size()) / (1024. * 1024. * 1024.)) << " GB" <<std::endl;
   size_t times = p.size() > 1024*1024*1024 ? 5 : 50;
 #if __cpp_exceptions
   try {
@@ -49,7 +49,7 @@ std::cout << "file size: "<<  (p.size() / (1024. * 1024 * 1024.)) << " GB" <<std
     return EXIT_FAILURE;
    }
 #endif
-   std::cout << "average speed: " << meanval / times << " GB/s"<< std::endl;
+   std::cout << "average speed: " << meanval / static_cast<double>(times) << " GB/s"<< std::endl;
    std::cout << "min speed    : " << minval << " GB/s" << std::endl;
    std::cout << "max speed    : " << maxval << " GB/s" << std::endl;
    return EXIT_SUCCESS;

--- a/benchmark/linux/linux-perf-events.h
+++ b/benchmark/linux/linux-perf-events.h
@@ -18,7 +18,7 @@ template <int TYPE = PERF_TYPE_HARDWARE> class LinuxEvents {
   int fd;
   bool working;
   perf_event_attr attribs;
-  int num_events;
+  size_t num_events;
   std::vector<uint64_t> temp_result_vec;
   std::vector<uint64_t> ids;
 
@@ -43,7 +43,7 @@ public:
     uint32_t i = 0;
     for (auto config : config_vec) {
       attribs.config = config;
-      fd = syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags);
+      fd = static_cast<int>(syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags));
       if (fd == -1) {
         report_error("perf_event_open");
       }

--- a/benchmark/minifiercompetition.cpp
+++ b/benchmark/minifiercompetition.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
   buffer[p.size()] = '\0';
 
   int repeat = 50;
-  int volume = p.size();
+  size_t volume = p.size();
   if (just_data) {
     printf(
         "name cycles_per_byte cycles_per_byte_err  gb_per_s gb_per_s_err \n");
@@ -113,7 +113,7 @@ int main(int argc, char *argv[]) {
 
   printf("minisize = %zu, original size = %zu  (minified down to %.2f percent "
          "of original) \n",
-         outlength, p.size(), outlength * 100.0 / p.size());
+         outlength, p.size(), static_cast<double>(outlength) * 100.0 / static_cast<double>(p.size()));
 
   /***
    * Is it worth it to minify before parsing?

--- a/benchmark/parse_stream.cpp
+++ b/benchmark/parse_stream.cpp
@@ -56,7 +56,7 @@ int main (int argc, char *argv[]){
             auto end = std::chrono::steady_clock::now();
 
             std::chrono::duration<double> secs = end - start;
-            double speedinGBs = (p.size()) / (secs.count() * 1000000000.0);
+            double speedinGBs = static_cast<double>(p.size()) / (static_cast<double>(secs.count()) * 1000000000.0);
             std::cout << speedinGBs << "\t\t\t\t" << count << std::endl;
 
             if (parse_res != simdjson::SUCCESS) {
@@ -88,7 +88,7 @@ int main (int argc, char *argv[]){
                 auto end = std::chrono::steady_clock::now();
 
                 std::chrono::duration<double> secs = end - start;
-                double speedinGBs = (p.size()) / (secs.count() * 1000000000.0);
+                double speedinGBs = static_cast<double>(p.size()) / (static_cast<double>(secs.count()) * 1000000000.0);
                 if (speedinGBs > batch_size_res.at(i))
                     batch_size_res[i] = speedinGBs;
 
@@ -136,7 +136,7 @@ int main (int argc, char *argv[]){
         }
 
         double min_result = *min_element(res.begin(), res.end());
-        double speedinGBs = (p.size()) / (min_result * 1000000000.0);
+        double speedinGBs = static_cast<double>(p.size()) / (min_result * 1000000000.0);
 
 
         std::cout << "Min:  " << min_result << " bytes read: " << p.size()

--- a/benchmark/parseandstatcompetition.cpp
+++ b/benchmark/parseandstatcompetition.cpp
@@ -336,7 +336,7 @@ int main(int argc, char *argv[]) {
   assert(stat_equal(s1, s2));
   assert(stat_equal(s1, s3));
   int repeat = 50;
-  int volume = p.size();
+  size_t volume = p.size();
   if (just_data) {
     printf("name cycles_per_byte cycles_per_byte_err gb_per_s gb_per_s_err \n");
   }

--- a/benchmark/parsingcompetition.cpp
+++ b/benchmark/parsingcompetition.cpp
@@ -77,14 +77,14 @@ never_inline size_t sum_line_lengths(char * data, size_t length) {
 }
 
 
-bool bench(const char *filename, bool verbose, bool just_data, int repeat_multiplier) {
+bool bench(const char *filename, bool verbose, bool just_data, double repeat_multiplier) {
   auto [p, err] = simdjson::padded_string::load(filename);
   if (err) {
     std::cerr << "Could not load the file " << filename << std::endl;
     return false;
   }
 
-  int repeat = (50000000 * repeat_multiplier) / p.size();
+  int repeat = static_cast<int>((50000000 * repeat_multiplier) / static_cast<double>(p.size()));
   if (repeat < 10) { repeat = 10; }
 
   if (verbose) {
@@ -97,7 +97,7 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
       std::cout << p.size() << " B";
     std::cout << ": will run " << repeat << " iterations." << std::endl;
   }
-  int volume = p.size();
+  size_t volume = p.size();
   if (just_data) {
     printf("%-42s %20s %20s %20s %20s \n", "name", "cycles_per_byte",
            "cycles_per_byte_err", "gb_per_s", "gb_per_s_err");
@@ -214,7 +214,7 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
     buffer[p.size()] = '\0';
     BEST_TIME(
         "jsmn           ",
-        (jsmn_parse(&jparser, buffer, p.size(), tokens.get(), p.size()) > 0),
+        (jsmn_parse(&jparser, buffer, p.size(), tokens.get(), static_cast<unsigned int>(p.size())) > 0),
         true, jsmn_init(&jparser), repeat, volume, !just_data);
   }
   memcpy(buffer, p.data(), p.size());
@@ -253,7 +253,7 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
     results.resize(evts.size());
     stats.resize(evts.size());
     std::fill(stats.begin(), stats.end(), 0); // unnecessary
-    for (int i = 0; i < repeat; i++) {
+    for (decltype(repeat) i = 0; i < repeat; i++) {
       unified.start();
       auto parse_error = parser.parse(p).error();
       if (parse_error)
@@ -265,13 +265,13 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
     printf("simdjson : cycles %10.0f instructions %10.0f branchmisses %10.0f "
            "cacheref %10.0f cachemisses %10.0f  bytespercachemiss %10.0f "
            "inspercycle %10.1f insperbyte %10.1f\n",
-           stats[0] * 1.0 / repeat, stats[1] * 1.0 / repeat,
-           stats[2] * 1.0 / repeat, stats[3] * 1.0 / repeat,
-           stats[4] * 1.0 / repeat, volume * repeat * 1.0 / stats[2],
-           stats[1] * 1.0 / stats[0], stats[1] * 1.0 / (volume * repeat));
+           static_cast<double>(stats[0]) / static_cast<double>(repeat), static_cast<double>(stats[1]) / static_cast<double>(repeat),
+           static_cast<double>(stats[2]) / static_cast<double>(repeat), static_cast<double>(stats[3]) / static_cast<double>(repeat),
+           static_cast<double>(stats[4]) / static_cast<double>(repeat), static_cast<double>(volume) * static_cast<double>(repeat) / static_cast<double>(stats[2]),
+           static_cast<double>(stats[1]) / static_cast<double>(stats[0]), static_cast<double>(stats[1]) / (static_cast<double>(volume) * static_cast<double>(repeat)));
 
     std::fill(stats.begin(), stats.end(), 0);
-    for (int i = 0; i < repeat; i++) {
+    for (decltype(repeat) i = 0; i < repeat; i++) {
       memcpy(buffer, p.data(), p.size());
       buffer[p.size()] = '\0';
       unified.start();
@@ -285,13 +285,13 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
     printf("RapidJSON: cycles %10.0f instructions %10.0f branchmisses %10.0f "
            "cacheref %10.0f cachemisses %10.0f  bytespercachemiss %10.0f "
            "inspercycle %10.1f insperbyte %10.1f\n",
-           stats[0] * 1.0 / repeat, stats[1] * 1.0 / repeat,
-           stats[2] * 1.0 / repeat, stats[3] * 1.0 / repeat,
-           stats[4] * 1.0 / repeat, volume * repeat * 1.0 / stats[2],
-           stats[1] * 1.0 / stats[0], stats[1] * 1.0 / (volume * repeat));
+           static_cast<double>(stats[0]) / static_cast<double>(repeat), static_cast<double>(stats[1]) / static_cast<double>(repeat),
+           static_cast<double>(stats[2]) / static_cast<double>(repeat), static_cast<double>(stats[3]) / static_cast<double>(repeat),
+           static_cast<double>(stats[4]) / static_cast<double>(repeat), static_cast<double>(volume) * static_cast<double>(repeat) / static_cast<double>(stats[2]),
+           static_cast<double>(stats[1]) / static_cast<double>(stats[0]), static_cast<double>(stats[1]) / (static_cast<double>(volume) * static_cast<double>(repeat)));
 
     std::fill(stats.begin(), stats.end(), 0); // unnecessary
-    for (int i = 0; i < repeat; i++) {
+    for (decltype(repeat) i = 0; i < repeat; i++) {
       memcpy(buffer, p.data(), p.size());
       unified.start();
       if (sajson::parse(sajson::bounded_allocation(ast_buffer, ast_buffer_size),
@@ -305,10 +305,10 @@ bool bench(const char *filename, bool verbose, bool just_data, int repeat_multip
     printf("sajson   : cycles %10.0f instructions %10.0f branchmisses %10.0f "
            "cacheref %10.0f cachemisses %10.0f  bytespercachemiss %10.0f "
            "inspercycle %10.1f insperbyte %10.1f\n",
-           stats[0] * 1.0 / repeat, stats[1] * 1.0 / repeat,
-           stats[2] * 1.0 / repeat, stats[3] * 1.0 / repeat,
-           stats[4] * 1.0 / repeat, volume * repeat * 1.0 / stats[2],
-           stats[1] * 1.0 / stats[0], stats[1] * 1.0 / (volume * repeat));
+           static_cast<double>(stats[0]) / static_cast<double>(repeat), static_cast<double>(stats[1]) / static_cast<double>(repeat),
+           static_cast<double>(stats[2]) / static_cast<double>(repeat), static_cast<double>(stats[3]) / static_cast<double>(repeat),
+           static_cast<double>(stats[4]) / static_cast<double>(repeat), static_cast<double>(volume) * static_cast<double>(repeat) / static_cast<double>(stats[2]),
+           static_cast<double>(stats[1]) / static_cast<double>(stats[0]), static_cast<double>(stats[1]) / (static_cast<double>(volume) * static_cast<double>(repeat)));
 
   }
 #endif //  __linux__

--- a/benchmark/perfdiff.cpp
+++ b/benchmark/perfdiff.cpp
@@ -32,7 +32,7 @@ std::string exec(const char* cmd) {
         std::cerr << "popen() failed!" << std::endl;
         abort();
     }
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+    while (fgets(buffer.data(), int(buffer.size()), pipe.get()) != nullptr) {
         result += buffer.data();
     }
     return result;
@@ -44,10 +44,10 @@ double readThroughput(std::string parseOutput) {
     double result = 0;
     int numResults = 0;
     while (std::getline(output, line)) {
-        int pos = 0;
+        std::string::size_type pos = 0;
         for (int i=0; i<5; i++) {
             pos = line.find('\t', pos);
-            if (pos < 0) {
+            if (pos == std::string::npos) {
                 std::cerr << "Command printed out a line with less than 5 fields in it:\n" << line << std::endl;
             }
             pos++;

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -199,8 +199,8 @@ int main(int argc, char *argv[]) {
       std::cerr << "failure?" << std::endl;
     }
   }
-  printf("%f %f %f %f ", cy1 * 1.0 / iterations, cl1 * 1.0 / iterations,
-         cy2 * 1.0 / iterations, cl2 * 1.0 / iterations);
+  printf("%f %f %f %f ", static_cast<double>(cy1) / static_cast<double>(iterations), static_cast<double>(cl1) / static_cast<double>(iterations),
+         static_cast<double>(cy2) / static_cast<double>(iterations), static_cast<double>(cl2) / static_cast<double>(iterations));
 #endif // __linux__
   printf("\n");
   return EXIT_SUCCESS;

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -105,6 +105,7 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
   // gcc doesn't seem to disable all warnings with all and extra, add warnings here as necessary
   #define SIMDJSON_PUSH_DISABLE_ALL_WARNINGS SIMDJSON_PUSH_DISABLE_WARNINGS \
     SIMDJSON_DISABLE_GCC_WARNING(-Wall) \
+    SIMDJSON_DISABLE_GCC_WARNING(-Wconversion) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wextra) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wattributes) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wimplicit-fallthrough) \

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -229,12 +229,12 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
   uint32_t string_length;
   size_t tape_idx = 0;
   uint64_t tape_val = tape[tape_idx];
-  uint8_t type = (tape_val >> 56);
+  uint8_t type = uint8_t(tape_val >> 56);
   os << tape_idx << " : " << type;
   tape_idx++;
   size_t how_many = 0;
   if (type == 'r') {
-    how_many = tape_val & internal::JSON_VALUE_MASK;
+    how_many = size_t(tape_val & internal::JSON_VALUE_MASK);
   } else {
     // Error: no starting root node?
     return false;
@@ -245,7 +245,7 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
     os << tape_idx << " : ";
     tape_val = tape[tape_idx];
     payload = tape_val & internal::JSON_VALUE_MASK;
-    type = (tape_val >> 56);
+    type = uint8_t(tape_val >> 56);
     switch (type) {
     case '"': // we have a string
       os << "string \"";
@@ -312,7 +312,7 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
   }
   tape_val = tape[tape_idx];
   payload = tape_val & internal::JSON_VALUE_MASK;
-  type = (tape_val >> 56);
+  type = uint8_t(tape_val >> 56);
   os << tape_idx << " : " << type << "\t// pointing to " << payload
      << " (start root)\n";
   return true;
@@ -471,7 +471,7 @@ inline error_code parser::allocate(size_t capacity, size_t max_depth) noexcept {
     //
     // Initialize stage 1 output
     //
-    uint32_t max_structures = ROUNDUP_N(capacity, 64) + 2 + 7;
+    size_t max_structures = ROUNDUP_N(capacity, 64) + 2 + 7;
     structural_indexes.reset( new (std::nothrow) uint32_t[max_structures] ); // TODO realloc
     if (!structural_indexes) {
       return MEMALLOC;
@@ -565,7 +565,7 @@ inline simdjson_result<element> array::at(const std::string_view &json_pointer) 
   size_t array_index = 0;
   size_t i;
   for (i = 0; i < json_pointer.length() && json_pointer[i] != '/'; i++) {
-    uint8_t digit = uint8_t(json_pointer[i]) - '0';
+    uint8_t digit = uint8_t(json_pointer[i] - '0');
     // Check for non-digit in array index. If it's there, we're trying to get a field in an object
     if (digit > 9) { return INCORRECT_TYPE; }
     array_index = array_index*10 + digit;
@@ -708,7 +708,7 @@ inline void object::iterator::operator++() noexcept {
   json_index = after_element();
 }
 inline std::string_view object::iterator::key() const noexcept {
-  size_t string_buf_index = tape_value();
+  size_t string_buf_index = size_t(tape_value());
   uint32_t len;
   memcpy(&len, &doc->string_buf[string_buf_index], sizeof(len));
   return std::string_view(
@@ -717,7 +717,7 @@ inline std::string_view object::iterator::key() const noexcept {
   );
 }
 inline const char* object::iterator::key_c_str() const noexcept {
-  return reinterpret_cast<const char *>(&doc->string_buf[tape_value() + sizeof(uint32_t)]);
+  return reinterpret_cast<const char *>(&doc->string_buf[size_t(tape_value()) + sizeof(uint32_t)]);
 }
 inline element object::iterator::value() const noexcept {
   return element(doc, json_index + 1);
@@ -757,7 +757,7 @@ template<>
 inline simdjson_result<const char *> element::get<const char *>() const noexcept {
   switch (tape_ref_type()) {
     case internal::tape_type::STRING: {
-      size_t string_buf_index = tape_value();
+      size_t string_buf_index = size_t(tape_value());
       return reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]);
     }
     default:
@@ -781,7 +781,7 @@ inline simdjson_result<uint64_t> element::get<uint64_t>() const noexcept {
       if (result < 0) {
         return NUMBER_OUT_OF_RANGE;
       }
-      return static_cast<uint64_t>(result);
+      return uint64_t(result);
     }
     return INCORRECT_TYPE;
   }
@@ -815,9 +815,9 @@ inline simdjson_result<double> element::get<double>() const noexcept {
   // information. (This could also be solved with profile-guided optimization.)
   if(unlikely(!is_double())) { // branch rarely taken
     if(is_uint64()) {
-      return next_tape_value<uint64_t>();
+      return double(next_tape_value<uint64_t>());
     } else if(is_int64()) {
-      return next_tape_value<int64_t>();
+      return double(next_tape_value<int64_t>());
     }
     return INCORRECT_TYPE;
   }
@@ -1096,27 +1096,27 @@ really_inline tape_ref::tape_ref(const document *_doc, size_t _json_index) noexc
 // most significant 8 bits.
 
 really_inline bool tape_ref::is_double() const noexcept {
-  constexpr uint64_t tape_double = static_cast<uint64_t>(tape_type::DOUBLE)<<56;
+  constexpr uint64_t tape_double = uint64_t(tape_type::DOUBLE)<<56;
   return doc->tape[json_index] == tape_double;
 }
 really_inline bool tape_ref::is_int64() const noexcept {
-  constexpr uint64_t tape_int64 = static_cast<uint64_t>(tape_type::INT64)<<56;
+  constexpr uint64_t tape_int64 = uint64_t(tape_type::INT64)<<56;
   return doc->tape[json_index] == tape_int64;
 }
 really_inline bool tape_ref::is_uint64() const noexcept {
-  constexpr uint64_t tape_uint64 = static_cast<uint64_t>(tape_type::UINT64)<<56;
+  constexpr uint64_t tape_uint64 = uint64_t(tape_type::UINT64)<<56;
   return doc->tape[json_index] == tape_uint64;
 }
 really_inline bool tape_ref::is_false() const noexcept {
-  constexpr uint64_t tape_false = static_cast<uint64_t>(tape_type::FALSE_VALUE)<<56;
+  constexpr uint64_t tape_false = uint64_t(tape_type::FALSE_VALUE)<<56;
   return doc->tape[json_index] == tape_false;
 }
 really_inline bool tape_ref::is_true() const noexcept {
-  constexpr uint64_t tape_true = static_cast<uint64_t>(tape_type::TRUE_VALUE)<<56;
+  constexpr uint64_t tape_true = uint64_t(tape_type::TRUE_VALUE)<<56;
   return doc->tape[json_index] == tape_true;
 }
 really_inline bool tape_ref::is_null_on_tape() const noexcept {
-  constexpr uint64_t tape_null = static_cast<uint64_t>(tape_type::NULL_VALUE)<<56;
+  constexpr uint64_t tape_null = uint64_t(tape_type::NULL_VALUE)<<56;
   return doc->tape[json_index] == tape_null;
 }
 
@@ -1140,10 +1140,10 @@ really_inline uint64_t internal::tape_ref::tape_value() const noexcept {
   return doc->tape[json_index] & internal::JSON_VALUE_MASK;
 }
 really_inline uint32_t internal::tape_ref::matching_brace_index() const noexcept {
-  return static_cast<uint32_t>(doc->tape[json_index]);
+  return uint32_t(doc->tape[json_index]);
 }
 really_inline uint32_t internal::tape_ref::scope_count() const noexcept {
-  return static_cast<uint32_t>((doc->tape[json_index] >> 32) & internal::JSON_COUNT_MASK);
+  return uint32_t((doc->tape[json_index] >> 32) & internal::JSON_COUNT_MASK);
 }
 
 template<typename T>
@@ -1158,7 +1158,7 @@ really_inline T tape_ref::next_tape_value() const noexcept {
   return x;
 }
 inline std::string_view internal::tape_ref::get_string_view() const noexcept {
-  size_t string_buf_index = tape_value();
+  size_t string_buf_index = size_t(tape_value());
   uint32_t len;
   memcpy(&len, &doc->string_buf[string_buf_index], sizeof(len));
   return std::string_view(

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -33,7 +33,7 @@ namespace internal {
  * complete
  * document, therefore the last json buffer location is the end of the batch
  * */
-inline size_t find_last_json_buf_idx(const uint8_t *buf, size_t size, const dom::parser &parser) {
+inline uint32_t find_last_json_buf_idx(const uint8_t *buf, size_t size, const dom::parser &parser) {
   // this function can be generally useful
   if (parser.n_structural_indexes == 0)
     return 0;
@@ -172,7 +172,7 @@ inline error_code document_stream::json_parse() noexcept {
       if (stage1_is_ok != simdjson::SUCCESS) {
         return stage1_is_ok;
       }
-      size_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
+      uint32_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
       if (last_index == 0) {
         if (parser.n_structural_indexes == 0) {
           return simdjson::EMPTY;
@@ -249,7 +249,7 @@ inline error_code document_stream::json_parse() noexcept {
     if (stage1_is_ok != simdjson::SUCCESS) {
       return stage1_is_ok;
     }
-    size_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
+    uint32_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
     if (last_index == 0) {
       if (parser.n_structural_indexes == 0) {
         return EMPTY;

--- a/include/simdjson/internal/jsonformatutils.h
+++ b/include/simdjson/internal/jsonformatutils.h
@@ -49,7 +49,7 @@ inline std::ostream& operator<<(std::ostream& out, const escape_json_string &une
       if ((unsigned char)unescaped.str[i] <= 0x1F) {
         // TODO can this be done once at the beginning, or will it mess up << char?
         std::ios::fmtflags f(out.flags());
-        out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << static_cast<int>(unescaped.str[i]);
+        out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << int(unescaped.str[i]);
         out.flags(f);
       } else {
         out << unescaped.str[i];

--- a/include/simdjson/parsedjson_iterator.h
+++ b/include/simdjson/parsedjson_iterator.h
@@ -187,7 +187,7 @@ public:
   // is referenced is undefined, and evaluation fails". Here we just return
   // the first corresponding value.
   inline bool move_to(const std::string &pointer) {
-      return move_to(pointer.c_str(), pointer.length());
+      return move_to(pointer.c_str(), uint32_t(pointer.length()));
   }
 
   private:

--- a/src/arm64/numberparsing.h
+++ b/src/arm64/numberparsing.h
@@ -26,7 +26,7 @@ static inline uint32_t parse_eight_digits_unrolled(const char *chars) {
   memcpy(&val, chars, sizeof(uint64_t));
   val = (val & 0x0F0F0F0F0F0F0F0F) * 2561 >> 8;
   val = (val & 0x00FF00FF00FF00FF) * 6553601 >> 16;
-  return (val & 0x0000FFFF0000FFFF) * 42949672960001 >> 32;
+  return uint32_t((val & 0x0000FFFF0000FFFF) * 42949672960001 >> 32);
 }
 
 #define SWAR_NUMBER_PARSING

--- a/src/arm64/simd.h
+++ b/src/arm64/simd.h
@@ -50,7 +50,7 @@ namespace simd {
     typedef uint16_t bitmask_t;
     typedef uint32_t bitmask2_t;
 
-    static really_inline simd8<bool> splat(bool _value) { return vmovq_n_u8(-(!!_value)); }
+    static really_inline simd8<bool> splat(bool _value) { return vmovq_n_u8(uint8_t(-(!!_value))); }
 
     really_inline simd8(const uint8x16_t _value) : base_u8<bool>(_value) {}
     // False constructor
@@ -159,8 +159,8 @@ namespace simd {
     really_inline void compress(uint16_t mask, L * output) const {
       // this particular implementation was inspired by work done by @animetosho
       // we do it in two steps, first 8 bytes and then second 8 bytes
-      uint8_t mask1 = static_cast<uint8_t>(mask); // least significant 8 bits
-      uint8_t mask2 = static_cast<uint8_t>(mask >> 8); // most significant 8 bits
+      uint8_t mask1 = uint8_t(mask); // least significant 8 bits
+      uint8_t mask2 = uint8_t(mask >> 8); // most significant 8 bits
       // next line just loads the 64-bit values thintable_epi8[mask1] and
       // thintable_epi8[mask2] into a 128-bit register, using only
       // two instructions on most compilers.
@@ -309,10 +309,10 @@ namespace simd {
     }
 
     really_inline void compress(uint64_t mask, T * output) const {
-      this->chunks[0].compress(mask, output);
-      this->chunks[1].compress(mask >> 16, output + 16 - count_ones(mask & 0xFFFF));
-      this->chunks[2].compress(mask >> 32, output + 32 - count_ones(mask & 0xFFFFFFFF));
-      this->chunks[3].compress(mask >> 48, output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
+      this->chunks[0].compress(uint16_t(mask), output);
+      this->chunks[1].compress(uint16_t(mask >> 16), output + 16 - count_ones(mask & 0xFFFF));
+      this->chunks[2].compress(uint16_t(mask >> 32), output + 32 - count_ones(mask & 0xFFFFFFFF));
+      this->chunks[3].compress(uint16_t(mask >> 48), output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
     }
 
     template <typename F>

--- a/src/arm64/stringparsing.h
+++ b/src/arm64/stringparsing.h
@@ -40,8 +40,8 @@ really_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8
   // smash them together into a 64-byte mask and get the bitmask from there.
   uint64_t bs_and_quote = simd8x64<bool>(v0 == '\\', v1 == '\\', v0 == '"', v1 == '"').to_bitmask();
   return {
-    static_cast<uint32_t>(bs_and_quote),      // bs_bits
-    static_cast<uint32_t>(bs_and_quote >> 32) // quote_bits
+    uint32_t(bs_and_quote),      // bs_bits
+    uint32_t(bs_and_quote >> 32) // quote_bits
   };
 }
 

--- a/src/document_parser_callbacks.h
+++ b/src/document_parser_callbacks.h
@@ -94,7 +94,7 @@ really_inline uint8_t *parser::on_start_string() noexcept {
 }
 
 really_inline bool parser::on_end_string(uint8_t *dst) noexcept {
-  uint32_t str_length = dst - (current_string_buf_loc + sizeof(uint32_t));
+  uint32_t str_length = uint32_t(dst - (current_string_buf_loc + sizeof(uint32_t)));
   // TODO check for overflow in case someone has a crazy string (>=4GB?)
   // But only add the overflow check when the document itself exceeds 4GB
   // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
@@ -126,7 +126,7 @@ really_inline bool parser::on_number_double(double value) noexcept {
 }
 
 really_inline void parser::write_tape(uint64_t val, internal::tape_type t) noexcept {
-  doc.tape[current_loc++] = val | ((static_cast<uint64_t>(static_cast<char>(t))) << 56);
+  doc.tape[current_loc++] = val | ((uint64_t(char(t))) << 56);
 }
 
 // this function is responsible for annotating the start of the scope
@@ -136,7 +136,7 @@ really_inline void parser::end_scope(uint32_t depth) noexcept {
   // the convention being that a cnt of 0xffffff or more is undetermined in value (>=  0xffffff).
   const uint32_t cntsat =  d.count > 0xFFFFFF ? 0xFFFFFF : d.count;
   // This is a load and an OR. It would be possible to just write once at doc.tape[d.tape_index]
-  doc.tape[d.tape_index] |= current_loc | (static_cast<uint64_t>(cntsat) << 32);
+  doc.tape[d.tape_index] |= current_loc | (uint64_t(cntsat) << 32);
 }
 
 } // namespace simdjson

--- a/src/fallback/stage1_find_marks.h
+++ b/src/fallback/stage1_find_marks.h
@@ -127,7 +127,7 @@ really_inline error_code scan() {
   }
   *next_structural_index = len;
   next_structural_index++;
-  doc_parser.n_structural_indexes = next_structural_index - doc_parser.structural_indexes.get();
+  doc_parser.n_structural_indexes = uint32_t(next_structural_index - doc_parser.structural_indexes.get());
   return error;
 }
 
@@ -148,7 +148,7 @@ WARN_UNUSED error_code implementation::stage1(const uint8_t *buf, size_t len, pa
   if (unlikely(len > parser.capacity())) {
     return CAPACITY;
   }
-  stage1::structural_scanner scanner(buf, len, parser, streaming);
+  stage1::structural_scanner scanner(buf, uint32_t(len), parser, streaming);
   return scanner.scan();
 }
 
@@ -201,7 +201,7 @@ WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, ui
     pos += meta[2] | quote;
 
     i += 1;
-    nonescape = (~nonescape) | (meta[1]);
+    nonescape = uint8_t(~nonescape) | (meta[1]);
   }
   dst_len = pos; // we intentionally do not work with a reference
   // for fear of aliasing

--- a/src/generic/json_string_scanner.h
+++ b/src/generic/json_string_scanner.h
@@ -107,7 +107,7 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
   const uint64_t in_string = prefix_xor(quote) ^ prev_in_string;
   // right shift of a signed value expected to be well-defined and standard
   // compliant as of C++20, John Regher from Utah U. says this is fine code
-  prev_in_string = static_cast<uint64_t>(static_cast<int64_t>(in_string) >> 63);
+  prev_in_string = uint64_t(static_cast<int64_t>(in_string) >> 63);
   // Use ^ to turn the beginning quote off, and the end quote on.
   return {
     backslash,

--- a/src/generic/json_structural_indexer.h
+++ b/src/generic/json_structural_indexer.h
@@ -22,11 +22,10 @@ public:
     // it helps tremendously.
     if (bits == 0)
         return;
-    auto cnt = count_ones(bits);
+    int cnt = static_cast<int>(count_ones(bits));
 
     // Do the first 8 all together
-    decltype(cnt) i;
-    for (i=0; i<8; i++) {
+    for (int i=0; i<8; i++) {
       this->tail[i] = idx + trailing_zeroes(bits);
       bits = clear_lowest_bit(bits);
     }
@@ -34,7 +33,7 @@ public:
     // Do the next 8 all together (we hope in most cases it won't happen at all
     // and the branch is easily predicted).
     if (unlikely(cnt > 8)) {
-      for (i=8; i<16; i++) {
+      for (int i=8; i<16; i++) {
         this->tail[i] = idx + trailing_zeroes(bits);
         bits = clear_lowest_bit(bits);
       }
@@ -43,7 +42,7 @@ public:
       // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
       // or the start of a value ("abc" true 123) every four characters.
       if (unlikely(cnt > 16)) {
-        i = 16;
+        int i = 16;
         do {
           this->tail[i] = idx + trailing_zeroes(bits);
           bits = clear_lowest_bit(bits);

--- a/src/generic/json_structural_indexer.h
+++ b/src/generic/json_structural_indexer.h
@@ -22,10 +22,11 @@ public:
     // it helps tremendously.
     if (bits == 0)
         return;
-    uint32_t cnt = count_ones(bits);
+    auto cnt = count_ones(bits);
 
     // Do the first 8 all together
-    for (int i=0; i<8; i++) {
+    decltype(cnt) i;
+    for (i=0; i<8; i++) {
       this->tail[i] = idx + trailing_zeroes(bits);
       bits = clear_lowest_bit(bits);
     }
@@ -33,7 +34,7 @@ public:
     // Do the next 8 all together (we hope in most cases it won't happen at all
     // and the branch is easily predicted).
     if (unlikely(cnt > 8)) {
-      for (int i=8; i<16; i++) {
+      for (i=8; i<16; i++) {
         this->tail[i] = idx + trailing_zeroes(bits);
         bits = clear_lowest_bit(bits);
       }
@@ -42,7 +43,7 @@ public:
       // branch mispredictions here. 16+ structurals per block means either punctuation ({} [] , :)
       // or the start of a value ("abc" true 123) every four characters.
       if (unlikely(cnt > 16)) {
-        uint32_t i = 16;
+        i = 16;
         do {
           this->tail[i] = idx + trailing_zeroes(bits);
           bits = clear_lowest_bit(bits);
@@ -77,14 +78,14 @@ private:
 really_inline void json_structural_indexer::next(simd::simd8x64<uint8_t> in, json_block block, size_t idx) {
   uint64_t unescaped = in.lteq(0x1F);
   checker.check_next_input(in);
-  indexer.write(idx-64, prev_structurals); // Output *last* iteration's structurals to the parser
+  indexer.write(uint32_t(idx-64), prev_structurals); // Output *last* iteration's structurals to the parser
   prev_structurals = block.structural_start();
   unescaped_chars_error |= block.non_quote_inside_string(unescaped);
 }
 
 really_inline error_code json_structural_indexer::finish(parser &parser, size_t idx, size_t len, bool streaming) {
   // Write out the final iteration's structurals
-  indexer.write(idx-64, prev_structurals);
+  indexer.write(uint32_t(idx-64), prev_structurals);
 
   error_code error = scanner.finish(streaming);
   if (unlikely(error != SUCCESS)) { return error; }
@@ -93,7 +94,7 @@ really_inline error_code json_structural_indexer::finish(parser &parser, size_t 
     return UNESCAPED_CHARS;
   }
 
-  parser.n_structural_indexes = indexer.tail - parser.structural_indexes.get();
+  parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
   /* a valid JSON file cannot have zero structural indexes - we should have
    * found something */
   if (unlikely(parser.n_structural_indexes == 0u)) {
@@ -105,7 +106,7 @@ really_inline error_code json_structural_indexer::finish(parser &parser, size_t 
   if (len != parser.structural_indexes[parser.n_structural_indexes - 1]) {
     /* the string might not be NULL terminated, but we add a virtual NULL
      * ending character. */
-    parser.structural_indexes[parser.n_structural_indexes++] = len;
+    parser.structural_indexes[parser.n_structural_indexes++] = uint32_t(len);
   }
   /* make it safe to dereference one beyond this array */
   parser.structural_indexes[parser.n_structural_indexes] = 0;

--- a/src/generic/numberparsing.h
+++ b/src/generic/numberparsing.h
@@ -16,7 +16,7 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative,
   if (-22 <= power && power <= 22 && i <= 9007199254740991) {
     // convert the integer into a double. This is lossless since
     // 0 <= i <= 2^53 - 1.
-    double d = i;
+    double d = double(i);
     //
     // The general idea is as follows.
     // If 0 <= s < 2^53 and if 10^0 <= p <= 10^22 then
@@ -122,7 +122,7 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative,
   ///////
   uint64_t upperbit = upper >> 63;
   uint64_t mantissa = upper >> (upperbit + 9);
-  lz += 1 ^ upperbit;
+  lz += int(1 ^ upperbit);
 
   // Here we have mantissa < (1<<54).
 
@@ -276,13 +276,13 @@ never_inline bool parse_large_integer(const uint8_t *const src,
     ++p;
     i = 0;
   } else {
-    unsigned char digit = *p - '0';
+    unsigned char digit = static_cast<unsigned char>(*p - '0');
     i = digit;
     p++;
     // the is_made_of_eight_digits_fast routine is unlikely to help here because
     // we rarely see large integer parts like 123456789
     while (is_integer(*p)) {
-      digit = *p - '0';
+      digit = static_cast<unsigned char>(*p - '0');
       if (mul_overflow(i, 10, &i)) {
 #ifdef JSON_TEST_NUMBERS // for unit testing
         found_invalid_number(src);
@@ -404,13 +404,13 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
 #endif
       return false;
     }
-    unsigned char digit = *p - '0';
+    unsigned char digit = static_cast<unsigned char>(*p - '0');
     i = digit;
     p++;
     // the is_made_of_eight_digits_fast routine is unlikely to help here because
     // we rarely see large integer parts like 123456789
     while (is_integer(*p)) {
-      digit = *p - '0';
+      digit = static_cast<unsigned char>(*p - '0');
       // a multiplication by 10 is cheaper than an arbitrary integer
       // multiplication
       i = 10 * i + digit; // might overflow, we will handle the overflow later
@@ -428,7 +428,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
     ++p;
     const char *const first_after_period = p;
     if (is_integer(*p)) {
-      unsigned char digit = *p - '0';
+      unsigned char digit = static_cast<unsigned char>(*p - '0');
       ++p;
       i = i * 10 + digit; // might overflow + multiplication by 10 is likely
                           // cheaper than arbitrary mult.
@@ -448,7 +448,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
     }
 #endif
     while (is_integer(*p)) {
-      unsigned char digit = *p - '0';
+      unsigned char digit = static_cast<unsigned char>(*p - '0');
       ++p;
       i = i * 10 + digit; // in rare cases, this will overflow, but that's ok
                           // because we have parse_highprecision_float later.
@@ -456,7 +456,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
     exponent = first_after_period - p;
   }
   int digit_count =
-      p - start_digits - 1; // used later to guard against overflows
+      int(p - start_digits) - 1; // used later to guard against overflows
   int64_t exp_number = 0;   // exponential part
   if (('e' == *p) || ('E' == *p)) {
     is_float = true;
@@ -474,16 +474,16 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
 #endif
       return false;
     }
-    unsigned char digit = *p - '0';
+    unsigned char digit = static_cast<unsigned char>(*p - '0');
     exp_number = digit;
     p++;
     if (is_integer(*p)) {
-      digit = *p - '0';
+      digit = static_cast<unsigned char>(*p - '0');
       exp_number = 10 * exp_number + digit;
       ++p;
     }
     if (is_integer(*p)) {
-      digit = *p - '0';
+      digit = static_cast<unsigned char>(*p - '0');
       exp_number = 10 * exp_number + digit;
       ++p;
     }
@@ -495,7 +495,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
 #endif
         return false;
       }
-      digit = *p - '0';
+      digit = static_cast<unsigned char>(*p - '0');
       exp_number = 10 * exp_number + digit;
       ++p;
     }
@@ -513,7 +513,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
         start++;
       }
       // we over-decrement by one when there is a '.'
-      digit_count -= (start - start_digits);
+      digit_count -= int(start - start_digits);
       if (digit_count >= 19) {
         // Ok, chances are good that we had an overflow!
         // this is almost never going to get called!!!

--- a/src/generic/stage2_streaming_build_tape.h
+++ b/src/generic/stage2_streaming_build_tape.h
@@ -1,7 +1,7 @@
 namespace stage2 {
 
 struct streaming_structural_parser: structural_parser {
-  really_inline streaming_structural_parser(const uint8_t *_buf, size_t _len, parser &_doc_parser, size_t _i) : structural_parser(_buf, _len, _doc_parser, _i) {}
+  really_inline streaming_structural_parser(const uint8_t *buf, size_t len, parser &_doc_parser, uint32_t next_structural) : structural_parser(buf, len, _doc_parser, next_structural) {}
 
   // override to add streaming
   WARN_UNUSED really_inline error_code start(UNUSED size_t len, ret_address finish_parser) {
@@ -41,7 +41,7 @@ struct streaming_structural_parser: structural_parser {
  ***********/
 WARN_UNUSED error_code implementation::stage2(const uint8_t *buf, size_t len, parser &doc_parser, size_t &next_json) const noexcept {
   static constexpr stage2::unified_machine_addresses addresses = INIT_ADDRESSES();
-  stage2::streaming_structural_parser parser(buf, len, doc_parser, next_json);
+  stage2::streaming_structural_parser parser(buf, len, doc_parser, uint32_t(next_json));
   error_code result = parser.start(len, addresses.finish);
   if (result) { return result; }
   //

--- a/src/haswell/bitmanipulation.h
+++ b/src/haswell/bitmanipulation.h
@@ -33,17 +33,19 @@ really_inline uint64_t clear_lowest_bit(uint64_t input_num) {
 
 /* result might be undefined when input_num is zero */
 really_inline int leading_zeroes(uint64_t input_num) {
-  return static_cast<int>(_lzcnt_u64(input_num));
+  return int(_lzcnt_u64(input_num));
 }
 
-really_inline int count_ones(uint64_t input_num) {
 #ifdef _MSC_VER
+really_inline unsigned __int64 count_ones(uint64_t input_num) {
   // note: we do not support legacy 32-bit Windows
   return __popcnt64(input_num);// Visual Studio wants two underscores
-#else
-  return _popcnt64(input_num);
-#endif
 }
+#else
+really_inline long long int count_ones(uint64_t input_num) {
+  return _popcnt64(input_num);
+}
+#endif
 
 really_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                 uint64_t *result) {

--- a/src/haswell/simd.h
+++ b/src/haswell/simd.h
@@ -61,7 +61,7 @@ namespace simd {
   // SIMD byte mask type (returned by things like eq and gt)
   template<>
   struct simd8<bool>: base8<bool> {
-    static really_inline simd8<bool> splat(bool _value) { return _mm256_set1_epi8(-(!!_value)); }
+    static really_inline simd8<bool> splat(bool _value) { return _mm256_set1_epi8(uint8_t(-(!!_value))); }
 
     really_inline simd8<bool>() : base8() {}
     really_inline simd8<bool>(const __m256i _value) : base8<bool>(_value) {}
@@ -125,10 +125,10 @@ namespace simd {
     really_inline void compress(uint32_t mask, L * output) const {
       // this particular implementation was inspired by work done by @animetosho
       // we do it in four steps, first 8 bytes and then second 8 bytes...
-      uint8_t mask1 = static_cast<uint8_t>(mask); // least significant 8 bits
-      uint8_t mask2 = static_cast<uint8_t>(mask >> 8); // second least significant 8 bits
-      uint8_t mask3 = static_cast<uint8_t>(mask >> 16); // ...
-      uint8_t mask4 = static_cast<uint8_t>(mask >> 24); // ...
+      uint8_t mask1 = uint8_t(mask); // least significant 8 bits
+      uint8_t mask2 = uint8_t(mask >> 8); // second least significant 8 bits
+      uint8_t mask3 = uint8_t(mask >> 16); // ...
+      uint8_t mask4 = uint8_t(mask >> 24); // ...
       // next line just loads the 64-bit values thintable_epi8[mask1] and
       // thintable_epi8[mask2] into a 128-bit register, using only
       // two instructions on most compilers.
@@ -305,8 +305,8 @@ namespace simd {
     }
 
     really_inline void compress(uint64_t mask, T * output) const {
-      uint32_t mask1 = static_cast<uint32_t>(mask);
-      uint32_t mask2 = static_cast<uint32_t>(mask >> 32);
+      uint32_t mask1 = uint32_t(mask);
+      uint32_t mask2 = uint32_t(mask >> 32);
       this->chunks[0].compress(mask1, output);
       this->chunks[1].compress(mask2, output + 32 - count_ones(mask1));
     }
@@ -347,7 +347,7 @@ namespace simd {
     }
 
     really_inline uint64_t to_bitmask() const {
-      uint64_t r_lo = static_cast<uint32_t>(this->chunks[0].to_bitmask());
+      uint64_t r_lo = uint32_t(this->chunks[0].to_bitmask());
       uint64_t r_hi =                       this->chunks[1].to_bitmask();
       return r_lo | (r_hi << 32);
     }

--- a/src/jsoncharutils.h
+++ b/src/jsoncharutils.h
@@ -280,27 +280,27 @@ static inline bool is_utf8_continuing(char c) {
 //
 inline size_t codepoint_to_utf8(uint32_t cp, uint8_t *c) {
   if (cp <= 0x7F) {
-    c[0] = cp;
+    c[0] = uint8_t(cp);
     return 1; // ascii
   }
   if (cp <= 0x7FF) {
-    c[0] = (cp >> 6) + 192;
-    c[1] = (cp & 63) + 128;
+    c[0] = uint8_t((cp >> 6) + 192);
+    c[1] = uint8_t((cp & 63) + 128);
     return 2; // universal plane
     //  Surrogates are treated elsewhere...
     //} //else if (0xd800 <= cp && cp <= 0xdfff) {
     //  return 0; // surrogates // could put assert here
   } else if (cp <= 0xFFFF) {
-    c[0] = (cp >> 12) + 224;
-    c[1] = ((cp >> 6) & 63) + 128;
-    c[2] = (cp & 63) + 128;
+    c[0] = uint8_t((cp >> 12) + 224);
+    c[1] = uint8_t(((cp >> 6) & 63) + 128);
+    c[2] = uint8_t((cp & 63) + 128);
     return 3;
   } else if (cp <= 0x10FFFF) { // if you know you have a valid code point, this
                                // is not needed
-    c[0] = (cp >> 18) + 240;
-    c[1] = ((cp >> 12) & 63) + 128;
-    c[2] = ((cp >> 6) & 63) + 128;
-    c[3] = (cp & 63) + 128;
+    c[0] = uint8_t((cp >> 18) + 240);
+    c[1] = uint8_t(((cp >> 12) & 63) + 128);
+    c[2] = uint8_t(((cp >> 6) & 63) + 128);
+    c[3] = uint8_t((cp & 63) + 128);
     return 4;
   }
   // will return 0 when the code point was too large.
@@ -347,8 +347,8 @@ really_inline value128 full_multiplication(uint64_t value1, uint64_t value2) {
   answer.low = _umul128(value1, value2, &answer.high);
 #else
   __uint128_t r = ((__uint128_t)value1) * value2;
-  answer.low = r;
-  answer.high = r >> 64;
+  answer.low = uint64_t(r);
+  answer.high = uint64_t(r >> 64);
 #endif
   return answer;
 }

--- a/src/westmere/bitmanipulation.h
+++ b/src/westmere/bitmanipulation.h
@@ -44,14 +44,16 @@ really_inline int leading_zeroes(uint64_t input_num) {
 #endif// _MSC_VER
 }
 
-really_inline int count_ones(uint64_t input_num) {
 #ifdef _MSC_VER
+really_inline unsigned __int64 count_ones(uint64_t input_num) {
   // note: we do not support legacy 32-bit Windows
   return __popcnt64(input_num);// Visual Studio wants two underscores
-#else
-  return _popcnt64(input_num);
-#endif
 }
+#else
+really_inline long long int count_ones(uint64_t input_num) {
+  return _popcnt64(input_num);
+}
+#endif
 
 really_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                 uint64_t *result) {

--- a/src/westmere/simd.h
+++ b/src/westmere/simd.h
@@ -62,7 +62,7 @@ namespace simd {
   // SIMD byte mask type (returned by things like eq and gt)
   template<>
   struct simd8<bool>: base8<bool> {
-    static really_inline simd8<bool> splat(bool _value) { return _mm_set1_epi8(-(!!_value)); }
+    static really_inline simd8<bool> splat(bool _value) { return _mm_set1_epi8(uint8_t(-(!!_value))); }
 
     really_inline simd8<bool>() : base8() {}
     really_inline simd8<bool>(const __m128i _value) : base8<bool>(_value) {}
@@ -124,8 +124,8 @@ namespace simd {
     really_inline void compress(uint16_t mask, L * output) const {
       // this particular implementation was inspired by work done by @animetosho
       // we do it in two steps, first 8 bytes and then second 8 bytes
-      uint8_t mask1 = static_cast<uint8_t>(mask); // least significant 8 bits
-      uint8_t mask2 = static_cast<uint8_t>(mask >> 8); // most significant 8 bits
+      uint8_t mask1 = uint8_t(mask); // least significant 8 bits
+      uint8_t mask2 = uint8_t(mask >> 8); // most significant 8 bits
       // next line just loads the 64-bit values thintable_epi8[mask1] and
       // thintable_epi8[mask2] into a 128-bit register, using only
       // two instructions on most compilers.
@@ -278,10 +278,10 @@ namespace simd {
     }
 
     really_inline void compress(uint64_t mask, T * output) const {
-      this->chunks[0].compress(mask, output);
-      this->chunks[1].compress(mask >> 16, output + 16 - count_ones(mask & 0xFFFF));
-      this->chunks[2].compress(mask >> 32, output + 32 - count_ones(mask & 0xFFFFFFFF));
-      this->chunks[3].compress(mask >> 48, output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
+      this->chunks[0].compress(uint16_t(mask), output);
+      this->chunks[1].compress(uint16_t(mask >> 16), output + 16 - count_ones(mask & 0xFFFF));
+      this->chunks[2].compress(uint16_t(mask >> 32), output + 32 - count_ones(mask & 0xFFFFFFFF));
+      this->chunks[3].compress(uint16_t(mask >> 48), output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
     }
 
     template <typename F>
@@ -330,7 +330,7 @@ namespace simd {
     }
 
     really_inline uint64_t to_bitmask() const {
-      uint64_t r0 = static_cast<uint32_t>(this->chunks[0].to_bitmask());
+      uint64_t r0 = uint32_t(this->chunks[0].to_bitmask());
       uint64_t r1 =                       this->chunks[1].to_bitmask();
       uint64_t r2 =                       this->chunks[2].to_bitmask();
       uint64_t r3 =                       this->chunks[3].to_bitmask();

--- a/src/westmere/stringparsing.h
+++ b/src/westmere/stringparsing.h
@@ -38,8 +38,8 @@ really_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8
   v1.store(dst + 16);
   uint64_t bs_and_quote = simd8x64<bool>(v0 == '\\', v1 == '\\', v0 == '"', v1 == '"').to_bitmask();
   return {
-    static_cast<uint32_t>(bs_and_quote),      // bs_bits
-    static_cast<uint32_t>(bs_and_quote >> 32) // quote_bits
+    uint32_t(bs_and_quote),      // bs_bits
+    uint32_t(bs_and_quote >> 32) // quote_bits
   };
 }
 

--- a/tests/allparserscheckfile.cpp
+++ b/tests/allparserscheckfile.cpp
@@ -138,7 +138,7 @@ int main(int argc, char *argv[]) {
     jsmn_init(&jsmnparser);
     memcpy(buffer, p.data(), p.size());
     buffer[p.size()] = '\0';
-    int r = jsmn_parse(&jsmnparser, buffer, p.size(), tokens.get(), p.size());
+    int r = jsmn_parse(&jsmnparser, buffer, p.size(), tokens.get(), static_cast<unsigned int>(p.size()));
     tokens = nullptr;
     jsmn_correct = (r > 0);
   }

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -73,7 +73,7 @@ namespace number_tests {
     std::cout << __func__ << std::endl;
     char buf[1024];
     simdjson::dom::parser parser;
-    int maxulp = 0;
+    uint64_t maxulp = 0;
     for (int i = -1075; i < 1024; ++i) {// large negative values should be zero.
       double expected = pow(2, i);
       auto n = sprintf(buf, "%.*e", std::numeric_limits<double>::max_digits10 - 1, expected);
@@ -81,7 +81,7 @@ namespace number_tests {
       fflush(NULL);
       auto [actual, error] = parser.parse(buf, n).get<double>();
       if (error) { std::cerr << error << std::endl; return false; }
-      int ulp = f64_ulp_dist(actual,expected);  
+      uint64_t ulp = f64_ulp_dist(actual,expected);  
       if(ulp > maxulp) maxulp = ulp;
       if(ulp > 0) {
         std::cerr << "JSON '" << buf << " parsed to " << actual << " instead of " << expected << std::endl;
@@ -284,12 +284,12 @@ namespace document_tests {
       data.emplace_back(std::string(buf, n));
     }
     for (size_t i = 0; i < n_records; ++i) {
-      auto n = sprintf(buf, "{\"counter\": %f, \"array\": [%s]}", i * 3.1416,
+      auto n = sprintf(buf, "{\"counter\": %f, \"array\": [%s]}", static_cast<double>(i) * 3.1416,
                       (i % 2) ? "true" : "false");
       data.emplace_back(std::string(buf, n));
     }
     for (size_t i = 0; i < n_records; ++i) {
-      auto n = sprintf(buf, "{\"number\": %e}", i * 10000.31321321);
+      auto n = sprintf(buf, "{\"number\": %e}", static_cast<double>(i) * 10000.31321321);
       data.emplace_back(std::string(buf, n));
     }
     data.emplace_back(std::string("true"));
@@ -1563,7 +1563,7 @@ namespace type_tests {
       && (expected_value >= 0 ?
           test_cast<uint64_t>(result, expected_value) :
           test_cast<uint64_t>(result, NUMBER_OUT_OF_RANGE))
-      && test_cast<double>(result, expected_value)
+      && test_cast<double>(result, static_cast<double>(expected_value))
       && test_cast<bool>(result, INCORRECT_TYPE)
       && test_is_null(result, false);
   }
@@ -1582,7 +1582,7 @@ namespace type_tests {
       && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, NUMBER_OUT_OF_RANGE)
       && test_cast<uint64_t>(result, expected_value)
-      && test_cast<double>(result, expected_value)
+      && test_cast<double>(result, static_cast<double>(expected_value))
       && test_cast<bool>(result, INCORRECT_TYPE)
       && test_is_null(result, false);
   }

--- a/tests/stringparsingcheck.cpp
+++ b/tests/stringparsingcheck.cpp
@@ -31,11 +31,11 @@ static inline bool read_hex(const char *p, unsigned &u) {
   while (i--) {
     unsigned char c = *p++;
     if (c >= '0' && c <= '9') {
-      c -= '0';
+      c = static_cast<unsigned char>(c - '0');
     } else if (c >= 'a' && c <= 'f') {
-      c = c - 'a' + 10;
+      c = static_cast<unsigned char>(c - 'a' + 10);
     } else if (c >= 'A' && c <= 'F') {
-      c = c - 'A' + 10;
+      c = static_cast<unsigned char>(c - 'A' + 10);
     } else {
       return false;
     }
@@ -48,20 +48,20 @@ static inline bool read_hex(const char *p, unsigned &u) {
 
 static inline void write_utf8(unsigned codepoint, char *&end) {
   if (codepoint < 0x80) {
-    *end++ = codepoint;
+    *end++ = static_cast<char>(codepoint);
   } else if (codepoint < 0x800) {
-    *end++ = 0xC0 | (codepoint >> 6);
-    *end++ = 0x80 | (codepoint & 0x3F);
+    *end++ = static_cast<char>(0xC0 | (codepoint >> 6));
+    *end++ = static_cast<char>(0x80 | (codepoint & 0x3F));
   } else if (codepoint < 0x10000) {
-    *end++ = 0xE0 | (codepoint >> 12);
-    *end++ = 0x80 | ((codepoint >> 6) & 0x3F);
-    *end++ = 0x80 | (codepoint & 0x3F);
+    *end++ = static_cast<char>(0xE0 | (codepoint >> 12));
+    *end++ = static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));
+    *end++ = static_cast<char>(0x80 | (codepoint & 0x3F));
   } else {
     assert(codepoint < 0x200000);
-    *end++ = 0xF0 | (codepoint >> 18);
-    *end++ = 0x80 | ((codepoint >> 12) & 0x3F);
-    *end++ = 0x80 | ((codepoint >> 6) & 0x3F);
-    *end++ = 0x80 | (codepoint & 0x3F);
+    *end++ = static_cast<char>(0xF0 | (codepoint >> 18));
+    *end++ = static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F));
+    *end++ = static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));
+    *end++ = static_cast<char>(0x80 | (codepoint & 0x3F));
   }
 }
 
@@ -357,7 +357,7 @@ bool validate(const char *dirname) {
                "\taverage string length: %.1f \n",
                name, isok ? " is valid     " : " is not valid ", bad_string,
                good_string, empty_string,
-               (double)total_string_length / good_string);
+               static_cast<double>(total_string_length) / static_cast<double>(good_string));
       } else if (bad_string > 0) {
         printf("File %40s %s --- bad strings: %10zu  \n", name,
                isok ? " is valid     " : " is not valid ", bad_string);


### PR DESCRIPTION
This:
- Adds -Wconversion on Linux
- Reenables conversion warnings on Windows

I made fewer underlying type changes when I fixed it this time, and it didn't get slower in my tests.

The bitmanipulation.h changes cause the functions to return the same type as the underlying intrinsics. I've found performance suffers when you don't do that (likely due to unnecessary conversions). I tried returning decltype(_popcnt64) and such, but that doesn't compile.

NOTE: I would be happy to use the `double(X)` idiom instead of `static_cast<double>(X)` if it's more idiomatic; I saw somewhere you should always use x_cast<>, but I can't find it now. I see recommendations to use C-style casts for numeric types, and I'm on board there. Thoughts? Care?