### PR TITLE
Run most build flavors on VS2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ test_script:
 matrix:
   fast_finish: true
   exclude:
-    # Don't build all variants on 2019, just running it to make sure readme_tests succeed
-    - image: Visual Studio 2019
+    # Don't build all variants on 2017, just running it to make sure readme_tests succeed
+    - image: Visual Studio 2017
       SIMDJSON_BUILD_STATIC: ON
       SIMDJSON_ENABLE_THREADS: OFF


### PR DESCRIPTION
Right now we run 3 build flavors on VS2017 and one on VS2019. 2017 takes a few minutes longer per build, so let's run most of our build flavors on 2019. Should reduce usual appveyor runtime by 4-6 minutes, since it runs serially.

See [this CI run](https://ci.appveyor.com/project/lemire/simdjson-jmmti/builds/32345113) for an example.