### PR TITLE
Fix CRT_SECURE_WARNINGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 #
 add_library(simdjson-flags INTERFACE)
 if(MSVC)
-  target_compile_options(simdjson-flags INTERFACE /nologo /D_CRT_SECURE_NO_WARNINGS)
+  target_compile_options(simdjson-flags INTERFACE /nologo)
   target_compile_options(simdjson-flags INTERFACE /WX /W3 /wd4267 /wd4244)
 else()
   target_compile_options(simdjson-flags INTERFACE -fPIC)

--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -422,7 +422,7 @@ struct benchmarker {
   void print(bool tabbed_output, size_t iterations) const {
     if (tabbed_output) {
       char* filename_copy = (char*)malloc(strlen(filename)+1);
-      strcpy(filename_copy, filename);
+      simdjson::internal::strcpy_s(filename_copy, strlen(filename)+1, filename);
       #if defined(__linux__)
       char* base = ::basename(filename_copy);
       #else

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <climits>
 #include <cctype>
+#include <stdio.h>
 
 namespace simdjson {
 
@@ -337,8 +338,8 @@ inline bool parser::dump_raw_tape(std::ostream &os) const noexcept {
 
 inline simdjson_result<size_t> parser::read_file(const std::string &path) noexcept {
   // Open the file
-  std::FILE *fp = std::fopen(path.c_str(), "rb");
-  if (fp == nullptr) {
+  std::FILE *fp;
+  if (internal::fopen_s(&fp, path.c_str(), "rb")) {
     return IO_ERROR;
   }
 

--- a/include/simdjson/inline/padded_string.h
+++ b/include/simdjson/inline/padded_string.h
@@ -8,6 +8,7 @@
 #include <cstring>
 #include <memory>
 #include <string>
+#include <stdio.h>
 
 namespace simdjson {
 namespace internal {
@@ -100,10 +101,10 @@ inline char *padded_string::data() noexcept { return data_ptr; }
 
 inline padded_string::operator std::string_view() const { return std::string_view(data(), length()); }
 
-inline simdjson_result<padded_string> padded_string::load(const std::string &filename) noexcept {
+inline simdjson_result<padded_string> padded_string::load(const std::string &path) noexcept {
   // Open the file
-  std::FILE *fp = std::fopen(filename.c_str(), "rb");
-  if (fp == nullptr) {
+  std::FILE *fp;
+  if (internal::fopen_s(&fp, path.c_str(), "rb")) {
     return IO_ERROR;
   }
 

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -76,7 +76,7 @@ namespace number_tests {
     int maxulp = 0;
     for (int i = -1075; i < 1024; ++i) {// large negative values should be zero.
       double expected = pow(2, i);
-      auto n = sprintf(buf, "%.*e", std::numeric_limits<double>::max_digits10 - 1, expected);
+      auto n = simdjson::internal::sprintf_s(buf, sizeof(buf), "%.*e", std::numeric_limits<double>::max_digits10 - 1, expected);
       buf[n] = '\0';
       fflush(NULL);
       auto [actual, error] = parser.parse(buf, n).get<double>();
@@ -169,7 +169,7 @@ namespace number_tests {
     char buf[1024];
     simdjson::dom::parser parser;
     for (int i = -1000000; i <= 308; ++i) {// large negative values should be zero.
-      auto n = sprintf(buf,"1e%d", i);
+      auto n = simdjson::internal::sprintf_s(buf, sizeof(buf), "1e%d", i);
       buf[n] = '\0';
       fflush(NULL);
 
@@ -277,19 +277,19 @@ namespace document_tests {
     std::vector<std::string> data;
     char buf[1024];
     for (size_t i = 0; i < n_records; ++i) {
-      auto n = sprintf(buf,
+      auto n = simdjson::internal::sprintf_s(buf, sizeof(buf),
                       "{\"id\": %zu, \"name\": \"name%zu\", \"gender\": \"%s\", "
                       "\"school\": {\"id\": %zu, \"name\": \"school%zu\"}}",
                       i, i, (i % 2) ? "male" : "female", i % 10, i % 10);
       data.emplace_back(std::string(buf, n));
     }
     for (size_t i = 0; i < n_records; ++i) {
-      auto n = sprintf(buf, "{\"counter\": %f, \"array\": [%s]}", i * 3.1416,
+      auto n = simdjson::internal::sprintf_s(buf, sizeof(buf), "{\"counter\": %f, \"array\": [%s]}", i * 3.1416,
                       (i % 2) ? "true" : "false");
       data.emplace_back(std::string(buf, n));
     }
     for (size_t i = 0; i < n_records; ++i) {
-      auto n = sprintf(buf, "{\"number\": %e}", i * 10000.31321321);
+      auto n = simdjson::internal::sprintf_s(buf, sizeof(buf), "{\"number\": %e}", i * 10000.31321321);
       data.emplace_back(std::string(buf, n));
     }
     data.emplace_back(std::string("true"));
@@ -398,7 +398,7 @@ namespace document_stream_tests {
     std::string data;
     char buf[1024];
     for (size_t i = 0; i < n_records; ++i) {
-      auto n = sprintf(buf,
+      auto n = simdjson::internal::sprintf_s(buf, sizeof(buf),
                       "{\"id\": %zu, \"name\": \"name%zu\", \"gender\": \"%s\", "
                       "\"ete\": {\"id\": %zu, \"name\": \"eventail%zu\"}}",
                       i, i, (i % 2) ? "homme" : "femme", i % 10, i % 10);
@@ -446,7 +446,7 @@ namespace document_stream_tests {
     std::string data;
     char buf[1024];
     for (size_t i = 0; i < n_records; ++i) {
-      auto n = sprintf(buf,
+      auto n = simdjson::internal::sprintf_s(buf, sizeof(buf),
                       "{\"id\": %zu, \"name\": \"name%zu\", \"gender\": \"%s\", "
                       "\"été\": {\"id\": %zu, \"name\": \"éventail%zu\"}}",
                       i, i, (i % 2) ? "⺃" : "⺕", i % 10, i % 10);

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -56,13 +56,14 @@ bool validate(const char *dirname) {
       printf("validating: file %s ", name);
       fflush(nullptr);
       size_t filelen = strlen(name);
-      char *fullpath = static_cast<char *>(malloc(dirlen + filelen + 1 + 1));
-      strcpy(fullpath, dirname);
+      size_t fullpathlen = dirlen + filelen + 1 + 1;
+      char *fullpath = static_cast<char *>(malloc(fullpathlen));
+      simdjson::internal::strcpy_s(fullpath, fullpathlen, dirname);
       if (needsep) {
         fullpath[dirlen] = '/';
-        strcpy(fullpath + dirlen + 1, name);
+        simdjson::internal::strcpy_s(fullpath + dirlen + 1, fullpathlen - dirlen - 1, name);
       } else {
-        strcpy(fullpath + dirlen, name);
+        simdjson::internal::strcpy_s(fullpath + dirlen, fullpathlen - dirlen, name);
       }
       auto [p, error] = simdjson::padded_string::load(fullpath);
       if (error) {

--- a/tests/parse_many_test.cpp
+++ b/tests/parse_many_test.cpp
@@ -64,13 +64,14 @@ bool validate(const char *dirname) {
             printf("validating: file %s ", name);
             fflush(nullptr);
             size_t filelen = strlen(name);
-            char *fullpath = static_cast<char *>(malloc(dirlen + filelen + 1 + 1));
-            strcpy(fullpath, dirname);
+            size_t fullpathlen = dirlen + filelen + 1 + 1;
+            char *fullpath = static_cast<char *>(malloc(fullpathlen));
+            simdjson::internal::strcpy_s(fullpath, fullpathlen, dirname);
             if (needsep) {
                 fullpath[dirlen] = '/';
-                strcpy(fullpath + dirlen + 1, name);
+                simdjson::internal::strcpy_s(fullpath + dirlen + 1, fullpathlen - dirlen - 1, name);
             } else {
-                strcpy(fullpath + dirlen, name);
+                simdjson::internal::strcpy_s(fullpath + dirlen, fullpathlen - dirlen, name);
             }
 
 


### PR DESCRIPTION
Turns out the _s functions aren't implemented most places :( So I implemented them.

Based on #755 (includes those commits) because deprecation warnings and _NO_CRT_SECURE_WARNINGS *both* have to be removed before the warnings show up.