### PR TITLE
default initialisaiton

### DIFF
--- a/include/simdjson/inline/padded_string.h
+++ b/include/simdjson/inline/padded_string.h
@@ -34,7 +34,7 @@ inline char *allocate_padded_buffer(size_t length) noexcept {
 } // namespace internal
 
 
-inline padded_string::padded_string() noexcept : viable_size(0), data_ptr(nullptr) {}
+inline padded_string::padded_string() noexcept {}
 inline padded_string::padded_string(size_t length) noexcept
     : viable_size(length), data_ptr(internal::allocate_padded_buffer(length)) {
   if (data_ptr != nullptr)

--- a/include/simdjson/inline/parsedjson_iterator.h
+++ b/include/simdjson/inline/parsedjson_iterator.h
@@ -247,8 +247,7 @@ dom::parser::Iterator::Iterator(
     location(o.location),
     tape_length(o.tape_length),
     current_type(o.current_type),
-    current_val(o.current_val),
-    depth_index()
+    current_val(o.current_val)
 {
   depth_index = new scopeindex_t[max_depth+1];
   memcpy(depth_index, o.depth_index, (depth + 1) * sizeof(depth_index[0]));

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -106,7 +106,7 @@ private:
   padded_string &operator=(const padded_string &o) = delete;
   padded_string(const padded_string &o) = delete;
 
-  size_t viable_size;
+  size_t viable_size{0};
   char *data_ptr{nullptr};
 
 }; // padded_string


### PR DESCRIPTION
Yesterday we set a rule that all members need to be initialized (Weffc++ discovered bunch of uninitialized) and that modern style for initialization should be used.

Two more cases that we missed yesterday.