### PR TITLE
Remalgamate when source/header files change

### DIFF
--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -3,12 +3,28 @@
 #
 # We should check whether bash is available here and avoid failures on systems where
 # bash is unavailable.
-if (NOT MSVC)
+set(SINGLEHEADER_FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/simdjson.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/simdjson.h
+  ${CMAKE_CURRENT_BINARY_DIR}/amalgamate_demo.cpp
+  ${CMAKE_CURRENT_BINARY_DIR}/README.md
+)
+set_source_files_properties(${SINGLEHEADER_FILES} PROPERTIES GENERATED TRUE)
+
+if (MSVC)
+  # MSVC doesn't have bash, so we use existing amalgamated files instead of generating them ...
+  add_custom_command(
+    OUTPUT ${SINGLEHEADER_FILES}
+    COMMAND ${CMAKE_COMMAND} -E copy
+      simdjson.cpp simdjson.h amalgamate_demo.cpp README.md
+      ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS simdjson.cpp simdjson.h amalgamate_demo.cpp README.md
+  )
+else()
   ##
   # Important! The script amalgamate.sh is not generally executable. It
   # assumes that bash is at /bin/bash which may not be true.
   ###
-  set(SINGLEHEADER_FILES simdjson.h simdjson.cpp amalgamate_demo.cpp README.md)
   add_custom_command(
     OUTPUT ${SINGLEHEADER_FILES}
     COMMAND ${CMAKE_COMMAND} -E env
@@ -16,26 +32,29 @@ if (NOT MSVC)
       AMALGAMATE_INPUT_PATH=${PROJECT_SOURCE_DIR}/include
       AMALGAMATE_OUTPUT_PATH=${CMAKE_CURRENT_BINARY_DIR}
       bash ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.sh
-    DEPENDS amalgamate.sh simdjson-source 
+    DEPENDS amalgamate.sh simdjson-source
   )
-
-  add_custom_target(amalgamate DEPENDS ${SINGLEHEADER_FILES})
-  add_executable(amalgamate_demo amalgamate_demo.cpp)
-  target_link_libraries(amalgamate_demo simdjson-include-source)
-  add_test(amalgamate_demo amalgamate_demo ${EXAMPLE_JSON} ${EXAMPLE_NDJSON})
 endif()
 
+add_custom_target(amalgamate DEPENDS ${SIINGLEHEADER_FILES})
 
 #
-# We also want to be able to build amalgamate_demo.cpp from the single header
-# files alone.
+# Include this if you intend to #include "simdjson.cpp" in your own .cpp files.
 #
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/simdjson.h ${CMAKE_CURRENT_BINARY_DIR}/single_header_from_repo/simdjson.h COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/simdjson.cpp ${CMAKE_CURRENT_BINARY_DIR}/single_header_from_repo/simdjson.cpp COPYONLY)
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/amalgamate_demo.cpp ${CMAKE_CURRENT_BINARY_DIR}/single_header_from_repo/amalgamate_demo.cpp COPYONLY)
-set(SINGLEHEADER_FILE ${CMAKE_CURRENT_BINARY_DIR}/single_header_from_repo/simdjson.h )
-add_library(singleheaderlib ${CMAKE_CURRENT_BINARY_DIR}/single_header_from_repo/simdjson.cpp ${SINGLEHEADER_FILE})
-add_executable(amalgamate_demo_from_repo ${CMAKE_CURRENT_BINARY_DIR}/single_header_from_repo/amalgamate_demo.cpp ${SINGLEHEADER_FILE})
-add_dependencies(amalgamate_demo_from_repo singleheaderlib)
-add_test(amalgamate_demo_from_repo amalgamate_demo_from_repo ${EXAMPLE_JSON} ${EXAMPLE_NDJSON})
+add_library(simdjson-singleheader-include-source INTERFACE)
+target_include_directories(simdjson-singleheader-include-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
+#
+# Include this to get "simdjson.cpp" included in your project as one of the sources.
+#
+add_library(simdjson-singleheader-source INTERFACE)
+target_sources(simdjson-singleheader-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/simdjson.cpp>)
+target_link_libraries(simdjson-singleheader-source INTERFACE simdjson-singleheader-include-source)
+add_dependencies(simdjson-singleheader-source amalgamate)
+
+#
+# Test the generated simdjson.cpp/simdjson.h using the generated amalgamate_demo.cpp
+#
+add_executable(amalgamate_demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamate_demo.cpp>)
+target_link_libraries(amalgamate_demo simdjson-singleheader-include-source)
+add_test(amalgamate_demo amalgamate_demo ${EXAMPLE_JSON} ${EXAMPLE_NDJSON})

--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -9,18 +9,29 @@ set(SINGLEHEADER_FILES
   ${CMAKE_CURRENT_BINARY_DIR}/amalgamate_demo.cpp
   ${CMAKE_CURRENT_BINARY_DIR}/README.md
 )
+set(SINGLEHEADER_REPO_FILES
+  ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate_demo.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+)
 set_source_files_properties(${SINGLEHEADER_FILES} PROPERTIES GENERATED TRUE)
 
 if (MSVC)
   # MSVC doesn't have bash, so we use existing amalgamated files instead of generating them ...
-  add_custom_command(
-    OUTPUT ${SINGLEHEADER_FILES}
-    COMMAND ${CMAKE_COMMAND} -E copy
-      simdjson.cpp simdjson.h amalgamate_demo.cpp README.md
-      ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS simdjson.cpp simdjson.h amalgamate_demo.cpp README.md
-  )
-else()
+  # (Do not do this if the source and destination are the same!)
+  if (NOT (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR}))
+    add_custom_command(
+      OUTPUT ${SINGLEHEADER_FILES}
+      COMMAND ${CMAKE_COMMAND} -E copy
+        ${SINGLEHEADER_REPO_FILES}
+        ${CMAKE_CURRENT_BINARY_DIR}
+      DEPENDS ${SINGLEHEADER_REPO_FILES}
+    )
+  endif()
+
+else(MSVC) 
+
   ##
   # Important! The script amalgamate.sh is not generally executable. It
   # assumes that bash is at /bin/bash which may not be true.
@@ -32,11 +43,38 @@ else()
       AMALGAMATE_INPUT_PATH=${PROJECT_SOURCE_DIR}/include
       AMALGAMATE_OUTPUT_PATH=${CMAKE_CURRENT_BINARY_DIR}
       bash ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate.sh
-    DEPENDS amalgamate.sh simdjson-source
+      #
+      # This is the best way I could find to make amalgamation trigger whenever source files or
+      # header files change: since the "simdjson" library has to get rebuilt when that happens, we
+      # take a dependency on the generated library file (even though we're not using it). Depending
+      # on simdjson-source doesn't do the trick because DEPENDS here can only depend on an
+      # *artifact*--it won't scan source and include files the way a concrete library or executable
+      # will.
+      #
+      # It sucks that we have to build the actual library to make it happen, but it's better than\
+      # nothing!
+      #
+      DEPENDS amalgamate.sh simdjson
   )
-endif()
 
-add_custom_target(amalgamate DEPENDS ${SIINGLEHEADER_FILES})
+  # This is used by "make amalgamate" to update the original source files. We obviously don't do
+  # this if source and generated files are in the same place--cmake gets mad!
+  if (NOT (${CMAKE_CURRENT_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_BINARY_DIR}))
+    add_custom_command(
+      # We don't really need want this to trigger other stuff, it's a terminal target.
+      OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.cpp ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.h ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate_demo.cpp ${CMAKE_CURRENT_SOURCE_DIR}/README.md
+      COMMAND ${CMAKE_COMMAND} -E copy ${SINGLEHEADER_FILES} ${CMAKE_CURRENT_SOURCE_DIR}
+      DEPENDS ${SINGLEHEADER_FILES}
+    )
+  endif()
+
+  #
+  # "make amalgamate" to generate the header files directly and update the original source
+  #
+  add_custom_target(amalgamate DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.cpp ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.h ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate_demo.cpp ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+  
+endif(MSVC)
+
 
 #
 # Include this if you intend to #include "simdjson.cpp" in your own .cpp files.
@@ -56,5 +94,5 @@ add_dependencies(simdjson-singleheader-source amalgamate)
 # Test the generated simdjson.cpp/simdjson.h using the generated amalgamate_demo.cpp
 #
 add_executable(amalgamate_demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamate_demo.cpp>)
-target_link_libraries(amalgamate_demo simdjson-singleheader-include-source)
+target_link_libraries(amalgamate_demo simdjson-singleheader-include-source simdjson-flags)
 add_test(amalgamate_demo amalgamate_demo ${EXAMPLE_JSON} ${EXAMPLE_NDJSON})


### PR DESCRIPTION
This causes us to reamalgamate, and rebuild amalgamated_demo.cpp, when the header/source files change.

It generates the headers in the intermediate output directory, so you don't get littered with amalgamated header source changes. (It's also necessary, or at least very convenient, to do this because of how cmake's dependency trees work.)

On Windows, it only copies the headers from the source repository.

`make amalgamate` can be run to *update* the headers in the source repository.