### PR TITLE
This adds another example

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -124,6 +124,27 @@ for (dom::object car : parser.parse(cars_json)) {
 }
 ```
 
+Here is a different example illustrating the same ideas:
+
+```C++
+auto abstract_json = R"( [
+    {  "12345" : {"a":12.34, "b":56.78, "c": 9998877}   },
+    {  "12545" : {"a":11.44, "b":12.78, "c": 11111111}  }
+  ] )"_padded;
+dom::parser parser;
+
+// Parse and iterate through an array of objects
+for (dom::object obj : parser.parse(abstract_json)) {
+    for(const auto& key_value : obj) {
+      cout << "key: " << key_value.key << " : ";
+      dom::object innerobj = key_value.value;
+      cout << "a: " << double(innerobj["a"]) << ", ";
+      cout << "b: " << double(innerobj["b"]) << ", ";
+      cout << "c: " << int64_t(innerobj["c"]) << endl;
+    }
+}
+```
+
 C++17 Support
 -------------
 
@@ -275,6 +296,49 @@ cout << "- Average tire pressure: " << (total_tire_pressure / 4) << endl;
 for (auto field : car) {
     cout << "- " << field.key << ": " << field.value << endl;
 }
+```
+
+Here is another example:
+
+```C++
+auto abstract_json = R"( [
+    {  "12345" : {"a":12.34, "b":56.78, "c": 9998877}   },
+    {  "12545" : {"a":11.44, "b":12.78, "c": 11111111}  }
+  ] )"_padded;
+dom::parser parser;
+dom::array rootarray;
+simdjson::error_code error;
+parser.parse(abstract_json).get<dom::array>().tie(rootarray, error);
+if (error) { cerr << error << endl; exit(1); }
+// Iterate through an array of objects
+for (dom::element elem : rootarray) {
+    dom::object obj;
+    elem.get<dom::object>().tie(obj, error);
+    if (error) { cerr << error << endl; exit(1); }
+    for(auto & key_value : obj) {
+      cout << "key: " << key_value.key << " : ";
+      dom::object innerobj;
+      key_value.value.get<dom::object>().tie(innerobj, error);
+      if (error) { cerr << error << endl; exit(1); }
+
+      double va;
+      innerobj["a"].get<double>().tie(va, error);
+      if (error) { cerr << error << endl; exit(1); }
+      cout << "a: " << va << ", ";
+
+      double vb;
+      innerobj["b"].get<double>().tie(vb, error);
+      if (error) { cerr << error << endl; exit(1); }
+      cout << "b: " << vb << ", ";
+
+      int64_t vc;
+      innerobj["c"].get<int64_t>().tie(vc, error);
+      if (error) { cerr << error << endl; exit(1); }
+      cout << "c: " << vc << endl;
+
+    }
+}
+
 ```
 
 ### Exceptions

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -52,6 +52,8 @@ void basics_dom_1() {
   }
 }
 
+
+
 void basics_dom_2() {
   auto cars_json = R"( [
     { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
@@ -62,6 +64,27 @@ void basics_dom_2() {
   dom::element cars = parser.parse(cars_json);
   cout << cars.at("0/tire_pressure/1") << endl; // Prints 39.9
 }
+
+void basics_dom_3() {
+  auto abstract_json = R"( [
+    {  "12345" : {"a":12.34, "b":56.78, "c": 9998877}   },
+    {  "12545" : {"a":11.44, "b":12.78, "c": 11111111}  }
+  ] )"_padded;
+  dom::parser parser;
+
+  // Parse and iterate through an array of objects
+  for (dom::object obj : parser.parse(abstract_json)) {
+    for(const auto& key_value : obj) {
+      cout << "key: " << key_value.key << " : ";
+      dom::object innerobj = key_value.value;
+      cout << "a: " << double(innerobj["a"]) << ", ";
+      cout << "b: " << double(innerobj["b"]) << ", ";
+      cout << "c: " << int64_t(innerobj["c"]) << endl;
+    }
+  }
+}
+
+
 
 namespace treewalk_1 {
   void print_json(dom::element element) {
@@ -210,5 +233,8 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #endif
 
 int main() {
+  basics_dom_1();
+  basics_dom_2();
+  basics_dom_3();
   return 0;
 }

--- a/tests/readme_examples_noexceptions.cpp
+++ b/tests/readme_examples_noexceptions.cpp
@@ -77,6 +77,46 @@ void basics_error_3() {
     }
   }
 }
+void basics_error_4() {
+  auto abstract_json = R"( [
+    {  "12345" : {"a":12.34, "b":56.78, "c": 9998877}   },
+    {  "12545" : {"a":11.44, "b":12.78, "c": 11111111}  }
+  ] )"_padded;
+  dom::parser parser;
+  dom::array rootarray;
+  simdjson::error_code error;
+  parser.parse(abstract_json).get<dom::array>().tie(rootarray, error);
+  if (error) { cerr << error << endl; exit(1); }
+  // Iterate through an array of objects
+  for (dom::element elem : rootarray) {
+    dom::object obj;
+    elem.get<dom::object>().tie(obj, error);
+    if (error) { cerr << error << endl; exit(1); }
+    for(auto & key_value : obj) {
+      cout << "key: " << key_value.key << " : ";
+      dom::object innerobj;
+      key_value.value.get<dom::object>().tie(innerobj, error);
+      if (error) { cerr << error << endl; exit(1); }
+
+      double va;
+      innerobj["a"].get<double>().tie(va, error);
+      if (error) { cerr << error << endl; exit(1); }
+      cout << "a: " << va << ", ";
+
+      double vb;
+      innerobj["b"].get<double>().tie(vb, error);
+      if (error) { cerr << error << endl; exit(1); }
+      cout << "b: " << vb << ", ";
+
+      int64_t vc;
+      innerobj["c"].get<int64_t>().tie(vc, error);
+      if (error) { cerr << error << endl; exit(1); }
+      cout << "c: " << vc << endl;
+
+    }
+  }
+}
+
 
 #ifdef SIMDJSON_CPLUSPLUS17
 void basics_error_3_cpp17() {
@@ -131,5 +171,8 @@ void basics_error_3_cpp17() {
 #endif
 
 int main() {
+  basics_error_2();
+  basics_error_3();
+  basics_error_4();
   return 0;
 }


### PR DESCRIPTION
@pps83  wrote in issue https://github.com/simdjson/simdjson/issues/745:

> Firs of all, I tried really really hard to get these basics working with simdjson. TO the point that I though it's broken and I wanted to abandon it. I just couldn't figure out how to iterate members.

> The reason was that I was assigning to element result of parsing, while I had to assing to object I think. This is what I do now:
```
        simdjson::dom::parser parser;
        auto jObj = parser.parse(json);
        if (jObj.error() || !jObj.is<simdjson::dom::object>())
        {
            LOG("failed to parse json");
            return;
        }
        for (const auto& x: jObj.get<simdjson::dom::object>())
        {
            // x.key is "12345", x.value is {"a":12.34, "b":56.78, "c": 9998877}
        }
```

(End quote)

So I decided to take his example, and make it one of our examples.
