### PR TITLE
Let us drop libc++

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ workflows:
       - clang6
       
       # libc++
-      - libcpp-clang9
+      # - libcpp-clang9 # disabled due to too many errors
       
       # full single-implementation tests
       - sanitize-gcc9


### PR DESCRIPTION
Let us disable libcpp_clang9.

We now have freeBSD tests where clang is the default.