### PR TITLE
Only build fuzzers when fuzzing.

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -42,10 +42,14 @@ if(ENABLE_FUZZING)
   endif ()
   target_link_libraries(simdjson-fuzzer INTERFACE simdjson-flags)
   target_link_libraries(simdjson-fuzzer INTERFACE ${SIMDJSON_FUZZ_LDFLAGS})
-  
+
+  # Define the fuzzers
+  add_custom_target(all_fuzzers)
+
   function(implement_fuzzer name)
     add_executable(${name} ${name}.cpp)
     target_link_libraries(${name} PRIVATE simdjson-fuzzer)
+    add_dependencies(all_fuzzers ${name})
     add_test(${name} ${name})
     set_property(TEST ${name} APPEND PROPERTY LABELS fuzz)
   endfunction()

--- a/fuzz/build_fuzzer_variants.sh
+++ b/fuzz/build_fuzzer_variants.sh
@@ -27,7 +27,7 @@ if [ ! -d build-$variant ] ; then
 	  -DSIMDJSON_FUZZ_LINKMAIN=On \
 	  -DSIMDJSON_IMPLEMENTATION_HASWELL=0
     
-    ninja
+    ninja all_fuzzers
     cd ..
 fi
 
@@ -45,7 +45,7 @@ if [ ! -d build-$variant ] ; then
 	  -DENABLE_FUZZING=On \
 	  -DSIMDJSON_FUZZ_LINKMAIN=On
     
-    ninja
+    ninja all_fuzzers
     cd ..
 fi
 
@@ -71,7 +71,7 @@ if [ ! -d build-$variant ] ; then
 	  -DSIMDJSON_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE \
 	  -DSIMDJSON_IMPLEMENTATION_HASWELL=0
     
-    ninja
+    ninja all_fuzzers
     cd ..
 fi
 
@@ -99,7 +99,7 @@ if which clang++-9 >/dev/null 2>&1 ; then
 	      -DSIMDJSON_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE \
 	      -DSIMDJSON_IMPLEMENTATION_HASWELL=0
 	
-	ninja
+	ninja all_fuzzers
 	cd ..
     fi
 else
@@ -127,7 +127,7 @@ if [ ! -d build-$variant ] ; then
 	  -DSIMDJSON_FUZZ_LINKMAIN=Off \
 	  -DSIMDJSON_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE
     
-    ninja
+    ninja all_fuzzers
     cd ..
 fi
 
@@ -152,7 +152,7 @@ if which clang++-9 >/dev/null 2>&1 ; then
 	      -DSIMDJSON_FUZZ_LINKMAIN=Off \
 	      -DSIMDJSON_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE
 	
-	ninja
+	ninja all_fuzzers
 	
 	cd ..
     fi

--- a/fuzz/measure_coverage.sh
+++ b/fuzz/measure_coverage.sh
@@ -26,7 +26,7 @@ if [ ! -d $bdir ] ; then
           -DSIMDJSON_BUILD_STATIC=On \
           -DENABLE_FUZZING=On \
 	  -DSIMDJSON_FUZZ_LINKMAIN=On
-    ninja
+    ninja all_fuzzers
     cd ..
 fi
 

--- a/fuzz/ossfuzz.sh
+++ b/fuzz/ossfuzz.sh
@@ -34,7 +34,7 @@ cmake .. \
 -DSIMDJSON_FUZZ_LINKMAIN=Off \
 -DSIMDJSON_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE
 
-cmake --build .
+cmake --build . --target all_fuzzers
 
 cp fuzz/fuzz_* $OUT
 


### PR DESCRIPTION
This makes fuzzers builds WAY faster by only building the fuzzers instead of rebuilding the tree 6 times. We should really build fewer variants too, but I'm hoping this change will get us past what's plaguing master at the moment by not building checkperf ...