### PR TITLE
Fix deprecation message to point at correct doc name

### DIFF
--- a/include/simdjson/parsedjson_iterator.h
+++ b/include/simdjson/parsedjson_iterator.h
@@ -16,7 +16,7 @@
 
 namespace simdjson {
 
-class [[deprecated("Use the new DOM navigation API instead (see doc/usage.md)")]] dom::parser::Iterator {
+class [[deprecated("Use the new DOM navigation API instead (see doc/basics.md)")]] dom::parser::Iterator {
 public:
   inline Iterator(const dom::parser &parser) noexcept(false);
   inline Iterator(const Iterator &o) noexcept;


### PR DESCRIPTION
This would have prevented *some* of the confusion that caused #819.