### PR TITLE
This will change the default of the parse benchmark so that it work over hot buffers

### DIFF
--- a/benchmark/checkperf.cmake
+++ b/benchmark/checkperf.cmake
@@ -84,7 +84,7 @@ if (Git_FOUND)
   add_test(
     NAME checkperf
     # COMMAND ECHO $<TARGET_FILE:perfdiff> \"$<TARGET_FILE:parse> -t ${SIMDJSON_CHECKPERF_ARGS}\" \"${CHECKPERF_PARSE} -t ${SIMDJSON_CHECKPERF_ARGS}\" }
-    COMMAND $<TARGET_FILE:perfdiff> $<TARGET_FILE:parse> ${CHECKPERF_PARSE} -t ${SIMDJSON_CHECKPERF_ARGS}
+    COMMAND $<TARGET_FILE:perfdiff> $<TARGET_FILE:parse> ${CHECKPERF_PARSE} -H -t ${SIMDJSON_CHECKPERF_ARGS}
   )
   set_property(TEST checkperf APPEND PROPERTY LABELS per_implementation)
   set_property(TEST checkperf APPEND PROPERTY DEPENDS parse perfdiff ${SIMDJSON_USER_CMAKECACHE})


### PR DESCRIPTION
Currently, the parse benchmark does the `new` calls outside the hot loop, but it uses newly allocated memory for the first time in the hot loop. This memory, though allocated at the C++ level, has not been allocated by the OS yet, necessarily.

Now, it would seem that Windows and the Windows Subsystem for Linux allocate memory differently. Maybe, Windows has slower OS-level memory allocation.  Possibly there are different tradeoffs. Whatever. This is all irrelevant to simdjson.

So let us omit entirely any kind of memory allocation during the hot loop.

My expectation is that this would resolve a good chunk of the mystery behind issue https://github.com/simdjson/simdjson/issues/812


Please keep in mind that we do urge our users to use "hot buffers" (to reuse the same parser instance several times).

BTW it has been thoroughly documented before as part of this project (though not on Windows) that OS-level memory allocation can be a bottleneck. So you don't want your hot loops to be doing that!

Note that I am not claiming that it fixes https://github.com/simdjson/simdjson/issues/812 For example, there is quite obviously a gap between the regular Visual Studio compiler and clangcl. For this side of the issue, we should investigate inlining thoroughly first with ` /d2inlinestats` and ` /d2inlinelogfull:FunctionName`. And there is still the mystery that `/arch:AVX2` appears to give a 10% performance boost to the haswell kernel: it should not.


Ok. So one consequence of this new default is that it will break comparisons between versions. But this is easily resolved: everyone ought to use `-H`. I keep it around in this PR for this reason.

cc @terrymah 


