### PR TITLE
Compare against master on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ platform: x64
 environment:
   matrix:
     - job_name: VS2019
-      CMAKE_ARGS: -DSIMDJSON_CHECKPERF_BRANCH=jkeiser/parse-t
+      CMAKE_ARGS:
     - job_name: VS2019CLANG
       CMAKE_ARGS: -T ClangCL
     - job_name: VS2017 (Static, No Threads)


### PR DESCRIPTION
When I checked in checkperf for Windows, I had to make it compare against a branch to get Windows command line arguments. Now master is fine.

This PR is mostly advisory and so that I can make sure appveyor doesn't break before checking in.