### PR TITLE
Default SIMDJSON_GOOGLE_BENCHMARKS to ON.

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -365,7 +365,8 @@ BENCHMARK(twitter_image_sizes);
 static void error_code_twitter_count(State& state) noexcept {
   // Prints the number of results in twitter.json
   dom::parser parser;
-  dom::element doc = parser.load(TWITTER_JSON);
+  auto [doc, error1] = parser.load(TWITTER_JSON);
+  if (error1) { return; }
   for (UNUSED auto _ : state) {
     auto [value, error] = doc["search_metadata"]["count"].get<uint64_t>();
     if (error) { return; }
@@ -377,7 +378,8 @@ BENCHMARK(error_code_twitter_count);
 static void error_code_twitter_default_profile(State& state) noexcept {
   // Count unique users with a default profile.
   dom::parser parser;
-  dom::element doc = parser.load(TWITTER_JSON);
+  auto [doc, error1] = parser.load(TWITTER_JSON);
+  if (error1) { std::cerr << error1 << std::endl; return; }
   for (UNUSED auto _ : state) {
     set<string_view> default_users;
 
@@ -404,7 +406,8 @@ SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_DEPRECATED_WARNING
 static void iterator_twitter_default_profile(State& state) {
   // Count unique users with a default profile.
-  padded_string json = padded_string::load(TWITTER_JSON);
+  auto [json, error1] = padded_string::load(TWITTER_JSON);
+  if (error1) { std::cerr << error1 << std::endl; return; }
   ParsedJson pj = build_parsed_json(json);
   for (UNUSED auto _ : state) {
     set<string_view> default_users;
@@ -444,7 +447,8 @@ BENCHMARK(iterator_twitter_default_profile);
 static void error_code_twitter_image_sizes(State& state) noexcept {
   // Count unique image sizes
   dom::parser parser;
-  dom::element doc = parser.load(TWITTER_JSON);
+  auto [doc, error1] = parser.load(TWITTER_JSON);
+  if (error1) { std::cerr << error1 << std::endl; return; }
   for (UNUSED auto _ : state) {
     set<tuple<uint64_t, uint64_t>> image_sizes;
     auto [statuses, error] = doc["statuses"].get<dom::array>();
@@ -473,7 +477,8 @@ SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_DEPRECATED_WARNING
 static void iterator_twitter_image_sizes(State& state) {
   // Count unique image sizes
-  padded_string json = padded_string::load(TWITTER_JSON);
+  auto [json, error1] = padded_string::load(TWITTER_JSON);
+  if (error1) { std::cerr << error1 << std::endl; return; }
   ParsedJson pj = build_parsed_json(json);
   for (UNUSED auto _ : state) {
     set<tuple<uint64_t, uint64_t>> image_sizes;
@@ -531,7 +536,8 @@ BENCHMARK(iterator_twitter_image_sizes);
 
 static void print_json(State& state) noexcept {
   // Prints the number of results in twitter.json
-  padded_string json = get_corpus(TWITTER_JSON);
+  auto [json, error1] = padded_string::load(TWITTER_JSON);
+  if (error1) { std::cerr << error1 << std::endl; return; }
   dom::parser parser;
   if (int error = json_parse(json, parser); error != SUCCESS) { cerr << error_message(error) << endl; return; }
   for (UNUSED auto _ : state) {

--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -104,6 +104,9 @@ static void parser_parse_error_code(State& state) {
   }
 }
 BENCHMARK(parser_parse_error_code);
+
+#if SIMDJSON_EXCEPTIONS
+
 static void parser_parse_exception(State& state) {
   dom::parser parser;
   if (parser.allocate(EMPTY_ARRAY.length())) { return; }
@@ -118,6 +121,8 @@ static void parser_parse_exception(State& state) {
 }
 BENCHMARK(parser_parse_exception);
 
+#endif // SIMDJSON_EXCEPTIONS
+
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_DEPRECATED_WARNING
 static void build_parsed_json(State& state) {
@@ -127,6 +132,7 @@ static void build_parsed_json(State& state) {
   }
 }
 SIMDJSON_POP_DISABLE_WARNINGS
+
 BENCHMARK(build_parsed_json);
 static void document_parse_error_code(State& state) {
   for (UNUSED auto _ : state) {
@@ -136,6 +142,9 @@ static void document_parse_error_code(State& state) {
   }
 }
 BENCHMARK(document_parse_error_code);
+
+#if SIMDJSON_EXCEPTIONS
+
 static void document_parse_exception(State& state) {
   for (UNUSED auto _ : state) {
     try {
@@ -148,5 +157,7 @@ static void document_parse_exception(State& state) {
   }
 }
 BENCHMARK(document_parse_exception);
+
+#endif // SIMDJSON_EXCEPTIONS
 
 BENCHMARK_MAIN();

--- a/simdjson-flags.cmake
+++ b/simdjson-flags.cmake
@@ -11,7 +11,7 @@ else()
   option(SIMDJSON_COMPETITION "Compile competitive benchmarks" ON)
   option(SIMDJSON_USE_LIBCPP "Use the libc++ library" OFF)
 endif()
-option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" OFF)
+option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" ON)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 


### PR DESCRIPTION
It takes a few extra seconds the first time you run `cmake` to do Google Benchmarks's configure, and it compiles gbench as well as our benchmarks, taking a few seconds more; but it's a pretty small cost to pay to have the benchmarks available by default.