### PR TITLE
CMake: Use separate headers internally, but install singleheader

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories( . linux )
-link_libraries(simdjson simdjson-flags simdjson-windows-headers)
+link_libraries(simdjson-internal simdjson-windows-headers)
 # add_executable(benchfeatures benchfeatures.cpp) # doesn't presently compile at all
 add_executable(get_corpus_benchmark get_corpus_benchmark.cpp)
 add_executable(perfdiff perfdiff.cpp)

--- a/benchmark/checkperf.cmake
+++ b/benchmark/checkperf.cmake
@@ -58,7 +58,9 @@ if (Git_FOUND)
   # - second, cmake ..
   add_custom_command(
     OUTPUT ${SIMDJSON_CHECKPERF_DIR}/build/cmake_install.cmake # We make many things but this seems the most cross-platform one we can depend on
-    COMMAND ${CMAKE_COMMAND} -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DSIMDJSON_COMPETITION=OFF -G ${CMAKE_GENERATOR} ..
+    COMMAND ${CMAKE_COMMAND}
+     -E env CXX=${CMAKE_CXX_COMPILER} CC=${CMAKE_C_COMPILER}
+     ${CMAKE_COMMAND} -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DSIMDJSON_COMPETITION=OFF -G ${CMAKE_GENERATOR} ../
     WORKING_DIRECTORY ${SIMDJSON_CHECKPERF_DIR}/build
     DEPENDS ${SIMDJSON_CHECKPERF_DIR}/build/CMakeCache.txt
   )

--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -43,7 +43,7 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
     )
     set_property(
       TEST ${TEST_NAME}
-      APPEND PROPERTY DEPENDS simdjson-source ${PROJECT_SOURCE_DIR}/examples/quickstart/${SOURCE_FILE}
+      APPEND PROPERTY DEPENDS simdjson-internal ${PROJECT_SOURCE_DIR}/examples/quickstart/${SOURCE_FILE}
     )
   endfunction(add_quickstart_test)
 

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -34,13 +34,10 @@ if(ENABLE_FUZZING)
 
   # Fuzzer build flags and libraries
   add_library(simdjson-fuzzer INTERFACE)
+  target_link_libraries(simdjson-fuzzer INTERFACE simdjson-internal)
   if (SIMDJSON_FUZZ_LINKMAIN)
-    target_link_libraries(simdjson-fuzzer INTERFACE simdjson-source)
     target_sources(simdjson-fuzzer INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/main.cpp)
-  else ()
-    target_link_libraries(simdjson-fuzzer INTERFACE simdjson)
   endif ()
-  target_link_libraries(simdjson-fuzzer INTERFACE simdjson-flags)
   target_link_libraries(simdjson-fuzzer INTERFACE ${SIMDJSON_FUZZ_LDFLAGS})
 
   # Define the fuzzers

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -9,8 +9,3 @@ target_compile_features(simdjson-headers INTERFACE cxx_std_11) # headers require
 target_include_directories(simdjson-headers INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCDIR}>)
-
-install(TARGETS simdjson-headers EXPORT simdjson-config INCLUDES DESTINATION include)
-install(DIRECTORY simdjson DESTINATION include FILES_MATCHING PATTERN *.h)
-install(DIRECTORY simdjson DESTINATION include FILES_MATCHING PATTERN *.hpp)
-install(FILES simdjson.h DESTINATION include)

--- a/simdjson-flags.cmake
+++ b/simdjson-flags.cmake
@@ -35,6 +35,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 # Flags used by exes and by the simdjson library (project-wide flags)
 #
 add_library(simdjson-flags INTERFACE)
+add_library(simdjson-public-flags INTERFACE)
 if(MSVC)
   target_compile_options(simdjson-flags INTERFACE /nologo /D_CRT_SECURE_NO_WARNINGS)
   target_compile_options(simdjson-flags INTERFACE /WX /W3 /sdl)
@@ -75,22 +76,23 @@ if(SIMDJSON_ENABLE_THREADS)
   find_package(Threads REQUIRED)
   set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
   set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  target_link_libraries(simdjson-flags INTERFACE ${CMAKE_THREAD_LIBS_INIT} )
+  target_link_libraries(simdjson-public-flags INTERFACE ${CMAKE_THREAD_LIBS_INIT} )
 endif()
 
 option(SIMDJSON_SANITIZE "Sanitize addresses" OFF)
 if(SIMDJSON_SANITIZE)
-  target_compile_options(simdjson-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
-  target_link_libraries(simdjson-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
+  target_compile_options(simdjson-public-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
+  target_link_libraries(simdjson-public-flags INTERFACE -fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=all)
 
   # Ubuntu bug for GCC 5.0+ (safe for all versions)
   if (CMAKE_COMPILER_IS_GNUCC)
-    target_link_libraries(simdjson-flags INTERFACE -fuse-ld=gold)
+    message(WARNING ${CMAKE_C_COMPILER_ID})
+    target_link_libraries(simdjson-public-flags INTERFACE "-fuse-ld=gold")
   endif()
 endif()
 
 if(SIMDJSON_USE_LIBCPP)
-  target_link_libraries(simdjson-flags INTERFACE -stdlib=libc++ -lc++abi)
+  target_link_libraries(simdjson-public-flags INTERFACE -stdlib=libc++ -lc++abi)
   # instead of the above line, we could have used
   # set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++  -lc++abi")
   # The next line is needed empirically.
@@ -105,3 +107,4 @@ if(${CMAKE_C_COMPILER_ID} MATCHES "Intel") # icc / icpc
 endif()
 
 install(TARGETS simdjson-flags EXPORT simdjson-config)
+install(TARGETS simdjson-public-flags EXPORT simdjson-config)

--- a/simdjson-flags.cmake
+++ b/simdjson-flags.cmake
@@ -86,7 +86,6 @@ if(SIMDJSON_SANITIZE)
 
   # Ubuntu bug for GCC 5.0+ (safe for all versions)
   if (CMAKE_COMPILER_IS_GNUCC)
-    message(WARNING ${CMAKE_C_COMPILER_ID})
     target_link_libraries(simdjson-public-flags INTERFACE "-fuse-ld=gold")
   endif()
 endif()

--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -17,6 +17,36 @@ set(SINGLEHEADER_REPO_FILES
 )
 set_source_files_properties(${SINGLEHEADER_FILES} PROPERTIES GENERATED TRUE)
 
+#
+# Build the library
+#
+if(SIMDJSON_BUILD_STATIC)
+  MESSAGE( STATUS "Building a static library." )
+  add_library(simdjson STATIC "")
+else()
+  MESSAGE( STATUS "Building a dynamic library." )
+  add_library(simdjson SHARED "")
+  target_compile_definitions(simdjson INTERFACE SIMDJSON_USING_LIBRARY=1)
+  if(MSVC)
+    MESSAGE( STATUS "Building a Windows DLL using Visual Studio, exporting all symbols automatically." )
+    set_target_properties(simdjson PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+  endif()
+endif()
+
+target_include_directories(simdjson PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_sources(simdjson PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/simdjson.cpp>)
+target_link_libraries(simdjson PRIVATE simdjson-flags PUBLIC simdjson-public-flags)
+
+if(NOT MSVC)
+  ## We output the library at the root of the current directory where cmake is invoked
+  ## This is handy but Visual Studio will happily ignore us
+  set_target_properties(simdjson PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+  MESSAGE( STATUS "Library output directory (does not apply to Visual Studio): " ${PROJECT_BINARY_DIR})
+endif()
+
 if (MSVC)
   # MSVC doesn't have bash, so we use existing amalgamated files instead of generating them ...
   # (Do not do this if the source and destination are the same!)
@@ -71,38 +101,8 @@ else(MSVC)
   # "make amalgamate" to generate the header files directly and update the original source
   #
   add_custom_target(amalgamate DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.cpp ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.h ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate_demo.cpp ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
+  add_dependencies(simdjson amalgamate)
 endif(MSVC)
-
-#
-# Build the library
-#
-if(SIMDJSON_BUILD_STATIC)
-  MESSAGE( STATUS "Building a static library." )
-  add_library(simdjson STATIC "")
-else()
-  MESSAGE( STATUS "Building a dynamic library." )
-  add_library(simdjson SHARED "")
-  target_compile_definitions(simdjson INTERFACE SIMDJSON_USING_LIBRARY=1)
-  if(MSVC)
-    MESSAGE( STATUS "Building a Windows DLL using Visual Studio, exporting all symbols automatically." )
-    set_target_properties(simdjson PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
-  endif()
-endif()
-
-add_dependencies(simdjson amalgamate)
-target_include_directories(simdjson PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
-
-target_sources(simdjson PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/simdjson.cpp>)
-target_link_libraries(simdjson PRIVATE simdjson-flags PUBLIC simdjson-public-flags)
-
-if(NOT MSVC)
-  ## We output the library at the root of the current directory where cmake is invoked
-  ## This is handy but Visual Studio will happily ignore us
-  set_target_properties(simdjson PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
-  MESSAGE( STATUS "Library output directory (does not apply to Visual Studio): " ${PROJECT_BINARY_DIR})
-endif()
 
 #
 # Installation

--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -95,7 +95,7 @@ target_include_directories(simdjson PUBLIC
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 target_sources(simdjson PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/simdjson.cpp>)
-target_link_libraries(simdjson PRIVATE simdjson-flags)
+target_link_libraries(simdjson PRIVATE simdjson-flags PUBLIC simdjson-public-flags)
 
 if(NOT MSVC)
   ## We output the library at the root of the current directory where cmake is invoked

--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -30,7 +30,7 @@ if (MSVC)
     )
   endif()
 
-else(MSVC) 
+else(MSVC)
 
   ##
   # Important! The script amalgamate.sh is not generally executable. It
@@ -54,7 +54,7 @@ else(MSVC)
       # It sucks that we have to build the actual library to make it happen, but it's better than\
       # nothing!
       #
-      DEPENDS amalgamate.sh simdjson
+      DEPENDS amalgamate.sh simdjson-internal
   )
 
   # This is used by "make amalgamate" to update the original source files. We obviously don't do
@@ -67,32 +67,64 @@ else(MSVC)
       DEPENDS ${SINGLEHEADER_FILES}
     )
   endif()
-
   #
   # "make amalgamate" to generate the header files directly and update the original source
   #
   add_custom_target(amalgamate DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.cpp ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.h ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate_demo.cpp ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
-  
 endif(MSVC)
 
+#
+# Build the library
+#
+if(SIMDJSON_BUILD_STATIC)
+  MESSAGE( STATUS "Building a static library." )
+  add_library(simdjson STATIC "")
+else()
+  MESSAGE( STATUS "Building a dynamic library." )
+  add_library(simdjson SHARED "")
+  target_compile_definitions(simdjson INTERFACE SIMDJSON_USING_LIBRARY=1)
+  if(MSVC)
+    MESSAGE( STATUS "Building a Windows DLL using Visual Studio, exporting all symbols automatically." )
+    set_target_properties(simdjson PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
+  endif()
+endif()
+
+add_dependencies(simdjson amalgamate)
+target_include_directories(simdjson PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+target_sources(simdjson PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/simdjson.cpp>)
+target_link_libraries(simdjson PRIVATE simdjson-flags)
+
+if(NOT MSVC)
+  ## We output the library at the root of the current directory where cmake is invoked
+  ## This is handy but Visual Studio will happily ignore us
+  set_target_properties(simdjson PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+  MESSAGE( STATUS "Library output directory (does not apply to Visual Studio): " ${PROJECT_BINARY_DIR})
+endif()
 
 #
-# Include this if you intend to #include "simdjson.cpp" in your own .cpp files.
+# Installation
 #
-add_library(simdjson-singleheader-include-source INTERFACE)
-target_include_directories(simdjson-singleheader-include-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+install(FILES simdjson.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-#
-# Include this to get "simdjson.cpp" included in your project as one of the sources.
-#
-add_library(simdjson-singleheader-source INTERFACE)
-target_sources(simdjson-singleheader-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/simdjson.cpp>)
-target_link_libraries(simdjson-singleheader-source INTERFACE simdjson-singleheader-include-source)
-add_dependencies(simdjson-singleheader-source amalgamate)
+install(TARGETS simdjson
+  EXPORT simdjson-config
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(EXPORT simdjson-config
+  FILE simdjson-config.cmake
+  NAMESPACE simdjson::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simdjson
+)
 
 #
 # Test the generated simdjson.cpp/simdjson.h using the generated amalgamate_demo.cpp
 #
 add_executable(amalgamate_demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamate_demo.cpp>)
-target_link_libraries(amalgamate_demo simdjson-singleheader-include-source simdjson-flags)
+target_link_libraries(amalgamate_demo simdjson)
 add_test(amalgamate_demo amalgamate_demo ${EXAMPLE_JSON} ${EXAMPLE_NDJSON})

--- a/singleheader/amalgamate.sh
+++ b/singleheader/amalgamate.sh
@@ -124,7 +124,7 @@ echo "/* auto-generated on ${timestamp}. Do not edit! */" > ${DEMOCPP}
 cat <<< '
 #include <iostream>
 #include "simdjson.h"
-#include "simdjson.cpp"
+
 int main(int argc, char *argv[]) {
   if(argc < 2) {
     std::cerr << "Please specify at least one file name. " << std::endl;

--- a/singleheader/amalgamate_demo.cpp
+++ b/singleheader/amalgamate_demo.cpp
@@ -1,8 +1,8 @@
-/* auto-generated on Mon 27 Apr 2020 21:20:37 EDT. Do not edit! */
+/* auto-generated on Fri 01 May 2020 01:06:51 AM +03. Do not edit! */
 
 #include <iostream>
 #include "simdjson.h"
-#include "simdjson.cpp"
+
 int main(int argc, char *argv[]) {
   if(argc < 2) {
     std::cerr << "Please specify at least one file name. " << std::endl;

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Mon 27 Apr 2020 21:20:37 EDT. Do not edit! */
+/* auto-generated on Fri 01 May 2020 01:06:51 AM +03. Do not edit! */
 /* begin file simdjson.cpp */
 #include "simdjson.h"
 

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on Mon 27 Apr 2020 21:20:37 EDT. Do not edit! */
+/* auto-generated on Fri 01 May 2020 01:06:51 AM +03. Do not edit! */
 /* begin file simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -5297,7 +5297,7 @@ inline simdjson_result<element> object::at_key_case_insensitive(const std::strin
     if (key.length() == field_key.length()) {
       bool equal = true;
       for (size_t i=0; i<field_key.length(); i++) {
-        equal = equal && std::tolower(key[i]) != std::tolower(field_key[i]);
+        equal = equal && std::tolower(key[i]) == std::tolower(field_key[i]);
       }
       if (equal) { return field.value(); }
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,16 +10,6 @@ target_link_libraries(simdjson-include-source INTERFACE simdjson-headers)
 target_include_directories(simdjson-include-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 #
-# For callers who intend to compile simdjson.cpp themselves.
-#
-# target_link_libraries(my-object simdjson-source) gives you the header and source directories, plus
-# the .cpp sources. It does not specify any compiler flags.
-#
-add_library(simdjson-source INTERFACE)
-target_sources(simdjson-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/simdjson.cpp)
-target_link_libraries(simdjson-source INTERFACE simdjson-include-source)
-
-#
 # simdjson is the distributed library compiled with flags.
 #
 # target_link_libraries(my-object simdjson) gives you the .so or .a to link against, plus the header
@@ -29,4 +19,4 @@ target_link_libraries(simdjson-source INTERFACE simdjson-include-source)
 # TODO: For some reason simdjson-internal cannot pass checkperf if built as a static library
 add_library(simdjson-internal SHARED simdjson.cpp)
 target_link_libraries(simdjson-internal PUBLIC simdjson-headers simdjson-flags)
-target_link_libraries(simdjson-internal PRIVATE simdjson-source)
+target_link_libraries(simdjson-internal PRIVATE simdjson-include-source)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,6 @@
 add_library(simdjson-include-source INTERFACE)
 target_link_libraries(simdjson-include-source INTERFACE simdjson-headers)
 target_include_directories(simdjson-include-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-install(TARGETS simdjson-include-source EXPORT simdjson-config)
 
 #
 # For callers who intend to compile simdjson.cpp themselves.
@@ -19,7 +18,6 @@ install(TARGETS simdjson-include-source EXPORT simdjson-config)
 add_library(simdjson-source INTERFACE)
 target_sources(simdjson-source INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>/simdjson.cpp)
 target_link_libraries(simdjson-source INTERFACE simdjson-include-source)
-install(TARGETS simdjson-source EXPORT simdjson-config)
 
 #
 # simdjson is the distributed library compiled with flags.
@@ -28,44 +26,7 @@ install(TARGETS simdjson-source EXPORT simdjson-config)
 # directory. It does not specify any compiler flags, even though simdjson.so/a was compiled with
 # target_link_libraries(simdjson PRIVATE simdjson-flags).
 #
-
-if(SIMDJSON_BUILD_STATIC)
-  MESSAGE( STATUS "Building a static library." )
-  add_library(simdjson STATIC "")
-else()
-  MESSAGE( STATUS "Building a dynamic library." )
-  add_library(simdjson SHARED "")
-  target_compile_definitions(simdjson INTERFACE SIMDJSON_USING_LIBRARY=1)
-  if(MSVC)
-    MESSAGE( STATUS "Building a Windows DLL using Visual Studio, exporting all symbols automatically." )
-    set_target_properties(simdjson PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS 1)
-  endif()
-endif()
-
-target_link_libraries(simdjson INTERFACE simdjson-headers) # Only expose the headers, not sources
-
-target_link_libraries(simdjson PRIVATE simdjson-source simdjson-flags)
-
-
-if(NOT MSVC)
-  ## We output the library at the root of the current directory where cmake is invoked
-  ## This is handy but Visual Studio will happily ignore us
-  set_target_properties(simdjson PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
-  MESSAGE( STATUS "Library output directory (does not apply to Visual Studio): " ${PROJECT_BINARY_DIR})
-endif()
-
-#
-# Installation
-#
-install(TARGETS simdjson
-  EXPORT simdjson-config
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-
-install(EXPORT simdjson-config
-  FILE simdjson-config.cmake
-  NAMESPACE simdjson::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/simdjson
-)
+# TODO: For some reason simdjson-internal cannot pass checkperf if built as a static library
+add_library(simdjson-internal SHARED simdjson.cpp)
+target_link_libraries(simdjson-internal PUBLIC simdjson-headers simdjson-flags)
+target_link_libraries(simdjson-internal PRIVATE simdjson-source)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ if (NOT MSVC) # Can't get simdjson-source to compile on Windows for some reason.
 endif()
 
 # All remaining tests link with simdjson proper
-link_libraries(simdjson)
+link_libraries(simdjson-internal)
 add_cpp_test(basictests LABELS acceptance per_implementation)
 add_cpp_test(errortests LABELS acceptance per_implementation)
 add_cpp_test(integer_tests LABELS acceptance per_implementation)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(simdjson simdjson-flags simdjson-windows-headers)
+link_libraries(simdjson-internal simdjson-flags simdjson-windows-headers)
 
 add_executable(json2json json2json.cpp)
 add_executable(jsonstats jsonstats.cpp)


### PR DESCRIPTION
Only single-header version of the library is installed (simdjson.h) as part of the public API. However, internally for tests and tools header files under include/ is used (simdjson-internal), and simdjson-include-source (numberparsingcheck and stringparsingcheck uses it)

Unfortunately, it still exports simdjson-flags but I am looking for a way to get rid of that too.