### PR TITLE
Remove references to iso646.h

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -502,7 +502,7 @@ struct benchmarker {
         double freqall = (all_stages.best.cycles() / all_stages.best.elapsed_sec()) / 1000000000.0;
         double freqmin = min(freq1, freq2);
         double freqmax = max(freq1, freq2);
-        if((freqall < 0.95 * freqmin) or (freqall > 1.05 * freqmax)) {
+        if ((freqall < 0.95 * freqmin) || (freqall > 1.05 * freqmax)) {
           printf("\nWarning: The processor frequency fluctuates in an expected way!!!\n"
           "Expect the overall speed not to match stage 1 and stage 2 speeds.\n"
           "Range for stage 1 and stage 2 : [%.3f GHz, %.3f GHz], overall: %.3f GHz.\n",

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -88,7 +88,7 @@ static inline bool is_ascii(char c) {
 // if the string ends with  UTF-8 values, backtrack
 // up to the first ASCII character. May return 0.
 static inline size_t trimmed_length_safe_utf8(const char * c, size_t len) {
-  while ((len > 0) and (not is_ascii(c[len - 1]))) {
+  while ((len > 0) && (!is_ascii(c[len - 1]))) {
     len--;
   }
   return len;

--- a/include/simdjson/inline/padded_string.h
+++ b/include/simdjson/inline/padded_string.h
@@ -42,7 +42,7 @@ inline padded_string::padded_string(size_t length) noexcept
 }
 inline padded_string::padded_string(const char *data, size_t length) noexcept
     : viable_size(length), data_ptr(internal::allocate_padded_buffer(length)) {
-  if ((data != nullptr) and (data_ptr != nullptr)) {
+  if ((data != nullptr) && (data_ptr != nullptr)) {
     memcpy(data_ptr, data, length);
     data_ptr[length] = '\0'; // easier when you need a c_str
   }

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -28,13 +28,6 @@
 #endif // __clang__
 #endif // _MSC_VER
 
-#ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-// https://en.wikipedia.org/wiki/C_alternative_tokens
-// This header should have no effect, except maybe
-// under Visual Studio.
-#include <iso646.h>
-#endif
-
 #if defined(__x86_64__) || defined(_M_AMD64)
 #define SIMDJSON_IS_X86_64 1
 #endif

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1348,7 +1348,7 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
 }
 
 really_inline error_code json_string_scanner::finish(bool streaming) {
-  if (prev_in_string and (not streaming)) {
+  if (prev_in_string && !streaming) {
     return UNCLOSED_STRING;
   }
   return SUCCESS;
@@ -3151,7 +3151,7 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
 }
 
 really_inline error_code json_string_scanner::finish(bool streaming) {
-  if (prev_in_string and (not streaming)) {
+  if (prev_in_string && !streaming) {
     return UNCLOSED_STRING;
   }
   return SUCCESS;
@@ -4705,7 +4705,7 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
 }
 
 really_inline error_code json_string_scanner::finish(bool streaming) {
-  if (prev_in_string and (not streaming)) {
+  if (prev_in_string && !streaming) {
     return UNCLOSED_STRING;
   }
   return SUCCESS;

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -82,13 +82,6 @@
 #endif // __clang__
 #endif // _MSC_VER
 
-#ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-// https://en.wikipedia.org/wiki/C_alternative_tokens
-// This header should have no effect, except maybe
-// under Visual Studio.
-#include <iso646.h>
-#endif
-
 #if defined(__x86_64__) || defined(_M_AMD64)
 #define SIMDJSON_IS_X86_64 1
 #endif
@@ -5875,7 +5868,7 @@ static inline bool is_ascii(char c) {
 // if the string ends with  UTF-8 values, backtrack
 // up to the first ASCII character. May return 0.
 static inline size_t trimmed_length_safe_utf8(const char * c, size_t len) {
-  while ((len > 0) and (not is_ascii(c[len - 1]))) {
+  while ((len > 0) && (!is_ascii(c[len - 1]))) {
     len--;
   }
   return len;
@@ -6255,7 +6248,7 @@ inline padded_string::padded_string(size_t length) noexcept
 }
 inline padded_string::padded_string(const char *data, size_t length) noexcept
     : viable_size(length), data_ptr(internal::allocate_padded_buffer(length)) {
-  if ((data != nullptr) and (data_ptr != nullptr)) {
+  if ((data != nullptr) && (data_ptr != nullptr)) {
     memcpy(data_ptr, data, length);
     data_ptr[length] = '\0'; // easier when you need a c_str
   }

--- a/src/generic/json_string_scanner.h
+++ b/src/generic/json_string_scanner.h
@@ -118,7 +118,7 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
 }
 
 really_inline error_code json_string_scanner::finish(bool streaming) {
-  if (prev_in_string and (not streaming)) {
+  if (prev_in_string && !streaming) {
     return UNCLOSED_STRING;
   }
   return SUCCESS;

--- a/tests/parse_many_test.cpp
+++ b/tests/parse_many_test.cpp
@@ -89,13 +89,13 @@ bool validate(const char *dirname) {
             if (contains("EXCLUDE", name)) {
                 // skipping
                 how_many--;
-            } else if (starts_with("pass", name) and (has_extension(extension1, name) or has_extension(extension2, name)) and error) {
+            } else if (starts_with("pass", name) && (has_extension(extension1, name) || has_extension(extension2, name)) && error) {
                 is_file_as_expected[i] = false;
                 printf("warning: file %s should pass but it fails. Error is: %s\n",
                        name, error_message(error));
                 printf("size of file in bytes: %zu \n", json.size());
                 everything_fine = false;
-            } else if ( starts_with("fail", name) and (not starts_with("fail10.json", name)) and !error) {
+            } else if ( starts_with("fail", name) && (!starts_with("fail10.json", name)) && !error) {
                 is_file_as_expected[i] = false;
                 printf("warning: file %s should fail but it passes.\n", name);
                 printf("size of file in bytes: %zu \n", json.size());


### PR DESCRIPTION
It's deprecated in c++ and should not be used