### PR TITLE
Only install singleheader/simdjson.h as part of the public API

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -11,6 +11,3 @@ target_include_directories(simdjson-headers INTERFACE
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCDIR}>)
 
 install(TARGETS simdjson-headers EXPORT simdjson-config INCLUDES DESTINATION include)
-install(DIRECTORY simdjson DESTINATION include FILES_MATCHING PATTERN *.h)
-install(DIRECTORY simdjson DESTINATION include FILES_MATCHING PATTERN *.hpp)
-install(FILES simdjson.h DESTINATION include)

--- a/singleheader/CMakeLists.txt
+++ b/singleheader/CMakeLists.txt
@@ -30,7 +30,7 @@ if (MSVC)
     )
   endif()
 
-else(MSVC) 
+else(MSVC)
 
   ##
   # Important! The script amalgamate.sh is not generally executable. It
@@ -72,7 +72,6 @@ else(MSVC)
   # "make amalgamate" to generate the header files directly and update the original source
   #
   add_custom_target(amalgamate DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.cpp ${CMAKE_CURRENT_SOURCE_DIR}/simdjson.h ${CMAKE_CURRENT_SOURCE_DIR}/amalgamate_demo.cpp ${CMAKE_CURRENT_SOURCE_DIR}/README.md)
-  
 endif(MSVC)
 
 
@@ -96,3 +95,5 @@ add_dependencies(simdjson-singleheader-source amalgamate)
 add_executable(amalgamate_demo $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/amalgamate_demo.cpp>)
 target_link_libraries(amalgamate_demo simdjson-singleheader-include-source simdjson-flags)
 add_test(amalgamate_demo amalgamate_demo ${EXAMPLE_JSON} ${EXAMPLE_NDJSON})
+
+install(FILES simdjson.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
PR in #841 got a bit messy since it touches many parts (flags, amalgamation, sanitizer). I decided to divide that into patches.

This one only installs singleheader/simdjson.h instead of the include/ directory.
@jkeiser noted in #841 that singleheader/simdjson.cpp is also part of the public API but I wasn't sure if I should install that under include/ that is why I left it out for now (but I can add if there is a consensus).