### PR TITLE
Make the string buffer valid UTF-8 [discussion]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
     steps:
       - cmake_build
       - run: ctest $CTEST_FLAGS -L acceptance
-      - run: ctest $CTEST_FLAGS -LE acceptance -E checkperf
+      - run: ctest $CTEST_FLAGS -LE acceptance
 
   cmake_test_all:
     steps:

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -1038,6 +1038,7 @@ public:
   really_inline bool on_null_atom() noexcept; ///< @private
   really_inline uint8_t *on_start_string() noexcept; ///< @private
   really_inline bool on_end_string(uint8_t *dst) noexcept; ///< @private
+  bool handle_long_string(uint8_t *dst) noexcept;///< @private
   really_inline bool on_number_s64(int64_t value) noexcept; ///< @private
   really_inline bool on_number_u64(uint64_t value) noexcept; ///< @private
   really_inline bool on_number_double(double value) noexcept; ///< @private

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -78,6 +78,8 @@ public:
   really_inline uint32_t scope_count() const noexcept;
   template<typename T>
   really_inline T next_tape_value() const noexcept;
+  really_inline uint32_t get_string_length() const noexcept;
+  really_inline const char * get_c_str() const noexcept;
   inline std::string_view get_string_view() const noexcept;
 
   /** The document this element references. */
@@ -219,7 +221,22 @@ public:
      * Get the key of this key/value pair.
      */
     inline std::string_view key() const noexcept;
-
+    /**
+    * Get the length (in bytes) of the key in this key/value pair.
+    * You should expect this function to be faster than key().size().
+    */
+    inline uint32_t key_length() const noexcept;
+    /**
+    * Returns true of the the key in this key/value pair is equal
+    * to the provided string_view.
+    */
+    inline bool key_equals(const std::string_view & o) const noexcept;
+    /**
+    * Returns true of the the key in this key/value pair is equal
+    * to the provided string_view in a case-insensitive manner.
+    * Case comparisons may only be handled correctly for ASCII strings.
+    */
+    inline bool key_equals_case_insensitive(const std::string_view & o) const noexcept;
     /**
      * Get the key of this key/value pair.
      */

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -226,7 +226,6 @@ inline error_code document::allocate(size_t capacity) noexcept {
 }
 
 inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
-  uint32_t string_length;
   size_t tape_idx = 0;
   uint64_t tape_val = tape[tape_idx];
   uint8_t type = uint8_t(tape_val >> 56);
@@ -249,11 +248,23 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
     switch (type) {
     case '"': // we have a string
       os << "string \"";
-      memcpy(&string_length, string_buf.get() + payload, sizeof(uint32_t));
-      os << internal::escape_json_string(std::string_view(
-        (const char *)(string_buf.get() + payload + sizeof(uint32_t)),
-        string_length
-      ));
+      {
+        // this legacy code must die
+        uint32_t len = (payload >> 32) & 0xFFFFFF; // grab 3 bytes
+        uint32_t string_buf_index = uint32_t(payload);
+        if(unlikely(len > 0x7fffff)) {
+          len ^= 0x800000;
+          len <<= 9;
+          uint32_t c1 = string_buf[string_buf_index - 2] - 32;
+          len |= c1 << 4;
+          uint32_t c2 = string_buf[string_buf_index - 1] - 32;
+          len |= c2;
+        }
+        os << internal::escape_json_string(std::string_view(
+          (const char *)(string_buf.get() +string_buf_index),
+          len
+        ));
+      }
       os << '"';
       os << '\n';
       break;
@@ -672,7 +683,7 @@ inline simdjson_result<element> object::at(const std::string_view &json_pointer)
 inline simdjson_result<element> object::at_key(const std::string_view &key) const noexcept {
   iterator end_field = end();
   for (iterator field = begin(); field != end_field; ++field) {
-    if (key == field.key()) {
+    if (field.key_equals(key)) {
       return field.value();
     }
   }
@@ -684,13 +695,8 @@ inline simdjson_result<element> object::at_key(const std::string_view &key) cons
 inline simdjson_result<element> object::at_key_case_insensitive(const std::string_view &key) const noexcept {
   iterator end_field = end();
   for (iterator field = begin(); field != end_field; ++field) {
-    auto field_key = field.key();
-    if (key.length() == field_key.length()) {
-      // See For case-insensitive string comparisons, avoid char-by-char functions
-      // https://lemire.me/blog/2020/04/30/for-case-insensitive-string-comparisons-avoid-char-by-char-functions/
-      // Note that it might be worth rolling our own strncasecmp function, with vectorization.
-      const bool equal = (simdjson_strncasecmp(key.data(), field_key.data(), key.length()) == 0);
-      if (equal) { return field.value(); }
+    if (field.key_equals_case_insensitive(key)) {
+      return field.value();
     }
   }
   return NO_SUCH_FIELD;
@@ -712,17 +718,53 @@ inline object::iterator& object::iterator::operator++() noexcept {
   return *this;
 }
 inline std::string_view object::iterator::key() const noexcept {
-  size_t string_buf_index = size_t(tape_value());
-  uint32_t len;
-  memcpy(&len, &doc->string_buf[string_buf_index], sizeof(len));
-  return std::string_view(
-    reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]),
-    len
-  );
+  return get_string_view();
+}
+inline uint32_t object::iterator::key_length() const noexcept {
+  return get_string_length();
 }
 inline const char* object::iterator::key_c_str() const noexcept {
-  return reinterpret_cast<const char *>(&doc->string_buf[size_t(tape_value()) + sizeof(uint32_t)]);
+  return get_c_str();
 }
+
+
+/**
+ * Design notes:
+ * Instead of constructing a string_view and then comparing it with a
+ * user-provided strings, it is probably more performant to have dedicated
+ * functions taking as a parameter the string we want to compare against
+ * and return true when they are equal. That avoids the creation of a temporary
+ * std::string_view. Though it is possible for the compiler to avoid entirely
+ * any overhead due to string_view, relying too much on compiler magic is
+ * problematic: compiler magic sometimes fail, and then what do you do?
+ * Also, enticing users to rely on high-performance function is probably better
+ * on the long run.
+ */
+
+inline bool object::iterator::key_equals(const std::string_view & o) const noexcept {
+  // We use the fact that the key length can be computed quickly
+  // without access to the string buffer.
+  const uint32_t len = key_length();
+  if(o.size() == len) {
+    // We avoid construction of a temporary string_view instance.
+    return (memcmp(o.data(), key_c_str(), len) == 0);
+  }
+  return false;
+}
+
+inline bool object::iterator::key_equals_case_insensitive(const std::string_view & o) const noexcept {
+  // We use the fact that the key length can be computed quickly
+  // without access to the string buffer.
+  const uint32_t len = key_length();
+  if(o.size() == len) {
+      // See For case-insensitive string comparisons, avoid char-by-char functions
+      // https://lemire.me/blog/2020/04/30/for-case-insensitive-string-comparisons-avoid-char-by-char-functions/
+      // Note that it might be worth rolling our own strncasecmp function, with vectorization.
+      return (simdjson_strncasecmp(o.data(), key_c_str(), len) == 0);
+  }
+  return false;
+}
+
 inline element object::iterator::value() const noexcept {
   return element(doc, json_index + 1);
 }
@@ -761,8 +803,7 @@ template<>
 inline simdjson_result<const char *> element::get<const char *>() const noexcept {
   switch (tape_ref_type()) {
     case internal::tape_type::STRING: {
-      size_t string_buf_index = size_t(tape_value());
-      return reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]);
+      return get_c_str();
     }
     default:
       return INCORRECT_TYPE;
@@ -1161,13 +1202,46 @@ really_inline T tape_ref::next_tape_value() const noexcept {
   memcpy(&x,&doc->tape[json_index + 1],sizeof(uint64_t));
   return x;
 }
+
+ /**
+ * Design notes:
+ * Instead of having references to the low-level string_buf all over the
+ * code, we hide all of the logic in get_string_length and get_c_str
+ * and build everything from there. Note that get_string_length is
+ * expected to be a very fast function, so it should be broadly available
+ */
+
+really_inline uint32_t internal::tape_ref::get_string_length() const noexcept {
+  uint64_t tape_val = uint64_t(tape_value());
+  uint32_t len = (tape_val >> 32) & 0xFFFFFF; // grab 3 bytes
+  if(unlikely(len > 0x7fffff)) {  // only go there if the highest bit is set
+    uint32_t string_buf_index = uint32_t(tape_val); // we will need to touch the string buffer
+    // we have a long string and we need to jump through some loops
+    len ^= 0x800000; // set the high bit to zero
+    len <<= 9; // we are just missing 9 bits, we have 23 bits. 23 + 9 = 32
+    // middle 5 bites
+    uint32_t c1 = doc->string_buf[string_buf_index - 2] - 32;
+    len |= c1 << 4;
+    // least significant five bits
+    uint32_t c2 = doc->string_buf[string_buf_index - 1] - 32;
+    len |= c2;
+  }
+  // if the slow path can be avoided, then we get the string length without
+  // touching (at all) the string buffer.
+  return len;
+}
+
+
+really_inline const char * internal::tape_ref::get_c_str() const noexcept {
+  uint64_t tape_val = uint64_t(tape_value());
+  uint32_t string_buf_index = uint32_t(tape_val);
+  return reinterpret_cast<const char *>(&doc->string_buf[string_buf_index]);
+}
+
 inline std::string_view internal::tape_ref::get_string_view() const noexcept {
-  size_t string_buf_index = size_t(tape_value());
-  uint32_t len;
-  memcpy(&len, &doc->string_buf[string_buf_index], sizeof(len));
   return std::string_view(
-    reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]),
-    len
+      get_c_str(),
+      get_string_length()
   );
 }
 

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -253,7 +253,6 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
         uint32_t len = (payload >> 32) & 0xFFFFFF; // grab 3 bytes
         uint32_t string_buf_index = uint32_t(payload);
         if(unlikely(len > 0x7fffff)) {
-          len ^= 0x800000;
           len <<= 9;
           uint32_t c1 = string_buf[string_buf_index - 2] - 32;
           len |= c1 << 4;

--- a/include/simdjson/parsedjson_iterator.h
+++ b/include/simdjson/parsedjson_iterator.h
@@ -70,8 +70,19 @@ public:
   // print_with_escapes) return value is valid UTF-8, it may contain NULL chars
   // within the string: get_string_length determines the true string length.
   inline const char *get_string() const {
+      uint32_t index =  uint32_t(current_val);
+      uint32_t len = (current_val >> 32) & 0xFFFFFF;
+      if(unlikely(len > 0x7fffff)) {
+          uint64_t string_buf_index = current_val;
+          len <<= 9;
+          uint32_t c1 = doc.string_buf[string_buf_index + 1] - 32;
+          len |= c1 << 4;
+          uint32_t c2 = doc.string_buf[string_buf_index + 2] - 32;
+          len |= c2;
+          index -= len;
+      }
       return reinterpret_cast<const char *>(
-          doc.string_buf.get() + uint32_t(current_val));
+          doc.string_buf.get() + index);
   }
 
   // return the length of the string in bytes
@@ -79,11 +90,10 @@ public:
       uint32_t len = (current_val >> 32) & 0xFFFFFF;
       if(unlikely(len > 0x7fffff)) {
           uint64_t string_buf_index = current_val;
-          len ^= 0x800000;
           len <<= 9;
-          uint32_t c1 = doc.string_buf[string_buf_index - 2] - 32;
+          uint32_t c1 = doc.string_buf[string_buf_index + 1] - 32;
           len |= c1 << 4;
-          uint32_t c2 = doc.string_buf[string_buf_index - 1] - 32;
+          uint32_t c2 = doc.string_buf[string_buf_index + 2] - 32;
           len |= c2;
       }
       // if the slow path can be avoided, then we get the string length without

--- a/src/document_parser_callbacks.h
+++ b/src/document_parser_callbacks.h
@@ -87,60 +87,55 @@ really_inline bool parser::on_null_atom() noexcept {
 }
 
 really_inline uint8_t *parser::on_start_string() noexcept {
-  /* We advance the pointer. */
-  // If we limit JSON documents to strictly less 4GB of
-  // string content, then current_string_buf_loc
-  // - doc.string_buf.get() fits in 32 bits. This leaves us
-  // three free bytes.
-  uint32_t position = uint32_t(current_string_buf_loc - doc.string_buf.get()); // cannot overflow because documents are limited to < 4GB
-  write_tape(uint64_t(position), internal::tape_type::STRING);
+  /* We do nothing, the actual work occurs in on_end_string() */
   return current_string_buf_loc;
 }
 
+bool parser::handle_long_string(uint8_t *dst) noexcept {
+  uint64_t str_length = dst - current_string_buf_loc;
+  // Oh gosh, we have a long string (8MB). We expect that this is
+  // highly uncommon. We want to keep everything else super efficient,
+  // so we will pay a complexity price for this one uncommon case.
+  int offset = 2;
+  uint64_t position = current_string_buf_loc - doc.string_buf.get() + offset;
+  uint64_t lenmark = uint64_t(0x800000 | (str_length >> 9));
+  uint64_t payload =  position |  (lenmark << 32);
+  write_tape(payload, internal::tape_type::STRING);
+  // We are going to make room. This copy is not free. However,
+  // it allows us to handle the common case with ease and with
+  // relatively little complexity. And a memcopy is not that slow:
+  // it may run at tens of GB/s.
+  // And we expect that it will effectively never happen in practice
+  // so there is no cause to complexify the rest of the code.
+  memmove(current_string_buf_loc + offset, current_string_buf_loc, str_length);
+  dst += offset;
+  // We have three free bytes, but
+  // we need a leading 1, so that's 24-1 = 23. 32-23=9 remaining bits.
+  // We have 9 bits left to code, which we do on the string buffer
+  // using two bytes. We encoding the binary data using ASCII characters.
+  // See https://lemire.me/blog/2020/05/02/encoding-binary-in-ascii-very-fast/
+  // for a more general approach.
+  //
+  // These two bytes will appear right before where the string is.
+  current_string_buf_loc[0] = uint8_t(32 + ((str_length & 0x1f0) >> 4)); // (0x1f0>>4)+32 = 63
+  current_string_buf_loc[1] = uint8_t(32 + (str_length & 0xf)); // 32 + 0xf = 47
+  *dst = 0;
+  current_string_buf_loc = dst + 1;
+  return true;
+
+}
+
 really_inline bool parser::on_end_string(uint8_t *dst) noexcept {
-  uint32_t str_length = uint32_t(dst - current_string_buf_loc);
+  uint64_t str_length = dst - current_string_buf_loc;
+  if(unlikely(str_length > 0x7fffff)) {
+    return handle_long_string(dst);
+  }
+  uint64_t position = current_string_buf_loc - doc.string_buf.get();
   // Long document support: Currently, simdjson supports only document
   // up to 4GB.
   // Should we change this constraint, we should then check for overflow in case
   // someone has a crazy string (>=4GB?).
-
-  // We have two scenarios here. Either the string length is
-  // less than 0x7fffff in which case, we have room in the string
-  // header and all is good. Otherwise, we can encode the
-  // string length in the document itself, taking care to
-  // ensure that we do so in ASCII.
-  if(likely(str_length <= 0x7fffff)) { // likely
-    doc.tape[current_loc-1] |=  uint64_t(str_length) << 32;
-  } else {
-    // Oh gosh, we have a long string (8MB). We expect that this is
-    // highly uncommon. We want to keep everything else super efficient,
-    // so we will pay a complexity price for this one uncommon case.
-    int offset = 2;
-    uint64_t payload = doc.tape[current_loc-1] & 0xFFFFFFFF;
-    payload += offset;
-    payload |=  uint64_t(0x800000 | (str_length >> 9)) << 32;
-    doc.tape[current_loc-1] =  payload  | ((uint64_t(char(internal::tape_type::STRING))) << 56);
-    // We are going to make room. This copy is not free. However,
-    // it allows us to handle the common case with ease and with
-    // relatively little complexity. And a memcopy is not that slow:
-    // it may run at tens of GB/s.
-    // And we expect that it will effectively never happen in practice
-    // so there is no cause to complexify the rest of the code.
-    memmove(current_string_buf_loc + offset, current_string_buf_loc, str_length);
-    dst += offset;
-    // We have three free bytes, but
-    // we need a leading 1, so that's 24-1 = 23. 32-23=9 remaining bits.
-    // We have 9 bits left to code, which we do on the string buffer
-    // using two bytes. We encoding the binary data using ASCII characters.
-    // See https://lemire.me/blog/2020/05/02/encoding-binary-in-ascii-very-fast/
-    // for a more general approach.
-    //
-    // These two bytes will appear right before where the string is.
-    current_string_buf_loc[0] = uint8_t(32 + ((str_length & 0x1f0) >> 4)); // (0x1f0>>4)+32 = 63
-    current_string_buf_loc[1] = uint8_t(32 + (str_length & 0xf)); // 32 + 0xf = 47
-  }
-  // NULL termination is still handy if you expect all your strings to
-  // be NULL terminated? It comes at a small cost.
+  write_tape(position | (str_length << 32), internal::tape_type::STRING);
   *dst = 0;
   current_string_buf_loc = dst + 1;
   return true;

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -203,6 +203,21 @@ namespace document_tests {
     }
     return true;
   }
+  bool humongous_strings() {
+    std::cout << __func__ << std::endl;
+    size_t N = 15000000;
+    simdjson::padded_string large = std::string("\"") + std::string(N, '.') + std::string("\"");
+    simdjson::dom::parser parser;
+    auto [doc, error] = parser.parse(large).get<std::string_view>();
+    if (error) {
+      printf("This json should  be valid.\n");
+      return false;
+    }
+    if(doc.size() != N) {
+      return false;
+    }
+    return true;
+  }
   bool count_array_example() {
     std::cout << __func__ << std::endl;
     simdjson::padded_string smalljson = "[1,2,3]"_padded;
@@ -337,7 +352,8 @@ namespace document_tests {
     return true;
   }
   bool run() {
-    return bad_example() &&
+    return humongous_strings() &&
+           bad_example() &&
            count_array_example() &&
            count_object_example() &&
            stable_test() &&

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -214,6 +214,11 @@ namespace document_tests {
       return false;
     }
     if(doc.size() != N) {
+      printf("Strings are of different size.\n");
+      return false;
+    }
+    if(doc != std::string(N, '.')) {
+      printf("Strings differ.\n");
       return false;
     }
     return true;


### PR DESCRIPTION
Would fix https://github.com/simdjson/simdjson/issues/185

This PR does...

- [X] Move the length of the string on the main tape. This may help performance since you can often determine that you do not have the right key simply by checking the string length. Thus many comparisons can be made without access to the string buffer.
- [X] Make the string buffer a valid string. Currently, we write the string length in the string buffer which makes it non-UTF8 valid. If we only add ASCII content, then we will be able to move the unicode validation off stage 1 and into a cheaper "stage 3". The advantage of that is that the validation would only be done on the actual string content.
- [X] We save a few bytes on the string buffer per string (four bytes). This might help performance a bit (for large files made of strings or at query time).


Negatives...

- [X] We now have to do extra work at query time to deal with the special case of a long string. It is mostly the cost of a never-taken inexpensive branch. It is not a great thing but it is also not disastrous.


Claims of performance regression are overrated. I think we have over-sensitive tests. Regarding performance, let us keep in mind that this PR opens the door to new optimizations, most importantly the removal of UTF8 validation from the main stage 1.



Regarding performance... for each file, the first row is this PR, the second is master...

Trial 1:


```
$ for i in ../jsonexamples/*.json ; do echo $i; ./benchmark/parse -n 100 $i | grep GB | head -n 1; ./../buildmaster/benchmark/parse -n 100 $i | grep GB | head -n 1; done
../jsonexamples/apache_builds.json
|    Speed        :  25.9950 ns per block ( 99.08%) -   0.4062 ns per byte -   4.1818 ns per structural -   2.4616 GB/s
|    Speed        :  25.9472 ns per block ( 98.96%) -   0.4055 ns per byte -   4.1741 ns per structural -   2.4661 GB/s
../jsonexamples/canada.json
|    Speed        :  71.3523 ns per block ( 99.35%) -   1.1149 ns per byte -   7.5056 ns per structural -   0.8969 GB/s
|    Speed        :  71.0723 ns per block ( 99.58%) -   1.1105 ns per byte -   7.4762 ns per structural -   0.9005 GB/s
../jsonexamples/citm_catalog.json
|    Speed        :  22.8718 ns per block ( 99.58%) -   0.3574 ns per byte -   4.5390 ns per structural -   2.7982 GB/s
|    Speed        :  22.8472 ns per block ( 99.44%) -   0.3570 ns per byte -   4.5342 ns per structural -   2.8012 GB/s
../jsonexamples/github_events.json
|    Speed        :  24.4774 ns per block ( 98.32%) -   0.3826 ns per byte -   5.3518 ns per structural -   2.6139 GB/s
|    Speed        :  24.2387 ns per block ( 97.99%) -   0.3788 ns per byte -   5.2996 ns per structural -   2.6396 GB/s
../jsonexamples/google_maps_api_compact_response.json
|    Speed        :  77.8378 ns per block ( 98.87%) -   1.2191 ns per byte -   4.6198 ns per structural -   0.8203 GB/s
|    Speed        :  76.4378 ns per block ( 98.71%) -   1.1972 ns per byte -   4.5367 ns per structural -   0.8353 GB/s
../jsonexamples/google_maps_api_response.json
|    Speed        :  42.3701 ns per block ( 98.46%) -   0.6623 ns per byte -   5.5460 ns per structural -   1.5099 GB/s
|    Speed        :  41.9608 ns per block ( 98.43%) -   0.6559 ns per byte -   5.4925 ns per structural -   1.5246 GB/s
../jsonexamples/gsoc-2018.json
|    Speed        :  19.2063 ns per block ( 98.89%) -   0.3001 ns per byte -  13.1682 ns per structural -   3.3322 GB/s
|    Speed        :  19.5210 ns per block ( 98.89%) -   0.3050 ns per byte -  13.3840 ns per structural -   3.2785 GB/s
../jsonexamples/instruments.json
|    Speed        :  29.4060 ns per block ( 99.43%) -   0.4595 ns per byte -   3.7259 ns per structural -   2.1764 GB/s
|    Speed        :  28.8954 ns per block ( 99.02%) -   0.4515 ns per byte -   3.6612 ns per structural -   2.2148 GB/s
../jsonexamples/marine_ik.json
|    Speed        :  75.3143 ns per block ( 99.45%) -   1.1768 ns per byte -   5.4601 ns per structural -   0.8498 GB/s
|    Speed        :  76.3359 ns per block ( 99.31%) -   1.1928 ns per byte -   5.5342 ns per structural -   0.8384 GB/s
../jsonexamples/mesh.json
|    Speed        :  74.2141 ns per block ( 98.48%) -   1.1597 ns per byte -   5.4748 ns per structural -   0.8623 GB/s
|    Speed        :  76.8083 ns per block ( 98.77%) -   1.2002 ns per byte -   5.6661 ns per structural -   0.8332 GB/s
../jsonexamples/mesh.pretty.json
|    Speed        :  44.6779 ns per block ( 98.76%) -   0.6981 ns per byte -   7.1844 ns per structural -   1.4324 GB/s
|    Speed        :  45.7237 ns per block ( 98.94%) -   0.7145 ns per byte -   7.3525 ns per structural -   1.3997 GB/s
../jsonexamples/numbers100.json
|    Speed        :  67.9624 ns per block ( 99.87%) -   1.0619 ns per byte -   7.9694 ns per structural -   0.9417 GB/s
|    Speed        :  69.6944 ns per block ( 99.17%) -   1.0890 ns per byte -   8.1725 ns per structural -   0.9183 GB/s
../jsonexamples/numbers10.json
|    Speed        :  65.3498 ns per block ( 99.03%) -   1.0211 ns per byte -   7.6633 ns per structural -   0.9793 GB/s
|    Speed        :  67.4611 ns per block ( 99.10%) -   1.0541 ns per byte -   7.9109 ns per structural -   0.9487 GB/s
../jsonexamples/numbers.json
|    Speed        :  65.2907 ns per block ( 98.67%) -   1.0203 ns per byte -   7.6575 ns per structural -   0.9801 GB/s
|    Speed        :  64.6130 ns per block ( 98.40%) -   1.0097 ns per byte -   7.5780 ns per structural -   0.9904 GB/s
../jsonexamples/random.json
|    Speed        :  41.7483 ns per block ( 99.62%) -   0.6524 ns per byte -   3.7837 ns per structural -   1.5328 GB/s
|    Speed        :  40.8523 ns per block ( 99.63%) -   0.6384 ns per byte -   3.7025 ns per structural -   1.5665 GB/s
../jsonexamples/repeat.json
|    Speed        :  49.7921 ns per block ( 98.19%) -   0.7805 ns per byte -   8.7148 ns per structural -   1.2813 GB/s
|    Speed        :  49.0562 ns per block ( 98.19%) -   0.7689 ns per byte -   8.5860 ns per structural -   1.3005 GB/s
../jsonexamples/tree-pretty.json
|    Speed        :  38.8500 ns per block ( 98.57%) -   0.6071 ns per byte -   5.2991 ns per structural -   1.6472 GB/s
|    Speed        :  38.3481 ns per block ( 98.77%) -   0.5993 ns per byte -   5.2306 ns per structural -   1.6687 GB/s
../jsonexamples/twitter10.json
|    Speed        :  29.0067 ns per block ( 99.41%) -   0.4532 ns per byte -   5.1792 ns per structural -   2.2064 GB/s
|    Speed        :  28.9903 ns per block ( 99.58%) -   0.4530 ns per byte -   5.1763 ns per structural -   2.2076 GB/s
../jsonexamples/twitter_api_compact_response.json
|    Speed        :  55.7532 ns per block ( 98.20%) -   0.8743 ns per byte -   7.1735 ns per structural -   1.1437 GB/s
|    Speed        :  55.1646 ns per block ( 98.38%) -   0.8651 ns per byte -   7.0977 ns per structural -   1.1559 GB/s
../jsonexamples/twitter_api_response.json
|    Speed        :  45.2008 ns per block ( 98.69%) -   0.7083 ns per byte -   7.5073 ns per structural -   1.4119 GB/s
|    Speed        :  45.9247 ns per block ( 98.11%) -   0.7196 ns per byte -   7.6275 ns per structural -   1.3897 GB/s
../jsonexamples/twitterescaped.json
|    Speed        :  55.7543 ns per block ( 99.64%) -   0.8712 ns per byte -   8.8661 ns per structural -   1.1478 GB/s
|    Speed        :  56.0678 ns per block ( 99.66%) -   0.8761 ns per byte -   8.9160 ns per structural -   1.1414 GB/s
../jsonexamples/twitter.json
|    Speed        :  26.2190 ns per block ( 99.28%) -   0.4097 ns per byte -   4.6818 ns per structural -   2.4408 GB/s
|    Speed        :  26.8413 ns per block ( 99.19%) -   0.4194 ns per byte -   4.7929 ns per structural -   2.3842 GB/s
../jsonexamples/twitter_timeline.json
|    Speed        :  46.8879 ns per block ( 98.43%) -   0.7327 ns per byte -   5.8093 ns per structural -   1.3647 GB/s
|    Speed        :  45.7470 ns per block ( 98.46%) -   0.7149 ns per byte -   5.6679 ns per structural -   1.3988 GB/s
../jsonexamples/update-center.json
|    Speed        :  33.8374 ns per block ( 99.14%) -   0.5287 ns per byte -   4.4450 ns per structural -   1.8914 GB/s
|    Speed        :  32.9998 ns per block ( 99.46%) -   0.5156 ns per byte -   4.3350 ns per structural -   1.9394 GB/s
```


Trial 2:

```
$ for i in ../jsonexamples/*.json ; do echo $i; ./benchmark/parse -n 100 $i | grep GB | head -n 1; ./../buildmaster/benchmark/parse -n 100 $i | grep GB | head -n 1; done
../jsonexamples/apache_builds.json
|    Speed        :  26.2665 ns per block ( 99.11%) -   0.4105 ns per byte -   4.2255 ns per structural -   2.4362 GB/s
|    Speed        :  25.8235 ns per block ( 98.99%) -   0.4036 ns per byte -   4.1542 ns per structural -   2.4780 GB/s
../jsonexamples/canada.json
|    Speed        :  71.2842 ns per block ( 99.48%) -   1.1138 ns per byte -   7.4985 ns per structural -   0.8978 GB/s
|    Speed        :  70.6490 ns per block ( 99.64%) -   1.1039 ns per byte -   7.4316 ns per structural -   0.9059 GB/s
../jsonexamples/citm_catalog.json
|    Speed        :  22.9087 ns per block ( 99.57%) -   0.3580 ns per byte -   4.5464 ns per structural -   2.7936 GB/s
|    Speed        :  23.0030 ns per block ( 99.37%) -   0.3594 ns per byte -   4.5651 ns per structural -   2.7822 GB/s
../jsonexamples/github_events.json
|    Speed        :  24.5658 ns per block ( 98.16%) -   0.3840 ns per byte -   5.3711 ns per structural -   2.6044 GB/s
|    Speed        :  27.7358 ns per block ( 98.69%) -   0.4335 ns per byte -   6.0642 ns per structural -   2.3068 GB/s
../jsonexamples/google_maps_api_compact_response.json
|    Speed        :  77.7568 ns per block ( 96.82%) -   1.2178 ns per byte -   4.6150 ns per structural -   0.8211 GB/s
|    Speed        :  76.5027 ns per block ( 98.50%) -   1.1982 ns per byte -   4.5406 ns per structural -   0.8346 GB/s
../jsonexamples/google_maps_api_response.json
|    Speed        :  42.5392 ns per block ( 98.25%) -   0.6649 ns per byte -   5.5682 ns per structural -   1.5039 GB/s
|    Speed        :  41.9118 ns per block ( 98.72%) -   0.6551 ns per byte -   5.4860 ns per structural -   1.5264 GB/s
../jsonexamples/gsoc-2018.json
|    Speed        :  19.2111 ns per block ( 98.84%) -   0.3002 ns per byte -  13.1715 ns per structural -   3.3314 GB/s
|    Speed        :  19.3856 ns per block ( 99.10%) -   0.3029 ns per byte -  13.2911 ns per structural -   3.3014 GB/s
../jsonexamples/instruments.json
|    Speed        :  29.2367 ns per block ( 99.36%) -   0.4568 ns per byte -   3.7045 ns per structural -   2.1890 GB/s
|    Speed        :  29.0363 ns per block ( 99.16%) -   0.4537 ns per byte -   3.6791 ns per structural -   2.2041 GB/s
../jsonexamples/marine_ik.json
|    Speed        :  75.2808 ns per block ( 99.24%) -   1.1763 ns per byte -   5.4577 ns per structural -   0.8501 GB/s
|    Speed        :  76.1925 ns per block ( 99.27%) -   1.1905 ns per byte -   5.5238 ns per structural -   0.8400 GB/s
../jsonexamples/mesh.json
|    Speed        :  74.0608 ns per block ( 98.40%) -   1.1573 ns per byte -   5.4635 ns per structural -   0.8641 GB/s
|    Speed        :  76.7349 ns per block ( 98.40%) -   1.1991 ns per byte -   5.6607 ns per structural -   0.8340 GB/s
../jsonexamples/mesh.pretty.json
|    Speed        :  44.4144 ns per block ( 98.55%) -   0.6940 ns per byte -   7.1420 ns per structural -   1.4409 GB/s
|    Speed        :  45.6643 ns per block ( 98.96%) -   0.7135 ns per byte -   7.3430 ns per structural -   1.4015 GB/s
../jsonexamples/numbers100.json
|    Speed        :  67.7806 ns per block ( 99.89%) -   1.0591 ns per byte -   7.9481 ns per structural -   0.9442 GB/s
|    Speed        :  69.6803 ns per block ( 99.20%) -   1.0888 ns per byte -   8.1709 ns per structural -   0.9185 GB/s
../jsonexamples/numbers10.json
|    Speed        :  65.4156 ns per block ( 99.20%) -   1.0222 ns per byte -   7.6710 ns per structural -   0.9783 GB/s
|    Speed        :  66.7233 ns per block ( 98.47%) -   1.0426 ns per byte -   7.8244 ns per structural -   0.9592 GB/s
../jsonexamples/numbers.json
|    Speed        :  65.3789 ns per block ( 98.72%) -   1.0217 ns per byte -   7.6678 ns per structural -   0.9788 GB/s
|    Speed        :  64.7263 ns per block ( 97.26%) -   1.0115 ns per byte -   7.5913 ns per structural -   0.9886 GB/s
../jsonexamples/random.json
|    Speed        :  41.9050 ns per block ( 99.64%) -   0.6548 ns per byte -   3.7979 ns per structural -   1.5271 GB/s
|    Speed        :  40.9663 ns per block ( 99.64%) -   0.6402 ns per byte -   3.7128 ns per structural -   1.5621 GB/s
../jsonexamples/repeat.json
|    Speed        :  49.7079 ns per block ( 98.39%) -   0.7791 ns per byte -   8.7001 ns per structural -   1.2835 GB/s
|    Speed        :  49.0899 ns per block ( 98.48%) -   0.7695 ns per byte -   8.5919 ns per structural -   1.2996 GB/s
../jsonexamples/tree-pretty.json
|    Speed        :  38.8685 ns per block ( 98.21%) -   0.6074 ns per byte -   5.3016 ns per structural -   1.6464 GB/s
|    Speed        :  38.2056 ns per block ( 98.55%) -   0.5970 ns per byte -   5.2112 ns per structural -   1.6750 GB/s
../jsonexamples/twitter10.json
|    Speed        :  28.8527 ns per block ( 99.38%) -   0.4508 ns per byte -   5.1517 ns per structural -   2.2181 GB/s
|    Speed        :  29.0336 ns per block ( 99.61%) -   0.4537 ns per byte -   5.1840 ns per structural -   2.2043 GB/s
../jsonexamples/twitter_api_compact_response.json
|    Speed        :  55.6962 ns per block ( 98.13%) -   0.8734 ns per byte -   7.1661 ns per structural -   1.1449 GB/s
|    Speed        :  55.7152 ns per block ( 98.19%) -   0.8737 ns per byte -   7.1686 ns per structural -   1.1445 GB/s
../jsonexamples/twitter_api_response.json
|    Speed        :  45.2594 ns per block ( 98.05%) -   0.7092 ns per byte -   7.5170 ns per structural -   1.4101 GB/s
|    Speed        :  45.0669 ns per block ( 96.12%) -   0.7062 ns per byte -   7.4851 ns per structural -   1.4161 GB/s
../jsonexamples/twitterescaped.json
|    Speed        :  56.4796 ns per block ( 99.61%) -   0.8825 ns per byte -   8.9815 ns per structural -   1.1331 GB/s
|    Speed        :  56.1566 ns per block ( 99.58%) -   0.8775 ns per byte -   8.9301 ns per structural -   1.1396 GB/s
../jsonexamples/twitter.json
|    Speed        :  26.3584 ns per block ( 99.05%) -   0.4119 ns per byte -   4.7067 ns per structural -   2.4279 GB/s
|    Speed        :  26.3824 ns per block ( 99.15%) -   0.4122 ns per byte -   4.7110 ns per structural -   2.4257 GB/s
../jsonexamples/twitter_timeline.json
|    Speed        :  46.5348 ns per block ( 98.60%) -   0.7272 ns per byte -   5.7655 ns per structural -   1.3751 GB/s
|    Speed        :  46.9106 ns per block ( 98.33%) -   0.7331 ns per byte -   5.8121 ns per structural -   1.3641 GB/s
../jsonexamples/update-center.json
|    Speed        :  33.8479 ns per block ( 99.00%) -   0.5289 ns per byte -   4.4464 ns per structural -   1.8908 GB/s
|    Speed        :  32.9145 ns per block ( 99.35%) -   0.5143 ns per byte -   4.3238 ns per structural -   1.9444 GB/s
```


Looking at the two trials, we have that this PR is marginally slower on instruments, random.json, tree-pretty.json, update-center.json,  while it is faster on mesh.pretty.json, mesh, numbers100.json, numbers10.json... On other files, it is mostly inconclusive, it depends on how often you run the trial.


Now we can look at instructions instead...

```
$ for i in ../jsonexamples/*.json ; do echo $i; ./benchmark/parse -n 100 $i | grep Instru | head -n 1; ./../buildmaster/benchmark/parse -n 100 $i | grep Instr | head -n 1; done
../jsonexamples/apache_builds.json
|    Instructions : 329.8361 per block    ( 99.99%) -   5.1545 per byte    -  53.0608 per structural    -    3.389 per cycle
|    Instructions : 327.6365 per block    ( 99.99%) -   5.1202 per byte    -  52.7070 per structural    -    3.431 per cycle
../jsonexamples/canada.json
|    Instructions : 902.6156 per block    (100.00%) -  14.1035 per byte    -  94.9470 per structural    -    3.454 per cycle
|    Instructions : 902.6152 per block    (100.00%) -  14.1035 per byte    -  94.9469 per structural    -    3.437 per cycle
../jsonexamples/citm_catalog.json
|    Instructions : 305.2628 per block    (100.00%) -   4.7698 per byte    -  60.5812 per structural    -    3.594 per cycle
|    Instructions : 304.3761 per block    (100.00%) -   4.7560 per byte    -  60.4052 per structural    -    3.595 per cycle
../jsonexamples/github_events.json
|    Instructions : 284.8350 per block    ( 99.98%) -   4.4519 per byte    -  62.2771 per structural    -    3.132 per cycle
|    Instructions : 283.9931 per block    ( 99.98%) -   4.4388 per byte    -  62.0930 per structural    -    3.157 per cycle
../jsonexamples/google_maps_api_compact_response.json
|    Instructions : 720.4108 per block    ( 99.95%) -  11.2831 per byte    -  42.7578 per structural    -    3.020 per cycle
|    Instructions : 715.7676 per block    ( 99.95%) -  11.2104 per byte    -  42.4822 per structural    -    3.104 per cycle
../jsonexamples/google_maps_api_response.json
|    Instructions : 381.8431 per block    ( 99.96%) -   5.9686 per byte    -  49.9814 per structural    -    3.037 per cycle
|    Instructions : 379.7377 per block    ( 99.96%) -   5.9357 per byte    -  49.7058 per structural    -    3.054 per cycle
../jsonexamples/gsoc-2018.json
|    Instructions : 180.8914 per block    (100.00%) -   2.8265 per byte    - 124.0225 per structural    -    2.541 per cycle
|    Instructions : 180.7656 per block    (100.00%) -   2.8245 per byte    - 123.9363 per structural    -    2.519 per cycle
../jsonexamples/instruments.json
|    Instructions : 367.5850 per block    ( 99.99%) -   5.7437 per byte    -  46.5755 per structural    -    3.411 per cycle
|    Instructions : 366.5899 per block    ( 99.99%) -   5.7281 per byte    -  46.4494 per structural    -    3.422 per cycle
../jsonexamples/marine_ik.json
|    Instructions : 827.5161 per block    (100.00%) -  12.9300 per byte    -  59.9932 per structural    -    2.983 per cycle
|    Instructions : 828.0154 per block    (100.00%) -  12.9378 per byte    -  60.0294 per structural    -    2.945 per cycle
../jsonexamples/mesh.json
|    Instructions : 880.6041 per block    (100.00%) -  13.7604 per byte    -  64.9620 per structural    -    3.223 per cycle
|    Instructions : 880.6040 per block    (100.00%) -  13.7604 per byte    -  64.9620 per structural    -    3.107 per cycle
../jsonexamples/mesh.pretty.json
|    Instructions : 533.7253 per block    (100.00%) -   8.3397 per byte    -  85.8249 per structural    -    3.259 per cycle
|    Instructions : 533.7252 per block    (100.00%) -   8.3397 per byte    -  85.8249 per structural    -    3.165 per cycle
../jsonexamples/numbers100.json
|    Instructions : 732.1301 per block    (100.00%) -  11.4395 per byte    -  85.8514 per structural    -    2.876 per cycle
|    Instructions : 732.1301 per block    (100.00%) -  11.4395 per byte    -  85.8514 per structural    -    2.855 per cycle
../jsonexamples/numbers10.json
|    Instructions : 732.2108 per block    (100.00%) -  11.4412 per byte    -  85.8634 per structural    -    3.036 per cycle
|    Instructions : 732.2104 per block    (100.00%) -  11.4412 per byte    -  85.8634 per structural    -    2.971 per cycle
../jsonexamples/numbers.json
|    Instructions : 733.6066 per block    (100.00%) -  11.4641 per byte    -  86.0391 per structural    -    3.036 per cycle
|    Instructions : 733.6027 per block    (100.00%) -  11.4641 per byte    -  86.0387 per structural    -    3.064 per cycle
../jsonexamples/random.json
|    Instructions : 524.0109 per block    (100.00%) -   8.1885 per byte    -  47.4912 per structural    -    3.389 per cycle
|    Instructions : 521.0006 per block    (100.00%) -   8.1415 per byte    -  47.2184 per structural    -    3.438 per cycle
../jsonexamples/repeat.json
|    Instructions : 378.6180 per block    ( 99.91%) -   5.9347 per byte    -  66.2675 per structural    -    2.845 per cycle
|    Instructions : 376.2978 per block    ( 99.91%) -   5.8983 per byte    -  65.8614 per structural    -    2.883 per cycle
../jsonexamples/tree-pretty.json
|    Instructions : 361.6759 per block    ( 99.97%) -   5.6518 per byte    -  49.3319 per structural    -    3.078 per cycle
|    Instructions : 361.1185 per block    ( 99.97%) -   5.6431 per byte    -  49.2559 per structural    -    3.088 per cycle
../jsonexamples/twitter10.json
|    Instructions : 314.9276 per block    (100.00%) -   4.9208 per byte    -  56.2309 per structural    -    2.963 per cycle
|    Instructions : 314.8655 per block    (100.00%) -   4.9198 per byte    -  56.2198 per structural    -    2.942 per cycle
../jsonexamples/twitter_api_compact_response.json
|    Instructions : 403.9304 per block    ( 99.90%) -   6.3346 per byte    -  51.9715 per structural    -    2.688 per cycle
|    Instructions : 403.3418 per block    ( 99.90%) -   6.3254 per byte    -  51.8958 per structural    -    2.723 per cycle
../jsonexamples/twitter_api_response.json
|    Instructions : 328.3096 per block    ( 99.92%) -   5.1443 per byte    -  54.5281 per structural    -    2.765 per cycle
|    Instructions : 328.1046 per block    ( 99.92%) -   5.1411 per byte    -  54.4941 per structural    -    2.755 per cycle
../jsonexamples/twitterescaped.json
|    Instructions : 580.4046 per block    (100.00%) -   9.0692 per byte    -  92.2968 per structural    -    2.765 per cycle
|    Instructions : 576.7145 per block    (100.00%) -   9.0115 per byte    -  91.7100 per structural    -    2.781 per cycle
../jsonexamples/twitter.json
|    Instructions : 315.2814 per block    (100.00%) -   4.9266 per byte    -  56.2980 per structural    -    3.235 per cycle
|    Instructions : 315.2185 per block    (100.00%) -   4.9256 per byte    -  56.2868 per structural    -    3.213 per cycle
../jsonexamples/twitter_timeline.json
|    Instructions : 424.2515 per block    ( 99.98%) -   6.6300 per byte    -  52.5635 per structural    -    2.798 per cycle
|    Instructions : 424.6773 per block    ( 99.98%) -   6.6367 per byte    -  52.6163 per structural    -    2.857 per cycle
../jsonexamples/update-center.json
|    Instructions : 368.6529 per block    (100.00%) -   5.7603 per byte    -  48.4279 per structural    -    2.955 per cycle
|    Instructions : 367.3625 per block    (100.00%) -   5.7401 per byte    -  48.2584 per structural    -    2.998 per cycle
```


You can see that the number of instructions is up slightly for google_maps_api_compact_response.json, mesh.json and down slightly for random.json, twitter_api_compact_response.json, twitter_timeline.json, update-center.json.

Compiler:

```
g++-8 (Homebrew GCC 8.3.0_1) 8.3.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Processor
```
Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
```

Ok. Let us switch to a different machine.


```
$ for i in ../jsonexamples/*.json ; do echo $i; ./benchmark/parse $i | grep GB | head -n 1; ./../buildmaster/benchmark/parse $i | grep GB | head -n 1; done
../jsonexamples/apache_builds.json
|    Speed        :  30.8824 ns per block ( 98.78%) -   0.4826 ns per byte -   4.9681 ns per structural -   2.0720 GB/s
|    Speed        :  30.8225 ns per block ( 99.04%) -   0.4817 ns per byte -   4.9584 ns per structural -   2.0761 GB/s
../jsonexamples/canada.json
|    Speed        :  77.6083 ns per block ( 99.77%) -   1.2126 ns per byte -   8.1637 ns per structural -   0.8246 GB/s
|    Speed        :  77.6773 ns per block ( 99.65%) -   1.2137 ns per byte -   8.1709 ns per structural -   0.8239 GB/s
../jsonexamples/citm_catalog.json
|    Speed        :  26.5066 ns per block ( 99.44%) -   0.4142 ns per byte -   5.2604 ns per structural -   2.4145 GB/s
|    Speed        :  26.8017 ns per block ( 99.53%) -   0.4188 ns per byte -   5.3189 ns per structural -   2.3879 GB/s
../jsonexamples/github_events.json
|    Speed        :  28.7682 ns per block ( 98.55%) -   0.4496 ns per byte -   6.2899 ns per structural -   2.2240 GB/s
|    Speed        :  29.0629 ns per block ( 98.20%) -   0.4542 ns per byte -   6.3544 ns per structural -   2.2014 GB/s
../jsonexamples/google_maps_api_compact_response.json
|    Speed        :  79.5514 ns per block ( 98.03%) -   1.2459 ns per byte -   4.7215 ns per structural -   0.8026 GB/s
|    Speed        :  79.7189 ns per block ( 98.31%) -   1.2486 ns per byte -   4.7315 ns per structural -   0.8009 GB/s
../jsonexamples/google_maps_api_response.json
|    Speed        :  42.1887 ns per block ( 97.37%) -   0.6595 ns per byte -   5.5223 ns per structural -   1.5164 GB/s
|    Speed        :  42.5588 ns per block ( 95.27%) -   0.6652 ns per byte -   5.5707 ns per structural -   1.5032 GB/s
../jsonexamples/gsoc-2018.json
|    Speed        :  20.1351 ns per block ( 99.53%) -   0.3146 ns per byte -  13.8050 ns per structural -   3.1785 GB/s
|    Speed        :  20.2191 ns per block ( 99.53%) -   0.3159 ns per byte -  13.8626 ns per structural -   3.1653 GB/s
../jsonexamples/instruments.json
|    Speed        :  33.6852 ns per block ( 98.61%) -   0.5263 ns per byte -   4.2681 ns per structural -   1.8999 GB/s
|    Speed        :  33.5306 ns per block ( 99.23%) -   0.5239 ns per byte -   4.2486 ns per structural -   1.9086 GB/s
../jsonexamples/marine_ik.json
|    Speed        :  78.6429 ns per block ( 99.00%) -   1.2288 ns per byte -   5.7014 ns per structural -   0.8138 GB/s
|    Speed        :  80.4505 ns per block ( 98.14%) -   1.2570 ns per byte -   5.8325 ns per structural -   0.7955 GB/s
../jsonexamples/mesh.json
|    Speed        :  77.1049 ns per block ( 98.57%) -   1.2048 ns per byte -   5.6880 ns per structural -   0.8300 GB/s
|    Speed        :  79.4238 ns per block ( 97.77%) -   1.2411 ns per byte -   5.8591 ns per structural -   0.8057 GB/s
../jsonexamples/mesh.pretty.json
|    Speed        :  47.4851 ns per block ( 99.35%) -   0.7420 ns per byte -   7.6358 ns per structural -   1.3477 GB/s
|    Speed        :  48.1229 ns per block ( 98.59%) -   0.7519 ns per byte -   7.7383 ns per structural -   1.3299 GB/s
../jsonexamples/numbers.json
|    Speed        :  65.2417 ns per block ( 98.96%) -   1.0195 ns per byte -   7.6517 ns per structural -   0.9808 GB/s
|    Speed        :  66.2451 ns per block ( 98.94%) -   1.0352 ns per byte -   7.7694 ns per structural -   0.9660 GB/s
../jsonexamples/random.json
|    Speed        :  46.9704 ns per block ( 99.41%) -   0.7340 ns per byte -   4.2569 ns per structural -   1.3624 GB/s
|    Speed        :  47.0733 ns per block ( 99.34%) -   0.7356 ns per byte -   4.2663 ns per structural -   1.3594 GB/s
../jsonexamples/repeat.json
|    Speed        :  46.7697 ns per block ( 97.73%) -   0.7331 ns per byte -   8.1858 ns per structural -   1.3641 GB/s
|    Speed        :  46.8258 ns per block ( 98.04%) -   0.7340 ns per byte -   8.1957 ns per structural -   1.3624 GB/s
../jsonexamples/tree-pretty.json
|    Speed        :  41.4296 ns per block ( 98.47%) -   0.6474 ns per byte -   5.6509 ns per structural -   1.5446 GB/s
|    Speed        :  41.3370 ns per block ( 98.09%) -   0.6460 ns per byte -   5.6383 ns per structural -   1.5481 GB/s
../jsonexamples/twitter_api_compact_response.json
|    Speed        :  55.8101 ns per block ( 96.42%) -   0.8752 ns per byte -   7.1808 ns per structural -   1.1425 GB/s
|    Speed        :  55.6772 ns per block ( 97.19%) -   0.8732 ns per byte -   7.1637 ns per structural -   1.1453 GB/s
../jsonexamples/twitter_api_response.json
|    Speed        :  44.6444 ns per block ( 97.68%) -   0.6995 ns per byte -   7.4149 ns per structural -   1.4295 GB/s
|    Speed        :  45.4854 ns per block ( 95.78%) -   0.7127 ns per byte -   7.5546 ns per structural -   1.4031 GB/s
../jsonexamples/twitterescaped.json
|    Speed        :  64.7402 ns per block ( 98.49%) -   1.0116 ns per byte -  10.2951 ns per structural -   0.9885 GB/s
|    Speed        :  65.1689 ns per block ( 99.34%) -   1.0183 ns per byte -  10.3632 ns per structural -   0.9820 GB/s
../jsonexamples/twitter.json
|    Speed        :  30.5152 ns per block ( 99.14%) -   0.4768 ns per byte -   5.4489 ns per structural -   2.0972 GB/s
|    Speed        :  31.1843 ns per block ( 99.12%) -   0.4873 ns per byte -   5.5684 ns per structural -   2.0522 GB/s
../jsonexamples/twitter_timeline.json
|    Speed        :  53.1455 ns per block ( 98.71%) -   0.8305 ns per byte -   6.5846 ns per structural -   1.2040 GB/s
|    Speed        :  53.1455 ns per block ( 98.46%) -   0.8305 ns per byte -   6.5846 ns per structural -   1.2040 GB/s
../jsonexamples/update-center.json
|    Speed        :  37.8335 ns per block ( 99.23%) -   0.5912 ns per byte -   4.9700 ns per structural -   1.6916 GB/s
|    Speed        :  37.9526 ns per block ( 99.11%) -   0.5930 ns per byte -   4.9856 ns per structural -   1.6863 GB/s
```

As you can see this PR is generally faster!!!

Compiler:

```
$ /opt/rh/devtoolset-8/root/usr/bin/c++ --version
c++ (GCC) 8.3.1 20190311 (Red Hat 8.3.1-3)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Processor:

```
AMD EPYC 7262 8-Core Processor
```



*Conclusion* This PR is not a performance regression on GCC 8.3. Some perf. numbers go down, some go up.

