### PR TITLE
This checks whether appveyor can cross-compile to ARM

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,11 @@ environment:
 
 build_script:
   - set
+  - mkdir buildarm
+  - cd buildarm
+  - cmake -A ARM64 .. -DCMAKE_CROSSCOMPILING=1 -DRUN_HAVE_STD_REGEX=0 -DRUN_HAVE_POSIX_REGEX=0 -DRUN_HAVE_GNU_POSIX_REGEX=0 -DRUN_HAVE_STEADY_CLOCK=0
+  - cmake --build . --target parse
+  - cd ..
   - mkdir build
   - cd build
   - cmake --version

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,35 +7,37 @@ platform: x64
 environment:
   matrix:
     - job_name: VS2019
-      CMAKE_ARGS:
+      CMAKE_ARGS:  -A %Platform%
     - job_name: VS2019CLANG
-      CMAKE_ARGS: -T ClangCL
+      CMAKE_ARGS:  -A %Platform% -T ClangCL
+    - job_name: VS2019ARM
+      CMAKE_ARGS: -A ARM64 -DCMAKE_CROSSCOMPILING=1 -DRUN_HAVE_STD_REGEX=0 -DRUN_HAVE_POSIX_REGEX=0 -DRUN_HAVE_GNU_POSIX_REGEX=0 -DRUN_HAVE_STEADY_CLOCK=0
     - job_name: VS2017 (Static, No Threads)
       image: Visual Studio 2017
-      CMAKE_ARGS: -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_ENABLE_THREADS=OFF
+      CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_ENABLE_THREADS=OFF
       CTEST_ARGS: -E checkperf
     - job_name: VS2019 (Win32)
       platform: Win32
-      CMAKE_ARGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_ENABLE_THREADS=ON # This should be the default. Testing anyway.
+      CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_ENABLE_THREADS=ON # This should be the default. Testing anyway.
       CTEST_ARGS: -E checkperf
 
 build_script:
-  - set
-  - mkdir buildarm
-  - cd buildarm
-  - cmake -A ARM64 .. -DCMAKE_CROSSCOMPILING=1 -DRUN_HAVE_STD_REGEX=0 -DRUN_HAVE_POSIX_REGEX=0 -DRUN_HAVE_GNU_POSIX_REGEX=0 -DRUN_HAVE_STEADY_CLOCK=0
-  - cmake --build . --target parse
-  - cd ..
   - mkdir build
   - cd build
   - cmake --version
-  - cmake -A %Platform% %CMAKE_ARGS% --parallel ..
+  - cmake %CMAKE_ARGS% --parallel ..
   - cmake -LH ..
   - cmake --build . --config %Configuration% --verbose --parallel
 
-test_script:
-  - ctest --output-on-failure -C %Configuration% --verbose %CTEST_ARGS% --parallel
-    
+for:
+-
+  matrix:
+    except:
+      - job_name: VS2019ARM
+
+  test_script:
+    - ctest --output-on-failure -C %Configuration% --verbose %CTEST_ARGS% --parallel
+
 clone_folder: c:\projects\simdjson
 
 matrix:


### PR DESCRIPTION
Ideally, we would want to be able to build for ARM64 on appveyor. This would not run anything, just cross-compile.

(This is not expected to result in a passing test, but how it fails should be informative.)