### PR TITLE
[for discussion] No more null termination

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
     steps:
       - cmake_build
       - run: ctest $CTEST_FLAGS -L acceptance
-      - run: ctest $CTEST_FLAGS -LE acceptance -E checkperf
+      - run: ctest $CTEST_FLAGS -LE acceptance
 
   cmake_test_all:
     steps:

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -1038,6 +1038,7 @@ public:
   really_inline bool on_null_atom() noexcept; ///< @private
   really_inline uint8_t *on_start_string() noexcept; ///< @private
   really_inline bool on_end_string(uint8_t *dst) noexcept; ///< @private
+  bool handle_long_string(uint8_t *dst) noexcept;///< @private
   really_inline bool on_number_s64(int64_t value) noexcept; ///< @private
   really_inline bool on_number_u64(uint64_t value) noexcept; ///< @private
   really_inline bool on_number_double(double value) noexcept; ///< @private

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -476,17 +476,6 @@ public:
    * @return The string value.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON element is not a string.
    */
-  inline explicit operator const char*() const noexcept(false);
-
-  /**
-   * Read this element as a null-terminated string.
-   *
-   * Does *not* convert other types to a string; requires that the JSON type of the element was
-   * an actual string.
-   *
-   * @return The string value.
-   * @exception simdjson_error(INCORRECT_TYPE) if the JSON element is not a string.
-   */
   inline operator std::string_view() const noexcept(false);
 
   /**

--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -78,6 +78,8 @@ public:
   really_inline uint32_t scope_count() const noexcept;
   template<typename T>
   really_inline T next_tape_value() const noexcept;
+  really_inline uint32_t get_string_length() const noexcept;
+  really_inline const char * get_c_str() const noexcept;
   inline std::string_view get_string_view() const noexcept;
 
   /** The document this element references. */
@@ -219,7 +221,22 @@ public:
      * Get the key of this key/value pair.
      */
     inline std::string_view key() const noexcept;
-
+    /**
+    * Get the length (in bytes) of the key in this key/value pair.
+    * You should expect this function to be faster than key().size().
+    */
+    inline uint32_t key_length() const noexcept;
+    /**
+    * Returns true of the the key in this key/value pair is equal
+    * to the provided string_view.
+    */
+    inline bool key_equals(const std::string_view & o) const noexcept;
+    /**
+    * Returns true of the the key in this key/value pair is equal
+    * to the provided string_view in a case-insensitive manner.
+    * Case comparisons may only be handled correctly for ASCII strings.
+    */
+    inline bool key_equals_case_insensitive(const std::string_view & o) const noexcept;
     /**
      * Get the key of this key/value pair.
      */

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -226,7 +226,6 @@ inline error_code document::allocate(size_t capacity) noexcept {
 }
 
 inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
-  uint32_t string_length;
   size_t tape_idx = 0;
   uint64_t tape_val = tape[tape_idx];
   uint8_t type = uint8_t(tape_val >> 56);
@@ -249,11 +248,23 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
     switch (type) {
     case '"': // we have a string
       os << "string \"";
-      memcpy(&string_length, string_buf.get() + payload, sizeof(uint32_t));
-      os << internal::escape_json_string(std::string_view(
-        (const char *)(string_buf.get() + payload + sizeof(uint32_t)),
-        string_length
-      ));
+      {
+        // this legacy code must die
+        uint32_t len = (payload >> 32) & 0xFFFFFF; // grab 3 bytes
+        uint32_t string_buf_index = uint32_t(payload);
+        if(unlikely(len > 0x7fffff)) {
+          len ^= 0x800000;
+          len <<= 9;
+          uint32_t c1 = string_buf[string_buf_index - 2] - 32;
+          len |= c1 << 4;
+          uint32_t c2 = string_buf[string_buf_index - 1] - 32;
+          len |= c2;
+        }
+        os << internal::escape_json_string(std::string_view(
+          (const char *)(string_buf.get() +string_buf_index),
+          len
+        ));
+      }
       os << '"';
       os << '\n';
       break;
@@ -672,7 +683,7 @@ inline simdjson_result<element> object::at(const std::string_view &json_pointer)
 inline simdjson_result<element> object::at_key(const std::string_view &key) const noexcept {
   iterator end_field = end();
   for (iterator field = begin(); field != end_field; ++field) {
-    if (key == field.key()) {
+    if (field.key_equals(key)) {
       return field.value();
     }
   }
@@ -684,13 +695,8 @@ inline simdjson_result<element> object::at_key(const std::string_view &key) cons
 inline simdjson_result<element> object::at_key_case_insensitive(const std::string_view &key) const noexcept {
   iterator end_field = end();
   for (iterator field = begin(); field != end_field; ++field) {
-    auto field_key = field.key();
-    if (key.length() == field_key.length()) {
-      // See For case-insensitive string comparisons, avoid char-by-char functions
-      // https://lemire.me/blog/2020/04/30/for-case-insensitive-string-comparisons-avoid-char-by-char-functions/
-      // Note that it might be worth rolling our own strncasecmp function, with vectorization.
-      const bool equal = (simdjson_strncasecmp(key.data(), field_key.data(), key.length()) == 0);
-      if (equal) { return field.value(); }
+    if (field.key_equals_case_insensitive(key)) {
+      return field.value();
     }
   }
   return NO_SUCH_FIELD;
@@ -712,17 +718,53 @@ inline object::iterator& object::iterator::operator++() noexcept {
   return *this;
 }
 inline std::string_view object::iterator::key() const noexcept {
-  size_t string_buf_index = size_t(tape_value());
-  uint32_t len;
-  memcpy(&len, &doc->string_buf[string_buf_index], sizeof(len));
-  return std::string_view(
-    reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]),
-    len
-  );
+  return get_string_view();
+}
+inline uint32_t object::iterator::key_length() const noexcept {
+  return get_string_length();
 }
 inline const char* object::iterator::key_c_str() const noexcept {
-  return reinterpret_cast<const char *>(&doc->string_buf[size_t(tape_value()) + sizeof(uint32_t)]);
+  return get_c_str();
 }
+
+
+/**
+ * Design notes:
+ * Instead of constructing a string_view and then comparing it with a
+ * user-provided strings, it is probably more performant to have dedicated
+ * functions taking as a parameter the string we want to compare against
+ * and return true when they are equal. That avoids the creation of a temporary
+ * std::string_view. Though it is possible for the compiler to avoid entirely
+ * any overhead due to string_view, relying too much on compiler magic is
+ * problematic: compiler magic sometimes fail, and then what do you do?
+ * Also, enticing users to rely on high-performance function is probably better
+ * on the long run.
+ */
+
+inline bool object::iterator::key_equals(const std::string_view & o) const noexcept {
+  // We use the fact that the key length can be computed quickly
+  // without access to the string buffer.
+  const uint32_t len = key_length();
+  if(o.size() == len) {
+    // We avoid construction of a temporary string_view instance.
+    return (memcmp(o.data(), key_c_str(), len) == 0);
+  }
+  return false;
+}
+
+inline bool object::iterator::key_equals_case_insensitive(const std::string_view & o) const noexcept {
+  // We use the fact that the key length can be computed quickly
+  // without access to the string buffer.
+  const uint32_t len = key_length();
+  if(o.size() == len) {
+      // See For case-insensitive string comparisons, avoid char-by-char functions
+      // https://lemire.me/blog/2020/04/30/for-case-insensitive-string-comparisons-avoid-char-by-char-functions/
+      // Note that it might be worth rolling our own strncasecmp function, with vectorization.
+      return (simdjson_strncasecmp(o.data(), key_c_str(), len) == 0);
+  }
+  return false;
+}
+
 inline element object::iterator::value() const noexcept {
   return element(doc, json_index + 1);
 }
@@ -761,8 +803,7 @@ template<>
 inline simdjson_result<const char *> element::get<const char *>() const noexcept {
   switch (tape_ref_type()) {
     case internal::tape_type::STRING: {
-      size_t string_buf_index = size_t(tape_value());
-      return reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]);
+      return get_c_str();
     }
     default:
       return INCORRECT_TYPE;
@@ -1161,13 +1202,46 @@ really_inline T tape_ref::next_tape_value() const noexcept {
   memcpy(&x,&doc->tape[json_index + 1],sizeof(uint64_t));
   return x;
 }
+
+ /**
+ * Design notes:
+ * Instead of having references to the low-level string_buf all over the
+ * code, we hide all of the logic in get_string_length and get_c_str
+ * and build everything from there. Note that get_string_length is
+ * expected to be a very fast function, so it should be broadly available
+ */
+
+really_inline uint32_t internal::tape_ref::get_string_length() const noexcept {
+  uint64_t tape_val = uint64_t(tape_value());
+  uint32_t len = (tape_val >> 32) & 0xFFFFFF; // grab 3 bytes
+  if(unlikely(len > 0x7fffff)) {  // only go there if the highest bit is set
+    uint32_t string_buf_index = uint32_t(tape_val); // we will need to touch the string buffer
+    // we have a long string and we need to jump through some loops
+    len ^= 0x800000; // set the high bit to zero
+    len <<= 9; // we are just missing 9 bits, we have 23 bits. 23 + 9 = 32
+    // middle 5 bites
+    uint32_t c1 = doc->string_buf[string_buf_index - 2] - 32;
+    len |= c1 << 4;
+    // least significant five bits
+    uint32_t c2 = doc->string_buf[string_buf_index - 1] - 32;
+    len |= c2;
+  }
+  // if the slow path can be avoided, then we get the string length without
+  // touching (at all) the string buffer.
+  return len;
+}
+
+
+really_inline const char * internal::tape_ref::get_c_str() const noexcept {
+  uint64_t tape_val = uint64_t(tape_value());
+  uint32_t string_buf_index = uint32_t(tape_val);
+  return reinterpret_cast<const char *>(&doc->string_buf[string_buf_index]);
+}
+
 inline std::string_view internal::tape_ref::get_string_view() const noexcept {
-  size_t string_buf_index = size_t(tape_value());
-  uint32_t len;
-  memcpy(&len, &doc->string_buf[string_buf_index], sizeof(len));
   return std::string_view(
-    reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]),
-    len
+      get_c_str(),
+      get_string_length()
   );
 }
 

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -253,7 +253,6 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
         uint32_t len = (payload >> 32) & 0xFFFFFF; // grab 3 bytes
         uint32_t string_buf_index = uint32_t(payload);
         if(unlikely(len > 0x7fffff)) {
-          len ^= 0x800000;
           len <<= 9;
           uint32_t c1 = string_buf[string_buf_index - 2] - 32;
           len |= c1 << 4;

--- a/include/simdjson/inline/document.h
+++ b/include/simdjson/inline/document.h
@@ -897,7 +897,6 @@ really_inline bool element::is() const noexcept {
 #if SIMDJSON_EXCEPTIONS
 
 inline element::operator bool() const noexcept(false) { return get<bool>(); }
-inline element::operator const char*() const noexcept(false) { return get<const char *>(); }
 inline element::operator std::string_view() const noexcept(false) { return get<std::string_view>(); }
 inline element::operator uint64_t() const noexcept(false) { return get<uint64_t>(); }
 inline element::operator int64_t() const noexcept(false) { return get<int64_t>(); }
@@ -1219,10 +1218,10 @@ really_inline uint32_t internal::tape_ref::get_string_length() const noexcept {
     // we have a long string and we need to jump through some loops
     len <<= 9; // we are just missing 9 bits, we have 23 bits. 23 + 9 = 32
     // middle 5 bites
-    uint32_t c1 = doc->string_buf[string_buf_index + 1] - 32;
+    uint32_t c1 = doc->string_buf[string_buf_index] - 32;
     len |= c1 << 4;
     // least significant five bits
-    uint32_t c2 = doc->string_buf[string_buf_index + 2] - 32;
+    uint32_t c2 = doc->string_buf[string_buf_index + 1] - 32;
     len |= c2;
   }
   // if the slow path can be avoided, then we get the string length without
@@ -1239,10 +1238,10 @@ really_inline const char * internal::tape_ref::get_c_str() const noexcept {
     // we have a long string and we need to jump through some loops
     len <<= 9; // we are just missing 9 bits, we have 23 bits. 23 + 9 = 32
     // middle 5 bites
-    uint32_t c1 = doc->string_buf[string_buf_index + 1] - 32;
+    uint32_t c1 = doc->string_buf[string_buf_index] - 32;
     len |= c1 << 4;
     // least significant five bits
-    uint32_t c2 = doc->string_buf[string_buf_index + 2] - 32;
+    uint32_t c2 = doc->string_buf[string_buf_index + 1] - 32;
     len |= c2;
     string_buf_index -= len;
   }

--- a/include/simdjson/inline/parsedjson_iterator.h
+++ b/include/simdjson/inline/parsedjson_iterator.h
@@ -72,7 +72,7 @@ void dom::parser::Iterator::move_to_value() {
 bool dom::parser::Iterator::move_to_key(const char *key) {
     if (down()) {
       do {
-        const bool right_key = (strcmp(get_string(), key) == 0);
+        const bool right_key = (strncmp(get_string(), key, get_string_length()) == 0);
         move_to_value();
         if (right_key) {
           return true;
@@ -87,7 +87,7 @@ bool dom::parser::Iterator::move_to_key_insensitive(
     const char *key) {
     if (down()) {
       do {
-        const bool right_key = (simdjson_strcasecmp(get_string(), key) == 0);
+        const bool right_key = (simdjson_strncasecmp(get_string(), key, get_string_length()) == 0);
         move_to_value();
         if (right_key) {
           return true;

--- a/include/simdjson/parsedjson_iterator.h
+++ b/include/simdjson/parsedjson_iterator.h
@@ -65,7 +65,7 @@ public:
       return doc.tape[location + 1];
   }
 
-  // get the string value at this node (NULL ended); valid only if get_type is "
+  // get the string value at this node; valid only if get_type is "
   // note that tabs, and line endings are escaped in the returned value (see
   // print_with_escapes) return value is valid UTF-8, it may contain NULL chars
   // within the string: get_string_length determines the true string length.
@@ -75,9 +75,9 @@ public:
       if(unlikely(len > 0x7fffff)) {
           uint64_t string_buf_index = current_val;
           len <<= 9;
-          uint32_t c1 = doc.string_buf[string_buf_index + 1] - 32;
+          uint32_t c1 = doc.string_buf[string_buf_index] - 32;
           len |= c1 << 4;
-          uint32_t c2 = doc.string_buf[string_buf_index + 2] - 32;
+          uint32_t c2 = doc.string_buf[string_buf_index + 1] - 32;
           len |= c2;
           index -= len;
       }
@@ -91,9 +91,9 @@ public:
       if(unlikely(len > 0x7fffff)) {
           uint64_t string_buf_index = current_val;
           len <<= 9;
-          uint32_t c1 = doc.string_buf[string_buf_index + 1] - 32;
+          uint32_t c1 = doc.string_buf[string_buf_index] - 32;
           len |= c1 << 4;
-          uint32_t c2 = doc.string_buf[string_buf_index + 2] - 32;
+          uint32_t c2 = doc.string_buf[string_buf_index + 1] - 32;
           len |= c2;
       }
       // if the slow path can be avoided, then we get the string length without

--- a/include/simdjson/parsedjson_iterator.h
+++ b/include/simdjson/parsedjson_iterator.h
@@ -70,8 +70,19 @@ public:
   // print_with_escapes) return value is valid UTF-8, it may contain NULL chars
   // within the string: get_string_length determines the true string length.
   inline const char *get_string() const {
+      uint32_t index =  uint32_t(current_val);
+      uint32_t len = (current_val >> 32) & 0xFFFFFF;
+      if(unlikely(len > 0x7fffff)) {
+          uint64_t string_buf_index = current_val;
+          len <<= 9;
+          uint32_t c1 = doc.string_buf[string_buf_index + 1] - 32;
+          len |= c1 << 4;
+          uint32_t c2 = doc.string_buf[string_buf_index + 2] - 32;
+          len |= c2;
+          index -= len;
+      }
       return reinterpret_cast<const char *>(
-          doc.string_buf.get() + uint32_t(current_val));
+          doc.string_buf.get() + index);
   }
 
   // return the length of the string in bytes
@@ -79,11 +90,10 @@ public:
       uint32_t len = (current_val >> 32) & 0xFFFFFF;
       if(unlikely(len > 0x7fffff)) {
           uint64_t string_buf_index = current_val;
-          len ^= 0x800000;
           len <<= 9;
-          uint32_t c1 = doc.string_buf[string_buf_index - 2] - 32;
+          uint32_t c1 = doc.string_buf[string_buf_index + 1] - 32;
           len |= c1 << 4;
-          uint32_t c2 = doc.string_buf[string_buf_index - 1] - 32;
+          uint32_t c2 = doc.string_buf[string_buf_index + 2] - 32;
           len |= c2;
       }
       // if the slow path can be avoided, then we get the string length without

--- a/src/document_parser_callbacks.h
+++ b/src/document_parser_callbacks.h
@@ -100,16 +100,15 @@ bool parser::handle_long_string(uint8_t *dst) noexcept {
   uint64_t lenmark = uint64_t(0x800000 | (str_length >> 9));
   uint64_t payload =  position |  (lenmark << 32);
   write_tape(payload, internal::tape_type::STRING);
-  dst[0] = 0;
   // We have three free bytes, but
   // we need a leading 1, so that's 24-1 = 23. 32-23=9 remaining bits.
   // We have 9 bits left to code, which we do on the string buffer
   // using two bytes. We encoding the binary data using ASCII characters.
   // See https://lemire.me/blog/2020/05/02/encoding-binary-in-ascii-very-fast/
   // for a more general approach.
-  dst[1] = uint8_t(32 + ((str_length & 0x1f0) >> 4)); // (0x1f0>>4)+32 = 63
-  dst[2] = uint8_t(32 + (str_length & 0xf)); // 32 + 0xf = 47
-  current_string_buf_loc = dst + 3;
+  dst[0] = uint8_t(32 + ((str_length & 0x1f0) >> 4)); // (0x1f0>>4)+32 = 63
+  dst[1] = uint8_t(32 + (str_length & 0xf)); // 32 + 0xf = 47
+  current_string_buf_loc = dst + 2;
   return true;
 }
 
@@ -124,8 +123,7 @@ really_inline bool parser::on_end_string(uint8_t *dst) noexcept {
   // Should we change this constraint, we should then check for overflow in case
   // someone has a crazy string (>=4GB?).
   write_tape(position | (str_length << 32), internal::tape_type::STRING);
-  *dst = 0;
-  current_string_buf_loc = dst + 1;
+  current_string_buf_loc = dst;
   return true;
 }
 

--- a/src/document_parser_callbacks.h
+++ b/src/document_parser_callbacks.h
@@ -87,60 +87,55 @@ really_inline bool parser::on_null_atom() noexcept {
 }
 
 really_inline uint8_t *parser::on_start_string() noexcept {
-  /* We advance the pointer. */
-  // If we limit JSON documents to strictly less 4GB of
-  // string content, then current_string_buf_loc
-  // - doc.string_buf.get() fits in 32 bits. This leaves us
-  // three free bytes.
-  uint32_t position = uint32_t(current_string_buf_loc - doc.string_buf.get()); // cannot overflow because documents are limited to < 4GB
-  write_tape(uint64_t(position), internal::tape_type::STRING);
+  /* We do nothing, the actual work occurs in on_end_string() */
   return current_string_buf_loc;
 }
 
+bool parser::handle_long_string(uint8_t *dst) noexcept {
+  uint64_t str_length = dst - current_string_buf_loc;
+  // Oh gosh, we have a long string (8MB). We expect that this is
+  // highly uncommon. We want to keep everything else super efficient,
+  // so we will pay a complexity price for this one uncommon case.
+  int offset = 2;
+  uint64_t position = current_string_buf_loc - doc.string_buf.get() + offset;
+  uint64_t lenmark = uint64_t(0x800000 | (str_length >> 9));
+  uint64_t payload =  position |  (lenmark << 32);
+  write_tape(payload, internal::tape_type::STRING);
+  // We are going to make room. This copy is not free. However,
+  // it allows us to handle the common case with ease and with
+  // relatively little complexity. And a memcopy is not that slow:
+  // it may run at tens of GB/s.
+  // And we expect that it will effectively never happen in practice
+  // so there is no cause to complexify the rest of the code.
+  memmove(current_string_buf_loc + offset, current_string_buf_loc, str_length);
+  dst += offset;
+  // We have three free bytes, but
+  // we need a leading 1, so that's 24-1 = 23. 32-23=9 remaining bits.
+  // We have 9 bits left to code, which we do on the string buffer
+  // using two bytes. We encoding the binary data using ASCII characters.
+  // See https://lemire.me/blog/2020/05/02/encoding-binary-in-ascii-very-fast/
+  // for a more general approach.
+  //
+  // These two bytes will appear right before where the string is.
+  current_string_buf_loc[0] = uint8_t(32 + ((str_length & 0x1f0) >> 4)); // (0x1f0>>4)+32 = 63
+  current_string_buf_loc[1] = uint8_t(32 + (str_length & 0xf)); // 32 + 0xf = 47
+  *dst = 0;
+  current_string_buf_loc = dst + 1;
+  return true;
+
+}
+
 really_inline bool parser::on_end_string(uint8_t *dst) noexcept {
-  uint32_t str_length = uint32_t(dst - current_string_buf_loc);
+  uint64_t str_length = dst - current_string_buf_loc;
+  if(unlikely(str_length > 0x7fffff)) {
+    return handle_long_string(dst);
+  }
+  uint64_t position = current_string_buf_loc - doc.string_buf.get();
   // Long document support: Currently, simdjson supports only document
   // up to 4GB.
   // Should we change this constraint, we should then check for overflow in case
   // someone has a crazy string (>=4GB?).
-
-  // We have two scenarios here. Either the string length is
-  // less than 0x7fffff in which case, we have room in the string
-  // header and all is good. Otherwise, we can encode the
-  // string length in the document itself, taking care to
-  // ensure that we do so in ASCII.
-  if(likely(str_length <= 0x7fffff)) { // likely
-    doc.tape[current_loc-1] |=  uint64_t(str_length) << 32;
-  } else {
-    // Oh gosh, we have a long string (8MB). We expect that this is
-    // highly uncommon. We want to keep everything else super efficient,
-    // so we will pay a complexity price for this one uncommon case.
-    int offset = 2;
-    uint64_t payload = doc.tape[current_loc-1] & 0xFFFFFFFF;
-    payload += offset;
-    payload |=  uint64_t(0x800000 | (str_length >> 9)) << 32;
-    doc.tape[current_loc-1] =  payload  | ((uint64_t(char(internal::tape_type::STRING))) << 56);
-    // We are going to make room. This copy is not free. However,
-    // it allows us to handle the common case with ease and with
-    // relatively little complexity. And a memcopy is not that slow:
-    // it may run at tens of GB/s.
-    // And we expect that it will effectively never happen in practice
-    // so there is no cause to complexify the rest of the code.
-    memmove(current_string_buf_loc + offset, current_string_buf_loc, str_length);
-    dst += offset;
-    // We have three free bytes, but
-    // we need a leading 1, so that's 24-1 = 23. 32-23=9 remaining bits.
-    // We have 9 bits left to code, which we do on the string buffer
-    // using two bytes. We encoding the binary data using ASCII characters.
-    // See https://lemire.me/blog/2020/05/02/encoding-binary-in-ascii-very-fast/
-    // for a more general approach.
-    //
-    // These two bytes will appear right before where the string is.
-    current_string_buf_loc[0] = uint8_t(32 + ((str_length & 0x1f0) >> 4)); // (0x1f0>>4)+32 = 63
-    current_string_buf_loc[1] = uint8_t(32 + (str_length & 0xf)); // 32 + 0xf = 47
-  }
-  // NULL termination is still handy if you expect all your strings to
-  // be NULL terminated? It comes at a small cost.
+  write_tape(position | (str_length << 32), internal::tape_type::STRING);
   *dst = 0;
   current_string_buf_loc = dst + 1;
   return true;

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -699,7 +699,7 @@ namespace dom_api_tests {
       return false;
     }
     if (!iter.down()) {
-      printf("Root should not be emtpy\n");
+      printf("Root should not be empty\n");
       return false;
     }
     if (!iter.is_string()) {
@@ -710,7 +710,7 @@ namespace dom_api_tests {
       printf("We should not be able to go back from the start of the scope.\n");
       return false;
     }
-    if (strcmp(iter.get_string(),"Image")!=0) {
+    if (strncmp(iter.get_string(),"Image", iter.get_string_length())!=0) {
       printf("There should be a single key, image.\n");
       return false;
     }
@@ -731,7 +731,7 @@ namespace dom_api_tests {
       printf("We should go back to the key.\n");
       return false;
     }
-    if (strcmp(iter.get_string(),"Width")!=0) {
+    if (strncmp(iter.get_string(),"Width", iter.get_string_length())!=0) {
       printf("There should be a  key Width.\n");
       return false;
     }
@@ -761,7 +761,7 @@ namespace dom_api_tests {
   bool object_iterator() {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "a": 1, "b": 2, "c": 3 })");
-    const char* expected_key[] = { "a", "b", "c" };
+    std::string_view expected_key[] = { "a", "b", "c" };
     uint64_t expected_value[] = { 1, 2, 3 };
     int i = 0;
 
@@ -1012,7 +1012,7 @@ namespace dom_api_tests {
   bool object_iterator_exception() {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "a": 1, "b": 2, "c": 3 })");
-    const char* expected_key[] = { "a", "b", "c" };
+    std::string_view expected_key[] = { "a", "b", "c" };
     uint64_t expected_value[] = { 1, 2, 3 };
     int i = 0;
 
@@ -1048,10 +1048,8 @@ namespace dom_api_tests {
     dom::parser parser;
     auto val = parser.parse(json).get<dom::array>().begin();
 
-    if (strcmp((const char*)*val, "hi")) { cerr << "Expected const char*(\"hi\") to be \"hi\", was " << (const char*)*val << endl; return false; }
     if (string_view(*val) != "hi") { cerr << "Expected string_view(\"hi\") to be \"hi\", was " << string_view(*val) << endl; return false; }
     ++val;
-    if (strcmp((const char*)*val, "has backslash\\")) { cerr << "Expected const char*(\"has backslash\\\\\") to be \"has backslash\\\", was " << (const char*)*val << endl; return false; }
     if (string_view(*val) != "has backslash\\") { cerr << "Expected string_view(\"has backslash\\\\\") to be \"has backslash\\\", was " << string_view(*val) << endl; return false; }
     return true;
   }
@@ -1249,12 +1247,6 @@ namespace type_tests {
     return test(actual);
   }
 
-  template<>
-  template<typename A, typename F>
-  bool test_implicit_cast<const char *>::with(A, F const &) {
-    return true;
-  }
-
   template<typename T>
   template<typename A>
   bool test_implicit_cast<T>::error_with(A input, simdjson::error_code expected_error) {
@@ -1266,12 +1258,6 @@ namespace type_tests {
       ASSERT_EQUAL(e.error(), expected_error);
       return true;
     }
-  }
-
-  template<>
-  template<typename A>
-  bool test_implicit_cast<const char *>::error_with(A, simdjson::error_code) {
-    return true;
   }
 
   template<typename T>
@@ -1521,7 +1507,6 @@ namespace type_tests {
       && test_cast<dom::array>(result)
       && test_cast<dom::object>(result, INCORRECT_TYPE)
       && test_cast<std::string_view>(result, INCORRECT_TYPE)
-      && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, INCORRECT_TYPE)
       && test_cast<uint64_t>(result, INCORRECT_TYPE)
       && test_cast<double>(result, INCORRECT_TYPE)
@@ -1540,7 +1525,6 @@ namespace type_tests {
       && test_cast<dom::array>(result, INCORRECT_TYPE)
       && test_cast<dom::object>(result)
       && test_cast<std::string_view>(result, INCORRECT_TYPE)
-      && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, INCORRECT_TYPE)
       && test_cast<uint64_t>(result, INCORRECT_TYPE)
       && test_cast<double>(result, INCORRECT_TYPE)
@@ -1559,7 +1543,6 @@ namespace type_tests {
       && test_cast<dom::array>(result, INCORRECT_TYPE)
       && test_cast<dom::object>(result, INCORRECT_TYPE)
       && test_cast<std::string_view>(result, "foo")
-      && test_cast<const char *>(result, "foo")
       && test_cast<int64_t>(result, INCORRECT_TYPE)
       && test_cast<uint64_t>(result, INCORRECT_TYPE)
       && test_cast<double>(result, INCORRECT_TYPE)
@@ -1577,7 +1560,6 @@ namespace type_tests {
       && test_cast<dom::array>(result, INCORRECT_TYPE)
       && test_cast<dom::object>(result, INCORRECT_TYPE)
       && test_cast<std::string_view>(result, INCORRECT_TYPE)
-      && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, expected_value)
       && (expected_value >= 0 ?
           test_cast<uint64_t>(result, expected_value) :
@@ -1598,7 +1580,6 @@ namespace type_tests {
       && test_cast<dom::array>(result, INCORRECT_TYPE)
       && test_cast<dom::object>(result, INCORRECT_TYPE)
       && test_cast<std::string_view>(result, INCORRECT_TYPE)
-      && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, NUMBER_OUT_OF_RANGE)
       && test_cast<uint64_t>(result, expected_value)
       && test_cast<double>(result, static_cast<double>(expected_value))
@@ -1616,7 +1597,6 @@ namespace type_tests {
       && test_cast<dom::array>(result, INCORRECT_TYPE)
       && test_cast<dom::object>(result, INCORRECT_TYPE)
       && test_cast<std::string_view>(result, INCORRECT_TYPE)
-      && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, INCORRECT_TYPE)
       && test_cast<uint64_t>(result, INCORRECT_TYPE)
       && test_cast<double>(result, expected_value)
@@ -1635,7 +1615,6 @@ namespace type_tests {
       && test_cast<dom::array>(result, INCORRECT_TYPE)
       && test_cast<dom::object>(result, INCORRECT_TYPE)
       && test_cast<std::string_view>(result, INCORRECT_TYPE)
-      && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, INCORRECT_TYPE)
       && test_cast<uint64_t>(result, INCORRECT_TYPE)
       && test_cast<double>(result, INCORRECT_TYPE)
@@ -1653,7 +1632,6 @@ namespace type_tests {
       && test_cast<dom::array>(result, INCORRECT_TYPE)
       && test_cast<dom::object>(result, INCORRECT_TYPE)
       && test_cast<std::string_view>(result, INCORRECT_TYPE)
-      && test_cast<const char *>(result, INCORRECT_TYPE)
       && test_cast<int64_t>(result, INCORRECT_TYPE)
       && test_cast<uint64_t>(result, INCORRECT_TYPE)
       && test_cast<double>(result, INCORRECT_TYPE)

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -203,6 +203,21 @@ namespace document_tests {
     }
     return true;
   }
+  bool humongous_strings() {
+    std::cout << __func__ << std::endl;
+    size_t N = 15000000;
+    simdjson::padded_string large = std::string("\"") + std::string(N, '.') + std::string("\"");
+    simdjson::dom::parser parser;
+    auto [doc, error] = parser.parse(large).get<std::string_view>();
+    if (error) {
+      printf("This json should  be valid.\n");
+      return false;
+    }
+    if(doc.size() != N) {
+      return false;
+    }
+    return true;
+  }
   bool count_array_example() {
     std::cout << __func__ << std::endl;
     simdjson::padded_string smalljson = "[1,2,3]"_padded;
@@ -337,7 +352,8 @@ namespace document_tests {
     return true;
   }
   bool run() {
-    return bad_example() &&
+    return humongous_strings() &&
+           bad_example() &&
            count_array_example() &&
            count_object_example() &&
            stable_test() &&

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -214,6 +214,11 @@ namespace document_tests {
       return false;
     }
     if(doc.size() != N) {
+      printf("Strings are of different size.\n");
+      return false;
+    }
+    if(doc != std::string(N, '.')) {
+      printf("Strings differ.\n");
       return false;
     }
     return true;


### PR DESCRIPTION
We start from https://github.com/simdjson/simdjson/pull/856 and add the optimization that there are no more null endings (which are unsafe anyway). Would also fix https://github.com/simdjson/simdjson/issues/185

In some cases, this goes faster. Twitter goes from 2.42GB/s to 2.47GB/s. It also uses less memory. But, importantly, it is also safer. We cannot guarantee that our strings are free of nulls, so promising a null terminated string, though correct, still leaves us open to the possibility that the original string had a null in it, in which case, the user is being mislead. Small concern, I know.

Another benefit is that we simplify the API.

```
$ for i in ../jsonexamples/*.json ; do echo $i; ./benchmark/parse $i | grep GB | head -n 1; ./../buildmaster/benchmark/parse $i | grep GB | head -n 1; done
../jsonexamples/apache_builds.json
|    Speed        :  25.4460 ns per block ( 99.29%) -   0.3977 ns per byte -   4.0935 ns per structural -   2.5147 GB/s
|    Speed        :  25.6340 ns per block ( 99.23%) -   0.4006 ns per byte -   4.1237 ns per structural -   2.4963 GB/s
../jsonexamples/canada.json
|    Speed        :  72.0404 ns per block ( 99.68%) -   1.1256 ns per byte -   7.5780 ns per structural -   0.8884 GB/s
|    Speed        :  71.0939 ns per block ( 99.64%) -   1.1109 ns per byte -   7.4784 ns per structural -   0.9002 GB/s
../jsonexamples/citm_catalog.json
|    Speed        :  22.7607 ns per block ( 99.68%) -   0.3556 ns per byte -   4.5170 ns per structural -   2.8118 GB/s
|    Speed        :  22.7995 ns per block ( 99.59%) -   0.3562 ns per byte -   4.5247 ns per structural -   2.8070 GB/s
../jsonexamples/github_events.json
|    Speed        :  23.9912 ns per block ( 98.82%) -   0.3750 ns per byte -   5.2455 ns per structural -   2.6668 GB/s
|    Speed        :  24.4489 ns per block ( 98.81%) -   0.3821 ns per byte -   5.3456 ns per structural -   2.6169 GB/s
../jsonexamples/google_maps_api_compact_response.json
|    Speed        :  76.7189 ns per block ( 98.55%) -   1.2016 ns per byte -   4.5534 ns per structural -   0.8322 GB/s
|    Speed        :  76.2270 ns per block ( 98.73%) -   1.1939 ns per byte -   4.5242 ns per structural -   0.8376 GB/s
../jsonexamples/google_maps_api_response.json
|    Speed        :  41.3848 ns per block ( 97.98%) -   0.6469 ns per byte -   5.4171 ns per structural -   1.5459 GB/s
|    Speed        :  41.9363 ns per block ( 98.69%) -   0.6555 ns per byte -   5.4893 ns per structural -   1.5255 GB/s
../jsonexamples/gsoc-2018.json
|    Speed        :  19.2413 ns per block ( 98.86%) -   0.3006 ns per byte -  13.1922 ns per structural -   3.3261 GB/s
|    Speed        :  19.4563 ns per block ( 98.96%) -   0.3040 ns per byte -  13.3396 ns per structural -   3.2894 GB/s
../jsonexamples/instruments.json
|    Speed        :  28.2678 ns per block ( 99.40%) -   0.4417 ns per byte -   3.5817 ns per structural -   2.2640 GB/s
|    Speed        :  28.8327 ns per block ( 99.25%) -   0.4505 ns per byte -   3.6533 ns per structural -   2.2196 GB/s
../jsonexamples/marine_ik.json
|    Speed        :  75.5895 ns per block ( 99.34%) -   1.1811 ns per byte -   5.4801 ns per structural -   0.8467 GB/s
|    Speed        :  75.9863 ns per block ( 98.98%) -   1.1873 ns per byte -   5.5088 ns per structural -   0.8423 GB/s
../jsonexamples/mesh.json
|    Speed        :  76.3198 ns per block ( 99.07%) -   1.1926 ns per byte -   5.6301 ns per structural -   0.8385 GB/s
|    Speed        :  76.9671 ns per block ( 98.77%) -   1.2027 ns per byte -   5.6779 ns per structural -   0.8315 GB/s
../jsonexamples/mesh.pretty.json
|    Speed        :  45.6256 ns per block ( 99.25%) -   0.7129 ns per byte -   7.3367 ns per structural -   1.4027 GB/s
|    Speed        :  45.5598 ns per block ( 98.89%) -   0.7119 ns per byte -   7.3262 ns per structural -   1.4047 GB/s
../jsonexamples/numbers100.json
|    Speed        :  68.2246 ns per block ( 99.72%) -   1.0660 ns per byte -   8.0002 ns per structural -   0.9381 GB/s
|    Speed        :  69.5935 ns per block ( 99.00%) -   1.0874 ns per byte -   8.1607 ns per structural -   0.9196 GB/s
../jsonexamples/numbers10.json
|    Speed        :  65.7411 ns per block ( 99.09%) -   1.0272 ns per byte -   7.7092 ns per structural -   0.9735 GB/s
|    Speed        :  66.8642 ns per block ( 98.47%) -   1.0448 ns per byte -   7.8409 ns per structural -   0.9571 GB/s
../jsonexamples/numbers.json
|    Speed        :  64.4949 ns per block ( 98.92%) -   1.0079 ns per byte -   7.5641 ns per structural -   0.9922 GB/s
|    Speed        :  64.7059 ns per block ( 96.80%) -   1.0112 ns per byte -   7.5889 ns per structural -   0.9890 GB/s
../jsonexamples/random.json
|    Speed        :  40.3545 ns per block ( 99.64%) -   0.6306 ns per byte -   3.6573 ns per structural -   1.5858 GB/s
|    Speed        :  41.1323 ns per block ( 99.69%) -   0.6428 ns per byte -   3.7278 ns per structural -   1.5558 GB/s
../jsonexamples/repeat.json
|    Speed        :  49.2921 ns per block ( 98.44%) -   0.7726 ns per byte -   8.6273 ns per structural -   1.2943 GB/s
|    Speed        :  48.7191 ns per block ( 98.70%) -   0.7636 ns per byte -   8.5270 ns per structural -   1.3095 GB/s
../jsonexamples/tree-pretty.json
|    Speed        :  37.8815 ns per block ( 98.32%) -   0.5920 ns per byte -   5.1670 ns per structural -   1.6893 GB/s
|    Speed        :  38.4759 ns per block ( 98.76%) -   0.6013 ns per byte -   5.2480 ns per structural -   1.6632 GB/s
../jsonexamples/twitter10.json
|    Speed        :  28.3515 ns per block ( 99.44%) -   0.4430 ns per byte -   5.0622 ns per structural -   2.2574 GB/s
|    Speed        :  28.9748 ns per block ( 99.60%) -   0.4527 ns per byte -   5.1735 ns per structural -   2.2088 GB/s
../jsonexamples/twitter_api_compact_response.json
|    Speed        :  54.3861 ns per block ( 98.11%) -   0.8529 ns per byte -   6.9976 ns per structural -   1.1725 GB/s
|    Speed        :  55.5190 ns per block ( 98.69%) -   0.8707 ns per byte -   7.1433 ns per structural -   1.1485 GB/s
../jsonexamples/twitter_api_response.json
|    Speed        :  44.4184 ns per block ( 98.32%) -   0.6960 ns per byte -   7.3773 ns per structural -   1.4368 GB/s
|    Speed        :  45.1255 ns per block ( 98.75%) -   0.7071 ns per byte -   7.4948 ns per structural -   1.4143 GB/s
../jsonexamples/twitterescaped.json
|    Speed        :  55.3273 ns per block ( 99.35%) -   0.8645 ns per byte -   8.7982 ns per structural -   1.1567 GB/s
|    Speed        :  55.3872 ns per block ( 99.62%) -   0.8655 ns per byte -   8.8078 ns per structural -   1.1555 GB/s
../jsonexamples/twitter.json
|    Speed        :  25.8887 ns per block ( 99.40%) -   0.4045 ns per byte -   4.6228 ns per structural -   2.4720 GB/s
|    Speed        :  26.4025 ns per block ( 99.30%) -   0.4126 ns per byte -   4.7145 ns per structural -   2.4239 GB/s
../jsonexamples/twitter_timeline.json
|    Speed        :  45.8424 ns per block ( 99.16%) -   0.7164 ns per byte -   5.6797 ns per structural -   1.3959 GB/s
|    Speed        :  46.0106 ns per block ( 99.02%) -   0.7190 ns per byte -   5.7006 ns per structural -   1.3908 GB/s
../jsonexamples/update-center.json
|    Speed        :  32.8592 ns per block ( 99.36%) -   0.5134 ns per byte -   4.3165 ns per structural -   1.9477 GB/s
|    Speed        :  33.1475 ns per block ( 99.50%) -   0.5179 ns per byte -   4.3544 ns per structural -   1.9307 GB/s
```