### PR TITLE
Fixes issue 871

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -3,7 +3,7 @@
 function(initialize_submodule DIRECTORY)
   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/.git)
     find_package(Git QUIET REQUIRED)
-    message(STATUS "${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/.git does not exist. Initializing ${DIRECTORY} submodule ...")
+    message(STATUS "${CMAKE_SOURCE_DIR}/${DIRECTORY}/.git does not exist. Initializing ${DIRECTORY} submodule ...")
     execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init ${DIRECTORY}
                     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                     RESULT_VARIABLE GIT_EXIT_CODE)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -3,9 +3,9 @@
 function(initialize_submodule DIRECTORY)
   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/.git)
     find_package(Git QUIET REQUIRED)
-    message(STATUS "${CMAKE_SOURCE_DIR}/${DIRECTORY}/.git does not exist. Initializing ${DIRECTORY} submodule ...")
+    message(STATUS "${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/.git does not exist. Initializing ${DIRECTORY} submodule ...")
     execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init ${DIRECTORY}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                     RESULT_VARIABLE GIT_EXIT_CODE)
     if(NOT GIT_EXIT_CODE EQUAL "0")
       message(FATAL_ERROR "${GIT_EXECUTABLE} submodule update --init dependencies/${DIRECTORY} failed with exit code ${GIT_EXIT_CODE}, please checkout submodules")

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -4,7 +4,7 @@ function(initialize_submodule DIRECTORY)
   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/.git)
     find_package(Git QUIET REQUIRED)
     message(STATUS "${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}/.git does not exist. Initializing ${DIRECTORY} submodule ...")
-    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init ${DIRECTORY}
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init ${CMAKE_CURRENT_SOURCE_DIR}/${DIRECTORY}
                     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
                     RESULT_VARIABLE GIT_EXIT_CODE)
     if(NOT GIT_EXIT_CODE EQUAL "0")


### PR DESCRIPTION
Fixes https://github.com/simdjson/simdjson/issues/871

In some circonstances (unknown to me), git will refuse to pull a submodule except if we do so from the root. This seems to happen from time to time on some machines. I do not understand.

However, it seems harmless to just do it from root and be done with the problem.