### PR TITLE
Don't write to tape in numberparsing

### DIFF
--- a/include/simdjson/document.h
+++ b/include/simdjson/document.h
@@ -967,7 +967,7 @@ public:
   using InvalidJSON [[deprecated("Use simdjson_error instead")]] = simdjson_error;
 
   /** @private Next location to write to in the tape */
-  uint32_t current_loc{0};
+  uint64_t *next_loc{nullptr};
 
   /** @private Number of structural indices passed from stage 1 to stage 2 */
   uint32_t n_structural_indexes{0};

--- a/src/generic/numberparsing.h
+++ b/src/generic/numberparsing.h
@@ -8,7 +8,7 @@ struct result {
     int64_t s;
   };
   bool success;
-  really_inline result(bool _success) : success{_success} {}
+  really_inline result(bool _success) : type{internal::tape_type::UINT64}, u{0}, success{_success} {}
   really_inline result(double value) : type{internal::tape_type::DOUBLE}, d{value}, success{true} {}
   really_inline result(uint64_t value) : type{internal::tape_type::UINT64}, u{value}, success{true} {}
   really_inline result(int64_t value) : type{internal::tape_type::INT64}, s{value}, success{true} {}

--- a/src/generic/stage2_build_tape.h
+++ b/src/generic/stage2_build_tape.h
@@ -384,9 +384,9 @@ struct structural_parser {
     doc_parser.error = UNINITIALIZED;
   }
 
-  WARN_UNUSED really_inline error_code start(size_t len, ret_address finish_state) {
+  WARN_UNUSED really_inline error_code start(ret_address finish_state) {
     init(); // sets is_valid to false
-    if (len > doc_parser.capacity()) {
+    if (structurals.len > doc_parser.capacity()) {
       return CAPACITY;
     }
     // Advance to the first character as soon as possible
@@ -416,7 +416,7 @@ struct structural_parser {
 WARN_UNUSED error_code implementation::stage2(const uint8_t *buf, size_t len, parser &doc_parser) const noexcept {
   static constexpr stage2::unified_machine_addresses addresses = INIT_ADDRESSES();
   stage2::structural_parser parser(buf, len, doc_parser);
-  error_code result = parser.start(len, addresses.finish);
+  error_code result = parser.start(addresses.finish);
   if (result) { return result; }
 
   //


### PR DESCRIPTION
This changes number parsing to *return* the number rather than write it immediately to tape. This makes it so we can more freely move tape writing around, and particularly keeps us from having to pass a pointer to the writer to the `never_inline parse_large_integer()` function; if you pass something important like structural_parser, for example, passing it de-optimizes the crap out of it (it is mostly enregistered).

This does not change performance at all on my machine. (In fact, it might actually have given it a roughly 1% bump, but that's possibly noise.)