### PR TITLE
Add logging to stage 2

### DIFF
--- a/src/arm64/stage2.cpp
+++ b/src/arm64/stage2.cpp
@@ -9,6 +9,7 @@
 namespace simdjson {
 namespace arm64 {
 
+#include "generic/stage2/logger.h"
 #include "generic/stage2/atomparsing.h"
 #include "generic/stage2/structural_iterator.h"
 #include "generic/stage2/structural_parser.h"

--- a/src/fallback/stage2.cpp
+++ b/src/fallback/stage2.cpp
@@ -7,6 +7,7 @@
 namespace simdjson {
 namespace fallback {
 
+#include "generic/stage2/logger.h"
 #include "generic/stage2/atomparsing.h"
 #include "generic/stage2/structural_iterator.h"
 #include "generic/stage2/structural_parser.h"

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -1,0 +1,64 @@
+// This is for an internal-only stage 2 specific logger.
+// Set LOG_ENABLED = true to log what stage 2 is doing!
+namespace logger {
+  static constexpr const char * DASHES = "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
+
+  static constexpr const bool LOG_ENABLED = false;
+  static constexpr const int LOG_EVENT_LEN = 30;
+  static constexpr const int LOG_BUFFER_LEN = 20;
+  static constexpr const int LOG_DETAIL_LEN = 50;
+
+  static int log_depth; // Not threadsafe. Log only.
+
+  // Helper to turn unprintable or newline characters into spaces
+  static really_inline char printable_char(char c) {
+    if (c >= 0x20) {
+      return c;
+    } else {
+      return ' ';
+    }
+  }
+
+  // Print the header and set up log_start
+  static really_inline void log_start() {
+    if (LOG_ENABLED) {
+      log_depth = 0;
+      printf("\n");
+      printf("| %-*s | %-*s | %*s | %*s | %*s | %-*s |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", 4, "Curr", 4, "Next", 5, "Next#", LOG_DETAIL_LEN, "Detail");
+      printf("|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, 4+2, DASHES, 4+2, DASHES, 5+2, DASHES, LOG_DETAIL_LEN+2, DASHES);
+    }
+  }
+
+  // Logs a single line of 
+  template<typename S>
+  static really_inline void log_line(S &structurals, const char *title_prefix, const char *title, const char *detail) {
+    if (LOG_ENABLED) {
+      printf("| %*s%s%-*s ", log_depth*2, "", title_prefix, LOG_EVENT_LEN - log_depth*2 - int(strlen(title_prefix)), title);
+      {
+        // Print the next N characters in the buffer.
+        printf("| ");
+        if (structurals.at_beginning()) {
+          // If the pointer is at the beginning, print a space followed by the beginning characters
+          // Print spaces for unprintable or newline characters.
+          printf(" ");
+          for (int i=0;i<LOG_BUFFER_LEN-1;i++) {
+            printf("%c", printable_char(structurals.buf[i]));
+          }
+        } else {
+          // Otherwise, print the characters starting from the buffer position.
+          // Print spaces for unprintable or newline characters.
+          for (int i=0;i<LOG_BUFFER_LEN;i++) {
+            printf("%c", printable_char(structurals.current()[i]));
+          }
+        }
+        printf(" ");
+      }
+      printf("|    %c ", printable_char(structurals.at_beginning() ? ' ' : structurals.current_char()));
+      printf("|    %c ", printable_char(structurals.peek_char()));
+      printf("| %5zd ", structurals.next_structural);
+      printf("| %-*s ", LOG_DETAIL_LEN, detail);
+      printf("|\n");
+    }
+  }
+} // namespace logger
+

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -17,6 +17,9 @@ public:
   really_inline char current_char() {
     return c;
   }
+  really_inline char peek_char() {
+    return buf[structural_indexes[next_structural]];
+  }
   really_inline const uint8_t* current() {
     return &buf[idx];
   }
@@ -53,6 +56,9 @@ public:
   }
   really_inline bool at_end(uint32_t n_structural_indexes) {
     return next_structural+1 == n_structural_indexes;
+  }
+  really_inline bool at_beginning() {
+    return next_structural == 0;
   }
   really_inline size_t next_structural_index() {
     return next_structural;

--- a/src/haswell/stage2.cpp
+++ b/src/haswell/stage2.cpp
@@ -7,6 +7,7 @@ TARGET_HASWELL
 namespace simdjson {
 namespace haswell {
 
+#include "generic/stage2/logger.h"
 #include "generic/stage2/atomparsing.h"
 #include "generic/stage2/structural_iterator.h"
 #include "generic/stage2/structural_parser.h"

--- a/src/westmere/stage2.cpp
+++ b/src/westmere/stage2.cpp
@@ -7,6 +7,7 @@ TARGET_WESTMERE
 namespace simdjson {
 namespace westmere {
 
+#include "generic/stage2/logger.h"
 #include "generic/stage2/atomparsing.h"
 #include "generic/stage2/structural_iterator.h"
 #include "generic/stage2/structural_parser.h"


### PR DESCRIPTION
This has been helping me a lot when debugging various experiments since stage 2 is normally kinda opaque as to where and what went wrong. By default, LOG_ENABLED is false and there is zero performance penalty. If you set it to true, you get output like this:

```
| Event                          | Buffer               | Curr | Next | Next# | Detail                                             |
|--------------------------------|----------------------|------|------|-------|----------------------------------------------------|
| +document                      | {         "Image": { |    { |    " |     1 |                                                    |
|   +object                      | {         "Image": { |    { |    " |     1 |                                                    |
|     key                        | "Image": {           |    " |    : |     2 |                                                    |
|     +object                    | {             "Width |    { |    " |     4 |                                                    |
|       key                      | "Width":  800,       |    " |    : |     5 |                                                    |
|       number                   | 800,             "He |    8 |    , |     7 |                                                    |
|       key                      | "Height": 600,       |    " |    : |     9 |                                                    |
|       number                   | 600,             "Ti |    6 |    , |    11 |                                                    |
|       key                      | "Title":  "View from |    " |    : |    13 |                                                    |
|       string                   | "View from 15th Floo |    " |    , |    15 |                                                    |
|       key                      | "Thumbnail": {       |    " |    : |    17 |                                                    |
|       +object                  | {                 "U |    { |    " |    19 |                                                    |
|         key                    | "Url":    "http://ww |    " |    : |    20 |                                                    |
|         string                 | "http://www.example. |    " |    , |    22 |                                                    |
|         key                    | "Height": 125,       |    " |    : |    24 |                                                    |
|         number                 | 125,                 |    1 |    , |    26 |                                                    |
|         key                    | "Width":  100        |    " |    : |    28 |                                                    |
|         number                 | 100             },   |    1 |    } |    30 |                                                    |
|       -object                  | },             "Anim |    } |    , |    31 |                                                    |
|       key                      | "Animated" : false,  |    " |    : |    33 |                                                    |
|       false                    | false,             " |    f |    , |    35 |                                                    |
|       key                      | "IDs": [116, 943, 23 |    " |    : |    37 |                                                    |
|       +array                   | [116, 943, 234, 3879 |    [ |    1 |    39 |                                                    |
|         number                 | 116, 943, 234, 38793 |    1 |    , |    40 |                                                    |
|         number                 | 943, 234, 38793]     |    9 |    , |    42 |                                                    |
|         number                 | 234, 38793]          |    2 |    , |    44 |                                                    |
|         number                 | 38793]           }   |    3 |    ] |    46 |                                                    |
|       -array                   | ]           }        |    ] |    } |    47 |                                                    |
|     -object                    | }       }            |    } |    } |    48 |                                                    |
|   -object                      | }                    |    } |      |    49 |                                                    |
| -document                      | }                    |    } |      |    49 |                                                    |
```