### PR TITLE
Fix MSVC build errors

### DIFF
--- a/windows/toni_ronnko_dirent.h
+++ b/windows/toni_ronnko_dirent.h
@@ -339,7 +339,13 @@ static void dirent_set_errno(int error);
  */
 static _WDIR *_wopendir(const wchar_t *dirname) {
   _WDIR *dirp;
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+  /* Desktop */
   DWORD n;
+#else
+  /* WinRT */
+  size_t n;
+#endif
   wchar_t *p;
 
   /* Must have directory name */


### PR DESCRIPTION
1. Add utf-8 compiler option for MSVC

   For non-UTF-8 locals, there will be warnings for those files that may contain non-ASCII characters.
   Because /WX is specified when using MSVC, these warnings are in turn treated as errors.
   > simdjson\src\generic/stage1/utf8_lookup2_algorithm.h(1,1): error C2220: the following warning is treated as an error
   > simdjson\src\generic/stage1/utf8_lookup2_algorithm.h(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (936). Save the file in Unicode format to prevent data loss

2. Fix build errors on UWP

   For x64-uwp, size_t is 64-bit, DWORD is 32-bit. When /WX compiler option is specified, error occurs.