### PR TITLE
Fix Ninja build

### DIFF
--- a/jsonexamples/generated/CMakeLists.txt
+++ b/jsonexamples/generated/CMakeLists.txt
@@ -4,9 +4,10 @@ set(generated_files
 )
 find_package(Ruby QUIET)
 if (RUBY_EXECUTABLE)
+  file(GLOB template_files ${CMAKE_CURRENT_SOURCE_DIR}/miss-templates/*.txt)
   add_custom_command(
     OUTPUT ${generated_files}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/miss-templates/*.txt
+    DEPENDS ${template_files}
     COMMAND ${RUBY_EXECUTABLE} genfeaturejson.rb ${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )


### PR DESCRIPTION
When using Ninja as generator, it failed to build:
```bash
$ cmake .. -G Ninja
$ ninja
```
> ninja: error: '/jsonexamples/generated/miss-templates/*.txt', needed by 'jsonexamples/generated/utf-8.json', missing and no known rule to make it

The build logs can be downloaded from here:
https://github.com/microsoft/vcpkg/runs/694967404