### PR TITLE
Port tools to cxxopts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "dependencies/benchmark"]
 	path = dependencies/benchmark
 	url = https://github.com/google/benchmark.git
+[submodule "dependencies/cxxopts"]
+	path = dependencies/cxxopts
+	url = https://github.com/jarro2783/cxxopts

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -62,13 +62,13 @@ if (SIMDJSON_COMPETITION)
   add_library(competition-ujson4c ujson4c/src/ujdecode.c)
   target_include_directories(competition-ujson4c PUBLIC ujson4c/3rdparty ujson4c/src)
 
-  initialize_submodule(cxxopts)
-  add_library(cxxopts INTERFACE)
-  target_include_directories(cxxopts INTERFACE cxxopts/include)
-
   add_library(competition-core INTERFACE)
   target_link_libraries(competition-core INTERFACE competition-json competition-rapidjson competition-sajson competition-cJSON competition-jsmn)
 
   add_library(competition-all INTERFACE)
   target_link_libraries(competition-all INTERFACE competition-core competition-jsoncppdist competition-json11 competition-fastjson competition-gason competition-ujson4c)
 endif()
+
+initialize_submodule(cxxopts)
+add_library(cxxopts INTERFACE)
+target_include_directories(cxxopts INTERFACE cxxopts/include)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -62,6 +62,10 @@ if (SIMDJSON_COMPETITION)
   add_library(competition-ujson4c ujson4c/src/ujdecode.c)
   target_include_directories(competition-ujson4c PUBLIC ujson4c/3rdparty ujson4c/src)
 
+  initialize_submodule(cxxopts)
+  add_library(cxxopts INTERFACE)
+  target_include_directories(cxxopts INTERFACE cxxopts/include)
+
   add_library(competition-core INTERFACE)
   target_link_libraries(competition-core INTERFACE competition-json competition-rapidjson competition-sajson competition-cJSON competition-jsmn)
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-link_libraries(simdjson simdjson-internal-flags simdjson-windows-headers)
+link_libraries(simdjson simdjson-internal-flags simdjson-windows-headers cxxopts)
 
 add_executable(json2json json2json.cpp)
 add_executable(jsonstats jsonstats.cpp)

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
   if(!result.count("file")) {
     std::cerr << "No filename specified." << std::endl;
     std::cerr << options.help() << std::endl;
-    exit(1);
+    return EXIT_SUCCESS;
   }
 
   const char *filename = result["file"].as<std::string>().c_str();

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -29,7 +29,7 @@ int main(int argc, char *argv[]) {
 
   if(result.count("help")) {
   	std::cerr << options.help() << std::endl;
-  	exit(1);
+  	return EXIT_SUCCESS;
   }
 
   bool rawdump = result["rawdump"].as<bool>();
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
   if(!result.count("file")) {
     std::cerr << "No filename specified." << std::endl;
     std::cerr << options.help() << std::endl;
-    return EXIT_SUCCESS;
+    return EXIT_FAILURE;
   }
 
   const char *filename = result["file"].as<std::string>().c_str();

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -198,13 +198,13 @@ int main(int argc, char *argv[]) {
 
   if(result.count("help")) {
     std::cerr << options.help() << std::endl;
-    exit(1);
+    return EXIT_SUCCESS;
   }
 
   if(!result.count("file")) {
     std::cerr << "No filename specified." << std::endl;
     std::cerr << options.help() << std::endl;
-    exit(1);
+    return EXIT_FAILURE;
   }
 
   const char *filename = result["file"].as<std::string>().c_str();

--- a/tools/minify.cpp
+++ b/tools/minify.cpp
@@ -33,12 +33,13 @@ int main(int argc, char *argv[]) {
     exit_usage("");
   }
 
-  if(!result.count("arch")) exit_usage("No implementation specified.");
   if(!result.count("file")) exit_usage("No filename specified.");
 
-  const simdjson::implementation *impl = simdjson::available_implementations[result["arch"].as<std::string>().c_str()];
-  if(!impl) exit_usage("Unsupported implementation.");
-  simdjson::active_implementation = impl;
+  if(result.count("arch")) {
+    const simdjson::implementation *impl = simdjson::available_implementations[result["arch"].as<std::string>().c_str()];
+    if(!impl) exit_usage("Unsupported implementation.");
+    simdjson::active_implementation = impl;
+  }
 
   std::string filename = result["file"].as<std::string>();
 

--- a/tools/minify.cpp
+++ b/tools/minify.cpp
@@ -9,14 +9,13 @@
 
 cxxopts::Options options("minify", "Runs the parser against the given json files in a loop, measuring speed and other statistics.");
 
-void exit_usage(std::string message) {
+void usage(std::string message) {
   std::cerr << message << std::endl;
   std::cerr << options.help() << std::endl;
   std::cerr << "Available parser implementations:" << std::endl;
   for (auto impl : simdjson::available_implementations) {
     std::cerr << "-a " << std::left << std::setw(9) << impl->name() << " - Use the " << impl->description() << " parser implementation." << std::endl;
   }
-  exit(1);
 }
 
 int main(int argc, char *argv[]) {
@@ -30,14 +29,21 @@ int main(int argc, char *argv[]) {
   auto result = options.parse(argc, argv);
 
   if(result.count("help")) {
-    exit_usage("");
+    usage("");
+    return EXIT_SUCCESS;
   }
 
-  if(!result.count("file")) exit_usage("No filename specified.");
+  if(!result.count("file")) {
+    usage("No filename specified.");
+    return EXIT_FAILURE;
+  }
 
   if(result.count("arch")) {
     const simdjson::implementation *impl = simdjson::available_implementations[result["arch"].as<std::string>().c_str()];
-    if(!impl) exit_usage("Unsupported implementation.");
+    if(!impl) {
+      usage("Unsupported implementation.");
+      return EXIT_FAILURE;
+    }
     simdjson::active_implementation = impl;
   }
 


### PR DESCRIPTION
As suggested in #814, porting tools from getopt to cxxopts (https://github.com/jarro2783/cxxopts).

The port currently only applies to the tools referenced in CMakeLists from the tools folder.