### PR TITLE
[1/4] Simplify parse_many() and fix bugs

### DIFF
--- a/include/simdjson/dom/document_stream.h
+++ b/include/simdjson/dom/document_stream.h
@@ -120,7 +120,7 @@ private:
   inline size_t next_batch_start() const noexcept;
 
   /** Pass the next batch through stage 1 with the given parser. */
-  inline void run_stage1(dom::parser &p, size_t batch_start) noexcept;
+  inline error_code run_stage1(dom::parser &p, size_t batch_start) noexcept;
 
   dom::parser &parser;
   const uint8_t *buf;
@@ -131,20 +131,19 @@ private:
   error_code error;
 
 #ifdef SIMDJSON_THREADS_ENABLED
-  /**
-   * Start a thread to run stage 1 on the next batch.
-   */
+  inline void load_from_stage1_thread() noexcept;
+
+  /** Start a thread to run stage 1 on the next batch. */
   inline void start_stage1_thread() noexcept;
 
-  /**
-   * Wait for the stage 1 thread to finish and capture the results.
-   */
+  /** Wait for the stage 1 thread to finish and capture the results. */
   inline void finish_stage1_thread() noexcept;
 
   /** The error returned from the stage 1 thread. */
   error_code stage1_thread_error{UNINITIALIZED};
   /** The thread used to run stage 1 against the next batch in the background. */
   std::thread stage1_thread{};
+
   /**
    * The parser used to run stage 1 in the background. Will be swapped
    * with the regular parser when finished.

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -11,7 +11,6 @@ namespace simdjson {
  */
 enum error_code {
   SUCCESS = 0,              ///< No error
-  SUCCESS_AND_HAS_MORE,     ///< @private No error and buffer still has more data
   CAPACITY,                 ///< This parser can't support a document that big
   MEMALLOC,                 ///< Error allocating memory, most likely out of memory
   TAPE_ERROR,               ///< Something went wrong while writing to the tape (stage 2), this is a generic error

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -7,124 +7,36 @@
 #include <stdexcept>
 
 namespace simdjson {
-namespace internal {
-
-/**
- * This algorithm is used to quickly identify the buffer position of
- * the last JSON document inside the current batch.
- *
- * It does its work by finding the last pair of structural characters
- * that represent the end followed by the start of a document.
- *
- * Simply put, we iterate over the structural characters, starting from
- * the end. We consider that we found the end of a JSON document when the
- * first element of the pair is NOT one of these characters: '{' '[' ';' ','
- * and when the second element is NOT one of these characters: '}' '}' ';' ','.
- *
- * This simple comparison works most of the time, but it does not cover cases
- * where the batch's structural indexes contain a perfect amount of documents.
- * In such a case, we do not have access to the structural index which follows
- * the last document, therefore, we do not have access to the second element in
- * the pair, and means that we cannot identify the last document. To fix this
- * issue, we keep a count of the open and closed curly/square braces we found
- * while searching for the pair. When we find a pair AND the count of open and
- * closed curly/square braces is the same, we know that we just passed a
- * complete
- * document, therefore the last json buffer location is the end of the batch
- * */
-inline uint32_t find_last_json_buf_idx(const uint8_t *buf, size_t size, const dom::parser &parser) {
-  // this function can be generally useful
-  if (parser.implementation->n_structural_indexes == 0)
-    return 0;
-  auto last_i = parser.implementation->n_structural_indexes - 1;
-  if (parser.implementation->structural_indexes[last_i] == size) {
-    if (last_i == 0)
-      return 0;
-    last_i = parser.implementation->n_structural_indexes - 2;
-  }
-  auto arr_cnt = 0;
-  auto obj_cnt = 0;
-  for (auto i = last_i; i > 0; i--) {
-    auto idxb = parser.implementation->structural_indexes[i];
-    switch (buf[idxb]) {
-    case ':':
-    case ',':
-      continue;
-    case '}':
-      obj_cnt--;
-      continue;
-    case ']':
-      arr_cnt--;
-      continue;
-    case '{':
-      obj_cnt++;
-      break;
-    case '[':
-      arr_cnt++;
-      break;
-    }
-    auto idxa = parser.implementation->structural_indexes[i - 1];
-    switch (buf[idxa]) {
-    case '{':
-    case '[':
-    case ':':
-    case ',':
-      continue;
-    }
-    if (!arr_cnt && !obj_cnt) {
-      return last_i + 1;
-    }
-    return i;
-  }
-  return 0;
-}
-
-// returns true if the provided byte value is an ASCII character
-static inline bool is_ascii(char c) {
-  return ((unsigned char)c) <= 127;
-}
-
-// if the string ends with  UTF-8 values, backtrack
-// up to the first ASCII character. May return 0.
-static inline size_t trimmed_length_safe_utf8(const char * c, size_t len) {
-  while ((len > 0) and (not is_ascii(c[len - 1]))) {
-    len--;
-  }
-  return len;
-}
-
-} // namespace internal
-
-} // namespace simdjson
-
-namespace simdjson {
 namespace dom {
+
 really_inline document_stream::document_stream(
   dom::parser &_parser,
-  const uint8_t *buf,
-  size_t len,
-  size_t batch_size,
+  const uint8_t *_buf,
+  size_t _len,
+  size_t _batch_size,
   error_code _error
 ) noexcept
   : parser{_parser},
-   _buf{buf},
-   _len{len},
-   _batch_size(batch_size),
-   error(_error)
+    buf{_buf},
+    len{_len},
+    batch_size{_batch_size},
+    error{_error}
 {
-  if (!error) { error = json_parse(); }
 }
 
 inline document_stream::~document_stream() noexcept {
 #ifdef SIMDJSON_THREADS_ENABLED
-  if (stage_1_thread.joinable()) {
-    stage_1_thread.join();
+  // TODO kill the thread, why should people have to wait for a non-side-effecting operation to complete
+  if (stage1_thread.joinable()) {
+    stage1_thread.join();
   }
 #endif
 }
 
 really_inline document_stream::iterator document_stream::begin() noexcept {
-  return iterator(*this, false);
+  start();
+  // If there are no documents, we're finished.
+  return iterator(*this, error == EMPTY);
 }
 
 really_inline document_stream::iterator document_stream::end() noexcept {
@@ -136,17 +48,15 @@ really_inline document_stream::iterator::iterator(document_stream& _stream, bool
 }
 
 really_inline simdjson_result<element> document_stream::iterator::operator*() noexcept {
-  error_code err = stream.error == SUCCESS_AND_HAS_MORE ? SUCCESS : stream.error;
-  if (err) { return err; }
+  // Once we have yielded any errors, we're finished.
+  if (stream.error) { finished = true; return stream.error; }
   return stream.parser.doc.root();
 }
 
 really_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
-  if (stream.error == SUCCESS_AND_HAS_MORE) {
-    stream.error = stream.json_parse();
-  } else {
-    finished = true;
-  }
+  stream.next();
+  // If that was the last document, we're finished.
+  if (stream.error == EMPTY) { finished = true; }
   return *this;
 }
 
@@ -154,130 +64,99 @@ really_inline bool document_stream::iterator::operator!=(const document_stream::
   return finished != other.finished;
 }
 
+inline void document_stream::start() noexcept {
+  if (error) { return; }
+
+  error = parser.ensure_capacity(batch_size);
+  if (error) { return; }
+
+  // Always run the first stage 1 parse immediately
+  batch_start = 0;
+  run_stage1(parser, batch_start);
+  if (error) { return; }
+
+#ifdef SIMDJSON_THREADS_ENABLED
+  if (next_batch_start() < len) {
+    // Kick off the first thread if needed
+    error = thread_parser.ensure_capacity(batch_size);
+    if (error) { return; }
+    start_stage1_thread();
+    if (error) { return; }
+  }
+#endif // SIMDJSON_THREADS_ENABLED
+
+  next();
+}
+
+inline void document_stream::next() noexcept {
+  if (error) { return; }
+
+  // Load the next document from the batch
+  error = parser.implementation->stage2_next(parser.doc);
+
+  // If that was the last document in the batch, load another batch (if available)
+  while (error == EMPTY) {
+    batch_start = next_batch_start();
+    if (batch_start >= len) { break; }
+
+#ifdef SIMDJSON_THREADS_ENABLED
+    load_from_stage1_thread();
+#else
+    run_stage1(parser, batch_start);
+#endif
+    if (error) { continue; } // If the error was EMPTY, we may want to load another batch.
+
+    // Run stage 2 on the first document in the batch
+    error = parser.implementation->stage2_next(parser.doc);
+  }
+}
+
+inline size_t document_stream::next_batch_start() const noexcept {
+  return batch_start + parser.implementation->structural_indexes[parser.implementation->n_structural_indexes];
+}
+
+inline void document_stream::run_stage1(dom::parser &p, size_t _batch_start) noexcept {
+  // If this is the final batch, pass partial = false
+  size_t remaining = len - _batch_start;
+  if (remaining <= batch_size) {
+    error = p.implementation->stage1(&buf[_batch_start], remaining, false);
+  } else {
+    error = p.implementation->stage1(&buf[_batch_start], batch_size, true);
+  }
+}
+
 #ifdef SIMDJSON_THREADS_ENABLED
 
-// threaded version of json_parse
-// todo: simplify this code further
-inline error_code document_stream::json_parse() noexcept {
-  error = parser.ensure_capacity(_batch_size);
-  if (error) { return error; }
-  error = parser_thread.ensure_capacity(_batch_size);
-  if (error) { return error; }
+inline void document_stream::load_from_stage1_thread() noexcept {
+  stage1_thread.join();
 
-  if (unlikely(load_next_batch)) {
-    // First time loading
-    if (!stage_1_thread.joinable()) {
-      _batch_size = (std::min)(_batch_size, remaining());
-      _batch_size = internal::trimmed_length_safe_utf8((const char *)buf(), _batch_size);
-      if (_batch_size == 0) {
-        return simdjson::UTF8_ERROR;
-      }
-      auto stage1_is_ok = error_code(parser.implementation->stage1(buf(), _batch_size, true));
-      if (stage1_is_ok != simdjson::SUCCESS) {
-        return stage1_is_ok;
-      }
-      uint32_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
-      if (last_index == 0) {
-        if (parser.implementation->n_structural_indexes == 0) {
-          return simdjson::EMPTY;
-        }
-      } else {
-        parser.implementation->n_structural_indexes = last_index + 1;
-      }
-    }
-    // the second thread is running or done.
-    else {
-      stage_1_thread.join();
-      if (stage1_is_ok_thread != simdjson::SUCCESS) {
-        return stage1_is_ok_thread;
-      }
-      std::swap(parser.implementation->structural_indexes, parser_thread.implementation->structural_indexes);
-      parser.implementation->n_structural_indexes = parser_thread.implementation->n_structural_indexes;
-      advance(last_json_buffer_loc);
-      n_bytes_parsed += last_json_buffer_loc;
-    }
-    // let us decide whether we will start a new thread
-    if (remaining() - _batch_size > 0) {
-      last_json_buffer_loc =
-          parser.implementation->structural_indexes[internal::find_last_json_buf_idx(buf(), _batch_size, parser)];
-      _batch_size = (std::min)(_batch_size, remaining() - last_json_buffer_loc);
-      if (_batch_size > 0) {
-        _batch_size = internal::trimmed_length_safe_utf8(
-            (const char *)(buf() + last_json_buffer_loc), _batch_size);
-        if (_batch_size == 0) {
-          return simdjson::UTF8_ERROR;
-        }
-        // let us capture read-only variables
-        const uint8_t *const b = buf() + last_json_buffer_loc;
-        const size_t bs = _batch_size;
-        // we call the thread on a lambda that will update
-        // this->stage1_is_ok_thread
-        // there is only one thread that may write to this value
-        stage_1_thread = std::thread([this, b, bs] {
-          this->stage1_is_ok_thread = error_code(parser_thread.implementation->stage1(b, bs, true));
-        });
-      }
-    }
-    next_json = 0;
-    load_next_batch = false;
-  } // load_next_batch
-  error_code res = parser.implementation->stage2(buf(), remaining(), parser.doc, next_json);
-  if (res == simdjson::SUCCESS_AND_HAS_MORE) {
-    n_parsed_docs++;
-    current_buffer_loc = parser.implementation->structural_indexes[next_json];
-    load_next_batch = (current_buffer_loc == last_json_buffer_loc);
-  } else if (res == simdjson::SUCCESS) {
-    n_parsed_docs++;
-    if (remaining() > _batch_size) {
-      current_buffer_loc = parser.implementation->structural_indexes[next_json - 1];
-      load_next_batch = true;
-      res = simdjson::SUCCESS_AND_HAS_MORE;
-    }
+  // Swap to the parser that was loaded up in the thread. Make sure the parser has
+  // enough memory to swap to, as well.
+  error = parser.ensure_capacity(batch_size);
+  if (error) { return error; }
+  std::swap(parser, stage1_thread_parser);
+  if (stage1_thread_error) { return stage1_thread_error; }
+
+  // If there's anything left, start the stage 1 thread!
+  if (next_batch_start() < len) {
+    start_stage1_thread();
   }
-  return res;
 }
 
-#else  // SIMDJSON_THREADS_ENABLED
-
-// single-threaded version of json_parse
-inline error_code document_stream::json_parse() noexcept {
-  error = parser.ensure_capacity(_batch_size);
-  if (error) { return error; }
-
-  if (unlikely(load_next_batch)) {
-    advance(current_buffer_loc);
-    n_bytes_parsed += current_buffer_loc;
-    _batch_size = (std::min)(_batch_size, remaining());
-    _batch_size = internal::trimmed_length_safe_utf8((const char *)buf(), _batch_size);
-    auto stage1_is_ok = (error_code)parser.implementation->stage1(buf(), _batch_size, true);
-    if (stage1_is_ok != simdjson::SUCCESS) {
-      return stage1_is_ok;
+inline void document_stream::start_stage1_thread() noexcept {
+  // we call the thread on a lambda that will update
+  // this->stage1_thread_error
+  // there is only one thread that may write to this value
+  // TODO this is NOT exception-safe.
+  this->stage1_thread_error = UNINITIALIZED; // In case something goes wrong, make sure it's an error
+  stage1_thread = std::thread([this] {
+    this->stage1_thread_error = this->thread_parser.ensure_capacity(this->batch_size);
+    if (!this->stage1_thread_error) {
+      this->stage1_thread_error = run_stage1(this->stage1_thread_parser, this->next_batch_start());
     }
-    uint32_t last_index = internal::find_last_json_buf_idx(buf(), _batch_size, parser);
-    if (last_index == 0) {
-      if (parser.implementation->n_structural_indexes == 0) {
-        return EMPTY;
-      }
-    } else {
-      parser.implementation->n_structural_indexes = last_index + 1;
-    }
-    load_next_batch = false;
-  } // load_next_batch
-  error_code res = parser.implementation->stage2(buf(), remaining(), parser.doc, next_json);
-  if (likely(res == simdjson::SUCCESS_AND_HAS_MORE)) {
-    n_parsed_docs++;
-    current_buffer_loc = parser.implementation->structural_indexes[next_json];
-  } else if (res == simdjson::SUCCESS) {
-    n_parsed_docs++;
-    if (remaining() > _batch_size) {
-      current_buffer_loc = parser.implementation->structural_indexes[next_json - 1];
-      next_json = 1;
-      load_next_batch = true;
-      res = simdjson::SUCCESS_AND_HAS_MORE;
-    }
-  }
-  return res;
+  });
 }
+
 #endif // SIMDJSON_THREADS_ENABLED
 
 } // namespace dom

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -72,16 +72,14 @@ public:
    *
    * Stage 2 of the document parser for parser::parse_many.
    *
-   * Guaranteed only to be called after stage1(), with buf and len being a subset of the total stage1 buf/len.
+   * Guaranteed only to be called after stage1().
    * Overridden by each implementation.
    *
-   * @param buf The json document to parse.
-   * @param len The length of the json document.
    * @param doc The document to output to.
    * @param next_json The next structural index. Start this at 0 the first time, and it will be updated to the next value to pass each time.
    * @return The error code, SUCCESS if there was no error, or SUCCESS_AND_HAS_MORE if there was no error and stage2 can be called again.
    */
-  WARN_UNUSED virtual error_code stage2(const uint8_t *buf, size_t len, dom::document &doc, size_t &next_json) noexcept = 0;
+  WARN_UNUSED virtual error_code stage2_next(dom::document &doc) noexcept = 0;
 
   /**
    * Change the capacity of this parser.
@@ -117,6 +115,8 @@ public:
   uint32_t n_structural_indexes{0};
   /** Structural indices passed from stage 1 to stage 2 */
   std::unique_ptr<uint32_t[]> structural_indexes{};
+  /** Next structural index to parse */
+  uint32_t next_structural_index{0};
 
   /**
    * The largest document this parser can support without reallocating.

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -76,8 +76,7 @@ public:
    * Overridden by each implementation.
    *
    * @param doc The document to output to.
-   * @param next_json The next structural index. Start this at 0 the first time, and it will be updated to the next value to pass each time.
-   * @return The error code, SUCCESS if there was no error, or SUCCESS_AND_HAS_MORE if there was no error and stage2 can be called again.
+   * @return The error code, SUCCESS if there was no error, or EMPTY if all documents have been parsed.
    */
   WARN_UNUSED virtual error_code stage2_next(dom::document &doc) noexcept = 0;
 

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -82,6 +82,7 @@ WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, ui
   return arm64::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
+#include "generic/stage1/find_next_document_index.h"
 #include "generic/stage1/utf8_lookup2_algorithm.h"
 #include "generic/stage1/json_structural_indexer.h"
 WARN_UNUSED error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {

--- a/src/error.cpp
+++ b/src/error.cpp
@@ -5,7 +5,6 @@ namespace internal {
 
   SIMDJSON_DLLIMPORTEXPORT const error_code_info error_codes[] {
     { SUCCESS, "No error" },
-    { SUCCESS_AND_HAS_MORE, "No error and buffer still has more data" },
     { CAPACITY, "This parser can't support a document that big" },
     { MEMALLOC, "Error allocating memory, we're most likely out of memory" },
     { TAPE_ERROR, "The JSON document has an improper structure: missing or superfluous commas, braces, missing keys, etc." },

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -9,15 +9,17 @@ namespace simdjson {
 namespace fallback {
 namespace stage1 {
 
+#include "generic/stage1/find_next_document_index.h"
+
 class structural_scanner {
 public:
 
-really_inline structural_scanner(dom_parser_implementation &_parser, bool _streaming)
+really_inline structural_scanner(dom_parser_implementation &_parser, bool _partial)
   : buf{_parser.buf},
     next_structural_index{_parser.structural_indexes.get()},
     parser{_parser},
     len{static_cast<uint32_t>(_parser.len)},
-    streaming{_streaming} {
+    partial{_partial} {
 }
 
 really_inline void add_structural() {
@@ -41,7 +43,12 @@ really_inline void validate_utf8_character() {
   // 2-byte
   if ((buf[idx] & 0b00100000) == 0) {
     // missing continuation
-    if (unlikely(idx+1 > len || !is_continuation(buf[idx+1]))) { error = UTF8_ERROR; idx++; return; }
+    if (unlikely(idx+1 > len || !is_continuation(buf[idx+1]))) {
+      if (idx+1 > len && partial) { idx = len; return; }
+      error = UTF8_ERROR;
+      idx++;
+      return;
+    }
     // overlong: 1100000_ 10______
     if (buf[idx] <= 0b11000001) { error = UTF8_ERROR; }
     idx += 2;
@@ -51,7 +58,12 @@ really_inline void validate_utf8_character() {
   // 3-byte
   if ((buf[idx] & 0b00010000) == 0) {
     // missing continuation
-    if (unlikely(idx+2 > len || !is_continuation(buf[idx+1]) || !is_continuation(buf[idx+2]))) { error = UTF8_ERROR; idx++; return; }
+    if (unlikely(idx+2 > len || !is_continuation(buf[idx+1]) || !is_continuation(buf[idx+2]))) {
+      if (idx+2 > len && partial) { idx = len; return; }
+      error = UTF8_ERROR;
+      idx++;
+      return;
+    }
     // overlong: 11100000 100_____ ________
     if (buf[idx] == 0b11100000 && buf[idx+1] <= 0b10011111) { error = UTF8_ERROR; }
     // surrogates: U+D800-U+DFFF 11101101 101_____
@@ -62,7 +74,12 @@ really_inline void validate_utf8_character() {
 
   // 4-byte
   // missing continuation
-  if (unlikely(idx+3 > len || !is_continuation(buf[idx+1]) || !is_continuation(buf[idx+2]) || !is_continuation(buf[idx+3]))) { error = UTF8_ERROR; idx++; return; }
+  if (unlikely(idx+3 > len || !is_continuation(buf[idx+1]) || !is_continuation(buf[idx+2]) || !is_continuation(buf[idx+3]))) {
+    if (idx+2 > len && partial) { idx = len; return; }
+    error = UTF8_ERROR;
+    idx++;
+    return;
+  }
   // overlong: 11110000 1000____ ________ ________
   if (buf[idx] == 0b11110000 && buf[idx+1] <= 0b10001111) { error = UTF8_ERROR; }
   // too large: > U+10FFFF:
@@ -87,7 +104,7 @@ really_inline void validate_string() {
       idx++;
     }
   }
-  if (idx >= len && !streaming) { error = UNCLOSED_STRING; }
+  if (idx >= len && !partial) { error = UNCLOSED_STRING; }
 }
 
 really_inline bool is_whitespace_or_operator(uint8_t c) {
@@ -128,16 +145,26 @@ really_inline error_code scan() {
         break;
     }
   }
-  if (unlikely(next_structural_index == parser.structural_indexes.get())) {
-    return EMPTY;
-  }
   *next_structural_index = len;
-  next_structural_index++;
   // We pad beyond.
   // https://github.com/simdjson/simdjson/issues/906
-  next_structural_index[0] = len;
-  next_structural_index[1] = 0;
+  next_structural_index[1] = len;
+  next_structural_index[2] = 0;
   parser.n_structural_indexes = uint32_t(next_structural_index - parser.structural_indexes.get());
+  parser.next_structural_index = 0;
+
+  if (unlikely(parser.n_structural_indexes == 0)) {
+    return EMPTY;
+  }
+
+  if (partial) {
+    auto new_structural_indexes = find_next_document_index(parser);
+    if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
+      return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
+    }
+    parser.n_structural_indexes = new_structural_indexes;
+  }
+
   return error;
 }
 
@@ -148,16 +175,16 @@ private:
   uint32_t len;
   uint32_t idx{0};
   error_code error{SUCCESS};
-  bool streaming;
+  bool partial;
 }; // structural_scanner
 
 } // namespace stage1
 
 
-WARN_UNUSED error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+WARN_UNUSED error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool partial) noexcept {
   this->buf = _buf;
   this->len = _len;
-  stage1::structural_scanner scanner(*this, streaming);
+  stage1::structural_scanner scanner(*this, partial);
   return scanner.scan();
 }
 

--- a/src/generic/dom_parser_implementation.h
+++ b/src/generic/dom_parser_implementation.h
@@ -28,11 +28,12 @@ public:
   really_inline dom_parser_implementation();
   dom_parser_implementation(const dom_parser_implementation &) = delete;
   dom_parser_implementation & operator=(const dom_parser_implementation &) = delete;
-    
+
   WARN_UNUSED error_code parse(const uint8_t *buf, size_t len, dom::document &doc) noexcept final;
-  WARN_UNUSED error_code stage1(const uint8_t *buf, size_t len, bool streaming) noexcept final;
+  WARN_UNUSED error_code stage1(const uint8_t *buf, size_t len, bool partial) noexcept final;
+  WARN_UNUSED error_code check_for_unclosed_array() noexcept;
   WARN_UNUSED error_code stage2(dom::document &doc) noexcept final;
-  WARN_UNUSED error_code stage2(const uint8_t *buf, size_t len, dom::document &doc, size_t &next_json) noexcept final;
+  WARN_UNUSED error_code stage2_next(dom::document &doc) noexcept final;
   WARN_UNUSED error_code set_capacity(size_t capacity) noexcept final;
   WARN_UNUSED error_code set_max_depth(size_t max_depth) noexcept final;
 };

--- a/src/generic/stage1/allocate.h
+++ b/src/generic/stage1/allocate.h
@@ -8,6 +8,8 @@ really_inline error_code set_capacity(internal::dom_parser_implementation &parse
   size_t max_structures = ROUNDUP_N(capacity, 64) + 2 + 7;
   parser.structural_indexes.reset( new (std::nothrow) uint32_t[max_structures] );
   if (!parser.structural_indexes) { return MEMALLOC; }
+  parser.structural_indexes[0] = 0;
+  parser.n_structural_indexes = 0;
   return SUCCESS;
 }
 

--- a/src/generic/stage1/buf_block_reader.h
+++ b/src/generic/stage1/buf_block_reader.h
@@ -24,6 +24,38 @@ private:
   size_t idx;
 };
 
+constexpr const int TITLE_SIZE = 12;
+
+// Routines to print masks and text for debugging bitmask operations
+UNUSED static char * format_input_text_64(const uint8_t *text) {
+  static char *buf = (char*)malloc(sizeof(simd8x64<uint8_t>) + 1);
+  for (size_t i=0; i<sizeof(simd8x64<uint8_t>); i++) {
+    buf[i] = int8_t(text[i]) < ' ' ? '_' : int8_t(text[i]);
+  }
+  buf[sizeof(simd8x64<uint8_t>)] = '\0';
+  return buf;
+}
+
+// Routines to print masks and text for debugging bitmask operations
+UNUSED static char * format_input_text(const simd8x64<uint8_t> in) {
+  static char *buf = (char*)malloc(sizeof(simd8x64<uint8_t>) + 1);
+  in.store((uint8_t*)buf);
+  for (size_t i=0; i<sizeof(simd8x64<uint8_t>); i++) {
+    if (buf[i] < ' ') { buf[i] = '_'; }
+  }
+  buf[sizeof(simd8x64<uint8_t>)] = '\0';
+  return buf;
+}
+
+UNUSED static char * format_mask(uint64_t mask) {
+  static char *buf = (char*)malloc(64 + 1);
+  for (size_t i=0; i<64; i++) {
+    buf[i] = (mask & (size_t(1) << i)) ? 'X' : ' ';
+  }
+  buf[64] = '\0';
+  return buf;
+}
+
 template<size_t STEP_SIZE>
 really_inline buf_block_reader<STEP_SIZE>::buf_block_reader(const uint8_t *_buf, size_t _len) : buf{_buf}, len{_len}, lenminusstep{len < STEP_SIZE ? 0 : len - STEP_SIZE}, idx{0} {}
 
@@ -50,24 +82,4 @@ really_inline size_t buf_block_reader<STEP_SIZE>::get_remainder(uint8_t *dst) co
 template<size_t STEP_SIZE>
 really_inline void buf_block_reader<STEP_SIZE>::advance() {
   idx += STEP_SIZE;
-}
-
-// Routines to print masks and text for debugging bitmask operations
-UNUSED static char * format_input_text(const simd8x64<uint8_t> in) {
-  static char *buf = (char*)malloc(sizeof(simd8x64<uint8_t>) + 1);
-  in.store((uint8_t*)buf);
-  for (size_t i=0; i<sizeof(simd8x64<uint8_t>); i++) {
-    if (buf[i] < ' ') { buf[i] = '_'; }
-  }
-  buf[sizeof(simd8x64<uint8_t>)] = '\0';
-  return buf;
-}
-
-UNUSED static char * format_mask(uint64_t mask) {
-  static char *buf = (char*)malloc(64 + 1);
-  for (size_t i=0; i<64; i++) {
-    buf[i] = (mask & (size_t(1) << i)) ? 'X' : ' ';
-  }
-  buf[64] = '\0';
-  return buf;
 }

--- a/src/generic/stage1/buf_block_reader.h
+++ b/src/generic/stage1/buf_block_reader.h
@@ -2,30 +2,51 @@
 template<size_t STEP_SIZE>
 struct buf_block_reader {
 public:
-  really_inline buf_block_reader(const uint8_t *_buf, size_t _len) : buf{_buf}, len{_len}, lenminusstep{len < STEP_SIZE ? 0 : len - STEP_SIZE}, idx{0} {}
-  really_inline size_t block_index() { return idx; }
-  really_inline bool has_full_block() const {
-    return idx < lenminusstep;
-  }
-  really_inline const uint8_t *full_block() const {
-    return &buf[idx];
-  }
-  really_inline bool has_remainder() const {
-    return idx < len;
-  }
-  really_inline void get_remainder(uint8_t *tmp_buf) const {
-    memset(tmp_buf, 0x20, STEP_SIZE);
-    memcpy(tmp_buf, buf + idx, len - idx);
-  }
-  really_inline void advance() {
-    idx += STEP_SIZE;
-  }
+  really_inline buf_block_reader(const uint8_t *_buf, size_t _len);
+  really_inline size_t block_index();
+  really_inline bool has_full_block() const;
+  really_inline const uint8_t *full_block() const;
+  really_inline bool has_remainder() const;
+  really_inline void get_remainder(uint8_t *tmp_buf) const;
+  really_inline void advance();
 private:
   const uint8_t *buf;
   const size_t len;
   const size_t lenminusstep;
   size_t idx;
 };
+
+template<size_t STEP_SIZE>
+really_inline buf_block_reader<STEP_SIZE>::buf_block_reader(const uint8_t *_buf, size_t _len) : buf{_buf}, len{_len}, lenminusstep{len < STEP_SIZE ? 0 : len - STEP_SIZE}, idx{0} {}
+
+template<size_t STEP_SIZE>
+really_inline size_t buf_block_reader<STEP_SIZE>::block_index() { return idx; }
+
+template<size_t STEP_SIZE>
+really_inline bool buf_block_reader<STEP_SIZE>::has_full_block() const {
+  return idx < lenminusstep;
+}
+
+template<size_t STEP_SIZE>
+really_inline const uint8_t *buf_block_reader<STEP_SIZE>::full_block() const {
+  return &buf[idx];
+}
+
+template<size_t STEP_SIZE>
+really_inline bool buf_block_reader<STEP_SIZE>::has_remainder() const {
+  return idx < len;
+}
+
+template<size_t STEP_SIZE>
+really_inline void buf_block_reader<STEP_SIZE>::get_remainder(uint8_t *tmp_buf) const {
+  memset(tmp_buf, 0x20, STEP_SIZE);
+  memcpy(tmp_buf, buf + idx, len - idx);
+}
+
+template<size_t STEP_SIZE>
+really_inline void buf_block_reader<STEP_SIZE>::advance() {
+  idx += STEP_SIZE;
+}
 
 // Routines to print masks and text for debugging bitmask operations
 UNUSED static char * format_input_text(const simd8x64<uint8_t> in) {

--- a/src/generic/stage1/buf_block_reader.h
+++ b/src/generic/stage1/buf_block_reader.h
@@ -6,8 +6,16 @@ public:
   really_inline size_t block_index();
   really_inline bool has_full_block() const;
   really_inline const uint8_t *full_block() const;
-  really_inline bool has_remainder() const;
-  really_inline void get_remainder(uint8_t *tmp_buf) const;
+  /**
+   * Get the last block, padded with spaces.
+   *
+   * There will always be a last block, with at least 1 byte, unless len == 0 (in which case this
+   * function fills the buffer with spaces and returns 0. In particular, if len == STEP_SIZE there
+   * will be 0 full_blocks and 1 remainder block with STEP_SIZE bytes and no spaces for padding.
+   *
+   * @return the number of effective characters in the last block.
+   */
+  really_inline size_t get_remainder(uint8_t *dst) const;
   really_inline void advance();
 private:
   const uint8_t *buf;
@@ -33,14 +41,10 @@ really_inline const uint8_t *buf_block_reader<STEP_SIZE>::full_block() const {
 }
 
 template<size_t STEP_SIZE>
-really_inline bool buf_block_reader<STEP_SIZE>::has_remainder() const {
-  return idx < len;
-}
-
-template<size_t STEP_SIZE>
-really_inline void buf_block_reader<STEP_SIZE>::get_remainder(uint8_t *tmp_buf) const {
-  memset(tmp_buf, 0x20, STEP_SIZE);
-  memcpy(tmp_buf, buf + idx, len - idx);
+really_inline size_t buf_block_reader<STEP_SIZE>::get_remainder(uint8_t *dst) const {
+  memset(dst, 0x20, STEP_SIZE); // memset STEP_SIZE because it's more efficient to write out 8 or 16 bytes at once.
+  memcpy(dst, buf + idx, len - idx);
+  return len - idx;
 }
 
 template<size_t STEP_SIZE>

--- a/src/generic/stage1/find_next_document_index.h
+++ b/src/generic/stage1/find_next_document_index.h
@@ -1,0 +1,86 @@
+/**
+  * This algorithm is used to quickly identify the last structural position that
+  * makes up a complete document.
+  *
+  * It does this by going backwards and finding the last *document boundary* (a
+  * place where one value follows another without a comma between them). If the
+  * last document (the characters after the boundary) has an equal number of
+  * start and end brackets, it is considered complete.
+  *
+  * Simply put, we iterate over the structural characters, starting from
+  * the end. We consider that we found the end of a JSON document when the
+  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
+  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  *
+  * This simple comparison works most of the time, but it does not cover cases
+  * where the batch's structural indexes contain a perfect amount of documents.
+  * In such a case, we do not have access to the structural index which follows
+  * the last document, therefore, we do not have access to the second element in
+  * the pair, and that means we cannot identify the last document. To fix this
+  * issue, we keep a count of the open and closed curly/square braces we found
+  * while searching for the pair. When we find a pair AND the count of open and
+  * closed curly/square braces is the same, we know that we just passed a
+  * complete document, therefore the last json buffer location is the end of the
+  * batch.
+  */
+really_inline static uint32_t find_next_document_index(dom_parser_implementation &parser) {
+  // TODO don't count separately, just figure out depth
+  auto arr_cnt = 0;
+  auto obj_cnt = 0;
+  for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
+    auto idxb = parser.structural_indexes[i];
+    switch (parser.buf[idxb]) {
+    case ':':
+    case ',':
+      continue;
+    case '}':
+      obj_cnt--;
+      continue;
+    case ']':
+      arr_cnt--;
+      continue;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+    }
+    auto idxa = parser.structural_indexes[i - 1];
+    switch (parser.buf[idxa]) {
+    case '{':
+    case '[':
+    case ':':
+    case ',':
+      continue;
+    }
+    // Last document is complete, so the next document will appear after!
+    if (!arr_cnt && !obj_cnt) {
+      return parser.n_structural_indexes;
+    }
+    // Last document is incomplete; mark the document at i + 1 as the next one
+    return i;
+  }
+  return 0;
+}
+
+// Skip the last character if it is partial
+really_inline static size_t trim_partial_utf8(const uint8_t *buf, size_t len) {
+  if (unlikely(len < 3)) {
+    switch (len) {
+      case 2:
+        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+        if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 2 bytes left
+        return len;
+      case 1:
+        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+        return len;
+      case 0:
+        return len;
+    }
+  }
+  if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+  if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 1 byte left
+  if (buf[len-3] >= 0b11110000) { return len-3; } // 4-byte characters with only 3 bytes left
+  return len;
+}

--- a/src/generic/stage1/json_minifier.h
+++ b/src/generic/stage1/json_minifier.h
@@ -59,13 +59,15 @@ template<size_t STEP_SIZE>
 error_code json_minifier::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) noexcept {
   buf_block_reader<STEP_SIZE> reader(buf, len);
   json_minifier minifier(dst);
+
+  // Index the first n-1 blocks
   while (reader.has_full_block()) {
     minifier.step<STEP_SIZE>(reader.full_block(), reader);
   }
 
-  if (likely(reader.has_remainder())) {
-    uint8_t block[STEP_SIZE];
-    reader.get_remainder(block);
+  // Index the last (remainder) block, padded with spaces
+  uint8_t block[STEP_SIZE];
+  if (likely(reader.get_remainder(block)) > 0) {
     minifier.step<STEP_SIZE>(block, reader);
   }
 

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -60,19 +60,21 @@ public:
   /**
    * Find the important bits of JSON in a 128-byte chunk, and add them to structural_indexes.
    *
-   * @param streaming Setting the streaming parameter to true allows the find_structural_bits to
+   * @param partial Setting the partial parameter to true allows the find_structural_bits to
    *   tolerate unclosed strings. The caller should still ensure that the input is valid UTF-8. If
    *   you are processing substrings, you may want to call on a function like trimmed_length_safe_utf8.
    */
   template<size_t STEP_SIZE>
-  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool streaming) noexcept;
+  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept;
 
 private:
   really_inline json_structural_indexer(uint32_t *structural_indexes);
   template<size_t STEP_SIZE>
   really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   really_inline void next(simd::simd8x64<uint8_t> in, json_block block, size_t idx);
-  really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool streaming);
+  really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
+  static really_inline uint32_t find_next_document_index(dom_parser_implementation &parser);
+  static really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -101,8 +103,9 @@ really_inline json_structural_indexer::json_structural_indexer(uint32_t *structu
 // workout.
 //
 template<size_t STEP_SIZE>
-error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool streaming) noexcept {
+error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept {
   if (unlikely(len > parser.capacity())) { return CAPACITY; }
+  if (partial) { len = trim_partial_utf8(buf, len); }
 
   buf_block_reader<STEP_SIZE> reader(buf, len);
   json_structural_indexer indexer(parser.structural_indexes.get());
@@ -117,7 +120,7 @@ error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_pa
   if (unlikely(reader.get_remainder(block) == 0)) { return EMPTY; }
   indexer.step<STEP_SIZE>(block, reader);
 
-  return indexer.finish(parser, reader.block_index(), len, streaming);
+  return indexer.finish(parser, reader.block_index(), len, partial);
 }
 
 template<>
@@ -147,11 +150,11 @@ really_inline void json_structural_indexer::next(simd::simd8x64<uint8_t> in, jso
   unescaped_chars_error |= block.non_quote_inside_string(unescaped);
 }
 
-really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, bool streaming) {
+really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial) {
   // Write out the final iteration's structurals
   indexer.write(uint32_t(idx-64), prev_structurals);
 
-  error_code error = scanner.finish(streaming);
+  error_code error = scanner.finish(partial);
   if (unlikely(error != SUCCESS)) { return error; }
 
   if (unescaped_chars_error) {
@@ -159,22 +162,13 @@ really_inline error_code json_structural_indexer::finish(dom_parser_implementati
   }
 
   parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
-  /* a valid JSON file cannot have zero structural indexes - we should have
-   * found something */
+  // a valid JSON file cannot have zero structural indexes - we should have found something
   if (unlikely(parser.n_structural_indexes == 0u)) {
     return EMPTY;
   }
   if (unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
     return UNEXPECTED_ERROR;
   }
-  if (len != parser.structural_indexes[parser.n_structural_indexes - 1]) {
-    /* the string might not be NULL terminated, but we add a virtual NULL
-     * ending character. */
-    parser.structural_indexes[parser.n_structural_indexes++] = uint32_t(len);
-  }
-  /* make it safe to dereference one beyond this array */
-  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
-  parser.structural_indexes[parser.n_structural_indexes + 1] = 0;
   /***
    * This is related to https://github.com/simdjson/simdjson/issues/906
    * Basically, we want to make sure that if the parsing continues beyond the last (valid)
@@ -189,7 +183,105 @@ really_inline error_code json_structural_indexer::finish(dom_parser_implementati
    * starts with [, it should end with ]. If we enforce that rule, then we would get
    * ][[ which is invalid.
    **/
+  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+  parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);
+  parser.structural_indexes[parser.n_structural_indexes + 2] = 0;
+  if (partial) {
+    auto new_structural_indexes = find_next_document_index(parser);
+    if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
+      return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
+    }
+    parser.n_structural_indexes = new_structural_indexes;
+  }
+  parser.next_structural_index = 0;
   return checker.errors();
+}
+
+/**
+  * This algorithm is used to quickly identify the last structural position that
+  * makes up a complete document.
+  *
+  * It does this by going backwards and finding the last *document boundary* (a
+  * place where one value follows another without a comma between them). If the
+  * last document (the characters after the boundary) has an equal number of
+  * start and end brackets, it is considered complete.
+  *
+  * Simply put, we iterate over the structural characters, starting from
+  * the end. We consider that we found the end of a JSON document when the
+  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
+  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  *
+  * This simple comparison works most of the time, but it does not cover cases
+  * where the batch's structural indexes contain a perfect amount of documents.
+  * In such a case, we do not have access to the structural index which follows
+  * the last document, therefore, we do not have access to the second element in
+  * the pair, and means that we cannot identify the last document. To fix this
+  * issue, we keep a count of the open and closed curly/square braces we found
+  * while searching for the pair. When we find a pair AND the count of open and
+  * closed curly/square braces is the same, we know that we just passed a
+  * complete
+  * document, therefore the last json buffer location is the end of the batch
+  */
+really_inline uint32_t json_structural_indexer::find_next_document_index(dom_parser_implementation &parser) {
+  // TODO don't count separately, just figure out depth
+  auto arr_cnt = 0;
+  auto obj_cnt = 0;
+  for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
+    auto idxb = parser.structural_indexes[i];
+    switch (parser.buf[idxb]) {
+    case ':':
+    case ',':
+      continue;
+    case '}':
+      obj_cnt--;
+      continue;
+    case ']':
+      arr_cnt--;
+      continue;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+    }
+    auto idxa = parser.structural_indexes[i - 1];
+    switch (parser.buf[idxa]) {
+    case '{':
+    case '[':
+    case ':':
+    case ',':
+      continue;
+    }
+    // Last document is complete, so the next document will appear after!
+    if (!arr_cnt && !obj_cnt) {
+      return parser.n_structural_indexes;
+    }
+    // Last document is incomplete; mark the document at i + 1 as the next one
+    return i;
+  }
+  return 0;
+}
+
+// Skip the last character if it is partial
+really_inline size_t json_structural_indexer::trim_partial_utf8(const uint8_t *buf, size_t len) {
+  if (unlikely(len < 3)) {
+    switch (len) {
+      case 2:
+        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+        if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 2 bytes left
+        return len;
+      case 1:
+        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+        return len;
+      case 0:
+        return len;
+    }
+  }
+  if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
+  if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 1 byte left
+  if (buf[len-3] >= 0b11110000) { return len-3; } // 4-byte characters with only 3 bytes left
+  return len;
 }
 
 } // namespace stage1

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -73,8 +73,6 @@ private:
   really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   really_inline void next(simd::simd8x64<uint8_t> in, json_block block, size_t idx);
   really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
-  static really_inline uint32_t find_next_document_index(dom_parser_implementation &parser);
-  static really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -98,7 +96,7 @@ really_inline json_structural_indexer::json_structural_indexer(uint32_t *structu
 // 3. Step 1 doesn't use enough capacity, so we run some extra stuff while we're waiting for that
 //    to finish: utf-8 checks and generating the output from the last iteration.
 //
-// The reason we run 2 inputs at a time, is steps 2 and 3 are//still* not enough to soak up all
+// The reason we run 2 inputs at a time, is steps 2 and 3 are *still* not enough to soak up all
 // available capacity with just one input. Running 2 at a time seems to give the CPU a good enough
 // workout.
 //
@@ -162,13 +160,6 @@ really_inline error_code json_structural_indexer::finish(dom_parser_implementati
   }
 
   parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
-  // a valid JSON file cannot have zero structural indexes - we should have found something
-  if (unlikely(parser.n_structural_indexes == 0u)) {
-    return EMPTY;
-  }
-  if (unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
-    return UNEXPECTED_ERROR;
-  }
   /***
    * This is related to https://github.com/simdjson/simdjson/issues/906
    * Basically, we want to make sure that if the parsing continues beyond the last (valid)
@@ -186,6 +177,14 @@ really_inline error_code json_structural_indexer::finish(dom_parser_implementati
   parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 2] = 0;
+  parser.next_structural_index = 0;
+  // a valid JSON file cannot have zero structural indexes - we should have found something
+  if (unlikely(parser.n_structural_indexes == 0u)) {
+    return EMPTY;
+  }
+  if (unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
+    return UNEXPECTED_ERROR;
+  }
   if (partial) {
     auto new_structural_indexes = find_next_document_index(parser);
     if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
@@ -193,95 +192,7 @@ really_inline error_code json_structural_indexer::finish(dom_parser_implementati
     }
     parser.n_structural_indexes = new_structural_indexes;
   }
-  parser.next_structural_index = 0;
   return checker.errors();
-}
-
-/**
-  * This algorithm is used to quickly identify the last structural position that
-  * makes up a complete document.
-  *
-  * It does this by going backwards and finding the last *document boundary* (a
-  * place where one value follows another without a comma between them). If the
-  * last document (the characters after the boundary) has an equal number of
-  * start and end brackets, it is considered complete.
-  *
-  * Simply put, we iterate over the structural characters, starting from
-  * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
-  *
-  * This simple comparison works most of the time, but it does not cover cases
-  * where the batch's structural indexes contain a perfect amount of documents.
-  * In such a case, we do not have access to the structural index which follows
-  * the last document, therefore, we do not have access to the second element in
-  * the pair, and means that we cannot identify the last document. To fix this
-  * issue, we keep a count of the open and closed curly/square braces we found
-  * while searching for the pair. When we find a pair AND the count of open and
-  * closed curly/square braces is the same, we know that we just passed a
-  * complete
-  * document, therefore the last json buffer location is the end of the batch
-  */
-really_inline uint32_t json_structural_indexer::find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
-  auto arr_cnt = 0;
-  auto obj_cnt = 0;
-  for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
-    auto idxb = parser.structural_indexes[i];
-    switch (parser.buf[idxb]) {
-    case ':':
-    case ',':
-      continue;
-    case '}':
-      obj_cnt--;
-      continue;
-    case ']':
-      arr_cnt--;
-      continue;
-    case '{':
-      obj_cnt++;
-      break;
-    case '[':
-      arr_cnt++;
-      break;
-    }
-    auto idxa = parser.structural_indexes[i - 1];
-    switch (parser.buf[idxa]) {
-    case '{':
-    case '[':
-    case ':':
-    case ',':
-      continue;
-    }
-    // Last document is complete, so the next document will appear after!
-    if (!arr_cnt && !obj_cnt) {
-      return parser.n_structural_indexes;
-    }
-    // Last document is incomplete; mark the document at i + 1 as the next one
-    return i;
-  }
-  return 0;
-}
-
-// Skip the last character if it is partial
-really_inline size_t json_structural_indexer::trim_partial_utf8(const uint8_t *buf, size_t len) {
-  if (unlikely(len < 3)) {
-    switch (len) {
-      case 2:
-        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
-        if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 2 bytes left
-        return len;
-      case 1:
-        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
-        return len;
-      case 0:
-        return len;
-    }
-  }
-  if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
-  if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 1 byte left
-  if (buf[len-3] >= 0b11110000) { return len-3; } // 4-byte characters with only 3 bytes left
-  return len;
 }
 
 } // namespace stage1

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -56,7 +56,7 @@ namespace logger {
       }
       printf("|    %c ", printable_char(structurals.at_beginning() ? ' ' : structurals.current_char()));
       printf("|    %c ", printable_char(structurals.peek_char()));
-      printf("| %5zd ", structurals.next_structural);
+      printf("| %5u ", structurals.structural_indexes[structurals.next_structural]);
       printf("| %-*s ", LOG_DETAIL_LEN, detail);
       printf("| %*zu ", LOG_INDEX_LEN, structurals.idx);
       printf("|\n");

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -52,10 +52,10 @@ public:
     return result;
   }
   really_inline bool past_end(uint32_t n_structural_indexes) {
-    return next_structural+1 > n_structural_indexes;
+    return next_structural > n_structural_indexes;
   }
   really_inline bool at_end(uint32_t n_structural_indexes) {
-    return next_structural+1 == n_structural_indexes;
+    return next_structural == n_structural_indexes;
   }
   really_inline bool at_beginning() {
     return next_structural == 0;

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -75,10 +75,7 @@ struct structural_parser {
   uint8_t *current_string_buf_loc{};
   uint32_t depth;
 
-  really_inline structural_parser(
-    dom_parser_implementation &_parser,
-    uint32_t next_structural = 0
-  ) : structurals(_parser.buf, _parser.len, _parser.structural_indexes.get(), next_structural), parser{_parser}, depth{0} {}
+  really_inline structural_parser(dom_parser_implementation &_parser, uint32_t next_structural = 0) : structurals(_parser.buf, _parser.len, _parser.structural_indexes.get(), next_structural), parser{_parser}, depth{0} {}
 
   WARN_UNUSED really_inline bool start_scope(ret_address_t continue_state) {
     parser.containing_scope[depth].tape_index = parser.current_loc;
@@ -333,7 +330,7 @@ struct structural_parser {
 
   WARN_UNUSED really_inline error_code start(size_t len, ret_address_t finish_state) {
     log_start();
-    init(); // sets is_valid to false
+    init();
     if (len > parser.capacity()) {
       return parser.error = CAPACITY;
     }
@@ -401,7 +398,7 @@ WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) no
     FAIL_IF( parser.start_array(addresses.finish) );
     // Make sure the outer array is closed before continuing; otherwise, there are ways we could get
     // into memory corruption. See https://github.com/simdjson/simdjson/issues/906
-    if (buf[structural_indexes[n_structural_indexes - 2]] != ']') {
+    if (buf[structural_indexes[n_structural_indexes - 1]] != ']') {
       goto error;
     }
     goto array_begin;

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -70,6 +70,7 @@ WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, ui
   return haswell::stage1::json_minifier::minify<128>(buf, len, dst, dst_len);
 }
 
+#include "generic/stage1/find_next_document_index.h"
 #include "generic/stage1/utf8_lookup2_algorithm.h"
 #include "generic/stage1/json_structural_indexer.h"
 WARN_UNUSED error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -71,6 +71,7 @@ WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, ui
   return westmere::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
+#include "generic/stage1/find_next_document_index.h"
 #include "generic/stage1/utf8_lookup2_algorithm.h"
 #include "generic/stage1/json_structural_indexer.h"
 WARN_UNUSED error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -561,9 +561,6 @@ namespace parse_api_tests {
     memcpy(&empty_batches_ndjson[BATCH_SIZE*3+2], "1", 1);
     memcpy(&empty_batches_ndjson[BATCH_SIZE*10+4], "2", 1);
     memcpy(&empty_batches_ndjson[BATCH_SIZE*11+6], "3", 1);
-    for (int i=0; i<16; i++) {
-      printf("| %.*s |", BATCH_SIZE, &empty_batches_ndjson[BATCH_SIZE*i]);
-    }
     for (auto [doc, error] : parser.parse_many(empty_batches_ndjson, BATCH_SIZE*16)) {
       if (error) { cerr << "Error in parse_many: " << error << endl; return false; }
       count++;

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -42,6 +42,57 @@ namespace parser_load {
     TEST_FAIL("No documents returned");
   }
 
+  bool parser_parse_many_documents_error_in_the_middle() {
+    TEST_START();
+    const padded_string DOC = "1 2 [} 3"_padded;
+    size_t count = 0;
+    dom::parser parser;
+    for (auto doc : parser.parse_many(DOC)) {
+      count++;
+      auto [val, error] = doc.get<uint64_t>();
+      if (count == 3) {
+        ASSERT_ERROR(error, TAPE_ERROR);
+      } else {
+        if (error) { TEST_FAIL(error); }
+        if (val != count) { cerr << "FAIL: expected " << count << ", got " << val << endl; return false; }
+      }
+    }
+    if (count != 3) { cerr << "FAIL: expected 2 documents and 1 error, got " << count << " total things" << endl; return false; }
+    TEST_SUCCEED();
+  }
+
+  bool parser_parse_many_documents_partial() {
+    TEST_START();
+    const padded_string DOC = "["_padded;
+    size_t count = 0;
+    dom::parser parser;
+    for (auto doc : parser.parse_many(DOC)) {
+      count++;
+      ASSERT_ERROR(doc.error(), TAPE_ERROR);
+    }
+    if (count != 1) { cerr << "FAIL: expected no documents and 1 error, got " << count << " total things" << endl; return false; }
+    TEST_SUCCEED();
+  }
+
+  bool parser_parse_many_documents_partial_at_the_end() {
+    TEST_START();
+    const padded_string DOC = "1 2 ["_padded;
+    size_t count = 0;
+    dom::parser parser;
+    for (auto doc : parser.parse_many(DOC)) {
+      count++;
+      auto [val, error] = doc.get<uint64_t>();
+      if (count == 3) {
+        ASSERT_ERROR(error, TAPE_ERROR);
+      } else {
+        if (error) { TEST_FAIL(error); }
+        if (val != count) { cerr << "FAIL: expected " << count << ", got " << val << endl; return false; }
+      }
+    }
+    if (count != 3) { cerr << "FAIL: expected 2 documents and 1 error, got " << count << " total things" << endl; return false; }
+    TEST_SUCCEED();
+  }
+
   bool parser_load_nonexistent() {
     TEST_START();
     dom::parser parser;
@@ -83,9 +134,18 @@ namespace parser_load {
     TEST_FAIL("No documents returned");
   }
   bool run() {
-    return parser_load_capacity() && parser_load_many_capacity()
-        && parser_load_nonexistent() && parser_load_many_nonexistent() && padded_string_load_nonexistent()
-        && parser_load_chain() && parser_load_many_chain();
+    return true
+        && parser_load_capacity()
+        && parser_load_many_capacity()
+        && parser_load_nonexistent()
+        && parser_load_many_nonexistent()
+        && padded_string_load_nonexistent()
+        && parser_load_chain()
+        && parser_load_many_chain()
+        && parser_parse_many_documents_error_in_the_middle()
+        && parser_parse_many_documents_partial()
+        && parser_parse_many_documents_partial_at_the_end()
+    ;
   }
 }
 

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -24,7 +24,7 @@ const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
 #define TEST_FAIL(MESSAGE) { cerr << "FAIL: " << (MESSAGE) << endl; return false; }
 #define TEST_SUCCEED() { return true; }
 namespace parser_load {
-  const char * NONEXISTENT_FILE = "this_file_does_not_exit.json";
+  const char * NONEXISTENT_FILE = "this_file_does_not_exist.json";
   bool parser_load_capacity() {
     TEST_START();
     dom::parser parser(1); // 1 byte max capacity

--- a/tests/parse_many_test.cpp
+++ b/tests/parse_many_test.cpp
@@ -83,17 +83,21 @@ bool validate(const char *dirname) {
             if (contains("EXCLUDE", name)) {
                 // skipping
                 how_many--;
-            } else if (starts_with("pass", name) and (has_extension(extension1, name) or has_extension(extension2, name)) and error) {
-                is_file_as_expected[i] = false;
-                printf("warning: file %s should pass but it fails. Error is: %s\n",
-                       name, error_message(error));
-                printf("size of file in bytes: %zu \n", json.size());
-                everything_fine = false;
-            } else if ( starts_with("fail", name) and (not starts_with("fail10.json", name)) and !error) {
-                is_file_as_expected[i] = false;
-                printf("warning: file %s should fail but it passes.\n", name);
-                printf("size of file in bytes: %zu \n", json.size());
-                everything_fine = false;
+            } else if (starts_with("pass", name) or starts_with("fail10.json", name) or starts_with("fail70.json", name)) {
+                if (error) {
+                    is_file_as_expected[i] = false;
+                    printf("warning: file %s should pass but it fails. Error is: %s\n",
+                        name, error_message(error));
+                    printf("size of file in bytes: %zu \n", json.size());
+                    everything_fine = false;
+                }
+            } else if ( starts_with("fail", name) ) {
+                if (!error) {
+                    is_file_as_expected[i] = false;
+                    printf("warning: file %s should fail but it passes.\n", name);
+                    printf("size of file in bytes: %zu \n", json.size());
+                    everything_fine = false;
+                }
             }
             free(fullpath);
         }


### PR DESCRIPTION
This simplifies parse_many(), fixes a bunch of bugs, and moves a lot of the logic to the implementation so it can be optimized.

This is the first in a series of 4 PRs which simplifies a lot of stage 2 and results in a performance improvement at the end.

## Benefits

1. Allows you to parse_many() an empty ndjson file and get back 0 documents. Previously it returned EMPTY.
2. Fixes a bug where if you had empty batches (batch_size bytes of whitespace between documents), it would return an error.
3. Fixes a bug where if you had errors in the middle of a document (like "1 2 [} 3"), it would just yield the first 2 documents and never tell you about the error.
4. Fixes a probable bug (I could repro it, but I am le tired) where, since we actually shrink the batch_size each time we encounter a partial UTF-8 character at the end of a batch, perfectly valid documents would eventually no longer fit in batch_size. We no longer shrink batch_size.
5. Moves all JSON and UTF-8 processing to the parser implementation. Now the UTF-8 cutoff and find_last_json_index are done in stage 1, which emits n_structural_indexes at the end. It only does this if you pass "bool partial = true," so complete documents are unaffected.
6. Pass `partial = false` when running stage1 on the last batch, so that any errors that are detected only at EOF get actually detected. I did not validate any of these, however.
7. Eliminates the use of SUCCESS_AND_HAS_MORE, returning EMPTY internally to signify no more documents were found. This is nice because we can always rely on if (error) { ... } to tell us if there is an error.

## Algorithm

The new algorithm:

1. `parse_many().begin()`, we load up the first document:
   A. Runs stage 1 on the first batch.
   B. Kicks off the stage 1 thread if there is more to parse.
   C. Calls next() to load the first document.
2. `++` calls `next()`, which loads up a document:
   A. Runs stage 2 on the current batch.
   B. If we get EMPTY back (no more documents in the batch), and there is more to parse, loads another batch:
       - Runs stage 1 the next batch, or gets it from the stage 1 thread.
       - Kicks off the stage 1 thread again if there is more to parse.
       - Goto A.
3. If `next()` returns EMPTY, we stop iterating. Any other error, we yield to the user before stopping.

## Performance

This doesn't seem to be any slower than before, according to parse_stream benchmark on amazon_cellphones. It's a little hard to tell, since the output of that is really variable, but running it a bunch of times gives me comparable numbers.

EDIT: gathered numbers from As far as parse itself goes, it looks like it's a little worse:

| File | Old Cyc | New Cyc | +% | Old Ins | New Ins | +% |
| --- | --: | --: | --: | --: | --: | --: |
| marine_ik | 273 | 260 | 5% | 821 | 816 | 1% |
| mesh | 275 | 266 | 3% | 877 | 870 | 1% |
| mesh.pretty | 166 | 165 | 0% | 533 | 530 | 1% |
| apache_builds | 94 | 95 | -1% | 319 | 318 | 0% |
| numbers | 231 | 233 | -1% | 725 | 721 | 1% |
| twitter_api_compact_response | 124 | 126 | -1% | 389 | 388 | 0% |
| gsoc-2018 | 70 | 71 | -1% | 178 | 178 | 0% |
| github_events | 86 | 87 | -2% | 278 | 278 | 0% |
| twitter_api_response | 100 | 102 | -2% | 318 | 317 | 0% |
| twitterescaped | 195 | 199 | -2% | 560 | 553 | 1% |
| repeat | 113 | 115 | -2% | 364 | 363 | 0% |
| twitter | 95 | 97 | -2% | 307 | 307 | 0% |
| twitter_timeline | 134 | 137 | -2% | 411 | 410 | 0% |
| random | 146 | 149 | -2% | 496 | 496 | 0% |
| google_maps_api_response | 111 | 115 | -3% | 365 | 364 | 0% |
| tree-pretty | 102 | 105 | -3% | 346 | 346 | 0% |
| update-center | 117 | 121 | -3% | 352 | 351 | 0% |
| instruments | 101 | 104 | -4% | 352 | 354 | 0% |
| canada | 263 | 280 | -6% | 916 | 911 | 1% |
| google_maps_api_compact_response | 206 | 220 | -7% | 682 | 680 | 0% |
| citm_catalog | 84 | 91 | -8% | 299 | 299 | 0% |

## End note

I also suspect we have a bug where partial UTF-8 at the end of the last block is not detected as an error, but *only* if it is at the *very* end of the last block. This doesn't fix that.