### PR TITLE
Temporary fix to #914

### DIFF
--- a/simdjson-flags.cmake
+++ b/simdjson-flags.cmake
@@ -74,10 +74,11 @@ endif()
 
 option(SIMDJSON_ENABLE_THREADS "Enable threaded operation" ON)
 if(SIMDJSON_ENABLE_THREADS)
-  find_package(Threads REQUIRED)
   set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
   set(THREADS_PREFER_PTHREAD_FLAG TRUE)
-  target_link_libraries(simdjson-flags INTERFACE ${CMAKE_THREAD_LIBS_INIT} )
+  find_package(Threads REQUIRED)
+  target_link_libraries(simdjson-flags INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+  target_compile_options(simdjson-flags INTERFACE ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 option(SIMDJSON_SANITIZE "Sanitize addresses" OFF)


### PR DESCRIPTION
The usual style of linking (Threads::Threads) works, but CMAKE_THREAD_LIBS_INIT doesn't since it is only used for linking the temporaries to the final object file and not when compiling the object files. 
This PR introduces a workaround but I do not like manually setting these flags (and I am not sure if it works other than GCC/Clang). 
I will try to make the Threads::Threads method work with CMake 3.9
