### PR TITLE
[3/4] Remove unneeded structural_iterator variables

### DIFF
--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -73,8 +73,6 @@ private:
   really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   really_inline void next(simd::simd8x64<uint8_t> in, json_block block, size_t idx);
   really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
-  static really_inline uint32_t find_next_document_index(dom_parser_implementation &parser);
-  static really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -195,93 +193,6 @@ really_inline error_code json_structural_indexer::finish(dom_parser_implementati
     parser.n_structural_indexes = new_structural_indexes;
   }
   return checker.errors();
-}
-
-/**
-  * This algorithm is used to quickly identify the last structural position that
-  * makes up a complete document.
-  *
-  * It does this by going backwards and finding the last *document boundary* (a
-  * place where one value follows another without a comma between them). If the
-  * last document (the characters after the boundary) has an equal number of
-  * start and end brackets, it is considered complete.
-  *
-  * Simply put, we iterate over the structural characters, starting from
-  * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
-  *
-  * This simple comparison works most of the time, but it does not cover cases
-  * where the batch's structural indexes contain a perfect amount of documents.
-  * In such a case, we do not have access to the structural index which follows
-  * the last document, therefore, we do not have access to the second element in
-  * the pair, and means that we cannot identify the last document. To fix this
-  * issue, we keep a count of the open and closed curly/square braces we found
-  * while searching for the pair. When we find a pair AND the count of open and
-  * closed curly/square braces is the same, we know that we just passed a
-  * complete
-  * document, therefore the last json buffer location is the end of the batch
-  */
-really_inline uint32_t json_structural_indexer::find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
-  auto arr_cnt = 0;
-  auto obj_cnt = 0;
-  for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {
-    auto idxb = parser.structural_indexes[i];
-    switch (parser.buf[idxb]) {
-    case ':':
-    case ',':
-      continue;
-    case '}':
-      obj_cnt--;
-      continue;
-    case ']':
-      arr_cnt--;
-      continue;
-    case '{':
-      obj_cnt++;
-      break;
-    case '[':
-      arr_cnt++;
-      break;
-    }
-    auto idxa = parser.structural_indexes[i - 1];
-    switch (parser.buf[idxa]) {
-    case '{':
-    case '[':
-    case ':':
-    case ',':
-      continue;
-    }
-    // Last document is complete, so the next document will appear after!
-    if (!arr_cnt && !obj_cnt) {
-      return parser.n_structural_indexes;
-    }
-    // Last document is incomplete; mark the document at i + 1 as the next one
-    return i;
-  }
-  return 0;
-}
-
-// Skip the last character if it is partial
-really_inline size_t json_structural_indexer::trim_partial_utf8(const uint8_t *buf, size_t len) {
-  if (unlikely(len < 3)) {
-    switch (len) {
-      case 2:
-        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
-        if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 2 bytes left
-        return len;
-      case 1:
-        if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
-        return len;
-      case 0:
-        return len;
-    }
-  }
-  if (buf[len-1] >= 0b11000000) { return len-1; } // 2-, 3- and 4-byte characters with only 1 byte left
-  if (buf[len-2] >= 0b11100000) { return len-2; } // 3- and 4-byte characters with only 1 byte left
-  if (buf[len-3] >= 0b11110000) { return len-3; } // 4-byte characters with only 3 bytes left
-  return len;
 }
 
 } // namespace stage1

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -62,9 +62,9 @@ namespace logger {
       }
       printf("|    %c ", printable_char(structurals.at_beginning() ? ' ' : structurals.current_char()));
       printf("|    %c ", printable_char(structurals.peek_char()));
-      printf("| %5u ", structurals.parser.structural_indexes[*structurals.next_structural]);
+      printf("| %5u ", structurals.parser.structural_indexes[*(structurals.current_structural+1)]);
       printf("| %-*s ", LOG_DETAIL_LEN, detail);
-      printf("| %*u ", LOG_INDEX_LEN, *(structurals.next_structural-1));
+      printf("| %*u ", LOG_INDEX_LEN, *structurals.current_structural);
       printf("|\n");
     }
   }

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -64,7 +64,7 @@ namespace logger {
       printf("|    %c ", printable_char(structurals.peek_char()));
       printf("| %5u ", structurals.parser.structural_indexes[*structurals.next_structural]);
       printf("| %-*s ", LOG_DETAIL_LEN, detail);
-      printf("| %*zu ", LOG_INDEX_LEN, structurals.idx);
+      printf("| %*u ", LOG_INDEX_LEN, *(structurals.next_structural-1));
       printf("|\n");
     }
   }

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -62,7 +62,7 @@ namespace logger {
       }
       printf("|    %c ", printable_char(structurals.at_beginning() ? ' ' : structurals.current_char()));
       printf("|    %c ", printable_char(structurals.peek_char()));
-      printf("| %5u ", structurals.structural_indexes[structurals.next_structural]);
+      printf("| %5u ", structurals.parser.structural_indexes[*structurals.next_structural]);
       printf("| %-*s ", LOG_DETAIL_LEN, detail);
       printf("| %*zu ", LOG_INDEX_LEN, structurals.idx);
       printf("|\n");

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -61,7 +61,7 @@ namespace logger {
         printf(" ");
       }
       printf("|    %c ", printable_char(structurals.at_beginning() ? ' ' : structurals.current_char()));
-      printf("|    %c ", printable_char(structurals.peek_char()));
+      printf("|    %c ", printable_char(structurals.peek_next_char()));
       printf("| %5u ", structurals.parser.structural_indexes[*(structurals.current_structural+1)]);
       printf("| %-*s ", LOG_DETAIL_LEN, detail);
       printf("| %*u ", LOG_INDEX_LEN, *structurals.current_structural);

--- a/src/generic/stage2/streaming_structural_parser.h
+++ b/src/generic/stage2/streaming_structural_parser.h
@@ -1,0 +1,168 @@
+namespace stage2 {
+
+struct streaming_structural_parser: structural_parser {
+  really_inline streaming_structural_parser(dom_parser_implementation &_parser) : structural_parser(_parser, _parser.next_structural_index) {}
+
+  // override to add streaming
+  WARN_UNUSED really_inline error_code start(ret_address_t finish_parser) {
+    // If there are no structurals left, return EMPTY
+    if (structurals.at_end(parser.n_structural_indexes)) {
+      return parser.error = EMPTY;
+    }
+
+    log_start();
+    init();
+
+    // Capacity ain't no thang for streaming, so we don't check it.
+    // Advance to the first character as soon as possible
+    advance_char();
+    // Push the root scope (there is always at least one scope)
+    if (start_document(finish_parser)) {
+      return parser.error = DEPTH_ERROR;
+    }
+    return SUCCESS;
+  }
+
+  // override to add streaming
+  WARN_UNUSED really_inline error_code finish() {
+    if ( structurals.past_end(parser.n_structural_indexes) ) {
+      log_error("IMPOSSIBLE: past the end of the JSON!");
+      return parser.error = TAPE_ERROR;
+    }
+    end_document();
+    parser.next_structural_index = uint32_t(structurals.next_structural_index());
+    if (depth != 0) {
+      log_error("Unclosed objects or arrays!");
+      return parser.error = TAPE_ERROR;
+    }
+    if (parser.containing_scope[depth].tape_index != 0) {
+      log_error("IMPOSSIBLE: root scope tape index did not start at 0!");
+      return parser.error = TAPE_ERROR;
+    }
+    return SUCCESS;
+  }
+};
+
+} // namespace stage2
+
+/************
+ * The JSON is parsed to a tape, see the accompanying tape.md file
+ * for documentation.
+ ***********/
+WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
+  this->doc = &_doc;
+  static constexpr stage2::unified_machine_addresses addresses = INIT_ADDRESSES();
+  stage2::streaming_structural_parser parser(*this);
+  error_code result = parser.start(addresses.finish);
+  if (result) { return result; }
+  //
+  // Read first value
+  //
+  switch (parser.structurals.current_char()) {
+  case '{':
+    FAIL_IF( parser.start_object(addresses.finish) );
+    goto object_begin;
+  case '[':
+    FAIL_IF( parser.start_array(addresses.finish) );
+    goto array_begin;
+  case '"':
+    FAIL_IF( parser.parse_string() );
+    goto finish;
+  case 't': case 'f': case 'n':
+    FAIL_IF( parser.parse_single_atom() );
+    goto finish;
+  case '0': case '1': case '2': case '3': case '4':
+  case '5': case '6': case '7': case '8': case '9':
+    FAIL_IF(
+      parser.structurals.with_space_terminated_copy([&](const uint8_t *copy, size_t idx) {
+        return parser.parse_number(&copy[idx], false);
+      })
+    );
+    goto finish;
+  case '-':
+    FAIL_IF(
+      parser.structurals.with_space_terminated_copy([&](const uint8_t *copy, size_t idx) {
+        return parser.parse_number(&copy[idx], true);
+      })
+    );
+    goto finish;
+  default:
+    parser.log_error("Document starts with a non-value character");
+    goto error;
+  }
+
+//
+// Object parser parsers
+//
+object_begin:
+  switch (parser.advance_char()) {
+  case '"': {
+    FAIL_IF( parser.parse_string(true) );
+    goto object_key_parser;
+  }
+  case '}':
+    parser.end_object();
+    goto scope_end;
+  default:
+    parser.log_error("Object does not start with a key");
+    goto error;
+  }
+
+object_key_parser:
+  if (parser.advance_char() != ':' ) { parser.log_error("Missing colon after key in object"); goto error; }
+  parser.increment_count();
+  parser.advance_char();
+  GOTO( parser.parse_value(addresses, addresses.object_continue) );
+
+object_continue:
+  switch (parser.advance_char()) {
+  case ',':
+    if (parser.advance_char() != '"' ) { parser.log_error("Key string missing at beginning of field in object"); goto error; }
+    FAIL_IF( parser.parse_string(true) );
+    goto object_key_parser;
+  case '}':
+    parser.end_object();
+    goto scope_end;
+  default:
+    parser.log_error("No comma between object fields");
+    goto error;
+  }
+
+scope_end:
+  CONTINUE( parser.parser.ret_address[parser.depth] );
+
+//
+// Array parser parsers
+//
+array_begin:
+  if (parser.advance_char() == ']') {
+    parser.end_array();
+    goto scope_end;
+  }
+  parser.increment_count();
+
+main_array_switch:
+  /* we call update char on all paths in, so we can peek at parser.c on the
+   * on paths that can accept a close square brace (post-, and at start) */
+  GOTO( parser.parse_value(addresses, addresses.array_continue) );
+
+array_continue:
+  switch (parser.advance_char()) {
+  case ',':
+    parser.increment_count();
+    parser.advance_char();
+    goto main_array_switch;
+  case ']':
+    parser.end_array();
+    goto scope_end;
+  default:
+    parser.log_error("Missing comma between array values");
+    goto error;
+  }
+
+finish:
+  return parser.finish();
+
+error:
+  return parser.error();
+}

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -2,12 +2,21 @@ namespace stage2 {
 
 class structural_iterator {
 public:
-  really_inline structural_iterator(const uint8_t* _buf, size_t _len, const uint32_t *_structural_indexes, size_t next_structural_index)
-    : buf{_buf},
-     len{_len},
-     structural_indexes{_structural_indexes},
-     next_structural{next_structural_index}
-    {}
+  const uint8_t* const buf;
+  const size_t len;
+  const uint32_t* const structural_indexes;
+  size_t next_structural; // next structural index
+  size_t idx{0}; // location of the structural character in the input (buf)
+  uint8_t c{0};  // used to track the (structural) character we are looking at
+  dom_parser_implementation &parser;
+
+  really_inline structural_iterator(dom_parser_implementation &_parser, size_t _next_structural)
+    : buf{_parser.buf},
+      len{_parser.len},
+      structural_indexes{_parser.structural_indexes.get()},
+      next_structural{_next_structural},
+      parser{_parser} {
+  }
   really_inline char advance_char() {
     idx = structural_indexes[next_structural];
     next_structural++;
@@ -63,13 +72,6 @@ public:
   really_inline size_t next_structural_index() {
     return next_structural;
   }
-
-  const uint8_t* const buf;
-  const size_t len;
-  const uint32_t* const structural_indexes;
-  size_t next_structural; // next structural index
-  size_t idx{0}; // location of the structural character in the input (buf)
-  uint8_t c{0};  // used to track the (structural) character we are looking at
 };
 
 } // namespace stage2

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -3,20 +3,18 @@ namespace stage2 {
 class structural_iterator {
 public:
   const uint8_t* const buf;
-  const uint32_t* const structural_indexes;
-  size_t next_structural; // next structural index
+  uint32_t *next_structural;
   size_t idx{0}; // location of the structural character in the input (buf)
   uint8_t c{0};  // used to track the (structural) character we are looking at
   dom_parser_implementation &parser;
 
-  really_inline structural_iterator(dom_parser_implementation &_parser, size_t _next_structural)
+  really_inline structural_iterator(dom_parser_implementation &_parser, size_t next_structural_index)
     : buf{_parser.buf},
-      structural_indexes{_parser.structural_indexes.get()},
-      next_structural{_next_structural},
+      next_structural{&_parser.structural_indexes[next_structural_index]},
       parser{_parser} {
   }
   really_inline char advance_char() {
-    idx = structural_indexes[next_structural];
+    idx = *next_structural;
     next_structural++;
     c = *current();
     return c;
@@ -25,7 +23,7 @@ public:
     return c;
   }
   really_inline char peek_char() {
-    return buf[structural_indexes[next_structural]];
+    return buf[*next_structural];
   }
   really_inline const uint8_t* current() {
     return &buf[idx];
@@ -59,16 +57,13 @@ public:
     return result;
   }
   really_inline bool past_end(uint32_t n_structural_indexes) {
-    return next_structural > n_structural_indexes;
+    return next_structural > &parser.structural_indexes[n_structural_indexes];
   }
   really_inline bool at_end(uint32_t n_structural_indexes) {
-    return next_structural == n_structural_indexes;
+    return next_structural == &parser.structural_indexes[n_structural_indexes];
   }
   really_inline bool at_beginning() {
-    return next_structural == 0;
-  }
-  really_inline size_t next_structural_index() {
-    return next_structural;
+    return next_structural == &parser.structural_indexes[0];
   }
 };
 

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -21,7 +21,7 @@ public:
     return buf[*current_structural];
   }
   // Get the next structural character without advancing
-  really_inline char peek_char() {
+  really_inline char peek_next_char() {
     return buf[*(current_structural+1)];
   }
   really_inline char advance_char() {

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -3,34 +3,33 @@ namespace stage2 {
 class structural_iterator {
 public:
   const uint8_t* const buf;
-  uint32_t *next_structural;
-  uint8_t c{0};  // used to track the (structural) character we are looking at
+  uint32_t *current_structural;
   dom_parser_implementation &parser;
 
-  really_inline structural_iterator(dom_parser_implementation &_parser, size_t next_structural_index)
+  // Start a structural 
+  really_inline structural_iterator(dom_parser_implementation &_parser, size_t start_structural_index)
     : buf{_parser.buf},
-      next_structural{&_parser.structural_indexes[next_structural_index]},
+      current_structural{&_parser.structural_indexes[start_structural_index]},
       parser{_parser} {
   }
-  really_inline char advance_char() {
-    c = buf[*next_structural];
-    next_structural++;
-    return c;
-  }
-  really_inline char current_char() {
-    return c;
-  }
-  really_inline char peek_char() {
-    return buf[*next_structural];
-  }
+  // Get the buffer position of the current structural character
   really_inline const uint8_t* current() {
-    return &buf[current_structural_index()];
+    return &buf[*current_structural];
+  }
+  // Get the current structural character
+  really_inline char current_char() {
+    return buf[*current_structural];
+  }
+  // Get the next structural character without advancing
+  really_inline char peek_char() {
+    return buf[*(current_structural+1)];
+  }
+  really_inline char advance_char() {
+    current_structural++;
+    return buf[*current_structural];
   }
   really_inline size_t remaining_len() {
-    return parser.len - current_structural_index();
-  }
-  really_inline uint32_t current_structural_index() {
-    return *(next_structural-1);
+    return parser.len - *current_structural;
   }
   template<typename F>
   really_inline bool with_space_terminated_copy(const F& f) {
@@ -53,18 +52,18 @@ public:
     }
     memcpy(copy, buf, parser.len);
     memset(copy + parser.len, ' ', SIMDJSON_PADDING);
-    bool result = f(reinterpret_cast<const uint8_t*>(copy), current_structural_index());
+    bool result = f(reinterpret_cast<const uint8_t*>(copy), *current_structural);
     free(copy);
     return result;
   }
   really_inline bool past_end(uint32_t n_structural_indexes) {
-    return next_structural > &parser.structural_indexes[n_structural_indexes];
+    return current_structural >= &parser.structural_indexes[n_structural_indexes];
   }
   really_inline bool at_end(uint32_t n_structural_indexes) {
-    return next_structural == &parser.structural_indexes[n_structural_indexes];
+    return current_structural == &parser.structural_indexes[n_structural_indexes];
   }
   really_inline bool at_beginning() {
-    return next_structural == &parser.structural_indexes[0];
+    return current_structural == parser.structural_indexes.get();
   }
 };
 

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -3,7 +3,6 @@ namespace stage2 {
 class structural_iterator {
 public:
   const uint8_t* const buf;
-  const size_t len;
   const uint32_t* const structural_indexes;
   size_t next_structural; // next structural index
   size_t idx{0}; // location of the structural character in the input (buf)
@@ -12,7 +11,6 @@ public:
 
   really_inline structural_iterator(dom_parser_implementation &_parser, size_t _next_structural)
     : buf{_parser.buf},
-      len{_parser.len},
       structural_indexes{_parser.structural_indexes.get()},
       next_structural{_next_structural},
       parser{_parser} {
@@ -33,7 +31,7 @@ public:
     return &buf[idx];
   }
   really_inline size_t remaining_len() {
-    return len - idx;
+    return parser.len - idx;
   }
   template<typename F>
   really_inline bool with_space_terminated_copy(const F& f) {
@@ -50,12 +48,12 @@ public:
     * practice unless you are in the strange scenario where you have many JSON
     * documents made of single atoms.
     */
-    char *copy = static_cast<char *>(malloc(len + SIMDJSON_PADDING));
+    char *copy = static_cast<char *>(malloc(parser.len + SIMDJSON_PADDING));
     if (copy == nullptr) {
       return true;
     }
-    memcpy(copy, buf, len);
-    memset(copy + len, ' ', SIMDJSON_PADDING);
+    memcpy(copy, buf, parser.len);
+    memset(copy + parser.len, ' ', SIMDJSON_PADDING);
     bool result = f(reinterpret_cast<const uint8_t*>(copy), idx);
     free(copy);
     return result;

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -4,7 +4,6 @@ class structural_iterator {
 public:
   const uint8_t* const buf;
   uint32_t *next_structural;
-  size_t idx{0}; // location of the structural character in the input (buf)
   uint8_t c{0};  // used to track the (structural) character we are looking at
   dom_parser_implementation &parser;
 
@@ -14,9 +13,8 @@ public:
       parser{_parser} {
   }
   really_inline char advance_char() {
-    idx = *next_structural;
+    c = buf[*next_structural];
     next_structural++;
-    c = *current();
     return c;
   }
   really_inline char current_char() {
@@ -26,10 +24,13 @@ public:
     return buf[*next_structural];
   }
   really_inline const uint8_t* current() {
-    return &buf[idx];
+    return &buf[current_structural_index()];
   }
   really_inline size_t remaining_len() {
-    return parser.len - idx;
+    return parser.len - current_structural_index();
+  }
+  really_inline uint32_t current_structural_index() {
+    return *(next_structural-1);
   }
   template<typename F>
   really_inline bool with_space_terminated_copy(const F& f) {
@@ -52,7 +53,7 @@ public:
     }
     memcpy(copy, buf, parser.len);
     memset(copy + parser.len, ' ', SIMDJSON_PADDING);
-    bool result = f(reinterpret_cast<const uint8_t*>(copy), idx);
+    bool result = f(reinterpret_cast<const uint8_t*>(copy), current_structural_index());
     free(copy);
     return result;
   }

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -70,15 +70,13 @@ struct number_writer {
 }; // struct number_writer
 
 struct structural_parser : structural_iterator {
-  dom_parser_implementation &parser;
   /** Next write location in the string buf for stage 2 parsing */
   uint8_t *current_string_buf_loc{};
   uint32_t depth;
 
   // For non-streaming, to pass an explicit 0 as next_structural, which enables optimizations
   really_inline structural_parser(dom_parser_implementation &_parser, uint32_t _next_structural)
-    : structural_iterator(_parser.buf, _parser.len, _parser.structural_indexes.get(), _next_structural),
-      parser{_parser},
+    : structural_iterator(_parser, _next_structural),
       depth{0} {
   }
 

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -268,7 +268,7 @@ struct structural_parser : structural_iterator {
 
   WARN_UNUSED really_inline error_code finish() {
     end_document();
-    parser.next_structural_index = uint32_t(next_structural_index());
+    parser.next_structural_index = uint32_t(next_structural - &parser.structural_indexes[0]);
 
     if (depth != 0) {
       log_error("Unclosed objects or arrays!");
@@ -388,7 +388,7 @@ WARN_UNUSED static error_code parse_structurals(dom_parser_implementation &dom_p
     // Make sure the outer array is closed before continuing; otherwise, there are ways we could get
     // into memory corruption. See https://github.com/simdjson/simdjson/issues/906
     if (!STREAMING) {
-      if (parser.buf[parser.structural_indexes[dom_parser.n_structural_indexes - 1]] != ']') {
+      if (parser.buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]] != ']') {
         goto error;
       }
     }

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -394,8 +394,10 @@ WARN_UNUSED static error_code parse_structurals(dom_parser_implementation &dom_p
     FAIL_IF( parser.start_array(addresses.finish) );
     // Make sure the outer array is closed before continuing; otherwise, there are ways we could get
     // into memory corruption. See https://github.com/simdjson/simdjson/issues/906
-    if (parser.structurals.buf[parser.structurals.structural_indexes[dom_parser.n_structural_indexes - 1]] != ']') {
-      goto error;
+    if (!STREAMING) {
+      if (parser.structurals.buf[parser.structurals.structural_indexes[dom_parser.n_structural_indexes - 1]] != ']') {
+        goto error;
+      }
     }
     goto array_begin;
   case '"':

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -438,7 +438,7 @@ scope_end:
 // Array parser states
 //
 array_begin:
-  if (parser.peek_char() == ']') {
+  if (parser.peek_next_char() == ']') {
     parser.advance_char();
     parser.end_array();
     goto scope_end;


### PR DESCRIPTION
This is the third in a series of 4 PRs which simplifies a lot of stage 2 and results in a performance improvement at the end.

This simplifies structural iteration by:

* Not storing `len` directly. Only needed at the beginning and at the end, don't waste a register on this.
* Storing `uint32_t *current_structural` instead of `uint32_t *structural_indexes` and `uint32_t next_structural`. (current_structural was used more than next_structural, so I changed the logic to fit and sure enough, got a reduction in instruction count.
* Removing cached versions of the current structural index and current structural *character*.
* Restructured the loop to fit, so that parse_value() just uses advance_char() directly instead of relying on some other branch having called advance_char().

Part of my hope is that we can reduce the complexity of the code to the point where the compiler no longer goes crazy on the sheer magnitude of it. This doesn't get us there, but it gets us closer :)

The original reason I went into this code was to see what it takes to add a streaming stage 1 and have advance_char() call stage 1 when it runs out of structurals. But I wanted a bit less complexity in what advance_char() does, first :)

For my sanity, this is based on #915, so will be checked in after that one, assuming it gets checked in.

## Performance

When I look at full numbers after merging, it looks like it has a fairly random effect, consistent with "stage 2, what you gonna do":

| File | Old Cyc | New Cyc | +% | Old Ins | New Ins | +% |
| --- | --: | --: | --: | --: | --: | --: |
| mesh | 275 | 261 | 5% | 877 | 883 | -1% |
| marine_ik | 273 | 263 | 4% | 821 | 827 | -1% |
| mesh.pretty | 166 | 162 | 2% | 533 | 536 | -1% |
| github_events | 86 | 85 | 1% | 278 | 276 | 1% |
| gsoc-2018 | 70 | 70 | 1% | 178 | 177 | 0% |
| apache_builds | 94 | 93 | 0% | 319 | 319 | 0% |
| update-center | 117 | 118 | 0% | 352 | 353 | 0% |
| citm_catalog | 84 | 84 | 0% | 299 | 304 | -2% |
| google_maps_api_response | 111 | 112 | 0% | 365 | 371 | -2% |
| twitter | 95 | 96 | -1% | 307 | 306 | 0% |
| random | 146 | 149 | -2% | 496 | 503 | -1% |
| twitter_api_compact_response | 124 | 127 | -3% | 389 | 387 | 1% |
| twitterescaped | 195 | 200 | -3% | 560 | 570 | -2% |
| repeat | 113 | 117 | -4% | 364 | 369 | -1% |
| google_maps_api_compact_response | 206 | 215 | -4% | 682 | 696 | -2% |
| twitter_api_response | 100 | 104 | -4% | 318 | 317 | 0% |
| instruments | 101 | 105 | -5% | 352 | 360 | -2% |
| twitter_timeline | 134 | 140 | -5% | 411 | 409 | 0% |
| tree-pretty | 102 | 107 | -5% | 346 | 350 | -1% |
| canada | 263 | 278 | -6% | 916 | 914 | 0% |
| numbers | 231 | 249 | -8% | 725 | 738 | -2% |