### PR TITLE
[4/4] Stop persisting current_loc (+2% parse throughput)

### DIFF
--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -107,9 +107,6 @@ public:
    */
   virtual ~dom_parser_implementation() = default;
 
-  /** Next location to write to in the tape */
-  uint32_t current_loc{0};
-
   /** Number of structural indices passed from stage 1 to stage 2 */
   uint32_t n_structural_indexes{0};
   /** Structural indices passed from stage 1 to stage 2 */

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -25,8 +25,8 @@ namespace logger {
     if (LOG_ENABLED) {
       log_depth = 0;
       printf("\n");
-      printf("| %-*s | %-*s | %*s | %*s | %*s | %-*s | %-*s |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", 4, "Curr", 4, "Next", 5, "Next#", LOG_DETAIL_LEN, "Detail", LOG_INDEX_LEN, "index");
-      printf("|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, 4+2, DASHES, 4+2, DASHES, 5+2, DASHES, LOG_DETAIL_LEN+2, DASHES, LOG_INDEX_LEN+2, DASHES);
+      printf("| %-*s | %-*s | %*s | %*s | %*s | %-*s | %-*s | %-*s |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", 4, "Curr", 4, "Next", 5, "Next#", 5, "Tape#", LOG_DETAIL_LEN, "Detail", LOG_INDEX_LEN, "index");
+      printf("|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, 4+2, DASHES, 4+2, DASHES, 5+2, DASHES, 5+2, DASHES, LOG_DETAIL_LEN+2, DASHES, LOG_INDEX_LEN+2, DASHES);
     }
   }
 
@@ -44,25 +44,17 @@ namespace logger {
       {
         // Print the next N characters in the buffer.
         printf("| ");
-        if (structurals.at_beginning()) {
-          // If the pointer is at the beginning, print a space followed by the beginning characters
-          // Print spaces for unprintable or newline characters.
-          printf(" ");
-          for (int i=0;i<LOG_BUFFER_LEN-1;i++) {
-            printf("%c", printable_char(structurals.buf[i]));
-          }
-        } else {
-          // Otherwise, print the characters starting from the buffer position.
-          // Print spaces for unprintable or newline characters.
-          for (int i=0;i<LOG_BUFFER_LEN;i++) {
-            printf("%c", printable_char(structurals.current()[i]));
-          }
+        // Otherwise, print the characters starting from the buffer position.
+        // Print spaces for unprintable or newline characters.
+        for (int i=0;i<LOG_BUFFER_LEN;i++) {
+          printf("%c", printable_char(structurals.current()[i]));
         }
         printf(" ");
       }
-      printf("|    %c ", printable_char(structurals.at_beginning() ? ' ' : structurals.current_char()));
+      printf("|    %c ", printable_char(structurals.current_char()));
       printf("|    %c ", printable_char(structurals.peek_next_char()));
       printf("| %5u ", structurals.parser.structural_indexes[*(structurals.current_structural+1)]);
+      printf("| %5u ", structurals.next_tape_index());
       printf("| %-*s ", LOG_DETAIL_LEN, detail);
       printf("| %*u ", LOG_INDEX_LEN, *structurals.current_structural);
       printf("|\n");

--- a/src/generic/stage2/tape_writer.h
+++ b/src/generic/stage2/tape_writer.h
@@ -1,0 +1,95 @@
+struct tape_writer {
+  /** The next place to write to tape */
+  uint64_t *next_tape_loc;
+  
+  /** Write a signed 64-bit value to tape. */
+  really_inline void append_s64(int64_t value) noexcept;
+
+  /** Write an unsigned 64-bit value to tape. */
+  really_inline void append_u64(uint64_t value) noexcept;
+
+  /** Write a double value to tape. */
+  really_inline void append_double(double value) noexcept;
+
+  /**
+   * Append a tape entry (an 8-bit type,and 56 bits worth of value).
+   */
+  really_inline void append(uint64_t val, internal::tape_type t) noexcept;
+
+  /**
+   * Skip the current tape entry without writing.
+   *
+   * Used to skip the start of the container, since we'll come back later to fill it in when the
+   * container ends.
+   */
+  really_inline void skip() noexcept;
+
+  /**
+   * Skip the number of tape entries necessary to write a large u64 or i64.
+   */
+  really_inline void skip_large_integer() noexcept;
+
+  /**
+   * Skip the number of tape entries necessary to write a double.
+   */
+  really_inline void skip_double() noexcept;
+
+  /**
+   * Write a value to a known location on tape.
+   *
+   * Used to go back and write out the start of a container after the container ends.
+   */
+  really_inline static void write(uint64_t &tape_loc, uint64_t val, internal::tape_type t) noexcept;
+
+private:
+  /**
+   * Append both the tape entry, and a supplementary value following it. Used for types that need
+   * all 64 bits, such as double and uint64_t.
+   */
+  template<typename T>
+  really_inline void append2(uint64_t val, T val2, internal::tape_type t) noexcept;
+}; // struct number_writer
+
+really_inline void tape_writer::append_s64(int64_t value) noexcept {
+  append2(0, value, internal::tape_type::INT64);
+}
+
+really_inline void tape_writer::append_u64(uint64_t value) noexcept {
+  append(0, internal::tape_type::UINT64);
+  *next_tape_loc = value;
+  next_tape_loc++;
+}
+
+/** Write a double value to tape. */
+really_inline void tape_writer::append_double(double value) noexcept {
+  append2(0, value, internal::tape_type::DOUBLE);
+}
+
+really_inline void tape_writer::skip() noexcept {
+  next_tape_loc++;
+}
+
+really_inline void tape_writer::skip_large_integer() noexcept {
+  next_tape_loc += 2;
+}
+
+really_inline void tape_writer::skip_double() noexcept {
+  next_tape_loc += 2;
+}
+
+really_inline void tape_writer::append(uint64_t val, internal::tape_type t) noexcept {
+  *next_tape_loc = val | ((uint64_t(char(t))) << 56);
+  next_tape_loc++;
+}
+
+template<typename T>
+really_inline void tape_writer::append2(uint64_t val, T val2, internal::tape_type t) noexcept {
+  append(val, t);
+  static_assert(sizeof(val2) == sizeof(*next_tape_loc), "Type is not 64 bits!");
+  memcpy(next_tape_loc, &val2, sizeof(val2));
+  next_tape_loc++;
+}
+
+really_inline void tape_writer::write(uint64_t &tape_loc, uint64_t val, internal::tape_type t) noexcept {
+  tape_loc = val | ((uint64_t(char(t))) << 56);
+}


### PR DESCRIPTION
This change makes it more likely the compiler will enregister the next tape write location (a very hot variable) by making it temporary to stage 2 (i.e. in structural_parser) instead of persisting it in dom_parser_implementation.

This is the last of a series of 4 PRs which simplifies a lot of stage 2 and results in a performance improvement at the end.

## Performance

It looks like an overall average throughput improvement close to 2%. The improvements in instruction count and throughput are both pretty much universal. canada.json loses 6% or so overall, but other number parsing things gain substantially. Looking at the numbers, everything has a slightly larger number of cache references, and canada.json is large enough that almost all of them are cache *misses*, accounting for the difference. The increased number of cache references absolutely does not accord with my theory of why the patch is faster. I'll experiment with that, but I consider this loss acceptable (and recoverable as we delve into streaming in earnest).

| File | Old Cyc | New Cyc | +% | Old Ins | New Ins | +% |
| --- | --: | --: | --: | --: | --: | --: |
|                                mesh | 275 | 257 | 7% | 877 | 850 | 3% |
|                           marine_ik | 273 | 258 | 5% | 821 | 801 | 3% |
|                              random | 146 | 142 | 3% | 496 | 490 | 1% |
|                         tree-pretty | 102 | 99 | 3% | 346 | 341 | 2% |
|                         instruments | 101 | 98 | 3% | 352 | 348 | 1% |
|                             twitter | 95 | 93 | 3% | 307 | 299 | 2% |
|                             numbers | 231 | 225 | 3% | 725 | 713 | 2% |
|                       github_events | 86 | 84 | 3% | 278 | 273 | 2% |
|                twitter_api_response | 100 | 97 | 3% | 318 | 310 | 3% |
|                       apache_builds | 94 | 91 | 2% | 319 | 316 | 1% |
|        twitter_api_compact_response | 124 | 121 | 2% | 389 | 379 | 3% |
|                         mesh.pretty | 166 | 162 | 2% | 533 | 521 | 2% |
|                        citm_catalog | 84 | 82 | 2% | 299 | 302 | -1% |
|                       update-center | 117 | 116 | 1% | 352 | 347 | 1% |
|                    twitter_timeline | 134 | 132 | 1% | 411 | 399 | 3% |
|                      twitterescaped | 195 | 192 | 1% | 560 | 556 | 1% |
|                           gsoc-2018 | 70 | 70 | 1% | 178 | 177 | 1% |
|            google_maps_api_response | 111 | 111 | 1% | 365 | 365 | 0% |
|    google_maps_api_compact_response | 206 | 206 | 0% | 682 | 683 | 0% |
|                              repeat | 113 | 114 | -1% | 364 | 364 | 0% |
|                              canada | 263 | 279 | -6% | 916 | 903 | 1% |

## PR Notes:

* This change doesn't have its awesome effect on master (it makes it worse). It doesn't get really good until #918--presumably because removing several variables from structural_iterator reduced reduced the number of decisions the compiler had to make about registers.
* number_writer: After moving current_loc to the structural_parser, the number_writer couldn't get to it anymore.
  - I couldn't change the `dom_parser_implementation &parser` to `structural_parser &parser`, because number_writer gets passed to parse_large_integer and slow_parse_float, and that would deenregister the whole thing.
  - So I changed current_loc from uint32_t to `uint64_t *` and had number_writer store *that*. That single pointer is enough to write values to the right place *and* update the pointer.
  - Unfortunately, that wasn't enough: any attempt to pass `next_tape_loc` by reference or pointer caused it to de-enregister (reasonably enough). So I pass it by value, let it write the number out, and then bump next_tape_loc after calling either slow_parse_float or parse_large_integer.
* I also changed number_writer to tape_writer and had structural_parser use it everywhere, so the write logic is largely localized.