### PR TITLE
Testing with GCC 10 and clang 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ executors:
           BUILD_FLAGS: -j
           CTEST_FLAGS: -j4 --output-on-failure
 
-   clang9:
+  clang9:
     docker:
       - image: conanio/clang9
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake static build
     executor: gcc10
     environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=ON }
-    steps: [ install_cmake, cmake_test_all, cmake_install_test ]
+    steps: [ cmake_test_all, cmake_install_test ]
   clang6:
     description: Build and run tests on clang 6 and AVX 2 with a cmake static build
     executor: clang6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,25 @@ executors:
           BUILD_FLAGS: -j
           CTEST_FLAGS: -j4 --output-on-failure
 
-  clang9:
+  gcc10:
+    docker:
+      - image: conanio/gcc10
+        environment:
+          CXX: g++-10
+          CC: gcc-10
+          BUILD_FLAGS: -j
+          CTEST_FLAGS: -j4 --output-on-failure
+
+  clang10:
+    docker:
+      - image: conanio/clang10
+        environment:
+          CXX: clang++-10
+          CC: clang-10
+          BUILD_FLAGS: -j
+          CTEST_FLAGS: -j4 --output-on-failure
+
+   clang9:
     docker:
       - image: conanio/clang9
         environment:
@@ -95,11 +113,21 @@ jobs:
     executor: gcc7
     environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=ON }
     steps: [ install_cmake, cmake_test_all, cmake_install_test ]
+  gcc10:
+    description: Build and run tests on GCC 10 and AVX 2 with a cmake static build
+    executor: gcc10
+    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=ON }
+    steps: [ install_cmake, cmake_test_all, cmake_install_test ]
   clang6:
     description: Build and run tests on clang 6 and AVX 2 with a cmake static build
     executor: clang6
     environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=ON }
-    steps: [ cmake_test_all, cmake_install_test ]
+    steps: [ cmake_test, cmake_install_test ]
+  clang10:
+    description: Build and run tests on clang 10 and AVX 2 with a cmake static build
+    executor: clang10
+    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=ON }
+    steps: [ cmake_test, cmake_install_test ]
   # libcpp
   libcpp-clang9:
     description: Build and run tests on clang 6 and AVX 2 with a cmake static build and libc++
@@ -111,12 +139,12 @@ jobs:
     description: Build and run tests on GCC 9 and AVX 2 with a cmake sanitize build
     executor: gcc9
     environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: -j4 --output-on-failure -E checkperf }
-    steps: [ cmake_test_all ]
+    steps: [ cmake_test ]
   sanitize-clang9:
     description: Build and run tests on clang 6 and AVX 2 with a cmake sanitize build
     executor: clang9
     environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: -j4 --output-on-failure -E checkperf }
-    steps: [ cmake_test_all ]
+    steps: [ cmake_test ]
   
   # dynamic
   dynamic-gcc9:
@@ -181,10 +209,12 @@ workflows:
     jobs:
       # full multi-implementation tests
       - gcc7
+      - gcc10
       - clang6
+      - clang10
       
       # libc++
-      # - libcpp-clang9 # disabled due to too many errors
+      - libcpp-clang9
       
       # full single-implementation tests
       - sanitize-gcc9

--- a/.drone.yml
+++ b/.drone.yml
@@ -144,7 +144,7 @@ steps:
     CC: gcc
     CXX: g++
     BUILD_FLAGS: -- -j
-    CTEST_FLAGS: -j4 --output-on-failure
+    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
   commands:
     - apt-get update -qq
     - apt-get install -y cmake

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ add_cpp_test(jsoncheck LABELS acceptance per_implementation)
 add_cpp_test(parse_many_test LABELS acceptance per_implementation)
 add_cpp_test(pointercheck LABELS acceptance per_implementation)
 add_cpp_test(extracting_values_example LABELS acceptance per_implementation)
-find_program(BASH bash) 
+find_program(BASH bash)
 
 
 # Script tests
@@ -77,7 +77,8 @@ if (BASH AND (NOT MSVC)) # The scripts are not robust enough to run under Window
   #
   # Competition parse test
   #
-  if (SIMDJSON_COMPETITION)
+  if ((SIMDJSON_COMPETITION) AND (!SIMDJSON_SANITIZE))
+    # It looks like RapidJSON does not pass the sanitizer under some conditions (Clang 10)
     add_executable(allparserscheckfile allparserscheckfile.cpp)
     target_link_libraries(allparserscheckfile competition-all)
 


### PR DESCRIPTION
- [X] This removes the perf test in clang6
- [X] adds gcc 10
- [X] adds clang 10
- [X] adds (back) libc++ clang 9 tests
- [X] Hopefully, it also removes the performance tests under ARM from CI. They are useless and just noise. Performance under ARM needs to be checked manually. (We don't even know what kind of processor they use in CI.)


Generally speaking, we should not have tests that fail constantly on good code. It is a bad policy. It trains us to ignore the results. Once something serious happens, we will miss it.

Fixes https://github.com/simdjson/simdjson/issues/869