### PR TITLE
Fewer performance tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
     description: Build and run tests on GCC 7 and AVX 2 with a cmake static build
     executor: gcc7
     environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=ON }
-    steps: [ install_cmake, cmake_test_all, cmake_install_test ]
+    steps: [ install_cmake, cmake_test, cmake_install_test ]
   gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake static build
     executor: gcc10
@@ -139,7 +139,7 @@ jobs:
     description: Build and run tests on clang 10 and AVX 2 with a cmake static build and libc++
     executor: clang10
     environment: { CMAKE_FLAGS: -DSIMDJSON_USE_LIBCPP=ON }
-    steps: [ cmake_test_all, cmake_install_test ]
+    steps: [ cmake_test, cmake_install_test ]
   # sanitize
   sanitize-gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake sanitize build

--- a/.drone.yml
+++ b/.drone.yml
@@ -168,7 +168,7 @@ steps:
     CXX: clang++-6.0
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF
     BUILD_FLAGS: -- -j
-    CTEST_FLAGS: -j4 --output-on-failure
+    CTEST_FLAGS: -j4 --output-on-failure  -E checkperf
   commands:
     - apt-get update -qq
     - apt-get install -y clang cmake git


### PR DESCRIPTION
The effect should be to disable three performance tests. 

The net result is that under circle ci, we will have just one perf test (gcc10).

All performance tests will now be disabled under drone.

The idea is to narrow down the noise to the bare essentials.