### PR TITLE
replace get<T>.tie(v,e) with get(v)

### DIFF
--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -13,8 +13,7 @@ const char *GSOC_JSON = SIMDJSON_BENCHMARK_DATA_DIR "gsoc-2018.json";
 static void parse_twitter(State& state) {
   dom::parser parser;
   padded_string docdata;
-  simdjson::error_code error;
-  padded_string::load(TWITTER_JSON).tie(docdata, error);
+  auto error = padded_string::load(TWITTER_JSON).get(docdata);
   if(error) {
       cerr << "could not parse twitter.json" << error << endl;
       return;
@@ -29,8 +28,8 @@ static void parse_twitter(State& state) {
   for (UNUSED auto _ : state) {
     dom::element doc;
     bytes += docdata.size();
-    parser.parse(docdata).tie(doc,error);
-    if(error) {
+    ;
+    if ((error = parser.parse(docdata).get(doc))) {
       cerr << "could not parse twitter.json" << error << endl;
       return;
     }
@@ -50,8 +49,7 @@ BENCHMARK(parse_twitter)->Repetitions(10)->ComputeStatistics("max", [](const std
 static void parse_gsoc(State& state) {
   dom::parser parser;
   padded_string docdata;
-  simdjson::error_code error;
-  padded_string::load(GSOC_JSON).tie(docdata, error);
+  auto error = padded_string::load(GSOC_JSON).get(docdata);
   if(error) {
       cerr << "could not parse gsoc-2018.json" << error << endl;
       return;
@@ -64,10 +62,9 @@ static void parse_gsoc(State& state) {
   }
   size_t bytes = 0;
   for (UNUSED auto _ : state) {
-    dom::element doc;
     bytes += docdata.size();
-    parser.parse(docdata).tie(doc,error);
-    if(error) {
+    dom::element doc;
+    if ((error = parser.parse(docdata).get(doc))) {
       cerr << "could not parse gsoc-2018.json" << error << endl;
       return;
     }

--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -267,8 +267,7 @@ struct benchmarker {
   benchmarker(const char *_filename, event_collector& _collector)
     : filename(_filename), collector(_collector), stats(NULL) {
     verbose() << "[verbose] loading " << filename << endl;
-    simdjson::error_code error;
-    padded_string::load(filename).tie(this->json, error);
+    auto error = padded_string::load(filename).get(json);
     if (error) {
       exit_error(string("Could not load the file ") + filename);
     }

--- a/benchmark/parseandstatcompetition.cpp
+++ b/benchmark/parseandstatcompetition.cpp
@@ -53,10 +53,9 @@ really_inline void simdjson_process_atom(stat_t &s,
   if (element.is<double>()) {
     s.number_count++;
   } else if (element.is<bool>()) {
-    simdjson::error_code err;
+    simdjson::error_code error;
     bool v;
-    element.get<bool>().tie(v, err);
-    if (v) {
+    if (element.get(v, error) && v) {
       s.true_count++;
     } else {
       s.false_count++;
@@ -67,11 +66,12 @@ really_inline void simdjson_process_atom(stat_t &s,
 }
 
 void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
+  error_code error;
   if (element.is<simdjson::dom::array>()) {
     s.array_count++;
-    auto [array, array_error] = element.get<simdjson::dom::array>();
-    if (array_error) {
-      std::cerr << array_error << std::endl;
+    dom::array array;
+    if (!element.get(array, error)) {
+      std::cerr << error << std::endl;
       abort();
     }
     for (auto child : array) {
@@ -84,9 +84,9 @@ void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
     }
   } else if (element.is<simdjson::dom::object>()) {
     s.object_count++;
-    auto [object, object_error] = element.get<simdjson::dom::object>();
-    if (object_error) {
-      std::cerr << object_error << std::endl;
+    dom::object object;
+    if (!element.get(object, error)) {
+      std::cerr << error << std::endl;
       abort();
     }
     for (auto field : object) {

--- a/benchmark/parseandstatcompetition.cpp
+++ b/benchmark/parseandstatcompetition.cpp
@@ -55,7 +55,7 @@ really_inline void simdjson_process_atom(stat_t &s,
   } else if (element.is<bool>()) {
     simdjson::error_code error;
     bool v;
-    if (element.get(v, error) && v) {
+    if (not (error = element.get(v)) && v) {
       s.true_count++;
     } else {
       s.false_count++;
@@ -70,7 +70,7 @@ void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
   if (element.is<simdjson::dom::array>()) {
     s.array_count++;
     dom::array array;
-    if (!element.get(array, error)) {
+    if ((error = element.get(array))) {
       std::cerr << error << std::endl;
       abort();
     }
@@ -85,7 +85,7 @@ void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
   } else if (element.is<simdjson::dom::object>()) {
     s.object_count++;
     dom::object object;
-    if (!element.get(object, error)) {
+    if ((error = element.get(object))) {
       std::cerr << error << std::endl;
       abort();
     }

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -52,7 +52,7 @@ really_inline void simdjson_process_atom(stat_t &s,
   } else if (element.is<bool>()) {
     simdjson::error_code err;
     bool v;
-    element.get<bool>().tie(v,err);
+    element.get(v,err);
     if (v) {
       s.true_count++;
     } else {

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -64,10 +64,11 @@ really_inline void simdjson_process_atom(stat_t &s,
 }
 
 void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
+  simdjson::error_code error;
   if (element.is<simdjson::dom::array>()) {
     s.array_count++;
-    auto [array, array_error] = element.get<simdjson::dom::array>();
-    if (array_error) { std::cerr << array_error << std::endl; abort(); }
+    simdjson::dom::array array;
+    if (!element.get(array, error)) { std::cerr << error << std::endl; abort(); }
     for (auto child : array) {
       if (child.is<simdjson::dom::array>() || child.is<simdjson::dom::object>()) {
         simdjson_recurse(s, child);
@@ -77,8 +78,8 @@ void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
     }
   } else if (element.is<simdjson::dom::object>()) {
     s.object_count++;
-    auto [object, object_error] = element.get<simdjson::dom::object>();
-    if (object_error) { std::cerr << object_error << std::endl; abort(); }
+    simdjson::dom::object object;
+    if (!element.get(object, error)) { std::cerr << error << std::endl; abort(); }
     for (auto field : object) {
       s.string_count++; // for key
       if (field.value.is<simdjson::dom::array>() || field.value.is<simdjson::dom::object>()) {

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -52,7 +52,7 @@ really_inline void simdjson_process_atom(stat_t &s,
   } else if (element.is<bool>()) {
     simdjson::error_code err;
     bool v;
-    element.get(v,err);
+    err = element.get(v);
     if (v) {
       s.true_count++;
     } else {
@@ -68,7 +68,7 @@ void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
   if (element.is<simdjson::dom::array>()) {
     s.array_count++;
     simdjson::dom::array array;
-    if (!element.get(array, error)) { std::cerr << error << std::endl; abort(); }
+    if ((error = element.get(array))) { std::cerr << error << std::endl; abort(); }
     for (auto child : array) {
       if (child.is<simdjson::dom::array>() || child.is<simdjson::dom::object>()) {
         simdjson_recurse(s, child);
@@ -79,7 +79,7 @@ void simdjson_recurse(stat_t &s, simdjson::dom::element element) {
   } else if (element.is<simdjson::dom::object>()) {
     s.object_count++;
     simdjson::dom::object object;
-    if (!element.get(object, error)) { std::cerr << error << std::endl; abort(); }
+    if ((error = element.get(object))) { std::cerr << error << std::endl; abort(); }
     for (auto field : object) {
       s.string_count++; // for key
       if (field.value.is<simdjson::dom::array>() || field.value.is<simdjson::dom::object>()) {

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -84,7 +84,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   double value; // variable where we store the value to be parsed
   simdjson::padded_string numberstring = "1.2"_padded; // our JSON input ("1.2")
   simdjson::dom::parser parser;
-  parser.parse(numberstring).get<double>().tie(value,error);
+  parser.parse(numberstring).get(value,error);
   if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
   ```
@@ -213,7 +213,7 @@ dom::parser parser;
 padded_string json = R"(  { "foo": 1, "bar": 2 }  )"_padded;
 dom::object object;
 simdjson::error_code error;
-parser.parse(json).get<dom::object>().tie(object, error);
+parser.parse(json).get(object, error);
 for (dom::key_value_pair field : object) {
   cout << field.key << " = " << field.value << endl;
 }
@@ -299,13 +299,13 @@ auto cars_json = R"( [
 dom::parser parser;
 dom::array cars;
 simdjson::error_code error;
-parser.parse(cars_json).get<dom::array>().tie(cars, error);
+parser.parse(cars_json).get(cars, error);
 if (error) { cerr << error << endl; exit(1); }
 
 // Iterating through an array of objects
 for (dom::element car_element : cars) {
 dom::object car;
-car_element.get<dom::object>().tie(car, error);
+car_element.get(car, error);
 if (error) { cerr << error << endl; exit(1); }
 
 // Accessing a field by name
@@ -318,18 +318,18 @@ cout << "Make/Model: " << make << "/" << model << endl;
 
 // Casting a JSON element to an integer
 uint64_t year;
-car["year"].get<uint64_t>().tie(year, error);
+car["year"].get(year, error);
 if (error) { cerr << error << endl; exit(1); }
 cout << "- This car is " << 2020 - year << "years old." << endl;
 
 // Iterating through an array of floats
 double total_tire_pressure = 0;
 dom::array tire_pressure_array;
-car["tire_pressure"].get<dom::array>().tie(tire_pressure_array, error);
+car["tire_pressure"].get(tire_pressure_array, error);
 if (error) { cerr << error << endl; exit(1); }
 for (dom::element tire_pressure_element : tire_pressure_array) {
     double tire_pressure;
-    tire_pressure_element.get<double>().tie(tire_pressure, error);
+    tire_pressure_element.get(tire_pressure, error);
     if (error) { cerr << error << endl; exit(1); }
     total_tire_pressure += tire_pressure;
 }
@@ -351,31 +351,31 @@ auto abstract_json = R"( [
 dom::parser parser;
 dom::array rootarray;
 simdjson::error_code error;
-parser.parse(abstract_json).get<dom::array>().tie(rootarray, error);
+parser.parse(abstract_json).get(rootarray, error);
 if (error) { cerr << error << endl; exit(1); }
 // Iterate through an array of objects
 for (dom::element elem : rootarray) {
     dom::object obj;
-    elem.get<dom::object>().tie(obj, error);
+    elem.get(obj, error);
     if (error) { cerr << error << endl; exit(1); }
     for(auto & key_value : obj) {
       cout << "key: " << key_value.key << " : ";
       dom::object innerobj;
-      key_value.value.get<dom::object>().tie(innerobj, error);
+      key_value.value.get(innerobj, error);
       if (error) { cerr << error << endl; exit(1); }
 
       double va;
-      innerobj["a"].get<double>().tie(va, error);
+      innerobj["a"].get(va, error);
       if (error) { cerr << error << endl; exit(1); }
       cout << "a: " << va << ", ";
 
       double vb;
-      innerobj["b"].get<double>().tie(vb, error);
+      innerobj["b"].get(vb, error);
       if (error) { cerr << error << endl; exit(1); }
       cout << "b: " << vb << ", ";
 
       int64_t vc;
-      innerobj["c"].get<int64_t>().tie(vc, error);
+      innerobj["c"].get(vc, error);
       if (error) { cerr << error << endl; exit(1); }
       cout << "c: " << vc << endl;
 
@@ -392,7 +392,7 @@ And another one:
   dom::parser parser;
   double v;
   simdjson::error_code error;
-  parser.parse(abstract_json)["str"]["123"]["abc"].get<double>().tie(v, error);
+  parser.parse(abstract_json)["str"]["123"]["abc"].get(v, error);
   if (error) { cerr << error << endl; exit(1); }
   cout << "number: " << v << endl;
 ```

--- a/examples/quickstart/quickstart_noexceptions.cpp
+++ b/examples/quickstart/quickstart_noexceptions.cpp
@@ -3,13 +3,11 @@
 int main(void) {
   simdjson::dom::parser parser;
   simdjson::dom::element tweets;
-  simdjson::error_code error;
-  parser.load("twitter.json").tie(tweets,error);
+  auto error = parser.load("twitter.json").get(tweets);
   if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   simdjson::dom::element res;
 
-  tweets["search_metadata"]["count"].tie(res,error);
-  if(error) {
+  if ((error = tweets["search_metadata"]["count"].get(res))) {
     std::cerr << "could not access keys" << std::endl;
     return EXIT_FAILURE;
   }

--- a/fuzz/fuzz_dump.cpp
+++ b/fuzz/fuzz_dump.cpp
@@ -49,9 +49,8 @@ static void print_json(std::ostream& os, simdjson::dom::element element) {
 }
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   simdjson::dom::parser parser;
-  simdjson::error_code error;
   simdjson::dom::element elem;
-  parser.parse(Data, Size).tie(elem, error);
+  auto error = parser.parse(Data, Size).get(elem);
 
   if (error) { return 1; }
   NulOStream os;

--- a/fuzz/fuzz_dump_raw_tape.cpp
+++ b/fuzz/fuzz_dump_raw_tape.cpp
@@ -8,9 +8,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     simdjson::dom::parser parser;
-    simdjson::error_code error;
     simdjson::dom::element elem;
-    parser.parse(Data, Size).tie(elem, error);
+    auto error = parser.parse(Data, Size).get(elem);
     if (error) { return 1; }
 
     NulOStream os;

--- a/fuzz/fuzz_minify.cpp
+++ b/fuzz/fuzz_minify.cpp
@@ -9,9 +9,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     std::string str(begin, end);
     simdjson::dom::parser parser;
-    simdjson::error_code error;
     simdjson::dom::element elem;
-    parser.parse(str).tie(elem, error);
+    auto error = parser.parse(str).get(elem);
     if (error) { return 1; }
 
     std::string minified=simdjson::minify(elem);

--- a/fuzz/fuzz_parser.cpp
+++ b/fuzz/fuzz_parser.cpp
@@ -4,8 +4,7 @@
 #include <string>
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   simdjson::dom::parser parser;
-  UNUSED simdjson::error_code error;
   UNUSED simdjson::dom::element elem;
-  parser.parse(Data, Size).tie(elem, error);
+  UNUSED auto error = parser.parse(Data, Size).get(elem);
   return 0;
 }

--- a/fuzz/fuzz_print_json.cpp
+++ b/fuzz/fuzz_print_json.cpp
@@ -8,9 +8,8 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   simdjson::dom::parser parser;
-  simdjson::error_code error;
   simdjson::dom::element elem;
-  parser.parse(Data, Size).tie(elem, error);
+  auto error = parser.parse(Data, Size).get(elem);
   if (!error) {
     NulOStream os;
     os<<elem;

--- a/include/simdjson/dom/document_stream.h
+++ b/include/simdjson/dom/document_stream.h
@@ -141,10 +141,18 @@ private:
    */
   really_inline document_stream(
     dom::parser &parser,
-    const uint8_t *buf,
-    size_t len,
     size_t batch_size,
-    error_code error = SUCCESS
+    const uint8_t *buf,
+    size_t len
+  ) noexcept;
+
+  /**
+   * Construct a document_stream with an initial error.
+   */
+  really_inline document_stream(
+    dom::parser &parser,
+    size_t batch_size,
+    error_code error
   ) noexcept;
 
   /**

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -206,6 +206,63 @@ public:
   template<typename T>
   really_inline simdjson_result<T> get() const noexcept;
 
+  /**
+   * Get the value as the provided type (T).
+   *
+   * Supported types:
+   * - Boolean: bool
+   * - Number: double, uint64_t, int64_t
+   * - String: std::string_view, const char *
+   * - Array: dom::array
+   * - Object: dom::object
+   *
+   * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
+   *
+   * @param value The variable to set to the value. May not be set if there is an error.
+   * @param error The variable to set to the error. Set to SUCCESS if there is no error.
+   *
+   * @returns true if the value was set, or false if there wsa an error.
+   */
+  template<typename T>
+  inline bool get(T &value, error_code &error) const noexcept;
+
+  /**
+   * Get the value as the provided type (T), setting error if it's not the given type.
+   *
+   * Supported types:
+   * - Boolean: bool
+   * - Number: double, uint64_t, int64_t
+   * - String: std::string_view, const char *
+   * - Array: dom::array
+   * - Object: dom::object
+   *
+   * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
+   *
+   * @param value The variable to set to the given type. value is undefined if there is an error.
+   * @param error The variable to store the error. error is set to error_code::SUCCEED if there is an error.
+   */
+  template<typename T>
+  inline void tie(T &value, error_code &error) && noexcept;
+
+  /**
+   * Get the value as the provided type (T).
+   *
+   * Supported types:
+   * - Boolean: bool
+   * - Number: double, uint64_t, int64_t
+   * - String: std::string_view, const char *
+   * - Array: dom::array
+   * - Object: dom::object
+   *
+   * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
+   *
+   * @param value The variable to set to the given type. value is undefined if there is an error.
+   *
+   * @returns true if the value was able to be set, false if there was an error.
+   */
+  template<typename T>
+  WARN_UNUSED inline bool tie(T &value) && noexcept;
+
 #if SIMDJSON_EXCEPTIONS
   /**
    * Read this element as a boolean.
@@ -421,6 +478,8 @@ public:
   inline simdjson_result<bool> is() const noexcept;
   template<typename T>
   inline simdjson_result<T> get() const noexcept;
+  template<typename T>
+  inline bool get(T &value, error_code &error) const noexcept;
 
   inline simdjson_result<dom::array> get_array() const noexcept;
   inline simdjson_result<dom::object> get_object() const noexcept;

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -204,7 +204,7 @@ public:
    *          INCORRECT_TYPE if the value cannot be cast to the given type.
    */
   template<typename T>
-  really_inline simdjson_result<T> get() const noexcept;
+  inline simdjson_result<T> get() const noexcept;
 
   /**
    * Get the value as the provided type (T).
@@ -219,12 +219,11 @@ public:
    * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
    *
    * @param value The variable to set to the value. May not be set if there is an error.
-   * @param error The variable to set to the error. Set to SUCCESS if there is no error.
    *
-   * @returns true if the value was set, or false if there wsa an error.
+   * @returns The error that occurred, or SUCCESS if there was no error.
    */
   template<typename T>
-  inline bool get(T &value, error_code &error) const noexcept;
+  WARN_UNUSED really_inline error_code get(T &value) const noexcept;
 
   /**
    * Get the value as the provided type (T), setting error if it's not the given type.
@@ -473,51 +472,51 @@ public:
   really_inline simdjson_result(dom::element &&value) noexcept; ///< @private
   really_inline simdjson_result(error_code error) noexcept; ///< @private
 
-  inline simdjson_result<dom::element_type> type() const noexcept;
+  really_inline simdjson_result<dom::element_type> type() const noexcept;
   template<typename T>
-  inline simdjson_result<bool> is() const noexcept;
+  really_inline simdjson_result<bool> is() const noexcept;
   template<typename T>
-  inline simdjson_result<T> get() const noexcept;
+  really_inline simdjson_result<T> get() const noexcept;
   template<typename T>
-  inline bool get(T &value, error_code &error) const noexcept;
+  WARN_UNUSED really_inline error_code get(T &value) const noexcept;
 
-  inline simdjson_result<dom::array> get_array() const noexcept;
-  inline simdjson_result<dom::object> get_object() const noexcept;
-  inline simdjson_result<const char *> get_c_str() const noexcept;
-  inline simdjson_result<std::string_view> get_string() const noexcept;
-  inline simdjson_result<int64_t> get_int64_t() const noexcept;
-  inline simdjson_result<uint64_t> get_uint64_t() const noexcept;
-  inline simdjson_result<double> get_double() const noexcept;
-  inline simdjson_result<bool> get_bool() const noexcept;
+  really_inline simdjson_result<dom::array> get_array() const noexcept;
+  really_inline simdjson_result<dom::object> get_object() const noexcept;
+  really_inline simdjson_result<const char *> get_c_str() const noexcept;
+  really_inline simdjson_result<std::string_view> get_string() const noexcept;
+  really_inline simdjson_result<int64_t> get_int64_t() const noexcept;
+  really_inline simdjson_result<uint64_t> get_uint64_t() const noexcept;
+  really_inline simdjson_result<double> get_double() const noexcept;
+  really_inline simdjson_result<bool> get_bool() const noexcept;
 
-  inline simdjson_result<bool> is_array() const noexcept;
-  inline simdjson_result<bool> is_object() const noexcept;
-  inline simdjson_result<bool> is_string() const noexcept;
-  inline simdjson_result<bool> is_int64_t() const noexcept;
-  inline simdjson_result<bool> is_uint64_t() const noexcept;
-  inline simdjson_result<bool> is_double() const noexcept;
-  inline simdjson_result<bool> is_bool() const noexcept;
-  inline simdjson_result<bool> is_null() const noexcept;
+  really_inline simdjson_result<bool> is_array() const noexcept;
+  really_inline simdjson_result<bool> is_object() const noexcept;
+  really_inline simdjson_result<bool> is_string() const noexcept;
+  really_inline simdjson_result<bool> is_int64_t() const noexcept;
+  really_inline simdjson_result<bool> is_uint64_t() const noexcept;
+  really_inline simdjson_result<bool> is_double() const noexcept;
+  really_inline simdjson_result<bool> is_bool() const noexcept;
+  really_inline simdjson_result<bool> is_null() const noexcept;
 
-  inline simdjson_result<dom::element> operator[](const std::string_view &key) const noexcept;
-  inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
-  inline simdjson_result<dom::element> at(const std::string_view &json_pointer) const noexcept;
-  inline simdjson_result<dom::element> at(size_t index) const noexcept;
-  inline simdjson_result<dom::element> at_key(const std::string_view &key) const noexcept;
-  inline simdjson_result<dom::element> at_key_case_insensitive(const std::string_view &key) const noexcept;
+  really_inline simdjson_result<dom::element> operator[](const std::string_view &key) const noexcept;
+  really_inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
+  really_inline simdjson_result<dom::element> at(const std::string_view &json_pointer) const noexcept;
+  really_inline simdjson_result<dom::element> at(size_t index) const noexcept;
+  really_inline simdjson_result<dom::element> at_key(const std::string_view &key) const noexcept;
+  really_inline simdjson_result<dom::element> at_key_case_insensitive(const std::string_view &key) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  inline operator bool() const noexcept(false);
-  inline explicit operator const char*() const noexcept(false);
-  inline operator std::string_view() const noexcept(false);
-  inline operator uint64_t() const noexcept(false);
-  inline operator int64_t() const noexcept(false);
-  inline operator double() const noexcept(false);
-  inline operator dom::array() const noexcept(false);
-  inline operator dom::object() const noexcept(false);
+  really_inline operator bool() const noexcept(false);
+  really_inline explicit operator const char*() const noexcept(false);
+  really_inline operator std::string_view() const noexcept(false);
+  really_inline operator uint64_t() const noexcept(false);
+  really_inline operator int64_t() const noexcept(false);
+  really_inline operator double() const noexcept(false);
+  really_inline operator dom::array() const noexcept(false);
+  really_inline operator dom::object() const noexcept(false);
 
-  inline dom::array::iterator begin() const noexcept(false);
-  inline dom::array::iterator end() const noexcept(false);
+  really_inline dom::array::iterator begin() const noexcept(false);
+  really_inline dom::array::iterator end() const noexcept(false);
 #endif // SIMDJSON_EXCEPTIONS
 };
 
@@ -533,7 +532,7 @@ public:
  *        underlying output stream, that error will be propagated (simdjson_error will not be
  *        thrown).
  */
-inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false);
+really_inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false);
 #endif
 
 } // namespace simdjson

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -119,8 +119,10 @@ struct simdjson_result_base : public std::pair<T, error_code> {
 
   /**
    * Move the value and the error to the provided variables.
+   *
+   * @return true if the value was set, false if there was an error.
    */
-  really_inline void tie(T &value, error_code &error) && noexcept;
+  really_inline bool tie(T &value, error_code &error) && noexcept;
 
   /**
    * The error.
@@ -181,8 +183,10 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
 
   /**
    * Move the value and the error to the provided variables.
+   *
+   * @return true if the value was set, false if there was an error.
    */
-  really_inline void tie(T& t, error_code & e) && noexcept;
+  really_inline bool tie(T &value, error_code &error) && noexcept;
 
   /**
    * The error.

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -120,9 +120,17 @@ struct simdjson_result_base : public std::pair<T, error_code> {
   /**
    * Move the value and the error to the provided variables.
    *
-   * @return true if the value was set, false if there was an error.
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   * @param error The variable to assign the error to. Set to SUCCESS if there is no error.
    */
-  really_inline bool tie(T &value, error_code &error) && noexcept;
+  really_inline void tie(T &value, error_code &error) && noexcept;
+
+  /**
+   * Move the value to the provided variable.
+   *
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   */
+  really_inline error_code get(T &value) && noexcept;
 
   /**
    * The error.
@@ -184,9 +192,17 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
   /**
    * Move the value and the error to the provided variables.
    *
-   * @return true if the value was set, false if there was an error.
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   * @param error The variable to assign the error to. Set to SUCCESS if there is no error.
    */
-  really_inline bool tie(T &value, error_code &error) && noexcept;
+  really_inline void tie(T &value, error_code &error) && noexcept;
+
+  /**
+   * Move the value to the provided variable.
+   *
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   */
+  WARN_UNUSED really_inline error_code get(T &value) && noexcept;
 
   /**
    * The error.

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -66,22 +66,35 @@ inline void stage1_worker::run(document_stream * ds, dom::parser * stage1, size_
 
 really_inline document_stream::document_stream(
   dom::parser &_parser,
-  const uint8_t *_buf,
-  size_t _len,
   size_t _batch_size,
-  error_code _error
+  const uint8_t *_buf,
+  size_t _len
 ) noexcept
   : parser{_parser},
     buf{_buf},
     len{_len},
     batch_size{_batch_size},
-    error{_error}
+    error{SUCCESS}
 {
 #ifdef SIMDJSON_THREADS_ENABLED
   if(worker.get() == nullptr) {
     error = MEMALLOC;
   }
 #endif
+}
+
+really_inline document_stream::document_stream(
+  dom::parser &_parser,
+  size_t _batch_size,
+  error_code _error
+) noexcept
+  : parser{_parser},
+    buf{nullptr},
+    len{0},
+    batch_size{_batch_size},
+    error{_error}
+{
+  assert(_error);
 }
 
 inline document_stream::~document_stream() noexcept {

--- a/include/simdjson/inline/element.h
+++ b/include/simdjson/inline/element.h
@@ -33,6 +33,15 @@ inline simdjson_result<T> simdjson_result<dom::element>::get() const noexcept {
   if (error()) { return error(); }
   return first.get<T>();
 }
+template<typename T>
+inline bool simdjson_result<dom::element>::get(T &value, error_code &_error) const noexcept {
+  if (error()) {
+    _error = error();
+    return !_error;
+  } else {
+    return first.get(value, _error);
+  }
+}
 
 inline simdjson_result<dom::array> simdjson_result<dom::element>::get_array() const noexcept {
   if (error()) { return error(); }
@@ -265,6 +274,11 @@ inline simdjson_result<object> element::get_object() const noexcept {
     default:
       return INCORRECT_TYPE;
   }
+}
+
+template<typename T>
+inline bool element::get(T &value, error_code &error) const noexcept {
+  return get<T>().tie(value, error);
 }
 
 template<typename T>

--- a/include/simdjson/inline/element.h
+++ b/include/simdjson/inline/element.h
@@ -24,154 +24,150 @@ inline simdjson_result<dom::element_type> simdjson_result<dom::element>::type() 
 }
 
 template<typename T>
-inline simdjson_result<bool> simdjson_result<dom::element>::is() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is() const noexcept {
   if (error()) { return error(); }
   return first.is<T>();
 }
 template<typename T>
-inline simdjson_result<T> simdjson_result<dom::element>::get() const noexcept {
+really_inline simdjson_result<T> simdjson_result<dom::element>::get() const noexcept {
   if (error()) { return error(); }
   return first.get<T>();
 }
 template<typename T>
-inline bool simdjson_result<dom::element>::get(T &value, error_code &_error) const noexcept {
-  if (error()) {
-    _error = error();
-    return !_error;
-  } else {
-    return first.get(value, _error);
-  }
+WARN_UNUSED really_inline error_code simdjson_result<dom::element>::get(T &value) const noexcept {
+  if (error()) { return error(); }
+  return first.get<T>(value);
 }
 
-inline simdjson_result<dom::array> simdjson_result<dom::element>::get_array() const noexcept {
+really_inline simdjson_result<dom::array> simdjson_result<dom::element>::get_array() const noexcept {
   if (error()) { return error(); }
   return first.get_array();
 }
-inline simdjson_result<dom::object> simdjson_result<dom::element>::get_object() const noexcept {
+really_inline simdjson_result<dom::object> simdjson_result<dom::element>::get_object() const noexcept {
   if (error()) { return error(); }
   return first.get_object();
 }
-inline simdjson_result<const char *> simdjson_result<dom::element>::get_c_str() const noexcept {
+really_inline simdjson_result<const char *> simdjson_result<dom::element>::get_c_str() const noexcept {
   if (error()) { return error(); }
   return first.get_c_str();
 }
-inline simdjson_result<std::string_view> simdjson_result<dom::element>::get_string() const noexcept {
+really_inline simdjson_result<std::string_view> simdjson_result<dom::element>::get_string() const noexcept {
   if (error()) { return error(); }
   return first.get_string();
 }
-inline simdjson_result<int64_t> simdjson_result<dom::element>::get_int64_t() const noexcept {
+really_inline simdjson_result<int64_t> simdjson_result<dom::element>::get_int64_t() const noexcept {
   if (error()) { return error(); }
   return first.get_int64_t();
 }
-inline simdjson_result<uint64_t> simdjson_result<dom::element>::get_uint64_t() const noexcept {
+really_inline simdjson_result<uint64_t> simdjson_result<dom::element>::get_uint64_t() const noexcept {
   if (error()) { return error(); }
   return first.get_uint64_t();
 }
-inline simdjson_result<double> simdjson_result<dom::element>::get_double() const noexcept {
+really_inline simdjson_result<double> simdjson_result<dom::element>::get_double() const noexcept {
   if (error()) { return error(); }
   return first.get_double();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::get_bool() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::get_bool() const noexcept {
   if (error()) { return error(); }
   return first.get_bool();
 }
 
-inline simdjson_result<bool> simdjson_result<dom::element>::is_array() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_array() const noexcept {
   if (error()) { return error(); }
   return first.is_array();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::is_object() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_object() const noexcept {
   if (error()) { return error(); }
   return first.is_object();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::is_string() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_string() const noexcept {
   if (error()) { return error(); }
   return first.is_string();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::is_int64_t() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_int64_t() const noexcept {
   if (error()) { return error(); }
   return first.is_int64_t();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::is_uint64_t() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_uint64_t() const noexcept {
   if (error()) { return error(); }
   return first.is_uint64_t();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::is_double() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_double() const noexcept {
   if (error()) { return error(); }
   return first.is_double();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::is_bool() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_bool() const noexcept {
   if (error()) { return error(); }
   return first.is_bool();
 }
 
-inline simdjson_result<bool> simdjson_result<dom::element>::is_null() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_null() const noexcept {
   if (error()) { return error(); }
   return first.is_null();
 }
 
-inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const std::string_view &key) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const std::string_view &key) const noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const char *key) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const char *key) const noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at(const std::string_view &json_pointer) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(const std::string_view &json_pointer) const noexcept {
   if (error()) { return error(); }
   return first.at(json_pointer);
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at(size_t index) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(size_t index) const noexcept {
   if (error()) { return error(); }
   return first.at(index);
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key(const std::string_view &key) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key(const std::string_view &key) const noexcept {
   if (error()) { return error(); }
   return first.at_key(key);
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key_case_insensitive(const std::string_view &key) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key_case_insensitive(const std::string_view &key) const noexcept {
   if (error()) { return error(); }
   return first.at_key_case_insensitive(key);
 }
 
 #if SIMDJSON_EXCEPTIONS
 
-inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
   return get<bool>();
 }
-inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
   return get<const char *>();
 }
-inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
   return get<std::string_view>();
 }
-inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
   return get<uint64_t>();
 }
-inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
   return get<int64_t>();
 }
-inline simdjson_result<dom::element>::operator double() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator double() const noexcept(false) {
   return get<double>();
 }
-inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
   return get<dom::array>();
 }
-inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
   return get<dom::object>();
 }
 
-inline dom::array::iterator simdjson_result<dom::element>::begin() const noexcept(false) {
+really_inline dom::array::iterator simdjson_result<dom::element>::begin() const noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.begin();
 }
-inline dom::array::iterator simdjson_result<dom::element>::end() const noexcept(false) {
+really_inline dom::array::iterator simdjson_result<dom::element>::end() const noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.end();
 }
 
-#endif
+#endif // SIMDJSON_EXCEPTIONS
 
 namespace dom {
 
@@ -277,12 +273,18 @@ inline simdjson_result<object> element::get_object() const noexcept {
 }
 
 template<typename T>
-inline bool element::get(T &value, error_code &error) const noexcept {
-  return get<T>().tie(value, error);
+WARN_UNUSED really_inline error_code element::get(T &value) const noexcept {
+  return get<T>().get(value);
+}
+// An element-specific version prevents recursion with simdjson_result::get<element>(value)
+template<>
+WARN_UNUSED really_inline error_code element::get<element>(element &value) const noexcept {
+  value = element(tape);
+  return SUCCESS;
 }
 
 template<typename T>
-inline bool element::is() const noexcept {
+really_inline bool element::is() const noexcept {
   auto result = get<T>();
   return !result.error();
 }
@@ -514,12 +516,12 @@ inline std::ostream& minifier<dom::element>::print(std::ostream& out) {
 #if SIMDJSON_EXCEPTIONS
 
 template<>
-inline std::ostream& minifier<simdjson_result<dom::element>>::print(std::ostream& out) {
+really_inline std::ostream& minifier<simdjson_result<dom::element>>::print(std::ostream& out) {
   if (value.error()) { throw simdjson_error(value.error()); }
   return out << minify<dom::element>(value.first);
 }
 
-inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false) {
+really_inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false) {
   return out << minify<simdjson_result<dom::element>>(value);
 }
 #endif

--- a/include/simdjson/inline/error.h
+++ b/include/simdjson/inline/error.h
@@ -41,12 +41,13 @@ namespace internal {
 //
 
 template<typename T>
-really_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
+really_inline bool simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
   // on the clang compiler that comes with current macOS (Apple clang version 11.0.0),
   // tie(width, error) = size["w"].get<uint64_t>();
   // fails with "error: no viable overloaded '='""
   value = std::forward<simdjson_result_base<T>>(*this).first;
   error = this->second;
+  return !error;
 }
 
 template<typename T>
@@ -95,8 +96,8 @@ really_inline simdjson_result_base<T>::simdjson_result_base() noexcept
 ///
 
 template<typename T>
-really_inline void simdjson_result<T>::tie(T &value, error_code &error) && noexcept {
-  std::forward<internal::simdjson_result_base<T>>(*this).tie(value, error);
+really_inline bool simdjson_result<T>::tie(T &value, error_code &error) && noexcept {
+  return std::forward<internal::simdjson_result_base<T>>(*this).tie(value, error);
 }
 
 template<typename T>

--- a/include/simdjson/inline/error.h
+++ b/include/simdjson/inline/error.h
@@ -41,13 +41,21 @@ namespace internal {
 //
 
 template<typename T>
-really_inline bool simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
+really_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
   // on the clang compiler that comes with current macOS (Apple clang version 11.0.0),
   // tie(width, error) = size["w"].get<uint64_t>();
   // fails with "error: no viable overloaded '='""
-  value = std::forward<simdjson_result_base<T>>(*this).first;
   error = this->second;
-  return !error;
+  if (!error) {
+    value = std::forward<simdjson_result_base<T>>(*this).first;
+  }
+}
+
+template<typename T>
+WARN_UNUSED really_inline error_code simdjson_result_base<T>::get(T &value) && noexcept {
+  error_code error;
+  std::forward<simdjson_result_base<T>>(*this).tie(value, error);
+  return error;
 }
 
 template<typename T>
@@ -96,8 +104,13 @@ really_inline simdjson_result_base<T>::simdjson_result_base() noexcept
 ///
 
 template<typename T>
-really_inline bool simdjson_result<T>::tie(T &value, error_code &error) && noexcept {
-  return std::forward<internal::simdjson_result_base<T>>(*this).tie(value, error);
+really_inline void simdjson_result<T>::tie(T &value, error_code &error) && noexcept {
+  std::forward<internal::simdjson_result_base<T>>(*this).tie(value, error);
+}
+
+template<typename T>
+WARN_UNUSED really_inline error_code simdjson_result<T>::get(T &value) && noexcept {
+  return std::forward<internal::simdjson_result_base<T>>(*this).get(value);
 }
 
 template<typename T>

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -199,5 +199,24 @@ static inline void aligned_free(void *mem_block) {
 static inline void aligned_free_char(char *mem_block) {
   aligned_free((void *)mem_block);
 }
+
+#ifdef NDEBUG
+
+#ifdef SIMDJSON_VISUAL_STUDIO
+#define SIMDJSON_UNREACHABLE() __assume(0)
+#define SIMDJSON_ASSUME(COND) __assume(COND)
+#else
+#define SIMDJSON_UNREACHABLE() __builtin_unreachable();
+#define SIMDJSON_ASSUME(COND) do { if (!(COND)) __builtin_unreachable(); } while (0)
+#endif
+
+#else // NDEBUG
+
+#include <cassert>
+#define SIMDJSON_UNREACHABLE() assert(0);
+#define SIMDJSON_ASSUME(COND) assert(COND)
+
+#endif
+
 } // namespace simdjson
 #endif // SIMDJSON_PORTABILITY_H

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -677,7 +677,7 @@ namespace parse_api_tests {
       if (error) { cerr << error << endl; return false; }
 
       dom::array arr;
-      doc.get<dom::array>().tie(arr, error); // let us get the array
+      doc.get(arr, error); // let us get the array
       if (error) { cerr << error << endl; return false; }
 
       if(arr.size() != 9) { cerr << "bad array size"<< endl; return false; }
@@ -1033,11 +1033,11 @@ namespace dom_api_tests {
     if (doc["obj"]["a"].get<uint64_t>().first != 1) { cerr << "Expected uint64_t(doc[\"obj\"][\"a\"]) to be 1, was " << doc["obj"]["a"].first << endl; return false; }
 
     object obj;
-    doc.get<dom::object>().tie(obj, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+    doc.get(obj, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
     if (error) { cerr << "Error: " << error << endl; return false; }
     if (obj["obj"]["a"].get<uint64_t>().first != 1) { cerr << "Expected uint64_t(doc[\"obj\"][\"a\"]) to be 1, was " << doc["obj"]["a"].first << endl; return false; }
 
-    obj["obj"].get<dom::object>().tie(obj, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+    obj["obj"].get(obj, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
     if (obj["a"].get<uint64_t>().first != 1) { cerr << "Expected uint64_t(obj[\"a\"]) to be 1, was " << obj["a"].first << endl; return false; }
     if (obj["b"].get<uint64_t>().first != 2) { cerr << "Expected uint64_t(obj[\"b\"]) to be 2, was " << obj["b"].first << endl; return false; }
     if (obj["c/d"].get<uint64_t>().first != 3) { cerr << "Expected uint64_t(obj[\"c\"]) to be 3, was " << obj["c"].first << endl; return false; }
@@ -1071,14 +1071,14 @@ namespace dom_api_tests {
     if (error) { cerr << "Error: " << error << endl; return false; }
     for (auto tweet : tweets) {
       object user;
-      tweet["user"].get<dom::object>().tie(user, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+      tweet["user"].get(user, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
       if (error) { cerr << "Error: " << error << endl; return false; }
       bool default_profile;
-      user["default_profile"].get<bool>().tie(default_profile, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+      user["default_profile"].get(default_profile, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
       if (error) { cerr << "Error: " << error << endl; return false; }
       if (default_profile) {
         std::string_view screen_name;
-        user["screen_name"].get<std::string_view>().tie(screen_name, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+        user["screen_name"].get(screen_name, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
         if (error) { cerr << "Error: " << error << endl; return false; }
         default_users.insert(screen_name);
       }
@@ -1099,13 +1099,13 @@ namespace dom_api_tests {
       if (!not_found) {
         for (auto image : media) {
           object sizes;
-          image["sizes"].get<dom::object>().tie(sizes, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+          image["sizes"].get(sizes, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
           if (error) { cerr << "Error: " << error << endl; return false; }
           for (auto size : sizes) {
             uint64_t width, height;
-            size.value["w"].get<uint64_t>().tie(width, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+            size.value["w"].get(width, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
             if (error) { cerr << "Error: " << error << endl; return false; }
-            size.value["h"].get<uint64_t>().tie(height, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+            size.value["h"].get(height, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
             if (error) { cerr << "Error: " << error << endl; return false; }
             image_sizes.insert(make_pair(width, height));
           }

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -289,8 +289,7 @@ namespace document_tests {
     myStream << parser.parse(json);
 #else
     simdjson::dom::element doc;
-    simdjson::error_code error;
-    parser.parse(json).tie(doc, error);
+    UNUSED auto error = parser.parse(json).get(doc);
     myStream << doc;
 #endif
     std::string newjson = myStream.str();
@@ -677,7 +676,7 @@ namespace parse_api_tests {
       if (error) { cerr << error << endl; return false; }
 
       dom::array arr;
-      doc.get(arr, error); // let us get the array
+      error = doc.get(arr); // let us get the array
       if (error) { cerr << error << endl; return false; }
 
       if(arr.size() != 9) { cerr << "bad array size"<< endl; return false; }
@@ -1019,8 +1018,8 @@ namespace dom_api_tests {
     // tie(val, error) = doc["d"]; fails with "no viable overloaded '='" on Apple clang version 11.0.0	    tie(val, error) = doc["d"];
     doc["d"].tie(val, error);
     if (error != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(doc[\"d\"]), got " << error << endl; return false; }
-    error = doc["d"].error();
-    if (error != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(doc[\"d\"]), got " << error << endl; return false; }
+    if (doc["d"].get(val) != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(doc[\"d\"]), got " << error << endl; return false; }
+    if (doc["d"].error() != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(doc[\"d\"]), got " << error << endl; return false; }
     return true;
   }
 
@@ -1033,11 +1032,11 @@ namespace dom_api_tests {
     if (doc["obj"]["a"].get<uint64_t>().first != 1) { cerr << "Expected uint64_t(doc[\"obj\"][\"a\"]) to be 1, was " << doc["obj"]["a"].first << endl; return false; }
 
     object obj;
-    doc.get(obj, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+    error = doc.get(obj); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
     if (error) { cerr << "Error: " << error << endl; return false; }
     if (obj["obj"]["a"].get<uint64_t>().first != 1) { cerr << "Expected uint64_t(doc[\"obj\"][\"a\"]) to be 1, was " << doc["obj"]["a"].first << endl; return false; }
 
-    obj["obj"].get(obj, error); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
+    error = obj["obj"].get(obj); //  tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0
     if (obj["a"].get<uint64_t>().first != 1) { cerr << "Expected uint64_t(obj[\"a\"]) to be 1, was " << obj["a"].first << endl; return false; }
     if (obj["b"].get<uint64_t>().first != 2) { cerr << "Expected uint64_t(obj[\"b\"]) to be 2, was " << obj["b"].first << endl; return false; }
     if (obj["c/d"].get<uint64_t>().first != 3) { cerr << "Expected uint64_t(obj[\"c\"]) to be 3, was " << obj["c"].first << endl; return false; }
@@ -1047,8 +1046,7 @@ namespace dom_api_tests {
     if (obj["a"].get<uint64_t>().first != 1) { cerr << "Expected uint64_t(obj[\"a\"]) to be 1, was " << obj["a"].first << endl; return false; }
 
     UNUSED element val;
-    doc["d"].tie(val, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
-    if (error != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(obj[\"d\"]), got " << error << endl; return false; }
+    if (doc["d"].get(val) != simdjson::NO_SUCH_FIELD) { cerr << "Expected NO_SUCH_FIELD error for uint64_t(obj[\"d\"]), got " << error << endl; return false; }
     return true;
   }
 
@@ -1071,14 +1069,14 @@ namespace dom_api_tests {
     if (error) { cerr << "Error: " << error << endl; return false; }
     for (auto tweet : tweets) {
       object user;
-      tweet["user"].get(user, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+      error = tweet["user"].get(user); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
       if (error) { cerr << "Error: " << error << endl; return false; }
       bool default_profile;
-      user["default_profile"].get(default_profile, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+      error = user["default_profile"].get(default_profile); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
       if (error) { cerr << "Error: " << error << endl; return false; }
       if (default_profile) {
         std::string_view screen_name;
-        user["screen_name"].get(screen_name, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+        error = user["screen_name"].get(screen_name); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
         if (error) { cerr << "Error: " << error << endl; return false; }
         default_users.insert(screen_name);
       }
@@ -1099,13 +1097,13 @@ namespace dom_api_tests {
       if (!not_found) {
         for (auto image : media) {
           object sizes;
-          image["sizes"].get(sizes, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+          error = image["sizes"].get(sizes); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
           if (error) { cerr << "Error: " << error << endl; return false; }
           for (auto size : sizes) {
             uint64_t width, height;
-            size.value["w"].get(width, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+            error = size.value["w"].get(width); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
             if (error) { cerr << "Error: " << error << endl; return false; }
-            size.value["h"].get(height, error); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
+            error = size.value["h"].get(height); // tie(...) = fails with "no viable overloaded '='" on Apple clang version 11.0.0;
             if (error) { cerr << "Error: " << error << endl; return false; }
             image_sizes.insert(make_pair(width, height));
           }
@@ -1414,8 +1412,7 @@ namespace type_tests {
     std::cout << "  test_type() expecting " << expected_type << std::endl;
     dom::element element = result.first;
     dom::element_type actual_type;
-    simdjson::error_code error;
-    result.type().tie(actual_type, error);
+    auto error = result.type().get(actual_type);
     ASSERT_SUCCESS(error);
     ASSERT_EQUAL(actual_type, expected_type);
 
@@ -1445,8 +1442,7 @@ namespace type_tests {
     // Grab the element out and check success
     dom::element element = result.first;
     bool actual_is_null;
-    simdjson::error_code error;
-    result.is_null().tie(actual_is_null, error);
+    auto error = result.is_null().get(actual_is_null);
     ASSERT_SUCCESS(error);
     ASSERT_EQUAL(actual_is_null, expected_is_null);
 

--- a/tests/cast_tester.h
+++ b/tests/cast_tester.h
@@ -58,7 +58,7 @@ template<typename T>
 bool cast_tester<T>::test_get(element element, T expected) {
   T actual;
   error_code error;
-  element.get<T>().tie(actual, error);
+  element.get(actual, error);
   ASSERT_SUCCESS(error);
   return assert_equal(actual, expected);
 }
@@ -67,7 +67,7 @@ template<typename T>
 bool cast_tester<T>::test_get(simdjson_result<element> element, T expected) {
   T actual;
   error_code error;
-  element.get<T>().tie(actual, error);
+  element.get(actual, error);
   ASSERT_SUCCESS(error);
   return assert_equal(actual, expected);
 }
@@ -76,7 +76,7 @@ template<typename T>
 bool cast_tester<T>::test_get_error(element element, error_code expected_error) {
   T actual;
   error_code error;
-  element.get<T>().tie(actual, error);
+  element.get(actual, error);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }
@@ -85,7 +85,7 @@ template<typename T>
 bool cast_tester<T>::test_get_error(simdjson_result<element> element, error_code expected_error) {
   T actual;
   error_code error;
-  element.get<T>().tie(actual, error);
+  element.get(actual, error);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }

--- a/tests/cast_tester.h
+++ b/tests/cast_tester.h
@@ -58,7 +58,7 @@ template<typename T>
 bool cast_tester<T>::test_get(element element, T expected) {
   T actual;
   error_code error;
-  element.get(actual, error);
+  error = element.get(actual);
   ASSERT_SUCCESS(error);
   return assert_equal(actual, expected);
 }
@@ -67,7 +67,7 @@ template<typename T>
 bool cast_tester<T>::test_get(simdjson_result<element> element, T expected) {
   T actual;
   error_code error;
-  element.get(actual, error);
+  error = element.get(actual);
   ASSERT_SUCCESS(error);
   return assert_equal(actual, expected);
 }
@@ -76,7 +76,7 @@ template<typename T>
 bool cast_tester<T>::test_get_error(element element, error_code expected_error) {
   T actual;
   error_code error;
-  element.get(actual, error);
+  error = element.get(actual);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }
@@ -85,7 +85,7 @@ template<typename T>
 bool cast_tester<T>::test_get_error(simdjson_result<element> element, error_code expected_error) {
   T actual;
   error_code error;
-  element.get(actual, error);
+  error = element.get(actual);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }
@@ -93,8 +93,7 @@ bool cast_tester<T>::test_get_error(simdjson_result<element> element, error_code
 template<typename T>
 bool cast_tester<T>::test_named_get(element element, T expected) {
   T actual;
-  error_code error;
-  named_get(element).tie(actual, error);
+  auto error = named_get(element).get(actual);
   ASSERT_SUCCESS(error);
   return assert_equal(actual, expected);
 }
@@ -102,8 +101,7 @@ bool cast_tester<T>::test_named_get(element element, T expected) {
 template<typename T>
 bool cast_tester<T>::test_named_get(simdjson_result<element> element, T expected) {
   T actual;
-  error_code error;
-  named_get(element).tie(actual, error);
+  auto error = named_get(element).get(actual);
   ASSERT_SUCCESS(error);
   return assert_equal(actual, expected);
 }
@@ -111,8 +109,7 @@ bool cast_tester<T>::test_named_get(simdjson_result<element> element, T expected
 template<typename T>
 bool cast_tester<T>::test_named_get_error(element element, error_code expected_error) {
   T actual;
-  error_code error;
-  named_get(element).tie(actual, error);
+  auto error = named_get(element).get(actual);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }
@@ -120,8 +117,7 @@ bool cast_tester<T>::test_named_get_error(element element, error_code expected_e
 template<typename T>
 bool cast_tester<T>::test_named_get_error(simdjson_result<element> element, error_code expected_error) {
   T actual;
-  error_code error;
-  named_get(element).tie(actual, error);
+  auto error = named_get(element).get(actual);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }
@@ -192,8 +188,7 @@ bool cast_tester<T>::test_is(element element, bool expected) {
 template<typename T>
 bool cast_tester<T>::test_is(simdjson_result<element> element, bool expected) {
   bool actual;
-  error_code error;
-  element.is<T>().tie(actual, error);
+  auto error = element.is<T>().get(actual);
   ASSERT_SUCCESS(error);
   ASSERT_EQUAL(actual, expected);
   return true;
@@ -202,8 +197,7 @@ bool cast_tester<T>::test_is(simdjson_result<element> element, bool expected) {
 template<typename T>
 bool cast_tester<T>::test_is_error(simdjson_result<element> element, error_code expected_error) {
   UNUSED bool actual;
-  error_code error;
-  element.is<T>().tie(actual, error);
+  auto error = element.is<T>().get(actual);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }
@@ -217,8 +211,7 @@ bool cast_tester<T>::test_named_is(element element, bool expected) {
 template<typename T>
 bool cast_tester<T>::test_named_is(simdjson_result<element> element, bool expected) {
   bool actual;
-  error_code error;
-  named_is(element).tie(actual, error);
+  auto error = named_is(element).get(actual);
   ASSERT_SUCCESS(error);
   ASSERT_EQUAL(actual, expected);
   return true;
@@ -227,8 +220,7 @@ bool cast_tester<T>::test_named_is(simdjson_result<element> element, bool expect
 template<typename T>
 bool cast_tester<T>::test_named_is_error(simdjson_result<element> element, error_code expected_error) {
   bool actual;
-  error_code error;
-  named_is(element, error).tie(actual, error);
+  auto error = named_is(element).get(actual);
   ASSERT_EQUAL(error, expected_error);
   return true;
 }

--- a/tests/extracting_values_example.cpp
+++ b/tests/extracting_values_example.cpp
@@ -6,7 +6,7 @@ int main() {
   double value; // variable where we store the value to be parsed
   simdjson::padded_string numberstring = "1.2"_padded; // our JSON input ("1.2")
   simdjson::dom::parser parser;
-  parser.parse(numberstring).get<double>().tie(value,error);
+  parser.parse(numberstring).get(value,error);
   if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
 }

--- a/tests/extracting_values_example.cpp
+++ b/tests/extracting_values_example.cpp
@@ -3,9 +3,9 @@
 
 int main() {
   simdjson::error_code error;
-  double value; // variable where we store the value to be parsed
   simdjson::padded_string numberstring = "1.2"_padded; // our JSON input ("1.2")
   simdjson::dom::parser parser;
+  double value; // variable where we store the value to be parsed
   parser.parse(numberstring).get(value,error);
   if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;

--- a/tests/extracting_values_example.cpp
+++ b/tests/extracting_values_example.cpp
@@ -6,7 +6,7 @@ int main() {
   simdjson::padded_string numberstring = "1.2"_padded; // our JSON input ("1.2")
   simdjson::dom::parser parser;
   double value; // variable where we store the value to be parsed
-  parser.parse(numberstring).get(value,error);
+  error = parser.parse(numberstring).get(value);
   if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
 }

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -157,7 +157,7 @@ void basics_cpp17_2() {
   padded_string json = R"(  { "foo": 1, "bar": 2 }  )"_padded;
   dom::object object;
   simdjson::error_code error;
-  parser.parse(json).get<dom::object>().tie(object, error);
+  parser.parse(json).get(object, error);
   for (dom::key_value_pair field : object) {
     cout << field.key << " = " << field.value << endl;
   }

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -155,9 +155,10 @@ void basics_cpp17_2() {
   // C++ 11 version for comparison
   dom::parser parser;
   padded_string json = R"(  { "foo": 1, "bar": 2 }  )"_padded;
-  dom::object object;
   simdjson::error_code error;
+  dom::object object;
   parser.parse(json).get(object, error);
+  if (!error) { cerr << error << endl; return; }
   for (dom::key_value_pair field : object) {
     cout << field.key << " = " << field.value << endl;
   }

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -157,7 +157,7 @@ void basics_cpp17_2() {
   padded_string json = R"(  { "foo": 1, "bar": 2 }  )"_padded;
   simdjson::error_code error;
   dom::object object;
-  parser.parse(json).get(object, error);
+  error = parser.parse(json).get(object);
   if (!error) { cerr << error << endl; return; }
   for (dom::key_value_pair field : object) {
     cout << field.key << " = " << field.value << endl;

--- a/tests/readme_examples_noexceptions.cpp
+++ b/tests/readme_examples_noexceptions.cpp
@@ -35,13 +35,13 @@ void basics_error_3() {
   dom::parser parser;
   dom::array cars;
   simdjson::error_code error;
-  parser.parse(cars_json).get<dom::array>().tie(cars, error);
+  parser.parse(cars_json).get(cars, error);
   if (error) { cerr << error << endl; exit(1); }
 
   // Iterating through an array of objects
   for (dom::element car_element : cars) {
     dom::object car;
-    car_element.get<dom::object>().tie(car, error);
+    car_element.get(car, error);
     if (error) { cerr << error << endl; exit(1); }
 
     // Accessing a field by name
@@ -54,18 +54,18 @@ void basics_error_3() {
 
     // Casting a JSON element to an integer
     uint64_t year;
-    car["year"].get<uint64_t>().tie(year, error);
+    car["year"].get(year, error);
     if (error) { cerr << error << endl; exit(1); }
     cout << "- This car is " << 2020 - year << "years old." << endl;
 
     // Iterating through an array of floats
     double total_tire_pressure = 0;
     dom::array tire_pressure_array;
-    car["tire_pressure"].get<dom::array>().tie(tire_pressure_array, error);
+    car["tire_pressure"].get(tire_pressure_array, error);
     if (error) { cerr << error << endl; exit(1); }
     for (dom::element tire_pressure_element : tire_pressure_array) {
       double tire_pressure;
-      tire_pressure_element.get<double>().tie(tire_pressure, error);
+      tire_pressure_element.get(tire_pressure, error);
       if (error) { cerr << error << endl; exit(1); }
       total_tire_pressure += tire_pressure;
     }
@@ -87,31 +87,31 @@ void basics_error_4() {
   dom::parser parser;
   dom::array rootarray;
   simdjson::error_code error;
-  parser.parse(abstract_json).get<dom::array>().tie(rootarray, error);
+  parser.parse(abstract_json).get(rootarray, error);
   if (error) { cerr << error << endl; exit(1); }
   // Iterate through an array of objects
   for (dom::element elem : rootarray) {
     dom::object obj;
-    elem.get<dom::object>().tie(obj, error);
+    elem.get(obj, error);
     if (error) { cerr << error << endl; exit(1); }
     for(auto & key_value : obj) {
       cout << "key: " << key_value.key << " : ";
       dom::object innerobj;
-      key_value.value.get<dom::object>().tie(innerobj, error);
+      key_value.value.get(innerobj, error);
       if (error) { cerr << error << endl; exit(1); }
 
       double va;
-      innerobj["a"].get<double>().tie(va, error);
+      innerobj["a"].get(va, error);
       if (error) { cerr << error << endl; exit(1); }
       cout << "a: " << va << ", ";
 
       double vb;
-      innerobj["b"].get<double>().tie(vb, error);
+      innerobj["b"].get(vb, error);
       if (error) { cerr << error << endl; exit(1); }
       cout << "b: " << vb << ", ";
 
       int64_t vc;
-      innerobj["c"].get<int64_t>().tie(vc, error);
+      innerobj["c"].get(vc, error);
       if (error) { cerr << error << endl; exit(1); }
       cout << "c: " << vc << endl;
 
@@ -125,7 +125,7 @@ void basics_error_5() {
   dom::parser parser;
   double v;
   simdjson::error_code error;
-  parser.parse(abstract_json)["str"]["123"]["abc"].get<double>().tie(v, error);
+  parser.parse(abstract_json)["str"]["123"]["abc"].get(v, error);
   if (error) { cerr << error << endl; exit(1); }
   cout << "number: " << v << endl;
 }
@@ -147,7 +147,7 @@ void basics_error_3_cpp17() {
   // Iterating through an array of objects
   for (dom::element car_element : cars) {
     dom::object car;
-    car_element.get<dom::object>().tie(car, error);
+    car_element.get(car, error);
     if (error) { cerr << error << endl; exit(1); }
 
     // Accessing a field by name
@@ -160,18 +160,18 @@ void basics_error_3_cpp17() {
 
     // Casting a JSON element to an integer
     uint64_t year;
-    car["year"].get<uint64_t>().tie(year, error);
+    car["year"].get(year, error);
     if (error) { cerr << error << endl; exit(1); }
     cout << "- This car is " << 2020 - year << "years old." << endl;
 
     // Iterating through an array of floats
     double total_tire_pressure = 0;
     dom::array tire_pressure_array;
-    car["tire_pressure"].get<dom::array>().tie(tire_pressure_array, error);
+    car["tire_pressure"].get(tire_pressure_array, error);
     if (error) { cerr << error << endl; exit(1); }
     for (dom::element tire_pressure_element : tire_pressure_array) {
       double tire_pressure;
-      tire_pressure_element.get<double>().tie(tire_pressure, error);
+      tire_pressure_element.get(tire_pressure, error);
       if (error) { cerr << error << endl; exit(1); }
       total_tire_pressure += tire_pressure;
     }

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -70,10 +70,11 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
   if (depth > s.maximum_depth) {
     s.maximum_depth = depth;
   }
+  simdjson::error_code error;
   if (element.is<simdjson::dom::array>()) {
     s.array_count++;
-    auto [array, array_error] = element.get<simdjson::dom::array>();
-    if (!array_error) {
+    simdjson::dom::array array;
+    if (element.get(array, error)) {
       size_t counter = 0;
       for (auto child : array) {
         counter++;
@@ -85,8 +86,8 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
     }
   } else if (element.is<simdjson::dom::object>()) {
     s.object_count++;
-    auto [object, object_error] = element.get<simdjson::dom::object>();
-    if (!object_error) {
+    simdjson::dom::object object;
+    if (element.get(object, error)) {
       size_t counter = 0;
       for (auto [key, value] : object) {
         counter++;
@@ -116,7 +117,6 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
       }
     }
   } else {
-    simdjson::error_code error;
     if (element.is<int64_t>()) {
       s.integer_count++; // because an int can be sometimes represented as a double, we
       // to check whether it is an integer first!!!

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -121,7 +121,7 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
       s.integer_count++; // because an int can be sometimes represented as a double, we
       // to check whether it is an integer first!!!
       int64_t v;
-      element.get<int64_t>().tie(v,error);
+      element.get(v,error);
       if((v >= std::numeric_limits<int32_t>::min()) and (v <= std::numeric_limits<int32_t>::max()) ) {
         s.integer32_count++;
       }
@@ -135,7 +135,7 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
       s.float_count++;
     } else if (element.is<bool>()) {
       bool v;
-      element.get<bool>().tie(v,error);
+      element.get(v,error);
       if (v) {
         s.true_count++;
       } else {
@@ -146,7 +146,7 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
     } else if (element.is<std::string_view>()) {
       s.string_count++;
       std::string_view v;
-      element.get<std::string_view>().tie(v,error);
+      element.get(v,error);
       if (is_ascii(v)) {
         s.ascii_string_count++;
       }

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -74,7 +74,7 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
   if (element.is<simdjson::dom::array>()) {
     s.array_count++;
     simdjson::dom::array array;
-    if (element.get(array, error)) {
+    if (not (error = element.get(array))) {
       size_t counter = 0;
       for (auto child : array) {
         counter++;
@@ -87,7 +87,7 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
   } else if (element.is<simdjson::dom::object>()) {
     s.object_count++;
     simdjson::dom::object object;
-    if (element.get(object, error)) {
+    if (not (error = element.get(object))) {
       size_t counter = 0;
       for (auto [key, value] : object) {
         counter++;
@@ -121,7 +121,8 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
       s.integer_count++; // because an int can be sometimes represented as a double, we
       // to check whether it is an integer first!!!
       int64_t v;
-      element.get(v,error);
+      error = element.get(v);
+      SIMDJSON_ASSUME(!error);
       if((v >= std::numeric_limits<int32_t>::min()) and (v <= std::numeric_limits<int32_t>::max()) ) {
         s.integer32_count++;
       }
@@ -135,7 +136,8 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
       s.float_count++;
     } else if (element.is<bool>()) {
       bool v;
-      element.get(v,error);
+      error = element.get(v);
+      SIMDJSON_ASSUME(!error);
       if (v) {
         s.true_count++;
       } else {
@@ -146,7 +148,8 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
     } else if (element.is<std::string_view>()) {
       s.string_count++;
       std::string_view v;
-      element.get(v,error);
+      error = element.get(v);
+      SIMDJSON_ASSUME(!error);
       if (is_ascii(v)) {
         s.ascii_string_count++;
       }
@@ -155,8 +158,7 @@ void recurse(simdjson::dom::element element, stat_t &s, size_t depth) {
         s.string_maximum_length = v.size();
       }
     } else {
-      std::cerr << "unrecognized node." << std::endl;
-      abort();
+      SIMDJSON_UNREACHABLE();
     }
   }
 }


### PR DESCRIPTION
This adds a get(v) method that acts as ergonomic shorthand for get<type>().tie(v, error). It returns the error code so you can use it in contorl flow. I like it even better than `auto [v,error]` as well, in most cases. It simplifies things considerably.

### Comparison

* New version:
  ```c++
  int64_t val;
  if ((error = obj["val"].get(val))) { cerr << error << endl; return; }
  cout << val << endl;
  ```
* Old version with auto (C++14): *this feels like it buries the lead (the fact that we're getting an int64_t out)*
  ```c++
  auto [val, error] = obj["val"].get<int64_t>();
  if (error) { cerr << error << endl; return; }
  cout << val << endl;
  ```
* Old version with tie (C++11): *this is verbose and not control flow friendly*
  ```c++
  int64_t val;
  obj["val"].get<int64_t>().tie(val, error);
  if (error) { cerr << error << endl; return; }
  cout << val << endl;
  ```
* New version without if: *For comparison, if you don't like stuff in your if statements :)*
  ```c++
  int64_t val;
  error = obj["val"].get(val);
  if (error) { cerr << error << endl; return; }
  cout << val << endl;
  ```

### Changes

* You don't have to write the type name twice anymore.
* You can include the call in control flow (as an if or while condition) if you so desire.
* It's even better than auto in many cases because it's easier see the type of your variable when you declare it (since it's prominent on the left where you are usually looking).
* I added it to simdjson_result and it feels consistent throughout the library.
* I had it stop assigning to value if there is an error, and uninitialized warnings revealed a few places where we were using value even when there was an error! I would like to leave this for developer safety--make it impossible to do this without a warning.
  - To do this, I added SIMDJSON_UNREACHABLE and SIMDJSON_ASSUME macros to use in perf tests.

## Example

I've converted the README, tools, benchmarks, and a lot of the examples to it.
