### PR TITLE
Return error from parse_many

### DIFF
--- a/benchmark/parse_stream.cpp
+++ b/benchmark/parse_stream.cpp
@@ -87,10 +87,15 @@ int main(int argc, char *argv[]) {
 
         auto start = std::chrono::steady_clock::now();
         count = 0;
-        for (auto result : parser.parse_many(p, i)) {
+        simdjson::dom::document_stream docs;
+        if ((error = parser.parse_many(p, i).get(docs))) {
+          std::wcerr << "Parsing failed with: " << error << std::endl;
+          exit(1);
+        }
+        for (auto result : docs) {
           error = result.error();
-          if (error != simdjson::SUCCESS) {
-            std::wcerr << "Parsing failed with: " <<  error_message(error) << std::endl;
+          if (error) {
+            std::wcerr << "Parsing failed with: " << error << std::endl;
             exit(1);
           }
           count++;
@@ -134,10 +139,15 @@ int main(int argc, char *argv[]) {
 
       auto start = std::chrono::steady_clock::now();
       // This includes allocation of the parser
-      for (auto result : parser.parse_many(p, optimal_batch_size)) {
+      simdjson::dom::document_stream docs;
+      if ((error = parser.parse_many(p, optimal_batch_size).get(docs))) {
+        std::wcerr << "Parsing failed with: " << error << std::endl;
+        exit(1);
+      }
+      for (auto result : docs) {
         error = result.error();
-        if (error != simdjson::SUCCESS) {
-          std::wcerr << "Parsing failed with: " << error_message(error) << std::endl;
+        if (error) {
+          std::wcerr << "Parsing failed with: " << error << std::endl;
           exit(1);
         }
       }

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -489,7 +489,8 @@ Here is a simple example, given "x.json" with this content:
 
 ```c++
 dom::parser parser;
-for (dom::element doc : parser.load_many(filename)) {
+dom::document_stream docs = parser.load_many(filename);
+for (dom::element doc : docs) {
   cout << doc["foo"] << endl;
 }
 // Prints 1 2 3

--- a/include/simdjson/dom/document_stream.h
+++ b/include/simdjson/dom/document_stream.h
@@ -143,8 +143,7 @@ public:
 private:
 
   document_stream &operator=(const document_stream &) = delete; // Disallow copying
-
-  document_stream(document_stream &other) = delete; // Disallow copying
+  document_stream(const document_stream &other) = delete; // Disallow copying
 
   /**
    * Construct a document_stream. Does not allocate or parse anything until the iterator is

--- a/include/simdjson/dom/document_stream.h
+++ b/include/simdjson/dom/document_stream.h
@@ -232,8 +232,8 @@ private:
 #endif // SIMDJSON_THREADS_ENABLED
 
   friend class dom::parser;
-  friend class simdjson_result<dom::document_stream>;
-  friend class internal::simdjson_result_base<dom::document_stream>;
+  friend struct simdjson_result<dom::document_stream>;
+  friend struct internal::simdjson_result_base<dom::document_stream>;
 
 }; // class document_stream
 

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -243,25 +243,6 @@ public:
   template<typename T>
   inline void tie(T &value, error_code &error) && noexcept;
 
-  /**
-   * Get the value as the provided type (T).
-   *
-   * Supported types:
-   * - Boolean: bool
-   * - Number: double, uint64_t, int64_t
-   * - String: std::string_view, const char *
-   * - Array: dom::array
-   * - Object: dom::object
-   *
-   * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
-   *
-   * @param value The variable to set to the given type. value is undefined if there is an error.
-   *
-   * @returns true if the value was able to be set, false if there was an error.
-   */
-  template<typename T>
-  WARN_UNUSED inline bool tie(T &value) && noexcept;
-
 #if SIMDJSON_EXCEPTIONS
   /**
    * Read this element as a boolean.

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -193,14 +193,13 @@ public:
    *                   spot is cache-related: small enough to fit in cache, yet big enough to
    *                   parse as many documents as possible in one tight loop.
    *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
-   * @return The stream. If there is an error, it will be returned during iteration. An empty input
-   *         will yield 0 documents rather than an EMPTY error. Errors:
+   * @return The stream, or an error. An empty input will yield 0 documents rather than an EMPTY error. Errors:
    *         - IO_ERROR if there was an error opening or reading the file.
    *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails.
    *         - CAPACITY if the parser does not have enough capacity and batch_size > max_capacity.
    *         - other json errors if parsing fails.
    */
-  inline document_stream load_many(const std::string &path, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> load_many(const std::string &path, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
 
   /**
    * Parse a buffer containing many JSON documents.
@@ -260,22 +259,21 @@ public:
    *                   spot is cache-related: small enough to fit in cache, yet big enough to
    *                   parse as many documents as possible in one tight loop.
    *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
-   * @return The stream. If there is an error, it will be returned during iteration. An empty input
-   *         will yield 0 documents rather than an EMPTY error. Errors:
+   * @return The stream, or an error. An empty input will yield 0 documents rather than an EMPTY error. Errors:
    *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails
    *         - CAPACITY if the parser does not have enough capacity and batch_size > max_capacity.
    *         - other json errors if parsing fails.
    */
-  inline document_stream parse_many(const uint8_t *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const uint8_t *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline document_stream parse_many(const char *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const char *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline document_stream parse_many(const std::string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const std::string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline document_stream parse_many(const padded_string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const padded_string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
 
   /** @private We do not want to allow implicit conversion from C string to std::string. */
-  really_inline simdjson_result<element> parse_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
+  simdjson_result<document_stream> parse_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
 
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -205,7 +205,7 @@ public:
    * Parse a buffer containing many JSON documents.
    *
    *   dom::parser parser;
-   *   for (const element doc : parser.parse_many(buf, len)) {
+   *   for (element doc : parser.parse_many(buf, len)) {
    *     cout << std::string(doc["title"]) << endl;
    *   }
    *

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -251,6 +251,5 @@ really_inline dom::document_stream::iterator simdjson_result<dom::document_strea
 }
 #endif // SIMDJSON_EXCEPTIONS
 
-
 } // namespace simdjson
 #endif // SIMDJSON_INLINE_DOCUMENT_STREAM_H

--- a/include/simdjson/inline/document_stream.h
+++ b/include/simdjson/inline/document_stream.h
@@ -70,7 +70,7 @@ really_inline document_stream::document_stream(
   size_t _len,
   size_t _batch_size
 ) noexcept
-  : parser{_parser},
+  : parser{&_parser},
     buf{_buf},
     len{_len},
     batch_size{_batch_size},
@@ -83,7 +83,15 @@ really_inline document_stream::document_stream(
 #endif
 }
 
-inline document_stream::~document_stream() noexcept {
+really_inline document_stream::document_stream() noexcept
+  : parser{nullptr},
+    buf{nullptr},
+    len{0},
+    batch_size{0},
+    error{UNINITIALIZED} {
+}
+
+really_inline document_stream::~document_stream() noexcept {
 }
 
 really_inline document_stream::iterator document_stream::begin() noexcept {
@@ -103,7 +111,7 @@ really_inline document_stream::iterator::iterator(document_stream& _stream, bool
 really_inline simdjson_result<element> document_stream::iterator::operator*() noexcept {
   // Once we have yielded any errors, we're finished.
   if (stream.error) { finished = true; return stream.error; }
-  return stream.parser.doc.root();
+  return stream.parser->doc.root();
 }
 
 really_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
@@ -120,12 +128,12 @@ really_inline bool document_stream::iterator::operator!=(const document_stream::
 inline void document_stream::start() noexcept {
   if (error) { return; }
 
-  error = parser.ensure_capacity(batch_size);
+  error = parser->ensure_capacity(batch_size);
   if (error) { return; }
 
   // Always run the first stage 1 parse immediately
   batch_start = 0;
-  error = run_stage1(parser, batch_start);
+  error = run_stage1(*parser, batch_start);
   if (error) { return; }
 
 #ifdef SIMDJSON_THREADS_ENABLED
@@ -149,8 +157,8 @@ inline void document_stream::next() noexcept {
   if (error) { return; }
 
   // Load the next document from the batch
-  doc_index = batch_start + parser.implementation->structural_indexes[parser.implementation->next_structural_index];
-  error = parser.implementation->stage2_next(parser.doc);
+  doc_index = batch_start + parser->implementation->structural_indexes[parser->implementation->next_structural_index];
+  error = parser->implementation->stage2_next(parser->doc);
   // If that was the last document in the batch, load another batch (if available)
   while (error == EMPTY) {
     batch_start = next_batch_start();
@@ -159,17 +167,17 @@ inline void document_stream::next() noexcept {
 #ifdef SIMDJSON_THREADS_ENABLED
     load_from_stage1_thread();
 #else
-    error = run_stage1(parser, batch_start);
+    error = run_stage1(*parser, batch_start);
 #endif
     if (error) { continue; } // If the error was EMPTY, we may want to load another batch.
     // Run stage 2 on the first document in the batch
-    doc_index = batch_start + parser.implementation->structural_indexes[parser.implementation->next_structural_index];
-    error = parser.implementation->stage2_next(parser.doc);
+    doc_index = batch_start + parser->implementation->structural_indexes[parser->implementation->next_structural_index];
+    error = parser->implementation->stage2_next(parser->doc);
   }
 }
 
 inline size_t document_stream::next_batch_start() const noexcept {
-  return batch_start + parser.implementation->structural_indexes[parser.implementation->n_structural_indexes];
+  return batch_start + parser->implementation->structural_indexes[parser->implementation->n_structural_indexes];
 }
 
 inline error_code document_stream::run_stage1(dom::parser &p, size_t _batch_start) noexcept {
@@ -188,7 +196,7 @@ inline void document_stream::load_from_stage1_thread() noexcept {
   worker->finish();
   // Swap to the parser that was loaded up in the thread. Make sure the parser has
   // enough memory to swap to, as well.
-  std::swap(parser, stage1_thread_parser);
+  std::swap(*parser, stage1_thread_parser);
   error = stage1_thread_error;
   if (error) { return; }
 

--- a/include/simdjson/inline/error.h
+++ b/include/simdjson/inline/error.h
@@ -53,9 +53,7 @@ really_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && 
 
 template<typename T>
 WARN_UNUSED really_inline error_code simdjson_result_base<T>::get(T &value) && noexcept {
-  error_code error;
-  std::forward<simdjson_result_base<T>>(*this).tie(value, error);
-  return error;
+  return std::forward<simdjson_result_base<T>>(*this).get(value);
 }
 
 template<typename T>

--- a/include/simdjson/inline/error.h
+++ b/include/simdjson/inline/error.h
@@ -53,7 +53,9 @@ really_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && 
 
 template<typename T>
 WARN_UNUSED really_inline error_code simdjson_result_base<T>::get(T &value) && noexcept {
-  return std::forward<simdjson_result_base<T>>(*this).get(value);
+  error_code error;
+  std::forward<simdjson_result_base<T>>(*this).tie(value, error);
+  return error;
 }
 
 template<typename T>

--- a/include/simdjson/inline/parser.h
+++ b/include/simdjson/inline/parser.h
@@ -80,17 +80,14 @@ inline simdjson_result<element> parser::load(const std::string &path) & noexcept
   size_t len;
   auto _error = read_file(path).get(len);
   if (_error) { return _error; }
-
   return parse(loaded_bytes.get(), len, false);
 }
 
-inline document_stream parser::load_many(const std::string &path, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::load_many(const std::string &path, size_t batch_size) noexcept {
   size_t len;
   auto _error = read_file(path).get(len);
-  if (_error) {
-    return document_stream(*this, batch_size, _error);
-  }
-  return document_stream(*this, batch_size, (const uint8_t*)loaded_bytes.get(), len);
+  if (_error) { return _error; }
+  return document_stream(*this, (const uint8_t*)loaded_bytes.get(), len, batch_size);
 }
 
 inline simdjson_result<element> parser::parse(const uint8_t *buf, size_t len, bool realloc_if_needed) & noexcept {
@@ -123,16 +120,16 @@ really_inline simdjson_result<element> parser::parse(const padded_string &s) & n
   return parse(s.data(), s.length(), false);
 }
 
-inline document_stream parser::parse_many(const uint8_t *buf, size_t len, size_t batch_size) noexcept {
-  return document_stream(*this, batch_size, buf, len);
+inline simdjson_result<document_stream> parser::parse_many(const uint8_t *buf, size_t len, size_t batch_size) noexcept {
+  return document_stream(*this, buf, len, batch_size);
 }
-inline document_stream parser::parse_many(const char *buf, size_t len, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::parse_many(const char *buf, size_t len, size_t batch_size) noexcept {
   return parse_many((const uint8_t *)buf, len, batch_size);
 }
-inline document_stream parser::parse_many(const std::string &s, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::parse_many(const std::string &s, size_t batch_size) noexcept {
   return parse_many(s.data(), s.length(), batch_size);
 }
-inline document_stream parser::parse_many(const padded_string &s, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::parse_many(const padded_string &s, size_t batch_size) noexcept {
   return parse_many(s.data(), s.length(), batch_size);
 }
 

--- a/singleheader/amalgamate.sh
+++ b/singleheader/amalgamate.sh
@@ -135,9 +135,8 @@ int main(int argc, char *argv[]) {
   }
   const char * filename = argv[1];
   simdjson::dom::parser parser;
-  simdjson::error_code error;
   UNUSED simdjson::dom::element elem;
-  parser.load(filename).tie(elem, error); // do the parsing
+  auto error = parser.load(filename).get(elem); // do the parsing
   if (error) {
     std::cout << "parse failed" << std::endl;
     std::cout << "error code: " << error << std::endl;
@@ -152,8 +151,12 @@ int main(int argc, char *argv[]) {
 
   // parse_many
   const char * filename2 = argv[2];
-  for (auto result : parser.load_many(filename2)) {
-    error = result.error();
+  simdjson::dom::document_stream stream;
+  error = parser.load_many(filename2).get(stream);
+  if (!error) {
+    for (auto result : stream) {
+      error = result.error();
+    }
   }
   if (error) {
     std::cout << "parse_many failed" << std::endl;

--- a/singleheader/amalgamate_demo.cpp
+++ b/singleheader/amalgamate_demo.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Fri 12 Jun 2020 13:09:36 EDT. Do not edit! */
+/* auto-generated on Sat Jun 20 21:35:29 PDT 2020. Do not edit! */
 
 #include <iostream>
 #include "simdjson.h"
@@ -9,9 +9,8 @@ int main(int argc, char *argv[]) {
   }
   const char * filename = argv[1];
   simdjson::dom::parser parser;
-  simdjson::error_code error;
   UNUSED simdjson::dom::element elem;
-  parser.load(filename).tie(elem, error); // do the parsing
+  auto error = parser.load(filename).get(elem); // do the parsing
   if (error) {
     std::cout << "parse failed" << std::endl;
     std::cout << "error code: " << error << std::endl;
@@ -26,8 +25,12 @@ int main(int argc, char *argv[]) {
 
   // parse_many
   const char * filename2 = argv[2];
-  for (auto result : parser.load_many(filename2)) {
-    error = result.error();
+  simdjson::dom::document_stream stream;
+  error = parser.load_many(filename2).get(stream);
+  if (!error) {
+    for (auto result : stream) {
+      error = result.error();
+    }
   }
   if (error) {
     std::cout << "parse_many failed" << std::endl;

--- a/singleheader/amalgamate_demo.cpp
+++ b/singleheader/amalgamate_demo.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Sat Jun 20 21:35:29 PDT 2020. Do not edit! */
+/* auto-generated on Sun Jun 21 11:49:12 PDT 2020. Do not edit! */
 
 #include <iostream>
 #include "simdjson.h"

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Fri 12 Jun 2020 13:09:36 EDT. Do not edit! */
+/* auto-generated on Sat Jun 20 21:35:29 PDT 2020. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 
@@ -585,6 +585,11 @@ const implementation *detect_best_supported_implementation_on_first_use::set_bes
 
 SIMDJSON_DLLIMPORTEXPORT const internal::available_implementation_list available_implementations{};
 SIMDJSON_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> active_implementation{&internal::detect_best_supported_implementation_on_first_use_singleton};
+
+WARN_UNUSED error_code minify(const char *buf, size_t len, char *dst, size_t &dst_len) noexcept {
+  return active_implementation->minify((const uint8_t *)buf, len, (uint8_t *)dst, dst_len);
+}
+
 
 } // namespace simdjson
 /* end file src/fallback/implementation.h */
@@ -2794,6 +2799,12 @@ really_inline simd8<bool> must_be_continuation(simd8<uint8_t> prev1, simd8<uint8
     return is_second_byte ^ is_third_byte ^ is_fourth_byte;
 }
 
+really_inline simd8<bool> must_be_2_3_continuation(simd8<uint8_t> prev2, simd8<uint8_t> prev3) {
+    simd8<bool> is_third_byte  = prev2 >= uint8_t(0b11100000u);
+    simd8<bool> is_fourth_byte = prev3 >= uint8_t(0b11110000u);
+    return is_third_byte ^ is_fourth_byte;
+}
+
 /* begin file src/generic/stage1/buf_block_reader.h */
 // Walks through a buffer in block-sized increments, loading the last part with spaces
 template<size_t STEP_SIZE>
@@ -2921,7 +2932,9 @@ public:
   really_inline error_code finish(bool streaming);
 
 private:
+  // Intended to be defined by the implementation
   really_inline uint64_t find_escaped(uint64_t escape);
+  really_inline uint64_t find_escaped_branchless(uint64_t escape);
 
   // Whether the last iteration was still inside a string (all 1's = true, all 0's = false).
   uint64_t prev_in_string = 0ULL;
@@ -2956,7 +2969,7 @@ private:
 // desired        |   x  | x x  x x  x x  x  x  |
 // text           |  \\\ | \\\"\\\" \\\" \\"\\" |
 //
-really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+really_inline uint64_t json_string_scanner::find_escaped_branchless(uint64_t backslash) {
   // If there was overflow, pretend the first character isn't a backslash
   backslash &= ~prev_escaped;
   uint64_t follows_escape = backslash << 1 | prev_escaped;
@@ -2985,13 +2998,23 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
   const uint64_t backslash = in.eq('\\');
   const uint64_t escaped = find_escaped(backslash);
   const uint64_t quote = in.eq('"') & ~escaped;
+
+  //
   // prefix_xor flips on bits inside the string (and flips off the end quote).
+  //
   // Then we xor with prev_in_string: if we were in a string already, its effect is flipped
   // (characters inside strings are outside, and characters outside strings are inside).
+  //
   const uint64_t in_string = prefix_xor(quote) ^ prev_in_string;
+
+  //
+  // Check if we're still in a string at the end of the box so the next block will know
+  //
   // right shift of a signed value expected to be well-defined and standard
   // compliant as of C++20, John Regher from Utah U. says this is fine code
+  //
   prev_in_string = uint64_t(static_cast<int64_t>(in_string) >> 63);
+
   // Use ^ to turn the beginning quote off, and the end quote on.
   return {
     backslash,
@@ -3116,6 +3139,15 @@ really_inline error_code json_scanner::finish(bool streaming) {
 
 } // namespace stage1
 /* end file src/generic/stage1/json_scanner.h */
+
+namespace stage1 {
+really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+  // On ARM, we don't short-circuit this if there are no backslashes, because the branch gives us no
+  // benefit and therefore makes things worse.
+  // if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
+  return find_escaped_branchless(backslash);
+}
+}
 
 /* begin file src/generic/stage1/json_minifier.h */
 // This file contains the common code every implementation uses in stage1
@@ -3288,7 +3320,7 @@ really_inline static size_t trim_partial_utf8(const uint8_t *buf, size_t len) {
   return len;
 }
 /* end file src/generic/stage1/find_next_document_index.h */
-/* begin file src/generic/stage1/utf8_lookup2_algorithm.h */
+/* begin file src/generic/stage1/utf8_lookup3_algorithm.h */
 //
 // Detect Unicode errors.
 //
@@ -3380,66 +3412,78 @@ namespace utf8_validation {
     static const int TOO_LARGE   = 0x10; // 11110100 (1001|101_)____
     static const int TOO_LARGE_2 = 0x20; // 1111(1___|011_|0101) 10______
 
+    // New with lookup3. We want to catch the case where an non-continuation 
+    // follows a leading byte
+    static const int TOO_SHORT_2_3_4 = 0x40; //  (110_|1110|1111) ____    (0___|110_|1111) ____
+    // We also want to catch a continuation that is preceded by an ASCII byte
+    static const int LONELY_CONTINUATION = 0x80; //  0___ ____    01__ ____
+
     // After processing the rest of byte 1 (the low bits), we're still not done--we have to check
     // byte 2 to be sure which things are errors and which aren't.
     // Since high_bits is byte 5, byte 2 is high_bits.prev<3>
     static const int CARRY = OVERLONG_2 | TOO_LARGE_2;
     const simd8<uint8_t> byte_2_high = input.shr<4>().lookup_16<uint8_t>(
         // ASCII: ________ [0___]____
-        CARRY, CARRY, CARRY, CARRY,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
         // ASCII: ________ [0___]____
-        CARRY, CARRY, CARRY, CARRY,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
         // Continuations: ________ [10__]____
-        CARRY | OVERLONG_3 | OVERLONG_4, // ________ [1000]____
-        CARRY | OVERLONG_3 | TOO_LARGE,  // ________ [1001]____
-        CARRY | TOO_LARGE  | SURROGATE,  // ________ [1010]____
-        CARRY | TOO_LARGE  | SURROGATE,  // ________ [1011]____
+        CARRY | OVERLONG_3 | OVERLONG_4 | LONELY_CONTINUATION, // ________ [1000]____
+        CARRY | OVERLONG_3 | TOO_LARGE | LONELY_CONTINUATION,  // ________ [1001]____
+        CARRY | TOO_LARGE  | SURROGATE | LONELY_CONTINUATION,  // ________ [1010]____
+        CARRY | TOO_LARGE  | SURROGATE | LONELY_CONTINUATION,  // ________ [1011]____
         // Multibyte Leads: ________ [11__]____
-        CARRY, CARRY, CARRY, CARRY
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,  // 110_
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4
     );
-
     const simd8<uint8_t> byte_1_high = prev1.shr<4>().lookup_16<uint8_t>(
       // [0___]____ (ASCII)
-      0, 0, 0, 0,
-      0, 0, 0, 0,
+      LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION,
+      LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION,
       // [10__]____ (continuation)
       0, 0, 0, 0,
       // [11__]____ (2+-byte leads)
-      OVERLONG_2, 0,                       // [110_]____ (2-byte lead)
-      OVERLONG_3 | SURROGATE,              // [1110]____ (3-byte lead)
-      OVERLONG_4 | TOO_LARGE | TOO_LARGE_2 // [1111]____ (4+-byte lead)
+      OVERLONG_2 | TOO_SHORT_2_3_4, TOO_SHORT_2_3_4,         // [110_]____ (2-byte lead)
+      OVERLONG_3 | SURROGATE | TOO_SHORT_2_3_4,              // [1110]____ (3-byte lead)
+      OVERLONG_4 | TOO_LARGE | TOO_LARGE_2 | TOO_SHORT_2_3_4 // [1111]____ (4+-byte lead)
     );
-
     const simd8<uint8_t> byte_1_low = (prev1 & 0x0F).lookup_16<uint8_t>(
       // ____[00__] ________
-      OVERLONG_2 | OVERLONG_3 | OVERLONG_4, // ____[0000] ________
-      OVERLONG_2,                           // ____[0001] ________
-      0, 0,
+      OVERLONG_2 | OVERLONG_3 | OVERLONG_4 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION, // ____[0000] ________
+      OVERLONG_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,                           // ____[0001] ________
+      TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[01__] ________
-      TOO_LARGE,                            // ____[0100] ________
-      TOO_LARGE_2,
-      TOO_LARGE_2,
-      TOO_LARGE_2,
+      TOO_LARGE | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,                            // ____[0100] ________
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[10__] ________
-      TOO_LARGE_2, TOO_LARGE_2, TOO_LARGE_2, TOO_LARGE_2,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[11__] ________
-      TOO_LARGE_2,
-      TOO_LARGE_2 | SURROGATE,                            // ____[1101] ________
-      TOO_LARGE_2, TOO_LARGE_2
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | SURROGATE | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,              // ____[1101] ________
+      TOO_LARGE_2 | TOO_SHORT_2_3_4| LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION
     );
-
     return byte_1_high & byte_1_low & byte_2_high;
   }
 
-  really_inline simd8<uint8_t> check_multibyte_lengths(simd8<uint8_t> input, simd8<uint8_t> prev_input, simd8<uint8_t> prev1) {
+  really_inline simd8<uint8_t> check_multibyte_lengths(simd8<uint8_t> input, simd8<uint8_t> prev_input,
+      simd8<uint8_t> prev1) {
     simd8<uint8_t> prev2 = input.prev<2>(prev_input);
     simd8<uint8_t> prev3 = input.prev<3>(prev_input);
-
-    // Cont is 10000000-101111111 (-65...-128)
-    simd8<bool> is_continuation = simd8<int8_t>(input) < int8_t(-64);
-    // must_be_continuation is architecture-specific because Intel doesn't have unsigned comparisons
-    return simd8<uint8_t>(must_be_continuation(prev1, prev2, prev3) ^ is_continuation);
+    // is_2_3_continuation uses one more instruction than lookup2
+    simd8<bool> is_2_3_continuation = (simd8<int8_t>(input).max(simd8<int8_t>(prev1))) < int8_t(-64);
+    // must_be_2_3_continuation has two fewer instructions than lookup 2
+    return simd8<uint8_t>(must_be_2_3_continuation(prev2, prev3) ^ is_2_3_continuation);
   }
+
 
   //
   // Return nonzero if there are incomplete multibyte characters at the end of the block:
@@ -3507,7 +3551,7 @@ namespace utf8_validation {
 }
 
 using utf8_validation::utf8_checker;
-/* end file src/generic/stage1/utf8_lookup2_algorithm.h */
+/* end file src/generic/stage1/utf8_lookup3_algorithm.h */
 /* begin file src/generic/stage1/json_structural_indexer.h */
 // This file contains the common code every implementation uses in stage1
 // It is intended to be included multiple times and compiled multiple times
@@ -4432,7 +4476,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       }
       // we over-decrement by one when there is a '.'
       digit_count -= int(start - start_digits);
-      if (unlikely(digit_count >= 19)) {
+      if (digit_count >= 19) {
         // Ok, chances are good that we had an overflow!
         // this is almost never going to get called!!!
         // we start anew, going slowly!!!
@@ -4442,7 +4486,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
         //
         bool success = slow_float_parsing((const char *) src, writer);
         // The number was already written, but we made a copy of the writer
-        // when we passed it to the parse_large_integer() function, so 
+        // when we passed it to the parse_large_integer() function, so
         writer.skip_double();
         return success;
       }
@@ -4481,7 +4525,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       // need to recover: we parse the whole thing again.
       bool success = parse_large_integer(src, writer, found_minus);
       // The number was already written, but we made a copy of the writer
-      // when we passed it to the parse_large_integer() function, so 
+      // when we passed it to the parse_large_integer() function, so
       writer.skip_large_integer();
       return success;
     }
@@ -6525,7 +6569,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       }
       // we over-decrement by one when there is a '.'
       digit_count -= int(start - start_digits);
-      if (unlikely(digit_count >= 19)) {
+      if (digit_count >= 19) {
         // Ok, chances are good that we had an overflow!
         // this is almost never going to get called!!!
         // we start anew, going slowly!!!
@@ -6535,7 +6579,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
         //
         bool success = slow_float_parsing((const char *) src, writer);
         // The number was already written, but we made a copy of the writer
-        // when we passed it to the parse_large_integer() function, so 
+        // when we passed it to the parse_large_integer() function, so
         writer.skip_double();
         return success;
       }
@@ -6574,7 +6618,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       // need to recover: we parse the whole thing again.
       bool success = parse_large_integer(src, writer, found_minus);
       // The number was already written, but we made a copy of the writer
-      // when we passed it to the parse_large_integer() function, so 
+      // when we passed it to the parse_large_integer() function, so
       writer.skip_large_integer();
       return success;
     }
@@ -8119,6 +8163,14 @@ really_inline simd8<bool> must_be_continuation(simd8<uint8_t> prev1, simd8<uint8
   return simd8<int8_t>(is_second_byte | is_third_byte | is_fourth_byte) > int8_t(0);
 }
 
+really_inline simd8<bool> must_be_2_3_continuation(simd8<uint8_t> prev2, simd8<uint8_t> prev3) {
+  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0b11100000u-1); // Only 111_____ will be > 0
+  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0b11110000u-1); // Only 1111____ will be > 0
+  // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
+  return simd8<int8_t>(is_third_byte | is_fourth_byte) > int8_t(0);
+}
+
+
 /* begin file src/generic/stage1/buf_block_reader.h */
 // Walks through a buffer in block-sized increments, loading the last part with spaces
 template<size_t STEP_SIZE>
@@ -8246,7 +8298,9 @@ public:
   really_inline error_code finish(bool streaming);
 
 private:
+  // Intended to be defined by the implementation
   really_inline uint64_t find_escaped(uint64_t escape);
+  really_inline uint64_t find_escaped_branchless(uint64_t escape);
 
   // Whether the last iteration was still inside a string (all 1's = true, all 0's = false).
   uint64_t prev_in_string = 0ULL;
@@ -8281,7 +8335,7 @@ private:
 // desired        |   x  | x x  x x  x x  x  x  |
 // text           |  \\\ | \\\"\\\" \\\" \\"\\" |
 //
-really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+really_inline uint64_t json_string_scanner::find_escaped_branchless(uint64_t backslash) {
   // If there was overflow, pretend the first character isn't a backslash
   backslash &= ~prev_escaped;
   uint64_t follows_escape = backslash << 1 | prev_escaped;
@@ -8310,13 +8364,23 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
   const uint64_t backslash = in.eq('\\');
   const uint64_t escaped = find_escaped(backslash);
   const uint64_t quote = in.eq('"') & ~escaped;
+
+  //
   // prefix_xor flips on bits inside the string (and flips off the end quote).
+  //
   // Then we xor with prev_in_string: if we were in a string already, its effect is flipped
   // (characters inside strings are outside, and characters outside strings are inside).
+  //
   const uint64_t in_string = prefix_xor(quote) ^ prev_in_string;
+
+  //
+  // Check if we're still in a string at the end of the box so the next block will know
+  //
   // right shift of a signed value expected to be well-defined and standard
   // compliant as of C++20, John Regher from Utah U. says this is fine code
+  //
   prev_in_string = uint64_t(static_cast<int64_t>(in_string) >> 63);
+
   // Use ^ to turn the beginning quote off, and the end quote on.
   return {
     backslash,
@@ -8441,6 +8505,13 @@ really_inline error_code json_scanner::finish(bool streaming) {
 
 } // namespace stage1
 /* end file src/generic/stage1/json_scanner.h */
+
+namespace stage1 {
+really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+  if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
+  return find_escaped_branchless(backslash);
+}
+}
 
 /* begin file src/generic/stage1/json_minifier.h */
 // This file contains the common code every implementation uses in stage1
@@ -8613,7 +8684,7 @@ really_inline static size_t trim_partial_utf8(const uint8_t *buf, size_t len) {
   return len;
 }
 /* end file src/generic/stage1/find_next_document_index.h */
-/* begin file src/generic/stage1/utf8_lookup2_algorithm.h */
+/* begin file src/generic/stage1/utf8_lookup3_algorithm.h */
 //
 // Detect Unicode errors.
 //
@@ -8705,66 +8776,78 @@ namespace utf8_validation {
     static const int TOO_LARGE   = 0x10; // 11110100 (1001|101_)____
     static const int TOO_LARGE_2 = 0x20; // 1111(1___|011_|0101) 10______
 
+    // New with lookup3. We want to catch the case where an non-continuation 
+    // follows a leading byte
+    static const int TOO_SHORT_2_3_4 = 0x40; //  (110_|1110|1111) ____    (0___|110_|1111) ____
+    // We also want to catch a continuation that is preceded by an ASCII byte
+    static const int LONELY_CONTINUATION = 0x80; //  0___ ____    01__ ____
+
     // After processing the rest of byte 1 (the low bits), we're still not done--we have to check
     // byte 2 to be sure which things are errors and which aren't.
     // Since high_bits is byte 5, byte 2 is high_bits.prev<3>
     static const int CARRY = OVERLONG_2 | TOO_LARGE_2;
     const simd8<uint8_t> byte_2_high = input.shr<4>().lookup_16<uint8_t>(
         // ASCII: ________ [0___]____
-        CARRY, CARRY, CARRY, CARRY,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
         // ASCII: ________ [0___]____
-        CARRY, CARRY, CARRY, CARRY,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
         // Continuations: ________ [10__]____
-        CARRY | OVERLONG_3 | OVERLONG_4, // ________ [1000]____
-        CARRY | OVERLONG_3 | TOO_LARGE,  // ________ [1001]____
-        CARRY | TOO_LARGE  | SURROGATE,  // ________ [1010]____
-        CARRY | TOO_LARGE  | SURROGATE,  // ________ [1011]____
+        CARRY | OVERLONG_3 | OVERLONG_4 | LONELY_CONTINUATION, // ________ [1000]____
+        CARRY | OVERLONG_3 | TOO_LARGE | LONELY_CONTINUATION,  // ________ [1001]____
+        CARRY | TOO_LARGE  | SURROGATE | LONELY_CONTINUATION,  // ________ [1010]____
+        CARRY | TOO_LARGE  | SURROGATE | LONELY_CONTINUATION,  // ________ [1011]____
         // Multibyte Leads: ________ [11__]____
-        CARRY, CARRY, CARRY, CARRY
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,  // 110_
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4
     );
-
     const simd8<uint8_t> byte_1_high = prev1.shr<4>().lookup_16<uint8_t>(
       // [0___]____ (ASCII)
-      0, 0, 0, 0,
-      0, 0, 0, 0,
+      LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION,
+      LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION,
       // [10__]____ (continuation)
       0, 0, 0, 0,
       // [11__]____ (2+-byte leads)
-      OVERLONG_2, 0,                       // [110_]____ (2-byte lead)
-      OVERLONG_3 | SURROGATE,              // [1110]____ (3-byte lead)
-      OVERLONG_4 | TOO_LARGE | TOO_LARGE_2 // [1111]____ (4+-byte lead)
+      OVERLONG_2 | TOO_SHORT_2_3_4, TOO_SHORT_2_3_4,         // [110_]____ (2-byte lead)
+      OVERLONG_3 | SURROGATE | TOO_SHORT_2_3_4,              // [1110]____ (3-byte lead)
+      OVERLONG_4 | TOO_LARGE | TOO_LARGE_2 | TOO_SHORT_2_3_4 // [1111]____ (4+-byte lead)
     );
-
     const simd8<uint8_t> byte_1_low = (prev1 & 0x0F).lookup_16<uint8_t>(
       // ____[00__] ________
-      OVERLONG_2 | OVERLONG_3 | OVERLONG_4, // ____[0000] ________
-      OVERLONG_2,                           // ____[0001] ________
-      0, 0,
+      OVERLONG_2 | OVERLONG_3 | OVERLONG_4 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION, // ____[0000] ________
+      OVERLONG_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,                           // ____[0001] ________
+      TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[01__] ________
-      TOO_LARGE,                            // ____[0100] ________
-      TOO_LARGE_2,
-      TOO_LARGE_2,
-      TOO_LARGE_2,
+      TOO_LARGE | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,                            // ____[0100] ________
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[10__] ________
-      TOO_LARGE_2, TOO_LARGE_2, TOO_LARGE_2, TOO_LARGE_2,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[11__] ________
-      TOO_LARGE_2,
-      TOO_LARGE_2 | SURROGATE,                            // ____[1101] ________
-      TOO_LARGE_2, TOO_LARGE_2
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | SURROGATE | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,              // ____[1101] ________
+      TOO_LARGE_2 | TOO_SHORT_2_3_4| LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION
     );
-
     return byte_1_high & byte_1_low & byte_2_high;
   }
 
-  really_inline simd8<uint8_t> check_multibyte_lengths(simd8<uint8_t> input, simd8<uint8_t> prev_input, simd8<uint8_t> prev1) {
+  really_inline simd8<uint8_t> check_multibyte_lengths(simd8<uint8_t> input, simd8<uint8_t> prev_input,
+      simd8<uint8_t> prev1) {
     simd8<uint8_t> prev2 = input.prev<2>(prev_input);
     simd8<uint8_t> prev3 = input.prev<3>(prev_input);
-
-    // Cont is 10000000-101111111 (-65...-128)
-    simd8<bool> is_continuation = simd8<int8_t>(input) < int8_t(-64);
-    // must_be_continuation is architecture-specific because Intel doesn't have unsigned comparisons
-    return simd8<uint8_t>(must_be_continuation(prev1, prev2, prev3) ^ is_continuation);
+    // is_2_3_continuation uses one more instruction than lookup2
+    simd8<bool> is_2_3_continuation = (simd8<int8_t>(input).max(simd8<int8_t>(prev1))) < int8_t(-64);
+    // must_be_2_3_continuation has two fewer instructions than lookup 2
+    return simd8<uint8_t>(must_be_2_3_continuation(prev2, prev3) ^ is_2_3_continuation);
   }
+
 
   //
   // Return nonzero if there are incomplete multibyte characters at the end of the block:
@@ -8832,7 +8915,7 @@ namespace utf8_validation {
 }
 
 using utf8_validation::utf8_checker;
-/* end file src/generic/stage1/utf8_lookup2_algorithm.h */
+/* end file src/generic/stage1/utf8_lookup3_algorithm.h */
 /* begin file src/generic/stage1/json_structural_indexer.h */
 // This file contains the common code every implementation uses in stage1
 // It is intended to be included multiple times and compiled multiple times
@@ -9762,7 +9845,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       }
       // we over-decrement by one when there is a '.'
       digit_count -= int(start - start_digits);
-      if (unlikely(digit_count >= 19)) {
+      if (digit_count >= 19) {
         // Ok, chances are good that we had an overflow!
         // this is almost never going to get called!!!
         // we start anew, going slowly!!!
@@ -9772,7 +9855,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
         //
         bool success = slow_float_parsing((const char *) src, writer);
         // The number was already written, but we made a copy of the writer
-        // when we passed it to the parse_large_integer() function, so 
+        // when we passed it to the parse_large_integer() function, so
         writer.skip_double();
         return success;
       }
@@ -9811,7 +9894,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       // need to recover: we parse the whole thing again.
       bool success = parse_large_integer(src, writer, found_minus);
       // The number was already written, but we made a copy of the writer
-      // when we passed it to the parse_large_integer() function, so 
+      // when we passed it to the parse_large_integer() function, so
       writer.skip_large_integer();
       return success;
     }
@@ -11327,6 +11410,14 @@ really_inline simd8<bool> must_be_continuation(simd8<uint8_t> prev1, simd8<uint8
   return simd8<int8_t>(is_second_byte | is_third_byte | is_fourth_byte) > int8_t(0);
 }
 
+really_inline simd8<bool> must_be_2_3_continuation(simd8<uint8_t> prev2, simd8<uint8_t> prev3) {
+  simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0b11100000u-1); // Only 111_____ will be > 0
+  simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0b11110000u-1); // Only 1111____ will be > 0
+  // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
+  return simd8<int8_t>(is_third_byte | is_fourth_byte) > int8_t(0);
+}
+
+
 /* begin file src/generic/stage1/buf_block_reader.h */
 // Walks through a buffer in block-sized increments, loading the last part with spaces
 template<size_t STEP_SIZE>
@@ -11454,7 +11545,9 @@ public:
   really_inline error_code finish(bool streaming);
 
 private:
+  // Intended to be defined by the implementation
   really_inline uint64_t find_escaped(uint64_t escape);
+  really_inline uint64_t find_escaped_branchless(uint64_t escape);
 
   // Whether the last iteration was still inside a string (all 1's = true, all 0's = false).
   uint64_t prev_in_string = 0ULL;
@@ -11489,7 +11582,7 @@ private:
 // desired        |   x  | x x  x x  x x  x  x  |
 // text           |  \\\ | \\\"\\\" \\\" \\"\\" |
 //
-really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+really_inline uint64_t json_string_scanner::find_escaped_branchless(uint64_t backslash) {
   // If there was overflow, pretend the first character isn't a backslash
   backslash &= ~prev_escaped;
   uint64_t follows_escape = backslash << 1 | prev_escaped;
@@ -11518,13 +11611,23 @@ really_inline json_string_block json_string_scanner::next(const simd::simd8x64<u
   const uint64_t backslash = in.eq('\\');
   const uint64_t escaped = find_escaped(backslash);
   const uint64_t quote = in.eq('"') & ~escaped;
+
+  //
   // prefix_xor flips on bits inside the string (and flips off the end quote).
+  //
   // Then we xor with prev_in_string: if we were in a string already, its effect is flipped
   // (characters inside strings are outside, and characters outside strings are inside).
+  //
   const uint64_t in_string = prefix_xor(quote) ^ prev_in_string;
+
+  //
+  // Check if we're still in a string at the end of the box so the next block will know
+  //
   // right shift of a signed value expected to be well-defined and standard
   // compliant as of C++20, John Regher from Utah U. says this is fine code
+  //
   prev_in_string = uint64_t(static_cast<int64_t>(in_string) >> 63);
+
   // Use ^ to turn the beginning quote off, and the end quote on.
   return {
     backslash,
@@ -11649,6 +11752,13 @@ really_inline error_code json_scanner::finish(bool streaming) {
 
 } // namespace stage1
 /* end file src/generic/stage1/json_scanner.h */
+
+namespace stage1 {
+really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+  if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
+  return find_escaped_branchless(backslash);
+}
+}
 
 /* begin file src/generic/stage1/json_minifier.h */
 // This file contains the common code every implementation uses in stage1
@@ -11821,7 +11931,7 @@ really_inline static size_t trim_partial_utf8(const uint8_t *buf, size_t len) {
   return len;
 }
 /* end file src/generic/stage1/find_next_document_index.h */
-/* begin file src/generic/stage1/utf8_lookup2_algorithm.h */
+/* begin file src/generic/stage1/utf8_lookup3_algorithm.h */
 //
 // Detect Unicode errors.
 //
@@ -11913,66 +12023,78 @@ namespace utf8_validation {
     static const int TOO_LARGE   = 0x10; // 11110100 (1001|101_)____
     static const int TOO_LARGE_2 = 0x20; // 1111(1___|011_|0101) 10______
 
+    // New with lookup3. We want to catch the case where an non-continuation 
+    // follows a leading byte
+    static const int TOO_SHORT_2_3_4 = 0x40; //  (110_|1110|1111) ____    (0___|110_|1111) ____
+    // We also want to catch a continuation that is preceded by an ASCII byte
+    static const int LONELY_CONTINUATION = 0x80; //  0___ ____    01__ ____
+
     // After processing the rest of byte 1 (the low bits), we're still not done--we have to check
     // byte 2 to be sure which things are errors and which aren't.
     // Since high_bits is byte 5, byte 2 is high_bits.prev<3>
     static const int CARRY = OVERLONG_2 | TOO_LARGE_2;
     const simd8<uint8_t> byte_2_high = input.shr<4>().lookup_16<uint8_t>(
         // ASCII: ________ [0___]____
-        CARRY, CARRY, CARRY, CARRY,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
         // ASCII: ________ [0___]____
-        CARRY, CARRY, CARRY, CARRY,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,
         // Continuations: ________ [10__]____
-        CARRY | OVERLONG_3 | OVERLONG_4, // ________ [1000]____
-        CARRY | OVERLONG_3 | TOO_LARGE,  // ________ [1001]____
-        CARRY | TOO_LARGE  | SURROGATE,  // ________ [1010]____
-        CARRY | TOO_LARGE  | SURROGATE,  // ________ [1011]____
+        CARRY | OVERLONG_3 | OVERLONG_4 | LONELY_CONTINUATION, // ________ [1000]____
+        CARRY | OVERLONG_3 | TOO_LARGE | LONELY_CONTINUATION,  // ________ [1001]____
+        CARRY | TOO_LARGE  | SURROGATE | LONELY_CONTINUATION,  // ________ [1010]____
+        CARRY | TOO_LARGE  | SURROGATE | LONELY_CONTINUATION,  // ________ [1011]____
         // Multibyte Leads: ________ [11__]____
-        CARRY, CARRY, CARRY, CARRY
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4,  // 110_
+        CARRY | TOO_SHORT_2_3_4, CARRY | TOO_SHORT_2_3_4
     );
-
     const simd8<uint8_t> byte_1_high = prev1.shr<4>().lookup_16<uint8_t>(
       // [0___]____ (ASCII)
-      0, 0, 0, 0,
-      0, 0, 0, 0,
+      LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION,
+      LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION, LONELY_CONTINUATION,
       // [10__]____ (continuation)
       0, 0, 0, 0,
       // [11__]____ (2+-byte leads)
-      OVERLONG_2, 0,                       // [110_]____ (2-byte lead)
-      OVERLONG_3 | SURROGATE,              // [1110]____ (3-byte lead)
-      OVERLONG_4 | TOO_LARGE | TOO_LARGE_2 // [1111]____ (4+-byte lead)
+      OVERLONG_2 | TOO_SHORT_2_3_4, TOO_SHORT_2_3_4,         // [110_]____ (2-byte lead)
+      OVERLONG_3 | SURROGATE | TOO_SHORT_2_3_4,              // [1110]____ (3-byte lead)
+      OVERLONG_4 | TOO_LARGE | TOO_LARGE_2 | TOO_SHORT_2_3_4 // [1111]____ (4+-byte lead)
     );
-
     const simd8<uint8_t> byte_1_low = (prev1 & 0x0F).lookup_16<uint8_t>(
       // ____[00__] ________
-      OVERLONG_2 | OVERLONG_3 | OVERLONG_4, // ____[0000] ________
-      OVERLONG_2,                           // ____[0001] ________
-      0, 0,
+      OVERLONG_2 | OVERLONG_3 | OVERLONG_4 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION, // ____[0000] ________
+      OVERLONG_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,                           // ____[0001] ________
+      TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[01__] ________
-      TOO_LARGE,                            // ____[0100] ________
-      TOO_LARGE_2,
-      TOO_LARGE_2,
-      TOO_LARGE_2,
+      TOO_LARGE | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,                            // ____[0100] ________
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[10__] ________
-      TOO_LARGE_2, TOO_LARGE_2, TOO_LARGE_2, TOO_LARGE_2,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
       // ____[11__] ________
-      TOO_LARGE_2,
-      TOO_LARGE_2 | SURROGATE,                            // ____[1101] ________
-      TOO_LARGE_2, TOO_LARGE_2
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,
+      TOO_LARGE_2 | SURROGATE | TOO_SHORT_2_3_4 | LONELY_CONTINUATION,              // ____[1101] ________
+      TOO_LARGE_2 | TOO_SHORT_2_3_4| LONELY_CONTINUATION,
+      TOO_LARGE_2 | TOO_SHORT_2_3_4 | LONELY_CONTINUATION
     );
-
     return byte_1_high & byte_1_low & byte_2_high;
   }
 
-  really_inline simd8<uint8_t> check_multibyte_lengths(simd8<uint8_t> input, simd8<uint8_t> prev_input, simd8<uint8_t> prev1) {
+  really_inline simd8<uint8_t> check_multibyte_lengths(simd8<uint8_t> input, simd8<uint8_t> prev_input,
+      simd8<uint8_t> prev1) {
     simd8<uint8_t> prev2 = input.prev<2>(prev_input);
     simd8<uint8_t> prev3 = input.prev<3>(prev_input);
-
-    // Cont is 10000000-101111111 (-65...-128)
-    simd8<bool> is_continuation = simd8<int8_t>(input) < int8_t(-64);
-    // must_be_continuation is architecture-specific because Intel doesn't have unsigned comparisons
-    return simd8<uint8_t>(must_be_continuation(prev1, prev2, prev3) ^ is_continuation);
+    // is_2_3_continuation uses one more instruction than lookup2
+    simd8<bool> is_2_3_continuation = (simd8<int8_t>(input).max(simd8<int8_t>(prev1))) < int8_t(-64);
+    // must_be_2_3_continuation has two fewer instructions than lookup 2
+    return simd8<uint8_t>(must_be_2_3_continuation(prev2, prev3) ^ is_2_3_continuation);
   }
+
 
   //
   // Return nonzero if there are incomplete multibyte characters at the end of the block:
@@ -12040,7 +12162,7 @@ namespace utf8_validation {
 }
 
 using utf8_validation::utf8_checker;
-/* end file src/generic/stage1/utf8_lookup2_algorithm.h */
+/* end file src/generic/stage1/utf8_lookup3_algorithm.h */
 /* begin file src/generic/stage1/json_structural_indexer.h */
 // This file contains the common code every implementation uses in stage1
 // It is intended to be included multiple times and compiled multiple times
@@ -12973,7 +13095,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       }
       // we over-decrement by one when there is a '.'
       digit_count -= int(start - start_digits);
-      if (unlikely(digit_count >= 19)) {
+      if (digit_count >= 19) {
         // Ok, chances are good that we had an overflow!
         // this is almost never going to get called!!!
         // we start anew, going slowly!!!
@@ -12983,7 +13105,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
         //
         bool success = slow_float_parsing((const char *) src, writer);
         // The number was already written, but we made a copy of the writer
-        // when we passed it to the parse_large_integer() function, so 
+        // when we passed it to the parse_large_integer() function, so
         writer.skip_double();
         return success;
       }
@@ -13022,7 +13144,7 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
       // need to recover: we parse the whole thing again.
       bool success = parse_large_integer(src, writer, found_minus);
       // The number was already written, but we made a copy of the writer
-      // when we passed it to the parse_large_integer() function, so 
+      // when we passed it to the parse_large_integer() function, so
       writer.skip_large_integer();
       return success;
     }

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Sat Jun 20 21:35:29 PDT 2020. Do not edit! */
+/* auto-generated on Sun Jun 21 11:49:12 PDT 2020. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on Fri 12 Jun 2020 13:09:36 EDT. Do not edit! */
+/* auto-generated on Sat Jun 20 21:50:03 PDT 2020. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -169,11 +169,11 @@ compiling for a known 64-bit platform."
 #define TARGET_WESTMERE TARGET_REGION("sse4.2,pclmul")
 #define TARGET_ARM64
 
-// Threading is disabled
-#undef SIMDJSON_THREADS_ENABLED
 // Is threading enabled?
 #if defined(BOOST_HAS_THREADS) || defined(_REENTRANT) || defined(_MT)
+#ifndef SIMDJSON_THREADS_ENABLED
 #define SIMDJSON_THREADS_ENABLED
+#endif
 #endif
 
 
@@ -183,7 +183,9 @@ compiling for a known 64-bit platform."
 #ifndef __OPTIMIZE__
 // Apple systems have small stack sizes in secondary threads.
 // Lack of compiler optimization may generate high stack usage.
-// So we are disabling multithreaded support for safety.
+// Users may want to disable threads for safety, but only when
+// in debug mode which we detect by the fact that the __OPTIMIZE__
+// macro is not defined.
 #undef SIMDJSON_THREADS_ENABLED
 #endif
 #endif
@@ -251,6 +253,25 @@ static inline void aligned_free(void *mem_block) {
 static inline void aligned_free_char(char *mem_block) {
   aligned_free((void *)mem_block);
 }
+
+#ifdef NDEBUG
+
+#ifdef SIMDJSON_VISUAL_STUDIO
+#define SIMDJSON_UNREACHABLE() __assume(0)
+#define SIMDJSON_ASSUME(COND) __assume(COND)
+#else
+#define SIMDJSON_UNREACHABLE() __builtin_unreachable();
+#define SIMDJSON_ASSUME(COND) do { if (!(COND)) __builtin_unreachable(); } while (0)
+#endif
+
+#else // NDEBUG
+
+#include <cassert>
+#define SIMDJSON_UNREACHABLE() assert(0);
+#define SIMDJSON_ASSUME(COND) assert(COND)
+
+#endif
+
 } // namespace simdjson
 #endif // SIMDJSON_PORTABILITY_H
 /* end file include/simdjson/portability.h */
@@ -2138,8 +2159,18 @@ struct simdjson_result_base : public std::pair<T, error_code> {
 
   /**
    * Move the value and the error to the provided variables.
+   *
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   * @param error The variable to assign the error to. Set to SUCCESS if there is no error.
    */
   really_inline void tie(T &value, error_code &error) && noexcept;
+
+  /**
+   * Move the value to the provided variable.
+   *
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   */
+  really_inline error_code get(T &value) && noexcept;
 
   /**
    * The error.
@@ -2200,8 +2231,18 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
 
   /**
    * Move the value and the error to the provided variables.
+   *
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   * @param error The variable to assign the error to. Set to SUCCESS if there is no error.
    */
-  really_inline void tie(T& t, error_code & e) && noexcept;
+  really_inline void tie(T &value, error_code &error) && noexcept;
+
+  /**
+   * Move the value to the provided variable.
+   *
+   * @param value The variable to assign the value to. May not be set if there is an error.
+   */
+  WARN_UNUSED really_inline error_code get(T &value) && noexcept;
 
   /**
    * The error.
@@ -2658,11 +2699,11 @@ public:
   /**
    * @private For internal implementation use
    *
-   * Run a full document parse (ensure_capacity, stage1 and stage2).
+   * Minify the input string assuming that it represents a JSON string, does not parse or validate.
    *
    * Overridden by each implementation.
    *
-   * @param buf the json document to parse. *MUST* be allocated up to len + SIMDJSON_PADDING bytes.
+   * @param buf the json document to minify.
    * @param len the length of the json document.
    * @param dst the buffer to write the minified document to. *MUST* be allocated up to len + SIMDJSON_PADDING bytes.
    * @param dst_len the number of bytes written. Output only.
@@ -2884,6 +2925,23 @@ public:
 
 namespace simdjson {
 
+
+
+/**
+ *
+ * Minify the input string assuming that it represents a JSON string, does not parse or validate.
+ * This function is much faster than parsing a JSON string and then writing a minified version of it.
+ * However, it does not validate the input.
+ *
+ *
+ * @param buf the json document to minify.
+ * @param len the length of the json document.
+ * @param dst the buffer to write the minified document to. *MUST* be allocated up to len + SIMDJSON_PADDING bytes.
+ * @param dst_len the number of bytes written. Output only.
+ * @return the error code, or SUCCESS if there was no error.
+ */
+WARN_UNUSED error_code minify(const char *buf, size_t len, char *dst, size_t &dst_len) noexcept;
+
 /**
  * Minifies a JSON element or document, printing the smallest possible valid JSON.
  *
@@ -2893,14 +2951,14 @@ namespace simdjson {
  *
  */
 template<typename T>
-class minify {
+class minifier {
 public:
   /**
    * Create a new minifier.
    *
    * @param _value The document or element to minify.
    */
-  inline minify(const T &_value) noexcept : value{_value} {}
+  inline minifier(const T &_value) noexcept : value{_value} {}
 
   /**
    * Minify JSON to a string.
@@ -2915,6 +2973,9 @@ private:
   const T &value;
 };
 
+template<typename T>
+inline minifier<T> minify(const T &value) noexcept { return minifier<T>(value); }
+
 /**
  * Minify JSON to an output stream.
  *
@@ -2923,7 +2984,7 @@ private:
  * @throw if there is an error with the underlying output stream. simdjson itself will not throw.
  */
 template<typename T>
-inline std::ostream& operator<<(std::ostream& out, minify<T> formatter) { return formatter.print(out); }
+inline std::ostream& operator<<(std::ostream& out, minifier<T> formatter) { return formatter.print(out); }
 
 } // namespace simdjson
 
@@ -2940,12 +3001,12 @@ class element;
 /**
  * JSON array.
  */
-class array : protected internal::tape_ref {
+class array {
 public:
   /** Create a new, invalid array */
   really_inline array() noexcept;
 
-  class iterator : protected internal::tape_ref {
+  class iterator {
   public:
     /**
      * Get the actual value
@@ -2965,7 +3026,8 @@ public:
      */
     inline bool operator!=(const iterator& other) const noexcept;
   private:
-    really_inline iterator(const document *doc, size_t json_index) noexcept;
+    really_inline iterator(const internal::tape_ref &tape) noexcept;
+    internal::tape_ref tape;
     friend class array;
   };
 
@@ -3004,19 +3066,30 @@ public:
   inline simdjson_result<element> at(const std::string_view &json_pointer) const noexcept;
 
   /**
-   * Get the value at the given index.
+   * Get the value at the given index. This function has linear-time complexity and
+   * is equivalent to the following:
+   * 
+   *    size_t i=0;
+   *    for (auto element : *this) {
+   *      if (i == index) { return element; }
+   *      i++;
+   *    }
+   *    return INDEX_OUT_OF_BOUNDS;
    *
+   * Avoid calling the at() function repeatedly.
+   * 
    * @return The value at the given index, or:
    *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
    */
   inline simdjson_result<element> at(size_t index) const noexcept;
 
 private:
-  really_inline array(const document *doc, size_t json_index) noexcept;
+  really_inline array(const internal::tape_ref &tape) noexcept;
+  internal::tape_ref tape;
   friend class element;
   friend struct simdjson_result<element>;
   template<typename T>
-  friend class simdjson::minify;
+  friend class simdjson::minifier;
 };
 
 /**
@@ -3146,7 +3219,7 @@ public:
 private:
   inline error_code allocate(size_t len) noexcept;
   template<typename T>
-  friend class simdjson::minify;
+  friend class simdjson::minifier;
   friend class parser;
 }; // class document
 
@@ -3305,6 +3378,10 @@ public:
    * documents that consist of an object or array may omit the whitespace between them, concatenating
    * with no separator. documents that consist of a single primitive (i.e. documents that are not
    * arrays or objects) MUST be separated with whitespace.
+   * 
+   * The documents must not exceed batch_size bytes (by default 1MB) or they will fail to parse.
+   * Setting batch_size to excessively large or excesively small values may impact negatively the
+   * performance.
    *
    * ### Error Handling
    *
@@ -3335,20 +3412,19 @@ public:
    *                   spot is cache-related: small enough to fit in cache, yet big enough to
    *                   parse as many documents as possible in one tight loop.
    *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
-   * @return The stream. If there is an error, it will be returned during iteration. An empty input
-   *         will yield 0 documents rather than an EMPTY error. Errors:
+   * @return The stream, or an error. An empty input will yield 0 documents rather than an EMPTY error. Errors:
    *         - IO_ERROR if there was an error opening or reading the file.
    *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails.
    *         - CAPACITY if the parser does not have enough capacity and batch_size > max_capacity.
    *         - other json errors if parsing fails.
    */
-  inline document_stream load_many(const std::string &path, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> load_many(const std::string &path, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
 
   /**
    * Parse a buffer containing many JSON documents.
    *
    *   dom::parser parser;
-   *   for (const element doc : parser.parse_many(buf, len)) {
+   *   for (element doc : parser.parse_many(buf, len)) {
    *     cout << std::string(doc["title"]) << endl;
    *   }
    *
@@ -3362,6 +3438,10 @@ public:
    * documents that consist of an object or array may omit the whitespace between them, concatenating
    * with no separator. documents that consist of a single primitive (i.e. documents that are not
    * arrays or objects) MUST be separated with whitespace.
+   * 
+   * The documents must not exceed batch_size bytes (by default 1MB) or they will fail to parse.
+   * Setting batch_size to excessively large or excesively small values may impact negatively the
+   * performance.
    *
    * ### Error Handling
    *
@@ -3398,22 +3478,21 @@ public:
    *                   spot is cache-related: small enough to fit in cache, yet big enough to
    *                   parse as many documents as possible in one tight loop.
    *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
-   * @return The stream. If there is an error, it will be returned during iteration. An empty input
-   *         will yield 0 documents rather than an EMPTY error. Errors:
+   * @return The stream, or an error. An empty input will yield 0 documents rather than an EMPTY error. Errors:
    *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails
    *         - CAPACITY if the parser does not have enough capacity and batch_size > max_capacity.
    *         - other json errors if parsing fails.
    */
-  inline document_stream parse_many(const uint8_t *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const uint8_t *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline document_stream parse_many(const char *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const char *buf, size_t len, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline document_stream parse_many(const std::string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const std::string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
   /** @overload parse_many(const uint8_t *buf, size_t len, size_t batch_size) */
-  inline document_stream parse_many(const padded_string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> parse_many(const padded_string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
 
   /** @private We do not want to allow implicit conversion from C string to std::string. */
-  really_inline simdjson_result<element> parse_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
+  simdjson_result<document_stream> parse_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
 
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
@@ -3562,10 +3641,63 @@ private:
 /* end file include/simdjson/dom/document.h */
 #ifdef SIMDJSON_THREADS_ENABLED
 #include <thread>
+#include <mutex>
+#include <condition_variable>
 #endif
 
 namespace simdjson {
 namespace dom {
+
+
+#ifdef SIMDJSON_THREADS_ENABLED
+/** @private Custom worker class **/
+struct stage1_worker {
+  stage1_worker() noexcept = default;
+  stage1_worker(const stage1_worker&) = delete;
+  stage1_worker(stage1_worker&&) = delete;
+  stage1_worker operator=(const stage1_worker&) = delete;
+  ~stage1_worker();
+  /** 
+   * We only start the thread when it is needed, not at object construction, this may throw.
+   * You should only call this once. 
+   **/
+  void start_thread();
+  /** 
+   * Start a stage 1 job. You should first call 'run', then 'finish'. 
+   * You must call start_thread once before.
+   */
+  void run(document_stream * ds, dom::parser * stage1, size_t next_batch_start);
+  /** Wait for the run to finish (blocking). You should first call 'run', then 'finish'. **/
+  void finish();
+
+private:
+
+  /** 
+   * Normally, we would never stop the thread. But we do in the destructor.
+   * This function is only safe assuming that you are not waiting for results. You 
+   * should have called run, then finish, and be done. 
+   **/
+  void stop_thread();
+
+  std::thread thread{};
+  /** These three variables define the work done by the thread. **/
+  dom::parser * stage1_thread_parser{};
+  size_t _next_batch_start{};
+  document_stream * owner{};
+  /** 
+   * We have two state variables. This could be streamlined to one variable in the future but 
+   * we use two for clarity.
+   */
+  bool has_work{false};
+  bool can_work{true};
+
+  /**
+   * We lock using a mutex.
+   */
+  std::mutex locking_mutex{};
+  std::condition_variable cond_var{};
+};
+#endif
 
 /**
  * A forward-only stream of documents.
@@ -3575,8 +3707,20 @@ namespace dom {
  */
 class document_stream {
 public:
+  /**
+   * Construct an uninitialized document_stream.
+   *
+   *  ```c++
+   *  document_stream docs;
+   *  error = parser.parse_many(json).get(docs);
+   *  ```
+   */
+  really_inline document_stream() noexcept;
   /** Move one document_stream to another. */
-  really_inline document_stream(document_stream && other) noexcept = default;
+  really_inline document_stream(document_stream &&other) noexcept = default;
+  /** Move one document_stream to another. */
+  really_inline document_stream &operator=(document_stream &&other) noexcept = default;
+
   really_inline ~document_stream() noexcept;
 
   /**
@@ -3597,7 +3741,22 @@ public:
      * @param other the end iterator to compare to.
      */
     really_inline bool operator!=(const iterator &other) const noexcept;
-
+    /**
+     * @private
+     * 
+     * Gives the current index in the input document in bytes.
+     *
+     *   document_stream stream = parser.parse_many(json,window);
+     *   for(auto i = stream.begin(); i != stream.end(); ++i) {
+     *      auto doc = *i;
+     *      size_t index = i.current_index();
+     *   }
+     * 
+     * This function (current_index()) is experimental and the usage
+     * may change in future versions of simdjson: we find the API somewhat
+     * awkward and we would like to offer something friendlier.  
+     */
+     really_inline size_t current_index() noexcept;
   private:
     really_inline iterator(document_stream &s, bool finished) noexcept;
     /** The document_stream we're iterating through. */
@@ -3620,7 +3779,7 @@ private:
 
   document_stream &operator=(const document_stream &) = delete; // Disallow copying
 
-  document_stream(document_stream &other) = delete;    // Disallow copying
+  document_stream(document_stream &other) = delete; // Disallow copying
 
   /**
    * Construct a document_stream. Does not allocate or parse anything until the iterator is
@@ -3630,8 +3789,7 @@ private:
     dom::parser &parser,
     const uint8_t *buf,
     size_t len,
-    size_t batch_size,
-    error_code error = SUCCESS
+    size_t batch_size
   ) noexcept;
 
   /**
@@ -3678,13 +3836,14 @@ private:
   /** Pass the next batch through stage 1 with the given parser. */
   inline error_code run_stage1(dom::parser &p, size_t batch_start) noexcept;
 
-  dom::parser &parser;
+  dom::parser *parser;
   const uint8_t *buf;
-  const size_t len;
-  const size_t batch_size;
-  size_t batch_start{0};
+  size_t len;
+  size_t batch_size;
   /** The error (or lack thereof) from the current document. */
   error_code error;
+  size_t batch_start{0};
+  size_t doc_index{};
 
 #ifdef SIMDJSON_THREADS_ENABLED
   inline void load_from_stage1_thread() noexcept;
@@ -3698,8 +3857,8 @@ private:
   /** The error returned from the stage 1 thread. */
   error_code stage1_thread_error{UNINITIALIZED};
   /** The thread used to run stage 1 against the next batch in the background. */
-  std::thread stage1_thread{};
-
+  friend struct stage1_worker;
+  std::unique_ptr<stage1_worker> worker{new(std::nothrow) stage1_worker()};
   /**
    * The parser used to run stage 1 in the background. Will be swapped
    * with the regular parser when finished.
@@ -3708,9 +3867,31 @@ private:
 #endif // SIMDJSON_THREADS_ENABLED
 
   friend class dom::parser;
+  friend class simdjson_result<dom::document_stream>;
+  friend class internal::simdjson_result_base<dom::document_stream>;
+
 }; // class document_stream
 
 } // namespace dom
+
+template<>
+struct simdjson_result<dom::document_stream> : public internal::simdjson_result_base<dom::document_stream> {
+public:
+  really_inline simdjson_result() noexcept; ///< @private
+  really_inline simdjson_result(error_code error) noexcept; ///< @private
+  really_inline simdjson_result(dom::document_stream &&value) noexcept; ///< @private
+
+#if SIMDJSON_EXCEPTIONS
+  really_inline dom::document_stream::iterator begin() noexcept(false);
+  really_inline dom::document_stream::iterator end() noexcept(false);
+#else // SIMDJSON_EXCEPTIONS
+  [[deprecated("parse_many() and load_many() may return errors. Use document_stream stream; error = parser.parse_many().get(doc); instead.")]]
+  really_inline dom::document_stream::iterator begin() noexcept;
+  [[deprecated("parse_many() and load_many() may return errors. Use document_stream stream; error = parser.parse_many().get(doc); instead.")]]
+  really_inline dom::document_stream::iterator end() noexcept;
+#endif // SIMDJSON_EXCEPTIONS
+}; // struct simdjson_result<dom::document_stream>
+
 } // namespace simdjson
 
 #endif // SIMDJSON_DOCUMENT_STREAM_H
@@ -3749,7 +3930,7 @@ enum class element_type {
  * References an element in a JSON document, representing a JSON null, boolean, string, number,
  * array or object.
  */
-class element : protected internal::tape_ref {
+class element {
 public:
   /** Create a new, invalid element. */
   really_inline element() noexcept;
@@ -3757,8 +3938,135 @@ public:
   /** The type of this element. */
   really_inline element_type type() const noexcept;
 
-  /** Whether this element is a json `null`. */
-  really_inline bool is_null() const noexcept;
+  /**
+   * Cast this element to an array.
+   *
+   * Equivalent to get<array>().
+   *
+   * @returns An object that can be used to iterate the array, or:
+   *          INCORRECT_TYPE if the JSON element is not an array.
+   */
+  inline simdjson_result<array> get_array() const noexcept;
+  /**
+   * Cast this element to an object.
+   *
+   * Equivalent to get<object>().
+   *
+   * @returns An object that can be used to look up or iterate the object's fields, or:
+   *          INCORRECT_TYPE if the JSON element is not an object.
+   */
+  inline simdjson_result<object> get_object() const noexcept;
+  /**
+   * Cast this element to a string.
+   *
+   * Equivalent to get<const char *>().
+   *
+   * @returns An pointer to a null-terminated string. This string is stored in the parser and will
+   *          be invalidated the next time it parses a document or when it is destroyed.
+   *          Returns INCORRECT_TYPE if the JSON element is not a string.
+   */
+  inline simdjson_result<const char *> get_c_str() const noexcept;
+  /**
+   * Cast this element to a string.
+   *
+   * Equivalent to get<std::string_view>().
+   *
+   * @returns A string. The string is stored in the parser and will be invalidated the next time it
+   *          parses a document or when it is destroyed.
+   *          Returns INCORRECT_TYPE if the JSON element is not a string.
+   */
+  inline simdjson_result<std::string_view> get_string() const noexcept;
+  /**
+   * Cast this element to a signed integer.
+   *
+   * Equivalent to get<int64_t>().
+   *
+   * @returns A signed 64-bit integer.
+   *          Returns INCORRECT_TYPE if the JSON element is not an integer, or NUMBER_OUT_OF_RANGE
+   *          if it is negative.
+   */
+  inline simdjson_result<int64_t> get_int64_t() const noexcept;
+  /**
+   * Cast this element to an unsigned integer.
+   *
+   * Equivalent to get<uint64_t>().
+   *
+   * @returns An unsigned 64-bit integer.
+   *          Returns INCORRECT_TYPE if the JSON element is not an integer, or NUMBER_OUT_OF_RANGE
+   *          if it is too large.
+   */
+  inline simdjson_result<uint64_t> get_uint64_t() const noexcept;
+  /**
+   * Cast this element to an double floating-point.
+   *
+   * Equivalent to get<double>().
+   *
+   * @returns A double value.
+   *          Returns INCORRECT_TYPE if the JSON element is not a number.
+   */
+  inline simdjson_result<double> get_double() const noexcept;
+  /**
+   * Cast this element to a bool.
+   *
+   * Equivalent to get<bool>().
+   *
+   * @returns A bool value.
+   *          Returns INCORRECT_TYPE if the JSON element is not a boolean.
+   */
+  inline simdjson_result<bool> get_bool() const noexcept;
+
+  /**
+   * Whether this element is a json array.
+   *
+   * Equivalent to is<array>().
+   */
+  inline bool is_array() const noexcept;
+  /**
+   * Whether this element is a json object.
+   *
+   * Equivalent to is<object>().
+   */
+  inline bool is_object() const noexcept;
+  /**
+   * Whether this element is a json string.
+   *
+   * Equivalent to is<std::string_view>() or is<const char *>().
+   */
+  inline bool is_string() const noexcept;
+  /**
+   * Whether this element is a json number that fits in a signed 64-bit integer.
+   *
+   * Equivalent to is<int64_t>().
+   */
+  inline bool is_int64_t() const noexcept;
+  /**
+   * Whether this element is a json number that fits in an unsigned 64-bit integer.
+   *
+   * Equivalent to is<uint64_t>().
+   */
+  inline bool is_uint64_t() const noexcept;
+  /**
+   * Whether this element is a json number that fits in a double.
+   *
+   * Equivalent to is<double>().
+   */
+  inline bool is_double() const noexcept;
+  /**
+   * Whether this element is a json number.
+   *
+   * Both integers and floating points will return true.
+   */
+  inline bool is_number() const noexcept;
+  /**
+   * Whether this element is a json `true` or `false`.
+   *
+   * Equivalent to is<bool>().
+   */
+  inline bool is_bool() const noexcept;
+  /**
+   * Whether this element is a json `null`.
+   */
+  inline bool is_null() const noexcept;
 
   /**
    * Tell whether the value can be cast to provided type (T).
@@ -3791,7 +4099,44 @@ public:
    *          INCORRECT_TYPE if the value cannot be cast to the given type.
    */
   template<typename T>
-  really_inline simdjson_result<T> get() const noexcept;
+  inline simdjson_result<T> get() const noexcept;
+
+  /**
+   * Get the value as the provided type (T).
+   *
+   * Supported types:
+   * - Boolean: bool
+   * - Number: double, uint64_t, int64_t
+   * - String: std::string_view, const char *
+   * - Array: dom::array
+   * - Object: dom::object
+   *
+   * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
+   *
+   * @param value The variable to set to the value. May not be set if there is an error.
+   *
+   * @returns The error that occurred, or SUCCESS if there was no error.
+   */
+  template<typename T>
+  WARN_UNUSED really_inline error_code get(T &value) const noexcept;
+
+  /**
+   * Get the value as the provided type (T), setting error if it's not the given type.
+   *
+   * Supported types:
+   * - Boolean: bool
+   * - Number: double, uint64_t, int64_t
+   * - String: std::string_view, const char *
+   * - Array: dom::array
+   * - Object: dom::object
+   *
+   * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
+   *
+   * @param value The variable to set to the given type. value is undefined if there is an error.
+   * @param error The variable to store the error. error is set to error_code::SUCCEED if there is an error.
+   */
+  template<typename T>
+  inline void tie(T &value, error_code &error) && noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -3963,13 +4308,14 @@ public:
   inline bool dump_raw_tape(std::ostream &out) const noexcept;
 
 private:
-  really_inline element(const document *doc, size_t json_index) noexcept;
+  really_inline element(const internal::tape_ref &tape) noexcept;
+  internal::tape_ref tape;
   friend class document;
   friend class object;
   friend class array;
   friend struct simdjson_result<element>;
   template<typename T>
-  friend class simdjson::minify;
+  friend class simdjson::minifier;
 };
 
 /**
@@ -4002,32 +4348,51 @@ public:
   really_inline simdjson_result(dom::element &&value) noexcept; ///< @private
   really_inline simdjson_result(error_code error) noexcept; ///< @private
 
-  inline simdjson_result<dom::element_type> type() const noexcept;
-  inline simdjson_result<bool> is_null() const noexcept;
+  really_inline simdjson_result<dom::element_type> type() const noexcept;
   template<typename T>
-  inline simdjson_result<bool> is() const noexcept;
+  really_inline simdjson_result<bool> is() const noexcept;
   template<typename T>
-  inline simdjson_result<T> get() const noexcept;
+  really_inline simdjson_result<T> get() const noexcept;
+  template<typename T>
+  WARN_UNUSED really_inline error_code get(T &value) const noexcept;
 
-  inline simdjson_result<dom::element> operator[](const std::string_view &key) const noexcept;
-  inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
-  inline simdjson_result<dom::element> at(const std::string_view &json_pointer) const noexcept;
-  inline simdjson_result<dom::element> at(size_t index) const noexcept;
-  inline simdjson_result<dom::element> at_key(const std::string_view &key) const noexcept;
-  inline simdjson_result<dom::element> at_key_case_insensitive(const std::string_view &key) const noexcept;
+  really_inline simdjson_result<dom::array> get_array() const noexcept;
+  really_inline simdjson_result<dom::object> get_object() const noexcept;
+  really_inline simdjson_result<const char *> get_c_str() const noexcept;
+  really_inline simdjson_result<std::string_view> get_string() const noexcept;
+  really_inline simdjson_result<int64_t> get_int64_t() const noexcept;
+  really_inline simdjson_result<uint64_t> get_uint64_t() const noexcept;
+  really_inline simdjson_result<double> get_double() const noexcept;
+  really_inline simdjson_result<bool> get_bool() const noexcept;
+
+  really_inline simdjson_result<bool> is_array() const noexcept;
+  really_inline simdjson_result<bool> is_object() const noexcept;
+  really_inline simdjson_result<bool> is_string() const noexcept;
+  really_inline simdjson_result<bool> is_int64_t() const noexcept;
+  really_inline simdjson_result<bool> is_uint64_t() const noexcept;
+  really_inline simdjson_result<bool> is_double() const noexcept;
+  really_inline simdjson_result<bool> is_bool() const noexcept;
+  really_inline simdjson_result<bool> is_null() const noexcept;
+
+  really_inline simdjson_result<dom::element> operator[](const std::string_view &key) const noexcept;
+  really_inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
+  really_inline simdjson_result<dom::element> at(const std::string_view &json_pointer) const noexcept;
+  really_inline simdjson_result<dom::element> at(size_t index) const noexcept;
+  really_inline simdjson_result<dom::element> at_key(const std::string_view &key) const noexcept;
+  really_inline simdjson_result<dom::element> at_key_case_insensitive(const std::string_view &key) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  inline operator bool() const noexcept(false);
-  inline explicit operator const char*() const noexcept(false);
-  inline operator std::string_view() const noexcept(false);
-  inline operator uint64_t() const noexcept(false);
-  inline operator int64_t() const noexcept(false);
-  inline operator double() const noexcept(false);
-  inline operator dom::array() const noexcept(false);
-  inline operator dom::object() const noexcept(false);
+  really_inline operator bool() const noexcept(false);
+  really_inline explicit operator const char*() const noexcept(false);
+  really_inline operator std::string_view() const noexcept(false);
+  really_inline operator uint64_t() const noexcept(false);
+  really_inline operator int64_t() const noexcept(false);
+  really_inline operator double() const noexcept(false);
+  really_inline operator dom::array() const noexcept(false);
+  really_inline operator dom::object() const noexcept(false);
 
-  inline dom::array::iterator begin() const noexcept(false);
-  inline dom::array::iterator end() const noexcept(false);
+  really_inline dom::array::iterator begin() const noexcept(false);
+  really_inline dom::array::iterator end() const noexcept(false);
 #endif // SIMDJSON_EXCEPTIONS
 };
 
@@ -4043,7 +4408,7 @@ public:
  *        underlying output stream, that error will be propagated (simdjson_error will not be
  *        thrown).
  */
-inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false);
+really_inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false);
 #endif
 
 } // namespace simdjson
@@ -4066,12 +4431,12 @@ class key_value_pair;
 /**
  * JSON object.
  */
-class object : protected internal::tape_ref {
+class object {
 public:
   /** Create a new, invalid object */
   really_inline object() noexcept;
 
-  class iterator : protected internal::tape_ref {
+  class iterator {
   public:
     /**
      * Get the actual key/value pair
@@ -4119,7 +4484,10 @@ public:
      */
     inline element value() const noexcept;
   private:
-    really_inline iterator(const document *doc, size_t json_index) noexcept;
+    really_inline iterator(const internal::tape_ref &tape) noexcept;
+
+    internal::tape_ref tape;
+
     friend class object;
   };
 
@@ -4150,6 +4518,8 @@ public:
    *   parser.parse(R"({ "a\n": 1 })")["a\n"].get<uint64_t>().value == 1
    *   parser.parse(R"({ "a\n": 1 })")["a\\n"].get<uint64_t>().error == NO_SUCH_FIELD
    *
+   * This function has linear-time complexity: the keys are checked one by one.
+   *
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    *         - INCORRECT_TYPE if this is not an object
@@ -4164,6 +4534,8 @@ public:
    *   dom::parser parser;
    *   parser.parse(R"({ "a\n": 1 })")["a\n"].get<uint64_t>().value == 1
    *   parser.parse(R"({ "a\n": 1 })")["a\\n"].get<uint64_t>().error == NO_SUCH_FIELD
+   *
+   * This function has linear-time complexity: the keys are checked one by one.
    *
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
@@ -4196,6 +4568,8 @@ public:
    *   parser.parse(R"({ "a\n": 1 })")["a\n"].get<uint64_t>().value == 1
    *   parser.parse(R"({ "a\n": 1 })")["a\\n"].get<uint64_t>().error == NO_SUCH_FIELD
    *
+   * This function has linear-time complexity: the keys are checked one by one.
+   *
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
@@ -4207,17 +4581,22 @@ public:
    *
    * Note: The key will be matched against **unescaped** JSON.
    *
+   * This function has linear-time complexity: the keys are checked one by one.
+   *
    * @return The value associated with this field, or:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
   inline simdjson_result<element> at_key_case_insensitive(const std::string_view &key) const noexcept;
 
 private:
-  really_inline object(const document *doc, size_t json_index) noexcept;
+  really_inline object(const internal::tape_ref &tape) noexcept;
+
+  internal::tape_ref tape;
+
   friend class element;
   friend struct simdjson_result<element>;
   template<typename T>
-  friend class simdjson::minify;
+  friend class simdjson::minifier;
 };
 
 /**
@@ -4840,16 +5219,16 @@ namespace dom {
 //
 // array inline implementation
 //
-really_inline array::array() noexcept : internal::tape_ref() {}
-really_inline array::array(const document *_doc, size_t _json_index) noexcept : internal::tape_ref(_doc, _json_index) {}
+really_inline array::array() noexcept : tape{} {}
+really_inline array::array(const internal::tape_ref &_tape) noexcept : tape{_tape} {}
 inline array::iterator array::begin() const noexcept {
-  return iterator(doc, json_index + 1);
+  return internal::tape_ref(tape.doc, tape.json_index + 1);
 }
 inline array::iterator array::end() const noexcept {
-  return iterator(doc, after_element() - 1);
+  return internal::tape_ref(tape.doc, tape.after_element() - 1);
 }
 inline size_t array::size() const noexcept {
-  return scope_count();
+  return tape.scope_count();
 }
 inline simdjson_result<element> array::at(const std::string_view &json_pointer) const noexcept {
   // - means "the append position" or "the element after the end of the array"
@@ -4873,7 +5252,7 @@ inline simdjson_result<element> array::at(const std::string_view &json_pointer) 
   if (i == 0) { return INVALID_JSON_POINTER; } // "Empty string in JSON pointer array index"
 
   // Get the child
-  auto child = array(doc, json_index).at(array_index);
+  auto child = array(tape).at(array_index);
   // If there is a /, we're not done yet, call recursively.
   if (i < json_pointer.length()) {
     child = child.at(json_pointer.substr(i+1));
@@ -4892,15 +5271,15 @@ inline simdjson_result<element> array::at(size_t index) const noexcept {
 //
 // array::iterator inline implementation
 //
-really_inline array::iterator::iterator(const document *_doc, size_t _json_index) noexcept : internal::tape_ref(_doc, _json_index) { }
+really_inline array::iterator::iterator(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 inline element array::iterator::operator*() const noexcept {
-  return element(doc, json_index);
+  return element(tape);
 }
 inline bool array::iterator::operator!=(const array::iterator& other) const noexcept {
-  return json_index != other.json_index;
+  return tape.json_index != other.tape.json_index;
 }
 inline array::iterator& array::iterator::operator++() noexcept {
-  json_index = after_element();
+  tape.json_index = tape.after_element();
   return *this;
 }
 
@@ -4911,7 +5290,7 @@ inline std::ostream& operator<<(std::ostream& out, const array &value) {
 } // namespace dom
 
 template<>
-inline std::ostream& minify<dom::array>::print(std::ostream& out) {
+inline std::ostream& minifier<dom::array>::print(std::ostream& out) {
   out << '[';
   auto iter = value.begin();
   auto end = value.end();
@@ -4927,7 +5306,7 @@ inline std::ostream& minify<dom::array>::print(std::ostream& out) {
 #if SIMDJSON_EXCEPTIONS
 
 template<>
-inline std::ostream& minify<simdjson_result<dom::array>>::print(std::ostream& out) {
+inline std::ostream& minifier<simdjson_result<dom::array>>::print(std::ostream& out) {
   if (value.error()) { throw simdjson_error(value.error()); }
   return out << minify<dom::array>(value.first);
 }
@@ -4949,32 +5328,93 @@ inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::ar
 #include <algorithm>
 #include <limits>
 #include <stdexcept>
-
 namespace simdjson {
 namespace dom {
+
+#ifdef SIMDJSON_THREADS_ENABLED
+inline void stage1_worker::finish() {
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  cond_var.wait(lock, [this]{return has_work == false;});
+}
+
+inline stage1_worker::~stage1_worker() {
+  stop_thread();
+}
+
+inline void stage1_worker::start_thread() {
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  if(thread.joinable()) {
+    return; // This should never happen but we never want to create more than one thread.
+  }
+  thread = std::thread([this]{
+      while(can_work) {
+        std::unique_lock<std::mutex> thread_lock(locking_mutex);
+        cond_var.wait(thread_lock, [this]{return has_work || !can_work;});
+        if(!can_work) {
+          break;
+        }
+        this->owner->stage1_thread_error = this->owner->run_stage1(*this->stage1_thread_parser,
+              this->_next_batch_start);
+        this->has_work = false;
+        thread_lock.unlock();
+        cond_var.notify_one(); // will notify "finish"
+      }
+    }
+  );
+}
+
+
+inline void stage1_worker::stop_thread() {
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  // We have to make sure that all locks can be released.
+  can_work = false;
+  has_work = false;
+  lock.unlock();
+  cond_var.notify_all();
+  if(thread.joinable()) {
+    thread.join();
+  }
+}
+
+inline void stage1_worker::run(document_stream * ds, dom::parser * stage1, size_t next_batch_start) {
+  std::unique_lock<std::mutex> lock(locking_mutex);
+  owner = ds;
+  _next_batch_start = next_batch_start;
+  stage1_thread_parser = stage1;
+  has_work = true;
+  lock.unlock();
+  cond_var.notify_one();// will notify the thread lock
+}
+#endif
 
 really_inline document_stream::document_stream(
   dom::parser &_parser,
   const uint8_t *_buf,
   size_t _len,
-  size_t _batch_size,
-  error_code _error
+  size_t _batch_size
 ) noexcept
-  : parser{_parser},
+  : parser{&_parser},
     buf{_buf},
     len{_len},
     batch_size{_batch_size},
-    error{_error}
+    error{SUCCESS}
 {
-}
-
-inline document_stream::~document_stream() noexcept {
 #ifdef SIMDJSON_THREADS_ENABLED
-  // TODO kill the thread, why should people have to wait for a non-side-effecting operation to complete
-  if (stage1_thread.joinable()) {
-    stage1_thread.join();
+  if(worker.get() == nullptr) {
+    error = MEMALLOC;
   }
 #endif
+}
+
+really_inline document_stream::document_stream() noexcept
+  : parser{nullptr},
+    buf{nullptr},
+    len{0},
+    batch_size{0},
+    error{UNINITIALIZED} {
+}
+
+really_inline document_stream::~document_stream() noexcept {
 }
 
 really_inline document_stream::iterator document_stream::begin() noexcept {
@@ -4994,7 +5434,7 @@ really_inline document_stream::iterator::iterator(document_stream& _stream, bool
 really_inline simdjson_result<element> document_stream::iterator::operator*() noexcept {
   // Once we have yielded any errors, we're finished.
   if (stream.error) { finished = true; return stream.error; }
-  return stream.parser.doc.root();
+  return stream.parser->doc.root();
 }
 
 really_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
@@ -5011,12 +5451,12 @@ really_inline bool document_stream::iterator::operator!=(const document_stream::
 inline void document_stream::start() noexcept {
   if (error) { return; }
 
-  error = parser.ensure_capacity(batch_size);
+  error = parser->ensure_capacity(batch_size);
   if (error) { return; }
 
   // Always run the first stage 1 parse immediately
   batch_start = 0;
-  error = run_stage1(parser, batch_start);
+  error = run_stage1(*parser, batch_start);
   if (error) { return; }
 
 #ifdef SIMDJSON_THREADS_ENABLED
@@ -5024,6 +5464,7 @@ inline void document_stream::start() noexcept {
     // Kick off the first thread if needed
     error = stage1_thread_parser.ensure_capacity(batch_size);
     if (error) { return; }
+    worker->start_thread();
     start_stage1_thread();
     if (error) { return; }
   }
@@ -5032,12 +5473,15 @@ inline void document_stream::start() noexcept {
   next();
 }
 
+really_inline size_t document_stream::iterator::current_index() noexcept {
+  return stream.doc_index;
+}
 inline void document_stream::next() noexcept {
   if (error) { return; }
 
   // Load the next document from the batch
-  error = parser.implementation->stage2_next(parser.doc);
-
+  doc_index = batch_start + parser->implementation->structural_indexes[parser->implementation->next_structural_index];
+  error = parser->implementation->stage2_next(parser->doc);
   // If that was the last document in the batch, load another batch (if available)
   while (error == EMPTY) {
     batch_start = next_batch_start();
@@ -5046,17 +5490,17 @@ inline void document_stream::next() noexcept {
 #ifdef SIMDJSON_THREADS_ENABLED
     load_from_stage1_thread();
 #else
-    error = run_stage1(parser, batch_start);
+    error = run_stage1(*parser, batch_start);
 #endif
     if (error) { continue; } // If the error was EMPTY, we may want to load another batch.
-
     // Run stage 2 on the first document in the batch
-    error = parser.implementation->stage2_next(parser.doc);
+    doc_index = batch_start + parser->implementation->structural_indexes[parser->implementation->next_structural_index];
+    error = parser->implementation->stage2_next(parser->doc);
   }
 }
 
 inline size_t document_stream::next_batch_start() const noexcept {
-  return batch_start + parser.implementation->structural_indexes[parser.implementation->n_structural_indexes];
+  return batch_start + parser->implementation->structural_indexes[parser->implementation->n_structural_indexes];
 }
 
 inline error_code document_stream::run_stage1(dom::parser &p, size_t _batch_start) noexcept {
@@ -5072,11 +5516,10 @@ inline error_code document_stream::run_stage1(dom::parser &p, size_t _batch_star
 #ifdef SIMDJSON_THREADS_ENABLED
 
 inline void document_stream::load_from_stage1_thread() noexcept {
-  stage1_thread.join();
-
+  worker->finish();
   // Swap to the parser that was loaded up in the thread. Make sure the parser has
   // enough memory to swap to, as well.
-  std::swap(parser, stage1_thread_parser);
+  std::swap(*parser, stage1_thread_parser);
   error = stage1_thread_error;
   if (error) { return; }
 
@@ -5093,14 +5536,45 @@ inline void document_stream::start_stage1_thread() noexcept {
   // TODO this is NOT exception-safe.
   this->stage1_thread_error = UNINITIALIZED; // In case something goes wrong, make sure it's an error
   size_t _next_batch_start = this->next_batch_start();
-  stage1_thread = std::thread([this, _next_batch_start] {
-    this->stage1_thread_error = run_stage1(this->stage1_thread_parser, _next_batch_start);
-  });
+
+  worker->run(this, & this->stage1_thread_parser, _next_batch_start);
 }
 
 #endif // SIMDJSON_THREADS_ENABLED
 
 } // namespace dom
+
+really_inline simdjson_result<dom::document_stream>::simdjson_result() noexcept
+  : simdjson_result_base() {
+}
+really_inline simdjson_result<dom::document_stream>::simdjson_result(error_code error) noexcept
+  : simdjson_result_base(error) {
+}
+really_inline simdjson_result<dom::document_stream>::simdjson_result(dom::document_stream &&value) noexcept
+  : simdjson_result_base(std::forward<dom::document_stream>(value)) {
+}
+
+#if SIMDJSON_EXCEPTIONS
+really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::begin() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first.begin();
+}
+really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::end() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first.end();
+}
+#else // SIMDJSON_EXCEPTIONS
+really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::begin() noexcept {
+  first.error = error();
+  return first.begin();
+}
+really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::end() noexcept {
+  first.error = error();
+  return first.end();
+}
+#endif // SIMDJSON_EXCEPTIONS
+
+
 } // namespace simdjson
 #endif // SIMDJSON_INLINE_DOCUMENT_STREAM_H
 /* end file include/simdjson/inline/document_stream.h */
@@ -5120,7 +5594,7 @@ namespace dom {
 // document inline implementation
 //
 inline element document::root() const noexcept {
-  return element(this, 1);
+  return element(internal::tape_ref(this, 1));
 }
 
 WARN_UNUSED
@@ -5265,133 +5739,195 @@ inline simdjson_result<dom::element_type> simdjson_result<dom::element>::type() 
   if (error()) { return error(); }
   return first.type();
 }
-inline simdjson_result<bool> simdjson_result<dom::element>::is_null() const noexcept {
-  if (error()) { return error(); }
-  return first.is_null();
-}
+
 template<typename T>
-inline simdjson_result<bool> simdjson_result<dom::element>::is() const noexcept {
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is() const noexcept {
   if (error()) { return error(); }
   return first.is<T>();
 }
 template<typename T>
-inline simdjson_result<T> simdjson_result<dom::element>::get() const noexcept {
+really_inline simdjson_result<T> simdjson_result<dom::element>::get() const noexcept {
   if (error()) { return error(); }
   return first.get<T>();
 }
+template<typename T>
+WARN_UNUSED really_inline error_code simdjson_result<dom::element>::get(T &value) const noexcept {
+  if (error()) { return error(); }
+  return first.get<T>(value);
+}
 
-inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const std::string_view &key) const noexcept {
+really_inline simdjson_result<dom::array> simdjson_result<dom::element>::get_array() const noexcept {
+  if (error()) { return error(); }
+  return first.get_array();
+}
+really_inline simdjson_result<dom::object> simdjson_result<dom::element>::get_object() const noexcept {
+  if (error()) { return error(); }
+  return first.get_object();
+}
+really_inline simdjson_result<const char *> simdjson_result<dom::element>::get_c_str() const noexcept {
+  if (error()) { return error(); }
+  return first.get_c_str();
+}
+really_inline simdjson_result<std::string_view> simdjson_result<dom::element>::get_string() const noexcept {
+  if (error()) { return error(); }
+  return first.get_string();
+}
+really_inline simdjson_result<int64_t> simdjson_result<dom::element>::get_int64_t() const noexcept {
+  if (error()) { return error(); }
+  return first.get_int64_t();
+}
+really_inline simdjson_result<uint64_t> simdjson_result<dom::element>::get_uint64_t() const noexcept {
+  if (error()) { return error(); }
+  return first.get_uint64_t();
+}
+really_inline simdjson_result<double> simdjson_result<dom::element>::get_double() const noexcept {
+  if (error()) { return error(); }
+  return first.get_double();
+}
+really_inline simdjson_result<bool> simdjson_result<dom::element>::get_bool() const noexcept {
+  if (error()) { return error(); }
+  return first.get_bool();
+}
+
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_array() const noexcept {
+  if (error()) { return error(); }
+  return first.is_array();
+}
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_object() const noexcept {
+  if (error()) { return error(); }
+  return first.is_object();
+}
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_string() const noexcept {
+  if (error()) { return error(); }
+  return first.is_string();
+}
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_int64_t() const noexcept {
+  if (error()) { return error(); }
+  return first.is_int64_t();
+}
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_uint64_t() const noexcept {
+  if (error()) { return error(); }
+  return first.is_uint64_t();
+}
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_double() const noexcept {
+  if (error()) { return error(); }
+  return first.is_double();
+}
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_bool() const noexcept {
+  if (error()) { return error(); }
+  return first.is_bool();
+}
+
+really_inline simdjson_result<bool> simdjson_result<dom::element>::is_null() const noexcept {
+  if (error()) { return error(); }
+  return first.is_null();
+}
+
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const std::string_view &key) const noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const char *key) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const char *key) const noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at(const std::string_view &json_pointer) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(const std::string_view &json_pointer) const noexcept {
   if (error()) { return error(); }
   return first.at(json_pointer);
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at(size_t index) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(size_t index) const noexcept {
   if (error()) { return error(); }
   return first.at(index);
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key(const std::string_view &key) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key(const std::string_view &key) const noexcept {
   if (error()) { return error(); }
   return first.at_key(key);
 }
-inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key_case_insensitive(const std::string_view &key) const noexcept {
+really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key_case_insensitive(const std::string_view &key) const noexcept {
   if (error()) { return error(); }
   return first.at_key_case_insensitive(key);
 }
 
 #if SIMDJSON_EXCEPTIONS
 
-inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
   return get<bool>();
 }
-inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
   return get<const char *>();
 }
-inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
   return get<std::string_view>();
 }
-inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
   return get<uint64_t>();
 }
-inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
   return get<int64_t>();
 }
-inline simdjson_result<dom::element>::operator double() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator double() const noexcept(false) {
   return get<double>();
 }
-inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
   return get<dom::array>();
 }
-inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
+really_inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
   return get<dom::object>();
 }
 
-inline dom::array::iterator simdjson_result<dom::element>::begin() const noexcept(false) {
+really_inline dom::array::iterator simdjson_result<dom::element>::begin() const noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.begin();
 }
-inline dom::array::iterator simdjson_result<dom::element>::end() const noexcept(false) {
+really_inline dom::array::iterator simdjson_result<dom::element>::end() const noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.end();
 }
 
-#endif
+#endif // SIMDJSON_EXCEPTIONS
 
 namespace dom {
 
 //
 // element inline implementation
 //
-really_inline element::element() noexcept : internal::tape_ref() {}
-really_inline element::element(const document *_doc, size_t _json_index) noexcept : internal::tape_ref(_doc, _json_index) { }
+really_inline element::element() noexcept : tape{} {}
+really_inline element::element(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 
 inline element_type element::type() const noexcept {
-  auto tape_type = tape_ref_type();
+  auto tape_type = tape.tape_ref_type();
   return tape_type == internal::tape_type::FALSE_VALUE ? element_type::BOOL : static_cast<element_type>(tape_type);
 }
-really_inline bool element::is_null() const noexcept {
-  return is_null_on_tape();
-}
 
-template<>
-inline simdjson_result<bool> element::get<bool>() const noexcept {
-  if(is_true()) {
+inline simdjson_result<bool> element::get_bool() const noexcept {
+  if(tape.is_true()) {
     return true;
-  } else if(is_false()) {
+  } else if(tape.is_false()) {
     return false;
   }
   return INCORRECT_TYPE;
 }
-template<>
-inline simdjson_result<const char *> element::get<const char *>() const noexcept {
-  switch (tape_ref_type()) {
+inline simdjson_result<const char *> element::get_c_str() const noexcept {
+  switch (tape.tape_ref_type()) {
     case internal::tape_type::STRING: {
-      return get_c_str();
+      return tape.get_c_str();
     }
     default:
       return INCORRECT_TYPE;
   }
 }
-template<>
-inline simdjson_result<std::string_view> element::get<std::string_view>() const noexcept {
-  switch (tape_ref_type()) {
+inline simdjson_result<std::string_view> element::get_string() const noexcept {
+  switch (tape.tape_ref_type()) {
     case internal::tape_type::STRING:
-      return get_string_view();
+      return tape.get_string_view();
     default:
       return INCORRECT_TYPE;
   }
 }
-template<>
-inline simdjson_result<uint64_t> element::get<uint64_t>() const noexcept {
-  if(unlikely(!is_uint64())) { // branch rarely taken
-    if(is_int64()) {
-      int64_t result = next_tape_value<int64_t>();
+inline simdjson_result<uint64_t> element::get_uint64_t() const noexcept {
+  if(unlikely(!tape.is_uint64())) { // branch rarely taken
+    if(tape.is_int64()) {
+      int64_t result = tape.next_tape_value<int64_t>();
       if (result < 0) {
         return NUMBER_OUT_OF_RANGE;
       }
@@ -5399,13 +5935,12 @@ inline simdjson_result<uint64_t> element::get<uint64_t>() const noexcept {
     }
     return INCORRECT_TYPE;
   }
-  return next_tape_value<int64_t>();
+  return tape.next_tape_value<int64_t>();
 }
-template<>
-inline simdjson_result<int64_t> element::get<int64_t>() const noexcept {
-  if(unlikely(!is_int64())) { // branch rarely taken
-    if(is_uint64()) {
-      uint64_t result = next_tape_value<uint64_t>();
+inline simdjson_result<int64_t> element::get_int64_t() const noexcept {
+  if(unlikely(!tape.is_int64())) { // branch rarely taken
+    if(tape.is_uint64()) {
+      uint64_t result = tape.next_tape_value<uint64_t>();
       // Wrapping max in parens to handle Windows issue: https://stackoverflow.com/questions/11544073/how-do-i-deal-with-the-max-macro-in-windows-h-colliding-with-max-in-std
       if (result > uint64_t((std::numeric_limits<int64_t>::max)())) {
         return NUMBER_OUT_OF_RANGE;
@@ -5414,10 +5949,9 @@ inline simdjson_result<int64_t> element::get<int64_t>() const noexcept {
     }
     return INCORRECT_TYPE;
   }
-  return next_tape_value<int64_t>();
+  return tape.next_tape_value<int64_t>();
 }
-template<>
-inline simdjson_result<double> element::get<double>() const noexcept {
+inline simdjson_result<double> element::get_double() const noexcept {
   // Performance considerations:
   // 1. Querying tape_ref_type() implies doing a shift, it is fast to just do a straight
   //   comparison.
@@ -5427,40 +5961,70 @@ inline simdjson_result<double> element::get<double>() const noexcept {
   // We can expect get<double> to refer to a double type almost all the time.
   // It is important to craft the code accordingly so that the compiler can use this
   // information. (This could also be solved with profile-guided optimization.)
-  if(unlikely(!is_double())) { // branch rarely taken
-    if(is_uint64()) {
-      return double(next_tape_value<uint64_t>());
-    } else if(is_int64()) {
-      return double(next_tape_value<int64_t>());
+  if(unlikely(!tape.is_double())) { // branch rarely taken
+    if(tape.is_uint64()) {
+      return double(tape.next_tape_value<uint64_t>());
+    } else if(tape.is_int64()) {
+      return double(tape.next_tape_value<int64_t>());
     }
     return INCORRECT_TYPE;
   }
   // this is common:
-  return next_tape_value<double>();
+  return tape.next_tape_value<double>();
 }
-template<>
-inline simdjson_result<array> element::get<array>() const noexcept {
-  switch (tape_ref_type()) {
+inline simdjson_result<array> element::get_array() const noexcept {
+  switch (tape.tape_ref_type()) {
     case internal::tape_type::START_ARRAY:
-      return array(doc, json_index);
+      return array(tape);
     default:
       return INCORRECT_TYPE;
   }
 }
-template<>
-inline simdjson_result<object> element::get<object>() const noexcept {
-  switch (tape_ref_type()) {
+inline simdjson_result<object> element::get_object() const noexcept {
+  switch (tape.tape_ref_type()) {
     case internal::tape_type::START_OBJECT:
-      return object(doc, json_index);
+      return object(tape);
     default:
       return INCORRECT_TYPE;
   }
 }
 
 template<typename T>
+WARN_UNUSED really_inline error_code element::get(T &value) const noexcept {
+  return get<T>().get(value);
+}
+// An element-specific version prevents recursion with simdjson_result::get<element>(value)
+template<>
+WARN_UNUSED really_inline error_code element::get<element>(element &value) const noexcept {
+  value = element(tape);
+  return SUCCESS;
+}
+
+template<typename T>
 really_inline bool element::is() const noexcept {
   auto result = get<T>();
   return !result.error();
+}
+
+template<> inline simdjson_result<array> element::get<array>() const noexcept { return get_array(); }
+template<> inline simdjson_result<object> element::get<object>() const noexcept { return get_object(); }
+template<> inline simdjson_result<const char *> element::get<const char *>() const noexcept { return get_c_str(); }
+template<> inline simdjson_result<std::string_view> element::get<std::string_view>() const noexcept { return get_string(); }
+template<> inline simdjson_result<int64_t> element::get<int64_t>() const noexcept { return get_int64_t(); }
+template<> inline simdjson_result<uint64_t> element::get<uint64_t>() const noexcept { return get_uint64_t(); }
+template<> inline simdjson_result<double> element::get<double>() const noexcept { return get_double(); }
+template<> inline simdjson_result<bool> element::get<bool>() const noexcept { return get_bool(); }
+
+inline bool element::is_array() const noexcept { return is<array>(); }
+inline bool element::is_object() const noexcept { return is<object>(); }
+inline bool element::is_string() const noexcept { return is<std::string_view>(); }
+inline bool element::is_int64_t() const noexcept { return is<int64_t>(); }
+inline bool element::is_uint64_t() const noexcept { return is<uint64_t>(); }
+inline bool element::is_double() const noexcept { return is<double>(); }
+inline bool element::is_bool() const noexcept { return is<bool>(); }
+
+inline bool element::is_null() const noexcept {
+  return tape.is_null_on_tape();
 }
 
 #if SIMDJSON_EXCEPTIONS
@@ -5490,11 +6054,11 @@ inline simdjson_result<element> element::operator[](const char *key) const noexc
   return at_key(key);
 }
 inline simdjson_result<element> element::at(const std::string_view &json_pointer) const noexcept {
-  switch (tape_ref_type()) {
+  switch (tape.tape_ref_type()) {
     case internal::tape_type::START_OBJECT:
-      return object(doc, json_index).at(json_pointer);
+      return object(tape).at(json_pointer);
     case internal::tape_type::START_ARRAY:
-      return array(doc, json_index).at(json_pointer);
+      return array(tape).at(json_pointer);
     default:
       return INCORRECT_TYPE;
   }
@@ -5510,7 +6074,7 @@ inline simdjson_result<element> element::at_key_case_insensitive(const std::stri
 }
 
 inline bool element::dump_raw_tape(std::ostream &out) const noexcept {
-  return doc->dump_raw_tape(out);
+  return tape.doc->dump_raw_tape(out);
 }
 
 inline std::ostream& operator<<(std::ostream& out, const element &value) {
@@ -5543,7 +6107,7 @@ inline std::ostream& operator<<(std::ostream& out, element_type type) {
 } // namespace dom
 
 template<>
-inline std::ostream& minify<dom::element>::print(std::ostream& out) {
+inline std::ostream& minifier<dom::element>::print(std::ostream& out) {
   using tape_type=internal::tape_type;
   size_t depth = 0;
   constexpr size_t MAX_DEPTH = 16;
@@ -5551,7 +6115,7 @@ inline std::ostream& minify<dom::element>::print(std::ostream& out) {
   is_object[0] = false;
   bool after_value = false;
 
-  internal::tape_ref iter(value);
+  internal::tape_ref iter(value.tape);
   do {
     // print commas after each value
     if (after_value) {
@@ -5569,7 +6133,7 @@ inline std::ostream& minify<dom::element>::print(std::ostream& out) {
       // If we're too deep, we need to recurse to go deeper.
       depth++;
       if (unlikely(depth >= MAX_DEPTH)) {
-        out << minify<dom::array>(dom::array(iter.doc, iter.json_index));
+        out << minify<dom::array>(dom::array(iter));
         iter.json_index = iter.matching_brace_index() - 1; // Jump to the ]
         depth--;
         break;
@@ -5596,7 +6160,7 @@ inline std::ostream& minify<dom::element>::print(std::ostream& out) {
       // If we're too deep, we need to recurse to go deeper.
       depth++;
       if (unlikely(depth >= MAX_DEPTH)) {
-        out << minify<dom::object>(dom::object(iter.doc, iter.json_index));
+        out << minify<dom::object>(dom::object(iter));
         iter.json_index = iter.matching_brace_index() - 1; // Jump to the }
         depth--;
         break;
@@ -5669,12 +6233,12 @@ inline std::ostream& minify<dom::element>::print(std::ostream& out) {
 #if SIMDJSON_EXCEPTIONS
 
 template<>
-inline std::ostream& minify<simdjson_result<dom::element>>::print(std::ostream& out) {
+really_inline std::ostream& minifier<simdjson_result<dom::element>>::print(std::ostream& out) {
   if (value.error()) { throw simdjson_error(value.error()); }
   return out << minify<dom::element>(value.first);
 }
 
-inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false) {
+really_inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false) {
   return out << minify<simdjson_result<dom::element>>(value);
 }
 #endif
@@ -5730,8 +6294,15 @@ really_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && 
   // on the clang compiler that comes with current macOS (Apple clang version 11.0.0),
   // tie(width, error) = size["w"].get<uint64_t>();
   // fails with "error: no viable overloaded '='""
-  value = std::forward<simdjson_result_base<T>>(*this).first;
   error = this->second;
+  if (!error) {
+    value = std::forward<simdjson_result_base<T>>(*this).first;
+  }
+}
+
+template<typename T>
+WARN_UNUSED really_inline error_code simdjson_result_base<T>::get(T &value) && noexcept {
+  return std::forward<simdjson_result_base<T>>(*this).get(value);
 }
 
 template<typename T>
@@ -5782,6 +6353,11 @@ really_inline simdjson_result_base<T>::simdjson_result_base() noexcept
 template<typename T>
 really_inline void simdjson_result<T>::tie(T &value, error_code &error) && noexcept {
   std::forward<internal::simdjson_result_base<T>>(*this).tie(value, error);
+}
+
+template<typename T>
+WARN_UNUSED really_inline error_code simdjson_result<T>::get(T &value) && noexcept {
+  return std::forward<internal::simdjson_result_base<T>>(*this).get(value);
 }
 
 template<typename T>
@@ -5887,16 +6463,16 @@ namespace dom {
 //
 // object inline implementation
 //
-really_inline object::object() noexcept : internal::tape_ref() {}
-really_inline object::object(const document *_doc, size_t _json_index) noexcept : internal::tape_ref(_doc, _json_index) { }
+really_inline object::object() noexcept : tape{} {}
+really_inline object::object(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 inline object::iterator object::begin() const noexcept {
-  return iterator(doc, json_index + 1);
+  return internal::tape_ref(tape.doc, tape.json_index + 1);
 }
 inline object::iterator object::end() const noexcept {
-  return iterator(doc, after_element() - 1);
+  return internal::tape_ref(tape.doc, tape.after_element() - 1);
 }
 inline size_t object::size() const noexcept {
-  return scope_count();
+  return tape.scope_count();
 }
 
 inline simdjson_result<element> object::operator[](const std::string_view &key) const noexcept {
@@ -5967,29 +6543,29 @@ inline simdjson_result<element> object::at_key_case_insensitive(const std::strin
 //
 // object::iterator inline implementation
 //
-really_inline object::iterator::iterator(const document *_doc, size_t _json_index) noexcept : internal::tape_ref(_doc, _json_index) { }
+really_inline object::iterator::iterator(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 inline const key_value_pair object::iterator::operator*() const noexcept {
   return key_value_pair(key(), value());
 }
 inline bool object::iterator::operator!=(const object::iterator& other) const noexcept {
-  return json_index != other.json_index;
+  return tape.json_index != other.tape.json_index;
 }
 inline object::iterator& object::iterator::operator++() noexcept {
-  json_index++;
-  json_index = after_element();
+  tape.json_index++;
+  tape.json_index = tape.after_element();
   return *this;
 }
 inline std::string_view object::iterator::key() const noexcept {
-  return get_string_view();
+  return tape.get_string_view();
 }
 inline uint32_t object::iterator::key_length() const noexcept {
-  return get_string_length();
+  return tape.get_string_length();
 }
 inline const char* object::iterator::key_c_str() const noexcept {
-  return reinterpret_cast<const char *>(&doc->string_buf[size_t(tape_value()) + sizeof(uint32_t)]);
+  return reinterpret_cast<const char *>(&tape.doc->string_buf[size_t(tape.tape_value()) + sizeof(uint32_t)]);
 }
 inline element object::iterator::value() const noexcept {
-  return element(doc, json_index + 1);
+  return element(internal::tape_ref(tape.doc, tape.json_index + 1));
 }
 
 /**
@@ -6044,7 +6620,7 @@ inline std::ostream& operator<<(std::ostream& out, const key_value_pair &value) 
 } // namespace dom
 
 template<>
-inline std::ostream& minify<dom::object>::print(std::ostream& out) {
+inline std::ostream& minifier<dom::object>::print(std::ostream& out) {
   out << '{';
   auto pair = value.begin();
   auto end = value.end();
@@ -6058,14 +6634,14 @@ inline std::ostream& minify<dom::object>::print(std::ostream& out) {
 }
 
 template<>
-inline std::ostream& minify<dom::key_value_pair>::print(std::ostream& out) {
+inline std::ostream& minifier<dom::key_value_pair>::print(std::ostream& out) {
   return out << '"' << internal::escape_json_string(value.key) << "\":" << value.value;
 }
 
 #if SIMDJSON_EXCEPTIONS
 
 template<>
-inline std::ostream& minify<simdjson_result<dom::object>>::print(std::ostream& out) {
+inline std::ostream& minifier<simdjson_result<dom::object>>::print(std::ostream& out) {
   if (value.error()) { throw simdjson_error(value.error()); }
   return out << minify<dom::object>(value.first);
 }
@@ -6786,23 +7362,21 @@ inline simdjson_result<size_t> parser::read_file(const std::string &path) noexce
 
 inline simdjson_result<element> parser::load(const std::string &path) & noexcept {
   size_t len;
-  error_code code;
-  read_file(path).tie(len, code);
-  if (code) { return code; }
-
+  auto _error = read_file(path).get(len);
+  if (_error) { return _error; }
   return parse(loaded_bytes.get(), len, false);
 }
 
-inline document_stream parser::load_many(const std::string &path, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::load_many(const std::string &path, size_t batch_size) noexcept {
   size_t len;
-  error_code code;
-  read_file(path).tie(len, code);
-  return document_stream(*this, (const uint8_t*)loaded_bytes.get(), len, batch_size, code);
+  auto _error = read_file(path).get(len);
+  if (_error) { return _error; }
+  return document_stream(*this, (const uint8_t*)loaded_bytes.get(), len, batch_size);
 }
 
 inline simdjson_result<element> parser::parse(const uint8_t *buf, size_t len, bool realloc_if_needed) & noexcept {
-  error_code code = ensure_capacity(len);
-  if (code) { return code; }
+  error_code _error = ensure_capacity(len);
+  if (_error) { return _error; }
 
   if (realloc_if_needed) {
     const uint8_t *tmp_buf = buf;
@@ -6812,11 +7386,11 @@ inline simdjson_result<element> parser::parse(const uint8_t *buf, size_t len, bo
     memcpy((void *)buf, tmp_buf, len);
   }
 
-  code = implementation->parse(buf, len, doc);
+  _error = implementation->parse(buf, len, doc);
   if (realloc_if_needed) {
     aligned_free((void *)buf); // must free before we exit
   }
-  if (code) { return code; }
+  if (_error) { return _error; }
 
   return doc.root();
 }
@@ -6830,16 +7404,16 @@ really_inline simdjson_result<element> parser::parse(const padded_string &s) & n
   return parse(s.data(), s.length(), false);
 }
 
-inline document_stream parser::parse_many(const uint8_t *buf, size_t len, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::parse_many(const uint8_t *buf, size_t len, size_t batch_size) noexcept {
   return document_stream(*this, buf, len, batch_size);
 }
-inline document_stream parser::parse_many(const char *buf, size_t len, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::parse_many(const char *buf, size_t len, size_t batch_size) noexcept {
   return parse_many((const uint8_t *)buf, len, batch_size);
 }
-inline document_stream parser::parse_many(const std::string &s, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::parse_many(const std::string &s, size_t batch_size) noexcept {
   return parse_many(s.data(), s.length(), batch_size);
 }
-inline document_stream parser::parse_many(const padded_string &s, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::parse_many(const padded_string &s, size_t batch_size) noexcept {
   return parse_many(s.data(), s.length(), batch_size);
 }
 
@@ -6859,15 +7433,22 @@ inline error_code parser::allocate(size_t capacity, size_t max_depth) noexcept {
   // Reallocate implementation and document if needed
   //
   error_code err;
+  //
+  // It is possible that we change max_depth without touching capacity, in
+  // which case, we do not want to reallocate the document buffers.
+  //
+  bool need_doc_allocation{false};
   if (implementation) {
+    need_doc_allocation = implementation->capacity() != capacity || !doc.tape;
     err = implementation->allocate(capacity, max_depth);
   } else {
+    need_doc_allocation = true;
     err = simdjson::active_implementation->create_dom_parser_implementation(capacity, max_depth, implementation);
   }
   if (err) { return err; }
-
-  if (implementation->capacity() != capacity || !doc.tape) {
-    return doc.allocate(capacity);
+  if (need_doc_allocation) {
+    err = doc.allocate(capacity);
+    if (err) { return err; }
   }
   return SUCCESS;
 }

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on Sat Jun 20 21:50:03 PDT 2020. Do not edit! */
+/* auto-generated on Sun Jun 21 11:49:12 PDT 2020. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -3778,8 +3778,7 @@ public:
 private:
 
   document_stream &operator=(const document_stream &) = delete; // Disallow copying
-
-  document_stream(document_stream &other) = delete; // Disallow copying
+  document_stream(const document_stream &other) = delete; // Disallow copying
 
   /**
    * Construct a document_stream. Does not allocate or parse anything until the iterator is
@@ -3867,8 +3866,8 @@ private:
 #endif // SIMDJSON_THREADS_ENABLED
 
   friend class dom::parser;
-  friend class simdjson_result<dom::document_stream>;
-  friend class internal::simdjson_result_base<dom::document_stream>;
+  friend struct simdjson_result<dom::document_stream>;
+  friend struct internal::simdjson_result_base<dom::document_stream>;
 
 }; // class document_stream
 
@@ -5574,7 +5573,6 @@ really_inline dom::document_stream::iterator simdjson_result<dom::document_strea
 }
 #endif // SIMDJSON_EXCEPTIONS
 
-
 } // namespace simdjson
 #endif // SIMDJSON_INLINE_DOCUMENT_STREAM_H
 /* end file include/simdjson/inline/document_stream.h */
@@ -6302,7 +6300,9 @@ really_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && 
 
 template<typename T>
 WARN_UNUSED really_inline error_code simdjson_result_base<T>::get(T &value) && noexcept {
-  return std::forward<simdjson_result_base<T>>(*this).get(value);
+  error_code error;
+  std::forward<simdjson_result_base<T>>(*this).tie(value, error);
+  return error;
 }
 
 template<typename T>

--- a/tests/cast_tester.h
+++ b/tests/cast_tester.h
@@ -26,6 +26,11 @@ public:
   bool test_get_error(element element, error_code expected_error);
   bool test_get_error(simdjson_result<element> element, error_code expected_error);
 
+  bool test_get_t(element element, T expected = {});
+  bool test_get_t(simdjson_result<element> element, T expected = {});
+  bool test_get_t_error(element element, error_code expected_error);
+  bool test_get_t_error(simdjson_result<element> element, error_code expected_error);
+
 #if SIMDJSON_EXCEPTIONS
   bool test_implicit_cast(element element, T expected = {});
   bool test_implicit_cast(simdjson_result<element> element, T expected = {});
@@ -57,68 +62,82 @@ private:
 template<typename T>
 bool cast_tester<T>::test_get(element element, T expected) {
   T actual;
-  error_code error;
-  error = element.get(actual);
-  ASSERT_SUCCESS(error);
+  ASSERT_SUCCESS(element.get(actual));
   return assert_equal(actual, expected);
 }
 
 template<typename T>
 bool cast_tester<T>::test_get(simdjson_result<element> element, T expected) {
   T actual;
-  error_code error;
-  error = element.get(actual);
-  ASSERT_SUCCESS(error);
+  ASSERT_SUCCESS(element.get(actual));
   return assert_equal(actual, expected);
 }
 
 template<typename T>
 bool cast_tester<T>::test_get_error(element element, error_code expected_error) {
   T actual;
-  error_code error;
-  error = element.get(actual);
-  ASSERT_EQUAL(error, expected_error);
+  ASSERT_EQUAL(element.get(actual), expected_error);
   return true;
 }
 
 template<typename T>
 bool cast_tester<T>::test_get_error(simdjson_result<element> element, error_code expected_error) {
   T actual;
-  error_code error;
-  error = element.get(actual);
-  ASSERT_EQUAL(error, expected_error);
+  ASSERT_EQUAL(element.get(actual), expected_error);
+  return true;
+}
+
+template<typename T>
+bool cast_tester<T>::test_get_t(element element, T expected) {
+  auto actual = element.get<T>();
+  ASSERT_SUCCESS(actual.error());
+  return assert_equal(actual.first, expected);
+}
+
+template<typename T>
+bool cast_tester<T>::test_get_t(simdjson_result<element> element, T expected) {
+  auto actual = element.get<T>();
+  ASSERT_SUCCESS(actual.error());
+  return assert_equal(actual.first, expected);
+}
+
+template<typename T>
+bool cast_tester<T>::test_get_t_error(element element, error_code expected_error) {
+  ASSERT_EQUAL(element.get<T>().error(), expected_error);
+  return true;
+}
+
+template<typename T>
+bool cast_tester<T>::test_get_t_error(simdjson_result<element> element, error_code expected_error) {
+  ASSERT_EQUAL(element.get<T>().error(), expected_error);
   return true;
 }
 
 template<typename T>
 bool cast_tester<T>::test_named_get(element element, T expected) {
   T actual;
-  auto error = named_get(element).get(actual);
-  ASSERT_SUCCESS(error);
+  ASSERT_SUCCESS(named_get(element).get(actual));
   return assert_equal(actual, expected);
 }
 
 template<typename T>
 bool cast_tester<T>::test_named_get(simdjson_result<element> element, T expected) {
   T actual;
-  auto error = named_get(element).get(actual);
-  ASSERT_SUCCESS(error);
+  ASSERT_SUCCESS(named_get(element).get(actual));
   return assert_equal(actual, expected);
 }
 
 template<typename T>
 bool cast_tester<T>::test_named_get_error(element element, error_code expected_error) {
   T actual;
-  auto error = named_get(element).get(actual);
-  ASSERT_EQUAL(error, expected_error);
+  ASSERT_EQUAL(named_get(element).get(actual), expected_error);
   return true;
 }
 
 template<typename T>
 bool cast_tester<T>::test_named_get_error(simdjson_result<element> element, error_code expected_error) {
   T actual;
-  auto error = named_get(element).get(actual);
-  ASSERT_EQUAL(error, expected_error);
+  ASSERT_EQUAL(named_get(element).get(actual), expected_error);
   return true;
 }
 
@@ -188,8 +207,7 @@ bool cast_tester<T>::test_is(element element, bool expected) {
 template<typename T>
 bool cast_tester<T>::test_is(simdjson_result<element> element, bool expected) {
   bool actual;
-  auto error = element.is<T>().get(actual);
-  ASSERT_SUCCESS(error);
+  ASSERT_SUCCESS(element.is<T>().get(actual));
   ASSERT_EQUAL(actual, expected);
   return true;
 }
@@ -197,8 +215,7 @@ bool cast_tester<T>::test_is(simdjson_result<element> element, bool expected) {
 template<typename T>
 bool cast_tester<T>::test_is_error(simdjson_result<element> element, error_code expected_error) {
   UNUSED bool actual;
-  auto error = element.is<T>().get(actual);
-  ASSERT_EQUAL(error, expected_error);
+  ASSERT_EQUAL(element.is<T>().get(actual), expected_error);
   return true;
 }
 
@@ -211,8 +228,7 @@ bool cast_tester<T>::test_named_is(element element, bool expected) {
 template<typename T>
 bool cast_tester<T>::test_named_is(simdjson_result<element> element, bool expected) {
   bool actual;
-  auto error = named_is(element).get(actual);
-  ASSERT_SUCCESS(error);
+  ASSERT_SUCCESS(named_is(element).get(actual));
   ASSERT_EQUAL(actual, expected);
   return true;
 }
@@ -220,8 +236,7 @@ bool cast_tester<T>::test_named_is(simdjson_result<element> element, bool expect
 template<typename T>
 bool cast_tester<T>::test_named_is_error(simdjson_result<element> element, error_code expected_error) {
   bool actual;
-  auto error = named_is(element).get(actual);
-  ASSERT_EQUAL(error, expected_error);
+  ASSERT_EQUAL(named_is(element).get(actual), expected_error);
   return true;
 }
 

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -105,12 +105,8 @@ namespace parser_load {
     TEST_START();
     dom::parser parser;
     dom::document_stream stream;
-    ASSERT_SUCCESS(parser.load_many(NONEXISTENT_FILE).get(stream));
-    for (auto doc : stream) {
-      ASSERT_ERROR(doc.error(), IO_ERROR);
-      TEST_SUCCEED();
-    }
-    TEST_FAIL("No documents returned");
+    ASSERT_ERROR(parser.load_many(NONEXISTENT_FILE).get(stream), IO_ERROR);
+    TEST_SUCCEED();
   }
   bool padded_string_load_nonexistent() {
     TEST_START();
@@ -122,21 +118,16 @@ namespace parser_load {
   bool parser_load_chain() {
     TEST_START();
     dom::parser parser;
-    auto error = parser.load(NONEXISTENT_FILE)["foo"].get<uint64_t>().error();
-    ASSERT_ERROR(error, IO_ERROR);
+    UNUSED uint64_t foo;
+    ASSERT_ERROR( parser.load(NONEXISTENT_FILE)["foo"].get(foo) , IO_ERROR);
     TEST_SUCCEED();
   }
   bool parser_load_many_chain() {
     TEST_START();
     dom::parser parser;
     dom::document_stream stream;
-    ASSERT_SUCCESS( parser.load_many(NONEXISTENT_FILE).get(stream) );
-    for (auto doc : stream) {
-      auto error = doc["foo"].get<uint64_t>().error();
-      ASSERT_ERROR(error, IO_ERROR);
-      TEST_SUCCEED();
-    }
-    TEST_FAIL("No documents returned");
+    ASSERT_ERROR( parser.load_many(NONEXISTENT_FILE).get(stream) , IO_ERROR );
+    TEST_SUCCEED();
   }
   bool run() {
     return true

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -21,6 +21,7 @@ const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
 
 #define TEST_START() { cout << "Running " << __func__ << " ..." << endl; }
 #define ASSERT_ERROR(ACTUAL, EXPECTED) if ((ACTUAL) != (EXPECTED)) { cerr << "FAIL: Unexpected error \"" << (ACTUAL) << "\" (expected \"" << (EXPECTED) << "\")" << endl; return false; }
+#define ASSERT_SUCCESS(CODE) do { simdjson::error_code error = CODE; if (error) { cerr << "FAIL: Unexpected error " << error << endl; return false; } } while (0);
 #define TEST_FAIL(MESSAGE) { cerr << "FAIL: " << (MESSAGE) << endl; return false; }
 #define TEST_SUCCEED() { return true; }
 namespace parser_load {
@@ -35,7 +36,9 @@ namespace parser_load {
   bool parser_load_many_capacity() {
     TEST_START();
     dom::parser parser(1); // 1 byte max capacity
-    for (auto doc : parser.load_many(TWITTER_JSON)) {
+    dom::document_stream docs;
+    ASSERT_SUCCESS(parser.load_many(TWITTER_JSON).get(docs));
+    for (auto doc : docs) {
       ASSERT_ERROR(doc.error(), CAPACITY);
       TEST_SUCCEED();
     }
@@ -47,7 +50,9 @@ namespace parser_load {
     const padded_string DOC = "1 2 [} 3"_padded;
     size_t count = 0;
     dom::parser parser;
-    for (auto doc : parser.parse_many(DOC)) {
+    dom::document_stream docs;
+    ASSERT_SUCCESS(parser.parse_many(DOC).get(docs));
+    for (auto doc : docs) {
       count++;
       auto [val, error] = doc.get<uint64_t>();
       if (count == 3) {
@@ -66,7 +71,9 @@ namespace parser_load {
     const padded_string DOC = "["_padded;
     size_t count = 0;
     dom::parser parser;
-    for (auto doc : parser.parse_many(DOC)) {
+    dom::document_stream docs;
+    ASSERT_SUCCESS(parser.parse_many(DOC).get(docs));
+    for (auto doc : docs) {
       count++;
       ASSERT_ERROR(doc.error(), TAPE_ERROR);
     }
@@ -79,7 +86,9 @@ namespace parser_load {
     const padded_string DOC = "1 2 ["_padded;
     size_t count = 0;
     dom::parser parser;
-    for (auto doc : parser.parse_many(DOC)) {
+    dom::document_stream docs;
+    ASSERT_SUCCESS(parser.parse_many(DOC).get(docs));
+    for (auto doc : docs) {
       count++;
       auto [val, error] = doc.get<uint64_t>();
       if (count == 3) {

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -14,16 +14,8 @@
 using namespace simdjson;
 using namespace std;
 
-#ifndef SIMDJSON_BENCHMARK_DATA_DIR
-#define SIMDJSON_BENCHMARK_DATA_DIR "jsonexamples/"
-#endif
-const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+#include "test_macros.h"
 
-#define TEST_START() { cout << "Running " << __func__ << " ..." << endl; }
-#define ASSERT_ERROR(ACTUAL, EXPECTED) if ((ACTUAL) != (EXPECTED)) { cerr << "FAIL: Unexpected error \"" << (ACTUAL) << "\" (expected \"" << (EXPECTED) << "\")" << endl; return false; }
-#define ASSERT_SUCCESS(CODE) do { simdjson::error_code error = CODE; if (error) { cerr << "FAIL: Unexpected error " << error << endl; return false; } } while (0);
-#define TEST_FAIL(MESSAGE) { cerr << "FAIL: " << (MESSAGE) << endl; return false; }
-#define TEST_SUCCEED() { return true; }
 namespace parser_load {
   const char * NONEXISTENT_FILE = "this_file_does_not_exist.json";
   bool parser_load_capacity() {
@@ -112,7 +104,9 @@ namespace parser_load {
   bool parser_load_many_nonexistent() {
     TEST_START();
     dom::parser parser;
-    for (auto doc : parser.load_many(NONEXISTENT_FILE)) {
+    dom::document_stream stream;
+    ASSERT_SUCCESS(parser.load_many(NONEXISTENT_FILE).get(stream));
+    for (auto doc : stream) {
       ASSERT_ERROR(doc.error(), IO_ERROR);
       TEST_SUCCEED();
     }
@@ -135,7 +129,9 @@ namespace parser_load {
   bool parser_load_many_chain() {
     TEST_START();
     dom::parser parser;
-    for (auto doc : parser.load_many(NONEXISTENT_FILE)) {
+    dom::document_stream stream;
+    ASSERT_SUCCESS( parser.load_many(NONEXISTENT_FILE).get(stream) );
+    for (auto doc : stream) {
       auto error = doc["foo"].get<uint64_t>().error();
       ASSERT_ERROR(error, IO_ERROR);
       TEST_SUCCEED();

--- a/tests/parse_many_test.cpp
+++ b/tests/parse_many_test.cpp
@@ -69,13 +69,16 @@ bool validate(const char *dirname) {
             snprintf(fullpath, fullpathlen, "%s%s%s", dirname, needsep ? "/" : "", name);
 
             /* The actual test*/
-            auto [json, error] = simdjson::padded_string::load(fullpath);
+            simdjson::padded_string json;
+            auto error = simdjson::padded_string::load(fullpath).get(json);
             if (!error) {
                 simdjson::dom::parser parser;
 
                 ++how_many;
-                for (auto result : parser.parse_many(json)) {
-                    error = result.error();
+                simdjson::dom::document_stream docs;
+                error = parser.parse_many(json).get(docs);
+                for (auto doc : docs) {
+                    error = doc.error();
                 }
             }
             printf("%s\n", error ? "ok" : "invalid");

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -26,9 +26,9 @@ template<>
 bool equals_expected<const char *>(const char *actual, const char *expected) {
   return !strcmp(actual, expected);
 }
-#define ASSERT_EQUAL(ACTUAL, EXPECTED) if (!equals_expected(ACTUAL, EXPECTED)) { std::cerr << "Expected " << #ACTUAL << " to be " << (EXPECTED) << ", got " << (ACTUAL) << " instead!" << std::endl; return false; }
+#define ASSERT_EQUAL(ACTUAL, EXPECTED) do { auto _actual = (ACTUAL); auto _expected = (EXPECTED); if (!equals_expected(_actual, _expected)) { std::cerr << "Expected " << #ACTUAL << " to be " << _expected << ", got " << _actual << " instead!" << std::endl; return false; } } while(0);
 #define ASSERT(RESULT, MESSAGE) if (!(RESULT)) { std::cerr << MESSAGE << std::endl; return false; }
 #define RUN_TEST(RESULT) if (!RESULT) { return false; }
-#define ASSERT_SUCCESS(ERROR) if (ERROR) { std::cerr << (ERROR) << std::endl; return false; }
+#define ASSERT_SUCCESS(ERROR) do { auto _error = (ERROR); if (_error) { std::cerr << _error << std::endl; return false; } } while(0);
 
 #endif // TEST_MACROS_H

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -26,9 +26,14 @@ template<>
 bool equals_expected<const char *>(const char *actual, const char *expected) {
   return !strcmp(actual, expected);
 }
+
+#define TEST_START() { cout << "Running " << __func__ << " ..." << endl; }
 #define ASSERT_EQUAL(ACTUAL, EXPECTED) do { auto _actual = (ACTUAL); auto _expected = (EXPECTED); if (!equals_expected(_actual, _expected)) { std::cerr << "Expected " << #ACTUAL << " to be " << _expected << ", got " << _actual << " instead!" << std::endl; return false; } } while(0);
+#define ASSERT_ERROR(ACTUAL, EXPECTED) do { auto _actual = (ACTUAL); auto _expected = (EXPECTED); if (_actual != _expected) { std::cerr << "FAIL: Unexpected error \"" << _actual << "\" (expected \"" << _expected << "\")" << std::endl; return false; } } while (0);
 #define ASSERT(RESULT, MESSAGE) if (!(RESULT)) { std::cerr << MESSAGE << std::endl; return false; }
 #define RUN_TEST(RESULT) if (!RESULT) { return false; }
 #define ASSERT_SUCCESS(ERROR) do { auto _error = (ERROR); if (_error) { std::cerr << _error << std::endl; return false; } } while(0);
+#define TEST_FAIL(MESSAGE) { std::cerr << "FAIL: " << (MESSAGE) << std::endl; return false; }
+#define TEST_SUCCEED() { return true; }
 
 #endif // TEST_MACROS_H


### PR DESCRIPTION
This makes it so parse_many and load_many behave like other APIs and return simdjson_result<document_stream>. Previously, if there was an error while loading, we would stash the error in the document_stream and return it when you first iterated.

The purpose here is to ensure we handle errors the same way everywhere (and to allow users to check for and recover from them as soon as they like).

### Concerns

This is a win for us internally, but it makes the use of parse_many() harder when you have exceptions off. I think the control flow makes more *sense* if you have exceptions off--you would expect the file itself to have at least one error--but it definitely makes the code you have to write harder:

Now:

```c++
document_stream stream;
if ((error = parser.parse_many(json).get(stream)) { exit(1); }
for (auto [doc, error] : stream) {
  ...
}
```

Before:

```c++
for (auto [doc, error] : parser.parse_many(json)) {
  ...
}
```

Fixes #952.