### PR TITLE
Fix #955

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,13 @@ add_subdirectory(singleheader)
 #
 # Compile tools / tests / benchmarks
 #
-add_subdirectory(dependencies)
-add_subdirectory(tests)
-add_subdirectory(examples)
-add_subdirectory(benchmark)
+if(NOT SIMDJSON_IGNORE_DEPENDENCIES)
+    add_subdirectory(dependencies)
+    add_subdirectory(tests)
+    add_subdirectory(benchmark)
+endif()
 add_subdirectory(fuzz)
+add_subdirectory(examples)
 
 #
 # Source files should be just ASCII

--- a/simdjson-flags.cmake
+++ b/simdjson-flags.cmake
@@ -35,6 +35,7 @@ endif()
 option(SIMDJSON_COMPETITION "Compile competitive benchmarks" ON)
 
 option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" ON)
+option(SIMDJSON_IGNORE_DEPENDENCIES "Ignores the dependencies folder. Useful if you don't want benchmarks" OFF)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 


### PR DESCRIPTION
Fixes #955 

If the option `SIMDJSON_IGNORE_DEPENDENCIES` is enabled the folders `dependencies`, `tests` and `benchmark` are ignored.