### PR TITLE
Compile with -Weffc++ in CI

### DIFF
--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -60,10 +60,8 @@ if(MSVC)
   target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl)
 else()
   target_compile_options(simdjson-internal-flags INTERFACE -fPIC)
-  if (NOT SIMDJSON_GOOGLE_BENCHMARKS) # Google Benchmark can't be compiled without warnings with -Weffc++
-    target_compile_options(simdjson-internal-flags INTERFACE -Weffc++)
-  endif()
-  target_compile_options(simdjson-internal-flags INTERFACE -Werror -Wall -Wextra -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
+  target_compile_options(simdjson-internal-flags INTERFACE -Werror -Wall -Wextra -Weffc++)
+  target_compile_options(simdjson-internal-flags INTERFACE -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
 endif()
 
 # Optional flags

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -117,6 +117,7 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
     SIMDJSON_DISABLE_GCC_WARNING(-Wextra) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wattributes) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wimplicit-fallthrough) \
+    SIMDJSON_DISABLE_GCC_WARNING(-Wnon-virtual-dtor) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wreturn-type) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wshadow) \
     SIMDJSON_DISABLE_GCC_WARNING(-Wunused-parameter) \

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -1,10 +1,13 @@
 #include <iostream>
 #include <unistd.h>
 #include "simdjson.h"
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #ifndef __cpp_exceptions
 #define CXXOPTS_NO_EXCEPTIONS
 #endif
 #include "cxxopts.hpp"
+SIMDJSON_POP_DISABLE_WARNINGS
 
 int main(int argc, char *argv[]) {
 #ifdef __cpp_exceptions

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -2,10 +2,13 @@
 #include <set>
 
 #include "simdjson.h"
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #ifndef __cpp_exceptions
 #define CXXOPTS_NO_EXCEPTIONS
 #endif
 #include "cxxopts.hpp"
+SIMDJSON_POP_DISABLE_WARNINGS
 
 size_t count_nonasciibytes(const uint8_t *input, size_t length) {
   size_t count = 0;

--- a/tools/minify.cpp
+++ b/tools/minify.cpp
@@ -5,10 +5,13 @@
 #include <unistd.h>
 
 #include "simdjson.h"
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #ifndef __cpp_exceptions
 #define CXXOPTS_NO_EXCEPTIONS
 #endif
 #include "cxxopts.hpp"
+SIMDJSON_POP_DISABLE_WARNINGS
 
 cxxopts::Options options("minify", "Runs the parser against the given json files in a loop, measuring speed and other statistics.");
 


### PR DESCRIPTION
Turns out we haven't been compiling with these warnings on in CI because we have SIMDJSON_GOOGLE_BENCHMARKS enabled. This helps explain why I sometimes get extra warnings and sometimes don't--when I am running with different options!