### PR TITLE
Removing optional since it is not C++11, and it is not used

### DIFF
--- a/include/simdjson/implementation.h
+++ b/include/simdjson/implementation.h
@@ -3,7 +3,6 @@
 
 #include "simdjson/common_defs.h"
 #include "simdjson/internal/dom_parser_implementation.h"
-#include <optional>
 #include <string>
 #include <atomic>
 #include <vector>


### PR DESCRIPTION
Fixes https://github.com/simdjson/simdjson/issues/985