### PR TITLE
Parse 18-digit positive integers quickly

### DIFF
--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -542,6 +542,22 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
     }
   } else {
     if (unlikely(digit_count >= 18)) { // this is uncommon!!!
+      // 18-digit positive numbers never overflow, but we have to figure out whether they will
+      // fit in a signed integer or not.
+      if (!negative && digit_count == 18) {
+        if (i <= uint64_t(INT64_MAX)) {
+          writer.append_s64(i);
+#ifdef JSON_TEST_NUMBERS // for unit testing
+          found_integer(i, src);
+#endif
+        } else {
+          writer.append_u64(i);
+#ifdef JSON_TEST_NUMBERS // for unit testing
+          found_unsigned_integer(i, src);
+#endif
+        }
+        return true;
+      }
       // there is a good chance that we had an overflow, so we need
       // need to recover: we parse the whole thing again.
       bool success = parse_large_integer(src, writer, found_minus);


### PR DESCRIPTION
Presently we treat 18-digit positive integers as potential overflow and reparse them slowly; but 18-digit integers are only potential overflow if they are negative. This PR checks if we have a positive 18-digit number, and emits a signed integer (or unsigned integer if it's > INT64_MAX) without reparsing, There are several files (including twitter) that appear to benefit from this.

I don't understand why instruction count doesn't go down, but throughput clearly goes up.

| File                                | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                                 |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| update-center                       |  45.1 |  43.4 |    3% | 142.1 | 142.1 |    0% |   2868 |   2566 |   10% |      0 |      0 |    0% |  25191 |  25196 |    0% |
| twitterescaped                      |  42.5 |  41.0 |    3% | 138.1 | 138.1 |    0% |   2117 |   1803 |   14% |      0 |      0 |    0% |  25138 |  24998 |    0% |
| twitter                             |  44.1 |  43.1 |    2% | 148.8 | 148.8 |    0% |   1777 |   1711 |    3% |      0 |      0 |    0% |  27145 |  27149 |    0% |
| repeat                              |  51.9 |  50.9 |    2% | 187.8 | 187.8 |    0% |      1 |      0 |    0% |      0 |      0 |    0% |      0 |      0 |    0% |
| instruments                         |  38.6 |  37.8 |    2% | 143.1 | 143.1 |    0% |    210 |    104 |   50% |      0 |      0 |    0% |  10577 |   9899 |    6% |
| random                              |  58.6 |  57.6 |    1% | 209.3 | 209.3 |    0% |   1010 |   1007 |    0% |      0 |      0 |    0% |  27766 |  27767 |    0% |
| gsoc-2018                           |  36.5 |  36.0 |    1% | 101.1 | 101.1 |    0% |  14875 |  15003 |    0% |  24699 |  20054 |   18% | 116879 | 116200 |    0% |
| marine_ik                           |  54.2 |  53.4 |    1% | 180.9 | 180.9 |    0% |   8793 |   8715 |    0% |  75205 |  62556 |   16% | 186956 | 185905 |    0% |
| twitter_api_response                |  37.8 |  37.5 |    0% | 140.1 | 140.1 |    0% |      1 |      0 |    0% |      0 |      0 |    0% |     99 |     50 |   49% |
| canada                              |  45.4 |  45.0 |    0% | 157.6 | 157.6 |    0% |   5298 |   5368 |   -1% |  12991 |  18249 |  -40% | 115807 | 116328 |    0% |
| twitter_timeline                    |  40.7 |  40.4 |    0% | 153.5 | 153.5 |    0% |      6 |      2 |   66% |      0 |      0 |    0% |    530 |    502 |    5% |
| mesh                                |  46.2 |  46.0 |    0% | 174.2 | 174.2 |    0% |    769 |    766 |    0% |      0 |      0 |    0% |  43017 |  43181 |    0% |
| numbers                             |  38.6 |  38.5 |    0% | 144.3 | 144.3 |    0% |    105 |    113 |   -7% |      0 |      0 |    0% |   6619 |   6865 |   -3% |
| twitter_api_compact_response        |  41.6 |  41.5 |    0% | 153.1 | 153.1 |    0% |      1 |      1 |    0% |      0 |      0 |    0% |     21 |      4 |   80% |
| google_maps_api_compact_response    |  50.1 |  50.0 |    0% | 190.3 | 190.3 |    0% |      1 |      2 | -100% |      0 |      0 |    0% |     30 |     29 |    3% |
| citm_catalog                        |  34.1 |  34.1 |    0% | 130.7 | 130.7 |    0% |    157 |    164 |   -4% |    376 |     20 |   94% |  71665 |  71598 |    0% |
| mesh.pretty                         |  35.8 |  35.8 |    0% | 137.7 | 137.7 |    0% |     29 |     40 |  -37% |      9 |     43 | -377% |  69235 |  69499 |    0% |
| tree-pretty                         |  36.8 |  36.8 |    0% | 140.6 | 140.6 |    0% |      1 |      0 |    0% |      0 |      0 |    0% |    228 |     80 |   64% |
| github_events                       |  34.2 |  34.2 |    0% | 129.8 | 129.8 |    0% |      2 |      4 | -100% |      0 |      0 |    0% |   1728 |   1488 |   13% |
| google_maps_api_response            |  36.1 |  36.1 |    0% | 137.2 | 137.2 |    0% |      1 |      0 |    0% |      0 |      0 |    0% |     54 |     97 |  -79% |
| apache_builds                       |  36.7 |  36.8 |    0% | 139.3 | 139.3 |    0% |     15 |     25 |  -66% |      0 |      0 |    0% |   5022 |   5148 |   -2% |