### PR TITLE
This introduces a new option to forcefully disable threads for people who also want them enabled

### DIFF
--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -117,7 +117,12 @@ if(SIMDJSON_ENABLE_THREADS)
 endif()
 
 # Some users compile simdjson with thread support but still do not want simdjson to use threads.
-option(SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT "Whether we enabled thread support or not (SIMDJSON_ENABLE_THREADS), do not use threads. This option does nothing when thread support is not enabled." OFF)
+#
+#  Important : Expect this option to disappear in the future.
+#
+option(SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT "Whether we enabled thread support or not (SIMDJSON_ENABLE_THREADS), do not use threads.\
+ This option does nothing when thread support is not enabled. We reserve the right to remove this option in a future release in\
+ favor of a runtime approach." OFF)
 if(SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT)
   target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT=1)
 endif()

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -105,7 +105,7 @@ if(NOT SIMDJSON_EXCEPTIONS)
   target_compile_definitions(simdjson-internal-flags INTERFACE SIMDJSON_EXCEPTIONS=0)
 endif()
 
-option(SIMDJSON_ENABLE_THREADS "Enable threaded operation" ON)
+option(SIMDJSON_ENABLE_THREADS "Link with thread support" ON)
 if(SIMDJSON_ENABLE_THREADS)
   set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
   set(THREADS_PREFER_PTHREAD_FLAG TRUE)
@@ -113,7 +113,13 @@ if(SIMDJSON_ENABLE_THREADS)
   target_link_libraries(simdjson-flags INTERFACE Threads::Threads)
   target_link_libraries(simdjson-flags INTERFACE ${CMAKE_THREAD_LIBS_INIT})
   target_compile_options(simdjson-flags INTERFACE ${CMAKE_THREAD_LIBS_INIT})
-  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_THREADS_ENABLED=1)
+  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_THREADS_ENABLED=1) # This will be set in the code automatically.
+endif()
+
+# Some users compile simdjson with thread support but still do not want simdjson to use threads.
+option(SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT "Whether we enabled thread support or not (SIMDJSON_ENABLE_THREADS), do not use threads. This option does nothing when thread support is not enabled." OFF)
+if(SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT)
+  target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT=1)
 endif()
 
 if(SIMDJSON_USE_LIBCPP)

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -101,6 +101,12 @@ A `document_stream` instance uses at most two threads: there is a main thread an
 You should expect the main thread to be fully occupied while the worker thread is partially busy
 (e.g., 80% of the time).
 
+If you compile simdjson with thread support and you still do not want simdjson to use threads,
+you can forcefully disable them by setting the SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT macro
+to 1 in C++, or by passing SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT=ON to cmake. It is a 
+compile-time decision: if you disable the threads with SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT,
+you will not be able to use threads in simdjson unless you recompile.
+
 Support
 -------
 

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -101,12 +101,6 @@ A `document_stream` instance uses at most two threads: there is a main thread an
 You should expect the main thread to be fully occupied while the worker thread is partially busy
 (e.g., 80% of the time).
 
-If you compile simdjson with thread support and you still do not want simdjson to use threads,
-you can forcefully disable them by setting the SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT macro
-to 1 in C++, or by passing SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT=ON to cmake. It is a 
-compile-time decision: if you disable the threads with SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT,
-you will not be able to use threads in simdjson unless you recompile.
-
 Support
 -------
 

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -122,7 +122,6 @@ compiling for a known 64-bit platform."
 #endif
 #endif
 
-
 // workaround for large stack sizes under -O0.
 // https://github.com/simdjson/simdjson/issues/691
 #ifdef __APPLE__
@@ -135,6 +134,13 @@ compiling for a known 64-bit platform."
 #undef SIMDJSON_THREADS_ENABLED
 #endif
 #endif
+
+
+#if SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT
+// No matter what happened, we undefine SIMDJSON_THREADS_ENABLED and so disable threads.
+#undef SIMDJSON_THREADS_ENABLED
+#endif
+
 
 #if defined(__clang__)
 #define NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))


### PR DESCRIPTION
Some people want to compile simdjson with thread support, and yet they do not want simdjson to use threads. There is no runtime way to do this right now. This PR introduces a compile-time "overwrite" option (SIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT) that would overwrite thread support and prevent simdjson from using threads, even if it is compiled with thread support.

This a temporary compile-time option. I expect that we will offer runtime control in the future.

Fixes https://github.com/simdjson/simdjson/issues/988