### PR TITLE
CMAKE_VS_PLATFORM_TOOLSET might be empty

### DIFF
--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -77,7 +77,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 
 if(MSVC)
-if(${CMAKE_VS_PLATFORM_TOOLSET} STREQUAL "v140")
+if("${MSVC_TOOLSET_VERSION}" STREQUAL "140")
   # Visual Studio 2015 issues warnings and we tolerate it,  cmake -G"Visual Studio 14" ..
   target_compile_options(simdjson-internal-flags INTERFACE /W0 /sdl)
 else()


### PR DESCRIPTION
# Issue
According to https://gitlab.kitware.com/cmake/cmake/-/issues/17976, `CMAKE_VS_PLATFORM_TOOLSET` is set only when using a Visual Studio generator.

When we use a Ninja generator(in `vcpkg`, Ninja is prefered if available), `CMAKE_VS_PLATFORM_TOOLSET` will be empty.
As a result:
> if(${CMAKE_VS_PLATFORM_TOOLSET} STREQUAL "v140")

will be treated as:
> if( STREQUAL "v140")

The build log can be downloaded from here: https://github.com/microsoft/vcpkg/pull/12140/checks?check_run_id=821747528

# How to reproduce?
Suppose we have a `CMakeSettings.json` which contains:
```json
{
  // See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
  "configurations": [
    {
      "name": "x86-Debug",
      "generator": "Ninja",
      "configurationType": "Debug",
      "inheritEnvironments": [ "msvc_x86" ],
      "buildRoot": "${projectDir}\\build\\Debug_x86",
      "installRoot": "${env.ProgramFiles(x86)}\\${name}",
      "cmakeCommandArgs": "",
      "buildCommandArgs": "",
      "ctestCommandArgs": ""
    },
    {
      "name": "x86-Release",
      "generator": "Ninja",
      "configurationType": "RelWithDebInfo",
      "inheritEnvironments": [ "msvc_x86" ],
      "buildRoot": "${projectDir}\\build\\Release_x86",
      "installRoot": "${env.ProgramFiles(x86)}\\${name}",
      "cmakeCommandArgs": "",
      "buildCommandArgs": "",
      "ctestCommandArgs": ""
    },
    {
      "name": "x64-Debug",
      "generator": "Ninja",
      "configurationType": "Debug",
      "inheritEnvironments": [ "msvc_x64" ],
      "buildRoot": "${projectDir}\\build\\Debug_x64",
      "installRoot": "${env.ProgramFiles}\\${name}",
      "cmakeCommandArgs": "",
      "buildCommandArgs": "",
      "ctestCommandArgs": ""
    },
    {
      "name": "x64-Release",
      "generator": "Ninja",
      "configurationType": "RelWithDebInfo",
      "inheritEnvironments": [ "msvc_x64" ],
      "buildRoot": "${projectDir}\\build\\Release_x64",
      "installRoot": "${env.ProgramFiles}\\${name}",
      "cmakeCommandArgs": "",
      "buildCommandArgs": "",
      "ctestCommandArgs": ""
    }
  ]
}

```
Put this file into the root dir of `simdjson` repository. Then, open Visual Studio 2019, click `File/Open/CMake` and select the top level `CMakeLists.txt` of `simdjson`, then you will see some outputs in the `Output` view:
![Annotation 2020-06-30 164700](https://user-images.githubusercontent.com/5435649/86105028-67d33100-baf1-11ea-8575-963f8d12e543.png)

# How to resolve?
We may also quote it like this:
> if("${CMAKE_VS_PLATFORM_TOOLSET}" STREQUAL "v140")

but that won't make the warnings disappeared in VS2015.

In this patch, I use `MSVC_TOOLSET_VERSION` instead.
