### PR TITLE
Remove some branches from number parsing

### DIFF
--- a/src/arm64/numberparsing.h
+++ b/src/arm64/numberparsing.h
@@ -21,7 +21,7 @@ namespace arm64 {
 
 // we don't have SSE, so let us use a scalar function
 // credit: https://johnnylee-sde.github.io/Fast-numeric-string-to-int/
-static inline uint32_t parse_eight_digits_unrolled(const char *chars) {
+static really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   uint64_t val;
   memcpy(&val, chars, sizeof(uint64_t));
   val = (val & 0x0F0F0F0F0F0F0F0F) * 2561 >> 8;

--- a/src/fallback/numberparsing.h
+++ b/src/fallback/numberparsing.h
@@ -16,12 +16,15 @@ void found_float(double result, const uint8_t *buf);
 
 namespace simdjson {
 namespace fallback {
-static inline uint32_t parse_eight_digits_unrolled(const char *chars) {
+static really_inline uint32_t parse_eight_digits_unrolled(const char *chars) {
   uint32_t result = 0;
   for (int i=0;i<8;i++) {
     result = result*10 + (chars[i] - '0');
   }
   return result;
+}
+static really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
+  return parse_eight_digits_unrolled((const char *)chars);
 }
 
 #define SWAR_NUMBER_PARSING

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -228,12 +228,6 @@ static bool parse_float_strtod(const char *ptr, double *outDouble) {
   return true;
 }
 
-really_inline bool is_integer(char c) {
-  return (c >= '0' && c <= '9');
-  // this gets compiled to (uint8_t)(c - '0') <= 9 on all decent compilers
-}
-
-
 // check quickly whether the next 8 chars are made of digits
 // at a glance, it looks better than Mula's
 // http://0x80.pl/articles/swar-digits-validate.html

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -383,6 +383,17 @@ really_inline bool write_float(const uint8_t *const src, bool negative, uint64_t
   return true;
 }
 
+// for performance analysis, it is sometimes  useful to skip parsing
+#ifdef SIMDJSON_SKIPNUMBERPARSING
+
+template<typename W>
+really_inline bool parse_number(const uint8_t *const, W &writer) {
+  writer.append_s64(0);        // always write zero
+  return true;                 // always succeeds
+}
+
+#else
+
 // parse the number at src
 // define JSON_TEST_NUMBERS for unit testing
 //
@@ -393,13 +404,7 @@ really_inline bool write_float(const uint8_t *const src, bool negative, uint64_t
 //
 // Our objective is accurate parsing (ULP of 0) at high speed.
 template<typename W>
-really_inline bool parse_number(UNUSED const uint8_t *const src,
-                                W &writer) {
-#ifdef SIMDJSON_SKIPNUMBERPARSING // for performance analysis, it is sometimes
-                                  // useful to skip parsing
-  writer.append_s64(0);        // always write zero
-  return true;                    // always succeeds
-#else
+really_inline bool parse_number(const uint8_t *const src, W &writer) {
 
   //
   // Check for minus sign
@@ -478,9 +483,9 @@ really_inline bool parse_number(UNUSED const uint8_t *const src,
     WRITE_INTEGER(negative ? 0 - i : i, src, writer);
   }
   return is_structural_or_whitespace(*p);
+}
 
 #endif // SIMDJSON_SKIPNUMBERPARSING
-}
 
 } // namespace numberparsing
 } // namespace stage2

--- a/src/haswell/numberparsing.h
+++ b/src/haswell/numberparsing.h
@@ -19,7 +19,7 @@ void found_float(double result, const uint8_t *buf);
 TARGET_HASWELL
 namespace simdjson {
 namespace haswell {
-static inline uint32_t parse_eight_digits_unrolled(const char *chars) {
+static really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   // this actually computes *16* values so we are being wasteful.
   const __m128i ascii0 = _mm_set1_epi8('0');
   const __m128i mul_1_10 =

--- a/src/westmere/numberparsing.h
+++ b/src/westmere/numberparsing.h
@@ -20,7 +20,7 @@ void found_float(double result, const uint8_t *buf);
 TARGET_WESTMERE
 namespace simdjson {
 namespace westmere {
-static inline uint32_t parse_eight_digits_unrolled(const char *chars) {
+static really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   // this actually computes *16* values so we are being wasteful.
   const __m128i ascii0 = _mm_set1_epi8('0');
   const __m128i mul_1_10 =


### PR DESCRIPTION
This simplifies integer parsing (and float parsing, a little bit), in particular removing a bunch of visible branches. (I say visible because I believe the compiler was getting rid of said branches given that performance and branch misses don't really change.) It does not change performance at all on Skylake / GCC 9.

The main changes:

1. **parse_digit:** Moved digit parsing to a common parse_digit() function, eliminating is_integer and doing the comparison against the parsed int. The compiler was already doing this for us, but this both makes the callers easier to read, and makes the intended flow clearer instead of having redundant operations in the code to be optimized.
2. **Remove `case '-'`:** Removed the `found_minus` parameter and the special cases for '-' in the structural_parser. This makes no performance difference on skylake, indicating it's an optimization with no benefit. Either (a) the compiler was already combining a lot of the inline code, or (b) the , and I don't know that we want it to be.
3. **Move error checks:** Instead of many error check branches, we consolidate error checks for each branch (int, dec, exp) to a single if() after the parse. The de-branching was likely already being done by the compiler, given the lack of performance improvement, but this gives the user less code to read and the compiler fewer decisions to make. This also simplifies the main body of the parse and makes it easier to follow, IMO.
4. **Remove redundant check:** Removed the weird double `if (is_integer)` we talked about in #990. I suspect the many if statements were the reason earlier attempts didn't take--it probably pushed some of the compiler's debranching optimizations over the edge. My experiments tell me the compiler is really not very good at debranching things by itself.
5. **Move exp overflow check:** Exponent overflow was being checked after each digit. Not a huge deal, but there is no reason to do this if you can check after (as with int parsing).