### PR TITLE
This enables  /Ob3 under Visual Studio 2019

### DIFF
--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -74,18 +74,17 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 
 if(MSVC)
-if(${CMAKE_VS_PLATFORM_TOOLSET} STREQUAL "v140")
+if(${MSVC_TOOLSET_VERSION} STREQUAL "140")
   # Visual Studio 2015 issues warnings and we tolerate it,  cmake -G"Visual Studio 14" ..
   target_compile_options(simdjson-internal-flags INTERFACE /W0 /sdl)
 else()
   # Recent version of Visual Studio expected (2017, 2019...). Prior versions are unsupported.
   target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl)
 endif()
-if(${CMAKE_VS_PLATFORM_TOOLSET} STRGREATER "v141")
+if(${MSVC_TOOLSET_VERSION} STRGREATER "141")
   string(REPLACE "/Ob2" "/Ob3" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}") #VS 2019
   message(STATUS " Visual Studio 2019 detected, new compile flags ${CMAKE_CXX_FLAGS_RELEASE}")
 endif()
-
 
 else()
   target_compile_options(simdjson-internal-flags INTERFACE -fPIC)

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -82,7 +82,7 @@ else()
   target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl)
 endif()
 if(${CMAKE_VS_PLATFORM_TOOLSET} STRGREATER "v141")
-  string(REPLACE "/Ob2" "/Ob2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}") #VS 2019
+  string(REPLACE "/Ob2" "/Ob3" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}") #VS 2019
   message(STATUS " Visual Studio 2019 detected, new compile flags ${CMAKE_CXX_FLAGS_RELEASE}")
 endif()
 

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -81,6 +81,12 @@ else()
   # Recent version of Visual Studio expected (2017, 2019...). Prior versions are unsupported.
   target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl)
 endif()
+if(${CMAKE_VS_PLATFORM_TOOLSET} STRGREATER "v141")
+  string(REPLACE "/Ob2" "/Ob2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}") #VS 2019
+  message(STATUS " Visual Studio 2019 detected, new compile flags ${CMAKE_CXX_FLAGS_RELEASE}")
+endif()
+
+
 else()
   target_compile_options(simdjson-internal-flags INTERFACE -fPIC)
   target_compile_options(simdjson-internal-flags INTERFACE -Werror -Wall -Wextra -Weffc++)


### PR DESCRIPTION
Comparisons with our main branch...

Command lines (using git bash)

```
git clone https://github.com/simdjson/simdjson.git

cd simdjson 

mkdir build
cd build

 git checkout master && rm -r -f * && cmake -G "Visual Studio 16 2019"  .. && cmake --build . --target parse --config Release --verbose &&./benchmark/Release/parse.exe ../jsonexamples/twitter.json

git checkout dlemire/enable_ob3_under_vs2019 && rm -r -f * && cmake -G "Visual Studio 16 2019"  .. && cmake --build . --target parse --config Release --verbose &&./benchmark/Release/parse.exe ../jsonexamples/twitter.json


```


main branch:
```
 git checkout master && rm -r -f * && cmake -G "Visual Studio 16 2019"  .. && cmake --build . --target parse --config Release --verbose &&./benchmark/Release/parse.exe ../jsonexamples/twitter.json

../jsonexamples/twitter.json
============================
     9867 blocks -     631515 bytes - 55262 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages
|    Speed        :  43.3016 ns per block ( 91.20%) -   0.6766 ns per byte -   7.7323 ns per structural -   1.4779 GB/s
|- Allocation
|    Speed        :   2.6854 ns per block (  5.66%) -   0.0420 ns per byte -   0.4795 ns per structural -  23.8308 GB/s
|- Stage 1
|    Speed        :  23.2367 ns per block ( 48.94%) -   0.3631 ns per byte -   4.1493 ns per structural -   2.7541 GB/s
|- Stage 2
|    Speed        :  17.3085 ns per block ( 36.46%) -   0.2705 ns per byte -   3.0907 ns per structural -   3.6974 GB/s

2340.3 documents parsed per second (best)
```

this PR:
```
git checkout dlemire/enable_ob3_under_vs2019 && rm -r -f * && cmake -G "Visual Studio 16 2019"  .. && cmake --build . --target parse --config Release --verbose &&./benchmark/Release/parse.exe ../jsonexamples/twitter.json


../jsonexamples/twitter.json
============================
     9867 blocks -     631515 bytes - 55262 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages
|    Speed        :  43.3725 ns per block ( 74.24%) -   0.6777 ns per byte -   7.7449 ns per structural -   1.4755 GB/s
|- Allocation
|    Speed        :   2.4321 ns per block (  4.16%) -   0.0380 ns per byte -   0.4343 ns per structural -  26.3131 GB/s
|- Stage 1
|    Speed        :  23.3685 ns per block ( 40.00%) -   0.3652 ns per byte -   4.1728 ns per structural -   2.7386 GB/s
|- Stage 2
|    Speed        :  17.4098 ns per block ( 29.80%) -   0.2720 ns per byte -   3.1088 ns per structural -   3.6759 GB/s

```