### PR TITLE
Fix undefined behavior: load of misaligned address

### DIFF
--- a/src/generic/stage2/atomparsing.h
+++ b/src/generic/stage2/atomparsing.h
@@ -1,7 +1,7 @@
 namespace stage2 {
 namespace atomparsing {
 
-really_inline uint32_t string_to_uint32(const char* str) { return *reinterpret_cast<const uint32_t *>(str); }
+really_inline uint32_t string_to_uint32(const char* str) { uint32_t val; std::memcpy(&val, str, sizeof(uint32_t)); return val; }
 
 WARN_UNUSED
 really_inline uint32_t str4ncmp(const uint8_t *src, const char* atom) {


### PR DESCRIPTION
UndefinedBehaviorSanitizer alerts about loading of misaligned address:

```
../contrib/simdjson/src/generic/stage2/atomparsing.h:4:67: runtime error: load of misaligned address 0x0000156b65c2 for type 'const uint32_t' (aka 'const unsigned int'), which requires 4 byte alignment
0x0000156b65c2: note: pointer points here
 6e 65  64 00 6e 75 6c 6c 00 61  6c 69 67 6e 6d 65 6e 74  00 6f 62 6a 65 63 74 2d  73 69 7a 65 00 69
              ^ 
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../contrib/simdjson/src/generic/stage2/atomparsing.h:4:67
```

This PR fixes that.