### PR TITLE
Fix clang warning -Wused-but-marked-unused.

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -98,8 +98,8 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 
 #else // SIMDJSON_REGULAR_VISUAL_STUDIO
 
-  #define really_inline inline __attribute__((always_inline, unused))
-  #define never_inline inline __attribute__((noinline, unused))
+  #define really_inline inline __attribute__((always_inline))
+  #define never_inline inline __attribute__((noinline))
 
   #define UNUSED __attribute__((unused))
   #define WARN_UNUSED __attribute__((warn_unused_result))

--- a/src/generic/stage1/find_next_document_index.h
+++ b/src/generic/stage1/find_next_document_index.h
@@ -23,7 +23,7 @@
   * complete document, therefore the last json buffer location is the end of the
   * batch.
   */
-really_inline static uint32_t find_next_document_index(dom_parser_implementation &parser) {
+really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
   // TODO don't count separately, just figure out depth
   auto arr_cnt = 0;
   auto obj_cnt = 0;
@@ -65,7 +65,7 @@ really_inline static uint32_t find_next_document_index(dom_parser_implementation
 }
 
 // Skip the last character if it is partial
-really_inline static size_t trim_partial_utf8(const uint8_t *buf, size_t len) {
+really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len) {
   if (unlikely(len < 3)) {
     switch (len) {
       case 2:


### PR DESCRIPTION
When compiling with "-Weverything" Clang is showing a lot of warnings like this

```
warning: 'parse' was marked unused but was used
      [-Wused-but-marked-unused]
```

For example, I get such warnings in this simple program:

```
#include <string>
#include <iostream>
#include <simdjson.h>

#pragma clang diagnostic warning "-Weverything"
#pragma clang diagnostic ignored "-Wc++98-compat"

int main()
{
    std::string_view json = "23.5";
    simdjson::dom::parser parser;
    auto doc = parser.parse(json.data(), json.size());
    std::cout << "json parsed" << (doc.error() ? " with error" : "") << std::endl;
    return 0;
}
```

It's because of these definition:

```
#define really_inline inline __attribute__((always_inline, unused))
#define never_inline inline __attribute__((noinline, unused))
```

Clang treats the `unused` attribute as though the function should never be used and warns us if it's actually used.
It seems we can fix that by just dropping the attribute. 