### PR TITLE
Preparing new patch release for 0.4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ project(simdjson
 
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 4)
-set(PROJECT_VERSION_PATCH 6)
-set(SIMDJSON_SEMANTIC_VERSION "0.4.6" CACHE STRING "simdjson semantic version")
+set(PROJECT_VERSION_PATCH 7)
+set(SIMDJSON_SEMANTIC_VERSION "0.4.7" CACHE STRING "simdjson semantic version")
 set(SIMDJSON_LIB_VERSION "2.0.0" CACHE STRING "simdjson library version")
 set(SIMDJSON_LIB_SOVERSION "2" CACHE STRING "simdjson library soversion")
 set(SIMDJSON_GITHUB_REPOSITORY https://github.com/simdjson/simdjson)

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = simdjson
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.4.6"
+PROJECT_NUMBER         = "0.4.7"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/simdjson/simdjson_version.h
+++ b/include/simdjson/simdjson_version.h
@@ -4,7 +4,7 @@
 #define SIMDJSON_SIMDJSON_VERSION_H
 
 /** The version of simdjson being used (major.minor.revision) */
-#define SIMDJSON_VERSION 0.4.6
+#define SIMDJSON_VERSION 0.4.7
 
 namespace simdjson {
 enum {
@@ -19,7 +19,7 @@ enum {
   /**
    * The revision (major.minor.REVISION) of simdjson being used.
    */
-  SIMDJSON_VERSION_REVISION = 6
+  SIMDJSON_VERSION_REVISION = 7
 };
 } // namespace simdjson
 

--- a/singleheader/amalgamate_demo.cpp
+++ b/singleheader/amalgamate_demo.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Wed Jul  1 14:00:57 EDT 2020. Do not edit! */
+/* auto-generated on Fri Jul 17 14:52:28 EDT 2020. Do not edit! */
 
 #include <iostream>
 #include "simdjson.h"

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on Wed Jul  1 14:00:57 EDT 2020. Do not edit! */
+/* auto-generated on Fri Jul 17 14:52:28 EDT 2020. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 
@@ -520,7 +520,6 @@ private:
 
 const detect_best_supported_implementation_on_first_use detect_best_supported_implementation_on_first_use_singleton;
 
-internal::atomic_ptr<const implementation> active_implementation{&internal::detect_best_supported_implementation_on_first_use_singleton};
 
 const std::initializer_list<const implementation *> available_implementation_pointers {
 #if SIMDJSON_IMPLEMENTATION_HASWELL

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on Wed Jul  1 14:00:57 EDT 2020. Do not edit! */
+/* auto-generated on Fri Jul 17 14:52:28 EDT 2020. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -2040,7 +2040,7 @@ SIMDJSON_DISABLE_UNDESIRED_WARNINGS
 #define SIMDJSON_SIMDJSON_VERSION_H
 
 /** The version of simdjson being used (major.minor.revision) */
-#define SIMDJSON_VERSION 0.4.6
+#define SIMDJSON_VERSION 0.4.7
 
 namespace simdjson {
 enum {
@@ -2055,7 +2055,7 @@ enum {
   /**
    * The revision (major.minor.REVISION) of simdjson being used.
    */
-  SIMDJSON_VERSION_REVISION = 6
+  SIMDJSON_VERSION_REVISION = 7
 };
 } // namespace simdjson
 

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -58,7 +58,6 @@ private:
 
 const detect_best_supported_implementation_on_first_use detect_best_supported_implementation_on_first_use_singleton;
 
-internal::atomic_ptr<const implementation> active_implementation{&internal::detect_best_supported_implementation_on_first_use_singleton};
 
 const std::initializer_list<const implementation *> available_implementation_pointers {
 #if SIMDJSON_IMPLEMENTATION_HASWELL


### PR DESCRIPTION
We had a serious performance problem for small files and I want to patch the 0.4.x series with PR https://github.com/simdjson/simdjson/pull/1044 from @vitlibar. It only affects very small files.

Let us take the file `{"level":"INFO","message":"This is a log message that is long enough to be representative of an actual message.","msgType":1,"source":"Test","thread":"main","timestamp":1400000000000000000,"version":1}` from https://github.com/simdjson/simdjson/issues/1023

```bash
$ git checkout v0.4.6
$ cmake --build . --target parse
$ ./benchmark/parse f.json
number of iterations 200

f.json
======
        3 blocks -        202 bytes -    28 structurals ( 13.9 %)
special blocks with: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         4 (100.0 %) - 8+ structurals         2 ( 50.0 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         0 (  0.0 %) - 8+ structurals         3 ( 75.0 %) - 16+ structurals         0 (  0.0 %)

All Stages
|    Speed        : 311.2500 ns per block ( 73.69%) -   6.1634 ns per byte -  44.4643 ns per structural -   0.1622 GB/s
|- Allocation
|    Speed        : 221.2500 ns per block ( 52.39%) -   4.3812 ns per byte -  31.6071 ns per structural -   0.2282 GB/s
|- Stage 1
|    Speed        :  34.5000 ns per block (  8.17%) -   0.6832 ns per byte -   4.9286 ns per structural -   1.4638 GB/s
|- Stage 2
|    Speed        :  53.7500 ns per block ( 12.73%) -   1.0644 ns per byte -   7.6786 ns per structural -   0.9395 GB/s

803212.9 documents parsed per second (best)
```


```bash
$ git checkout dlemire/version047
$ cmake --build . --target parse
$ ./benchmark/parse f.json
number of iterations 200

f.json
======
        3 blocks -        202 bytes -    28 structurals ( 13.9 %)
special blocks with: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         4 (100.0 %) - 8+ structurals         2 ( 50.0 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         0 (  0.0 %) - 8+ structurals         3 ( 75.0 %) - 16+ structurals         0 (  0.0 %)

All Stages
|    Speed        : 218.7500 ns per block ( 86.00%) -   4.3317 ns per byte -  31.2500 ns per structural -   0.2309 GB/s
|- Allocation
|    Speed        : 128.5000 ns per block ( 50.52%) -   2.5446 ns per byte -  18.3571 ns per structural -   0.3930 GB/s
|- Stage 1
|    Speed        :  33.5000 ns per block ( 13.17%) -   0.6634 ns per byte -   4.7857 ns per structural -   1.5075 GB/s
|- Stage 2
|    Speed        :  55.0000 ns per block ( 21.62%) -   1.0891 ns per byte -   7.8571 ns per structural -   0.9182 GB/s

1142857.1 documents parsed per second (best)
```

So we had slightly over 100 ns of overhead removed.

Further reading: [The cost of runtime dispatch](https://lemire.me/blog/2020/07/17/the-cost-of-runtime-dispatch/)