### PR TITLE
This removes parallelization of the GCC 7 builds.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
         environment:
           CXX: g++
           CC: gcc
-          BUILD_FLAGS: -j
+          BUILD_FLAGS:
           CTEST_FLAGS: -j4 --output-on-failure
 
   gcc8:


### PR DESCRIPTION
The compiler keeps failing, probably because it runs out of memory.