### PR TITLE
Set DEFAULT_BATCH_SIZE to 10MB as specified in the documentation

### DIFF
--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -21,7 +21,7 @@ class document_stream;
 class element;
 
 /** The default batch size for parser.parse_many() and parser.load_many() */
-static constexpr size_t DEFAULT_BATCH_SIZE = 1000000;
+static constexpr size_t DEFAULT_BATCH_SIZE = 10000000;
 
 /**
   * A persistent document parser.

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -3305,7 +3305,7 @@ class document_stream;
 class element;
 
 /** The default batch size for parser.parse_many() and parser.load_many() */
-static constexpr size_t DEFAULT_BATCH_SIZE = 1000000;
+static constexpr size_t DEFAULT_BATCH_SIZE = 10000000;
 
 /**
   * A persistent document parser.


### PR DESCRIPTION
The documentation says:

> batch_size | ... Defaults to 10MB, which has been a reasonable sweet spot in our tests.

However the constant is set to `1MB`.

Not sure which is right, but I assume it's `10MB`.


