### PR TITLE
Add missing strings.h include for non-windows builds (required by strcasecmp)

### DIFF
--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -6,6 +6,9 @@
 #include <cstdlib>
 #include <cfloat>
 #include <cassert>
+#ifndef _WIN32
+#include <strings.h>
+#endif
 
 #ifdef _MSC_VER
 #define SIMDJSON_VISUAL_STUDIO 1


### PR DESCRIPTION
addresses #1066