### PR TITLE
Remove most computed GOTOs

### DIFF
--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -200,6 +200,12 @@ struct structural_parser : structural_iterator {
   }
   WARN_UNUSED really_inline ret_address_t parse_value(const unified_machine_addresses &addresses, ret_address_t continue_state) {
     switch (advance_char()) {
+    case '{':
+      FAIL_IF( start_object(continue_state) );
+      return addresses.object_begin;
+    case '[':
+      FAIL_IF( start_array(continue_state) );
+      return addresses.array_begin;
     case '"':
       FAIL_IF( parse_string() );
       return continue_state;
@@ -223,12 +229,6 @@ struct structural_parser : structural_iterator {
     case '5': case '6': case '7': case '8': case '9':
       FAIL_IF( parse_number() );
       return continue_state;
-    case '{':
-      FAIL_IF( start_object(continue_state) );
-      return addresses.object_begin;
-    case '[':
-      FAIL_IF( start_array(continue_state) );
-      return addresses.array_begin;
     default:
       log_error("Non-value found when value was expected!");
       return addresses.error;

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -13,39 +13,23 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace stage2 {
 
 #ifdef SIMDJSON_USE_COMPUTED_GOTO
-#define INIT_ADDRESSES() { &&array_begin, &&array_continue, &&error, &&finish, &&object_begin, &&object_continue }
-#define GOTO(address) { goto *(address); }
+#define INIT_ADDRESSES() { &&array_continue, &&finish, &&object_continue }
 #define CONTINUE(address) { goto *(address); }
 #else // SIMDJSON_USE_COMPUTED_GOTO
-#define INIT_ADDRESSES() { '[', 'a', 'e', 'f', '{', 'o' };
-#define GOTO(address)                 \
-  {                                   \
-    switch(address) {                 \
-      case '[': goto array_begin;     \
-      case 'a': goto array_continue;  \
-      case 'e': goto error;           \
-      case 'f': goto finish;          \
-      case '{': goto object_begin;    \
-      case 'o': goto object_continue; \
-    }                                 \
-  }
-// For the more constrained end_xxx() situation
+#define INIT_ADDRESSES() { 0, 1, 2 };
 #define CONTINUE(address)             \
   {                                   \
     switch(address) {                 \
-      case 'a': goto array_continue;  \
-      case 'o': goto object_continue; \
-      case 'f': goto finish;          \
+      case 0: goto array_continue;    \
+      case 1: goto finish;            \
+      case 2: goto object_continue;   \
     }                                 \
   }
 #endif // SIMDJSON_USE_COMPUTED_GOTO
 
 struct unified_machine_addresses {
-  ret_address_t array_begin;
   ret_address_t array_continue;
-  ret_address_t error;
   ret_address_t finish;
-  ret_address_t object_begin;
   ret_address_t object_continue;
 };
 


### PR DESCRIPTION
This removes most computed GOTOs, leaving only finish/array_continue/object_continue, which are used when an array or object is closed to figure out whether the parent was an array or object. It appears to be a slight improvement on gcc9 / skylake-x:

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| mesh.pretty                      |  24646 | 185.1 | 177.8 |    3% | 585.6 | 583.9 |    0% |  14104 |  13514 |    4% |   8285 |   4375 |   47% |  86999 |  87986 |   -1% |
| mesh                             |  11306 | 303.6 | 294.2 |    3% | 987.5 | 992.9 |    0% |   9668 |  10356 |   -7% |    523 |    568 |   -8% |  55582 |  56564 |   -1% |
| numbers                          |   2345 | 252.8 | 246.5 |    2% | 802.3 | 789.5 |    1% |   2147 |   2287 |   -6% |      8 |      0 |    0% |    171 |     49 |   71% |
| marine_ik                        |  46616 | 292.9 | 285.7 |    2% | 911.7 | 913.5 |    0% |  53660 |  53666 |    0% | 130738 | 125051 |    4% | 255806 | 255855 |    0% |
| canada                           |  35172 | 293.8 | 289.4 |    1% | 979.8 | 969.7 |    1% |  18959 |  18918 |    0% |  36153 |  38448 |   -6% | 154920 | 154863 |    0% |
| twitterescaped                   |   8787 | 188.5 | 186.4 |    1% | 509.6 | 501.9 |    1% |   4835 |   5090 |   -5% |     14 |     39 | -178% |  29340 |  26898 |    8% |
| apache_builds                    |   1988 |  84.3 |  83.7 |    0% | 308.1 | 307.9 |    0% |    122 |    117 |    4% |      0 |      0 |    0% |      3 |     23 | -666% |
| github_events                    |   1017 |  78.7 |  78.3 |    0% | 269.0 | 267.0 |    0% |    120 |    128 |   -6% |      0 |      0 |    0% |      0 |      0 |    0% |
| update-center                    |   8330 | 112.5 | 112.5 |    0% | 343.3 | 342.2 |    0% |   5710 |   5660 |    0% |      0 |     33 |    0% |  30869 |  29288 |    5% |
| gsoc-2018                        |  51997 |  75.3 |  75.7 |    0% | 171.4 | 167.9 |    2% |  32256 |  30670 |    4% |  66122 |  70950 |   -7% | 168426 | 168372 |    0% |
| random                           |   7976 | 138.9 | 140.1 |    0% | 496.2 | 500.6 |    0% |   2008 |   2030 |   -1% |      0 |      1 |    0% |  33485 |  32923 |    1% |
| twitter                          |   9867 |  90.7 |  91.6 |    0% | 298.3 | 297.4 |    0% |   3247 |   3617 |  -11% |    172 |      0 |    0% |  30335 |  31599 |   -4% |
| citm_catalog                     |  26987 |  82.8 |  84.9 |   -2% | 311.9 | 314.7 |    0% |   1756 |   1760 |    0% |   3801 |   4788 |  -25% |  89368 |  88787 |    0% |
| instruments                      |   3442 |  99.9 | 102.9 |   -2% | 375.8 | 384.5 |   -2% |    385 |    497 |  -29% |      0 |     21 |    0% |   1920 |   1449 |   24% |

Removing the remaining computed GOTOs is possible as well, but requires some thinking / tweaking.