### PR TITLE
[3/3] Return errors immediately instead of using goto

### DIFF
--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -144,13 +144,12 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  error_code result = stage2::parse_structurals<false>(*this, _doc);
-  if (result) { return result; }
+  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
     logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return error = TAPE_ERROR;
+    return TAPE_ERROR;
   }
 
   return SUCCESS;
@@ -161,8 +160,8 @@ WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_do
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  error_code err = stage1(_buf, _len, false);
-  if (err) { return err; }
+  auto error = stage1(_buf, _len, false);
+  if (error) { return error; }
   return stage2(_doc);
 }
 

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -321,13 +321,12 @@ namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  error_code result = stage2::parse_structurals<false>(*this, _doc);
-  if (result) { return result; }
+  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
     logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return error = TAPE_ERROR;
+    return TAPE_ERROR;
   }
 
   return SUCCESS;
@@ -338,8 +337,8 @@ WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_do
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  error_code err = stage1(_buf, _len, false);
-  if (err) { return err; }
+  auto error = stage1(_buf, _len, false);
+  if (error) { return error; }
   return stage2(_doc);
 }
 

--- a/src/generic/dom_parser_implementation.h
+++ b/src/generic/dom_parser_implementation.h
@@ -28,8 +28,6 @@ public:
   size_t len{0};
   /** Document passed to stage 2 */
   dom::document *doc{};
-  /** Error code (TODO remove, this is not even used, we just set it so the g++ optimizer doesn't get confused) */
-  error_code error{UNINITIALIZED};
 
   really_inline dom_parser_implementation();
   dom_parser_implementation(const dom_parser_implementation &) = delete;

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -107,13 +107,12 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  error_code result = stage2::parse_structurals<false>(*this, _doc);
-  if (result) { return result; }
+  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
     logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return error = TAPE_ERROR;
+    return TAPE_ERROR;
   }
 
   return SUCCESS;
@@ -124,8 +123,8 @@ WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_do
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  error_code err = stage1(_buf, _len, false);
-  if (err) { return err; }
+  auto error = stage1(_buf, _len, false);
+  if (error) { return error; }
   return stage2(_doc);
 }
 

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -113,13 +113,12 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  error_code result = stage2::parse_structurals<false>(*this, _doc);
-  if (result) { return result; }
+  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
     logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return error = TAPE_ERROR;
+    return TAPE_ERROR;
   }
 
   return SUCCESS;
@@ -130,8 +129,8 @@ WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_do
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  error_code err = stage1(_buf, _len, false);
-  if (err) { return err; }
+  auto error = stage1(_buf, _len, false);
+  if (error) { return error; }
   return stage2(_doc);
 }
 


### PR DESCRIPTION
Third in a three-part PR series: #1065 (anonymous namespaces) -- #1078 (remove computed GOTOs) -- 1079 (return errors instead of goto)

This eliminates the indirect "goto error, then decide what error to use" in favor of returning the detected error then and there. While there is no doubt that such a routine may ultimately be useful, all current errors are in fact knowable immediately.

The purpose here is to move towards a SAX model, where the actual methods return whatever error codes they want, and we honor them. I expect the SAX model to be very important for DOM-constructing language bindings. I'd also like stage 2 to be a consumer of this model, personally--even if it means stage 2 is a tiny bit slower than usual, eating our own dogfood will keep us from regressing performance for language bindings which will *definitely* benefit from it.

### Performance

This PR by itself generally reduces instruction count.

On Intel gcc9, overall performance impact is unclear. Taken as an average across our examples, it's a slight loss. It is a win on larger files with lots of numbers, but a loss on smaller files with fewer numbers. It will definitely fail the performance tests, because twitter.json takes a hit.

ARM gcc9 is a clear win for some files and neutral on the rest, with a consistent instruction count reduction.

I think it's worth it, personally, but I totally respect if others have different opinions :) At this point, I've given up trying to microtweak stage 2: my methodology is now to make as minimal a change as possible so that the desired outcome is clear, and if I see jitter like the table below, I don't worry if it's 1% up or down.

### skylake-x gcc10

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| mesh                             |  11306 | 311.0 | 272.5 |   12% | 978.9 | 986.9 |    0% |  10152 |   9784 |    3% |      3 |      9 | -200% |  60498 |  60832 |    0% |
| marine_ik                        |  46616 | 298.3 | 268.5 |   10% | 912.6 | 903.9 |    0% |  53695 |  53082 |    1% | 111046 | 111469 |    0% | 255885 | 255877 |    0% |
| numbers                          |   2345 | 253.7 | 231.2 |    8% | 790.8 | 790.8 |    0% |   2190 |   2170 |    0% |      0 |      0 |    0% |      0 |      0 |    0% |
| mesh.pretty                      |  24646 | 179.8 | 166.0 |    7% | 579.2 | 579.5 |    0% |  13553 |  13777 |   -1% |    898 |    672 |   25% |  88147 |  88167 |    0% |
| canada                           |  35172 | 289.1 | 273.1 |    5% | 982.2 | 980.9 |    0% |  18546 |  19699 |   -6% |  23380 |  22607 |    3% | 154761 | 154788 |    0% |
| citm_catalog                     |  26987 |  84.9 |  83.5 |    1% | 314.5 | 307.0 |    2% |   1752 |   1732 |    1% |   1283 |   1156 |    9% |  89467 |  89478 |    0% |
| gsoc-2018                        |  51997 |  73.4 |  75.3 |   -2% | 169.8 | 169.1 |    0% |  30913 |  31988 |   -3% |  53116 |  48815 |    8% | 168469 | 168456 |    0% |
| apache_builds                    |   1988 |  87.6 |  89.9 |   -2% | 311.4 | 309.6 |    0% |     97 |    104 |   -7% |      0 |      0 |    0% |      2 |      0 |    0% |
| instruments                      |   3442 | 108.8 | 112.1 |   -3% | 373.6 | 369.2 |    1% |    473 |    480 |   -1% |     54 |      2 |   96% |   1784 |    503 |   71% |
| twitterescaped                   |   8787 | 191.0 | 197.1 |   -3% | 515.5 | 512.6 |    0% |   4952 |   5217 |   -5% |      0 |      3 |    0% |  30813 |  29913 |    2% |
| github_events                    |   1017 |  78.9 |  81.7 |   -3% | 269.4 | 267.0 |    0% |    102 |    123 |  -20% |      0 |      0 |    0% |      0 |      0 |    0% |
| twitter                          |   9867 |  92.9 |  96.6 |   -3% | 296.8 | 294.2 |    0% |   3381 |   3470 |   -2% |     27 |      9 |   66% |  32722 |  33478 |   -2% |
| random                           |   7976 | 145.4 | 151.4 |   -4% | 497.3 | 494.5 |    0% |   2066 |   2034 |    1% |    167 |      8 |   95% |  37461 |  37310 |    0% |
| update-center                    |   8330 | 116.7 | 122.8 |   -5% | 344.8 | 343.5 |    0% |   5928 |   5692 |    3% |      2 |      5 | -150% |  32764 |  32912 |    0% |

### ampere gcc9

Against #1078 (i.e. just the performance impact of this checkin):

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| mesh.pretty                      |  24646 | 593.5 | 577.1 |    2% | 631.6 | 626.9 |    0% |  40119 |  25234 |   37% |  59084 |  59066 |    0% | 2032971 | 2012650 |    0% |
| canada                           |  35172 | 837.3 | 817.2 |    2% | 1026.4 | 1009.7 |    1% |  57833 |  47835 |   17% |  91747 |  91816 |    0% | 5107523 | 5086385 |    0% |
| numbers                          |   2345 | 910.1 | 893.1 |    1% | 869.7 | 861.2 |    0% |   3278 |   3242 |    1% |   6034 |   6014 |    0% | 259464 | 258410 |    0% |
| twitter                          |   9867 | 495.4 | 488.7 |    1% | 387.2 | 386.1 |    0% |  15331 |  15540 |   -1% |  23447 |  23422 |    0% | 868625 | 864061 |    0% |
| twitterescaped                   |   8787 | 740.2 | 734.5 |    0% | 629.8 | 628.5 |    0% |  17867 |  18644 |   -4% |  21363 |  21348 |    0% | 1571612 | 1565310 |    0% |
| github_events                    |   1017 | 462.8 | 459.8 |    0% | 359.9 | 358.4 |    0% |   1557 |   1459 |    6% |   2411 |   2406 |    0% |  88723 |  87482 |    1% |
| mesh                             |  11306 | 941.4 | 936.4 |    0% | 1054.9 | 1053.6 |    0% |  20258 |  21501 |   -6% |  32337 |  32326 |    0% | 1683103 | 1682105 |    0% |
| update-center                    |   8330 | 543.8 | 541.1 |    0% | 465.8 | 461.6 |    0% |  13183 |  13208 |    0% |  20798 |  20812 |    0% | 1033463 | 1027255 |    0% |
| marine_ik                        |  46616 | 887.0 | 884.4 |    0% | 987.6 | 977.2 |    1% | 101317 |  99758 |    1% | 133945 | 134007 |    0% | 7783747 | 7633161 |    1% |
| gsoc-2018                        |  51997 | 360.5 | 359.6 |    0% | 239.4 | 238.5 |    0% |  39563 |  39383 |    0% | 109702 | 109628 |    0% | 2765611 | 2750072 |    0% |
| random                           |   7976 | 705.1 | 704.1 |    0% | 643.1 | 639.2 |    0% |   6753 |   8184 |  -21% |  21611 |  21610 |    0% | 1248389 | 1236281 |    0% |
| apache_builds                    |   1988 | 472.1 | 472.0 |    0% | 418.2 | 414.7 |    0% |    630 |    634 |    0% |   4841 |   4826 |    0% | 203312 | 199809 |    1% |
| instruments                      |   3442 | 480.0 | 480.2 |    0% | 462.6 | 462.7 |    0% |   3206 |   3196 |    0% |   8724 |   8679 |    0% | 338926 | 332916 |    1% |
| citm_catalog                     |  26987 | 390.8 | 393.1 |    0% | 373.4 | 373.7 |    0% |   4608 |   5619 |  -21% |  62720 |  62719 |    0% | 1960294 | 1874639 |    4% |