### PR TITLE
Turns out that passing dom::element by reference can be a performance killer.

### DIFF
--- a/benchmark/parseandstatcompetition.cpp
+++ b/benchmark/parseandstatcompetition.cpp
@@ -142,7 +142,8 @@ static void GenStatPlus(Stat &stat, const dom::element v) {
     break;
   case dom::element_type::OBJECT:
     for (dom::key_value_pair kv : dom::object(v)) {
-      GenStatPlus(stat, dom::element(kv.value));
+      GenStatPlus(stat, kv.value);
+      stat.stringLength += kv.key.size();
       stat.memberCount++;
       stat.stringCount++;
     }

--- a/benchmark/parseandstatcompetition.cpp
+++ b/benchmark/parseandstatcompetition.cpp
@@ -131,7 +131,7 @@ struct Stat {
   size_t stringLength; // Number of code units in all strings
 };
 
-static void GenStatPlus(Stat &stat, const dom::element &v) {
+static void GenStatPlus(Stat &stat, const dom::element v) {
   switch (v.type()) {
   case dom::element_type::ARRAY:
     for (dom::element child : dom::array(v)) {

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -12,7 +12,7 @@ are still some scenarios where tuning can enhance performance.
 * [Number parsing](#number-parsing)
 * [Visual Studio](#visual-studio)
 * [Downclocking](#downclocking)
-
+* [Best Use of the DOM API](#best-use-of-the-dom-api)
 
 Reusing the parser for maximum efficiency
 -----------------------------------------
@@ -181,3 +181,9 @@ On some Intel processors, using SIMD instructions in a sustained manner on the s
 The simdjson library does not currently support AVX-512 instructions and it does not make use of heavy 256-bit instructions. We do use vectorized multiplications, but only using 128-bit registers. Thus there should be no downclocking due to simdjson on recent processors. 
 
 You may still be worried about which SIMD instruction set is used by simdjson.  Thankfully,  [you can always determine and change which architecture-specific implementation is used](implementation-selection.md) by simdjson. Thus even if your CPU supports AVX2, you do not need to use AVX2. You are in control.
+
+Best Use of the DOM API
+-------------------------
+
+The simdjson API provides access to the JSON DOM (document-object-model) content as a tree of `dom::element` instances, each representing an object, an array or an atomic type (null, true, false, number). These `dom::element` instances are lightweight objects (e.g., spanning 16 bytes) and it might be advantageous to pass them by value, as opposed to passing them by reference or by pointer.
+


### PR DESCRIPTION
Removing one character in the code is enough to boost our API traversal performance.
```
$ ./benchmark/parseandstatcompetition ../jsonexamples/twitter.json
API traversal tests
Based on https://github.com/miloyip/nativejson-benchmark
simdjson (old)                        :   0.454 cycles/byte 	  1.398 instructions/byte 	  7.483 GB/s 11850.026 documents/s
simdjson                                	:   0.360 cycles/byte 	  1.242 instructions/byte 	  9.447 GB/s 14959.982 documents/s
rapid                                   	:   0.471 cycles/byte 	  0.926 instructions/byte 	  7.212 GB/s 11420.218 documents/s

$ ./benchmark/parseandstatcompetition ../jsonexamples/gsoc-2018.json
API traversal tests
Based on https://github.com/miloyip/nativejson-benchmark
simdjson (old)                     	:   0.111 cycles/byte 	  0.368 instructions/byte 	 30.673 GB/s 9217.185 documents/s
simdjson                                	:   0.094 cycles/byte 	  0.327 instructions/byte 	 36.211 GB/s 10881.156 documents/s
rapid                                   	:   0.104 cycles/byte 	  0.257 instructions/byte 	 32.600 GB/s 9796.046 documents/s

$ ./benchmark/parseandstatcompetition ../jsonexamples/random.json
API traversal tests
Based on https://github.com/miloyip/nativejson-benchmark
simdjson  (old)                       :   0.819 cycles/byte 	  3.032 instructions/byte 	  4.145 GB/s 8120.113 documents/s
simdjson                                	:   0.684 cycles/byte 	  2.679 instructions/byte 	  4.963 GB/s 9721.669 documents/s
rapid                                   	:   0.830 cycles/byte 	  2.017 instructions/byte 	  4.091 GB/s 8014.490 documents/s

$ ./benchmark/parseandstatcompetition ../jsonexamples/canada.json
API traversal tests
Based on https://github.com/miloyip/nativejson-benchmark
simdjson   (old)                      :   1.248 cycles/byte 	  4.779 instructions/byte 	  2.719 GB/s 1207.711 documents/s
simdjson                                	:   1.001 cycles/byte 	  4.086 instructions/byte 	  3.390 GB/s 1506.149 documents/s
rapid                                   	:   0.730 cycles/byte 	  2.724 instructions/byte 	  4.649 GB/s 2065.058 documents/s
```


Fixes https://github.com/simdjson/simdjson/issues/932