### PR TITLE
Special case empty objects and arrays

### DIFF
--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -34,11 +34,8 @@ public:
     return parser.len - *current_structural;
   }
 
-  really_inline bool past_end(uint32_t n_structural_indexes) {
-    return current_structural >= &parser.structural_indexes[n_structural_indexes];
-  }
-  really_inline bool at_end(uint32_t n_structural_indexes) {
-    return current_structural == &parser.structural_indexes[n_structural_indexes];
+  really_inline bool at_end() {
+    return current_structural == &parser.structural_indexes[parser.n_structural_indexes];
   }
   really_inline bool at_beginning() {
     return current_structural == parser.structural_indexes.get();

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -223,6 +223,16 @@ struct structural_parser : structural_iterator {
     return SUCCESS;
   }
 
+  WARN_UNUSED really_inline error_code start() {
+    logger::log_start();
+
+    // If there are no structurals left, return EMPTY
+    if (at_end()) { return EMPTY; }
+
+    // Push the root scope (there is always at least one scope)
+    return start_document();
+  }
+
   WARN_UNUSED really_inline error_code finish() {
     end_document();
     parser.next_structural_index = uint32_t(current_structural + 1 - &parser.structural_indexes[0]);
@@ -235,27 +245,8 @@ struct structural_parser : structural_iterator {
     return SUCCESS;
   }
 
-  really_inline void init() {
-    log_start();
-  }
-
-  WARN_UNUSED really_inline error_code start() {
-    // If there are no structurals left, return EMPTY
-    if (at_end(parser.n_structural_indexes)) {
-      return EMPTY;
-    }
-
-    init();
-    // Push the root scope (there is always at least one scope)
-    return start_document();
-  }
-
   really_inline void log_value(const char *type) {
     logger::log_line(*this, "", type, "");
-  }
-
-  static really_inline void log_start() {
-    logger::log_start();
   }
 
   really_inline void log_start_value(const char *type) {


### PR DESCRIPTION
This:

* Special cases empty objects and arrays, writing them immediately without incrementing / decrementing depth or involving the container stack.
* Simplifies start() somewhat (while I was in there).
* Reduces the work we do on start_document/end_document. More reduction could be done, but any further reduction seems to reduce performance, so I left it off for the time being.

## Performance

When we open an array or object, there is already a special if statement to check for an immediate close, so this shouldn't change branchiness in any way. It does, however, move the check into the caller (the place we detect the { or [) so that it can branch to the correct place after handling the value, avoiding the need for the container stack.

### Haswell

Instruction count and throughput are both improved, as should be expected. skylake-x gcc10.1:

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| mesh                             |  11306 | 311.0 | 289.7 |    6% | 978.9 | 996.2 |   -1% |  10152 |  10466 |   -3% |      3 |    780 | -25900% |  60498 |  54164 |   10% |
| marine_ik                        |  46616 | 298.3 | 281.5 |    5% | 912.6 | 908.4 |    0% |  53695 |  53964 |    0% | 111046 | 160214 |  -44% | 255885 | 255883 |    0% |
| numbers                          |   2345 | 253.7 | 239.9 |    5% | 790.8 | 803.6 |   -1% |   2190 |   2159 |    1% |      0 |      3 |    0% |      0 |   2212 |    0% |
| instruments                      |   3442 | 108.8 | 104.8 |    3% | 373.6 | 375.5 |    0% |    473 |    510 |   -7% |     54 |      1 |   98% |   1784 |   6278 | -251% |
| twitterescaped                   |   8787 | 191.0 | 184.8 |    3% | 515.5 | 492.2 |    4% |   4952 |   5087 |   -2% |      0 |     18 |    0% |  30813 |  29309 |    4% |
| canada                           |  35172 | 289.1 | 280.3 |    3% | 982.2 | 976.0 |    0% |  18546 |  18826 |   -1% |  23380 |  60725 | -159% | 154761 | 154109 |    0% |
| mesh.pretty                      |  24646 | 179.8 | 174.4 |    3% | 579.2 | 583.4 |    0% |  13553 |  13755 |   -1% |    898 |  10871 | -1110% |  88147 |  83040 |    5% |
| twitter                          |   9867 |  92.9 |  90.2 |    2% | 296.8 | 288.5 |    2% |   3381 |   3366 |    0% |     27 |      2 |   92% |  32722 |  31590 |    3% |
| update-center                    |   8330 | 116.7 | 113.8 |    2% | 344.8 | 332.0 |    3% |   5928 |   5806 |    2% |      2 |     10 | -400% |  32764 |  31447 |    4% |
| github_events                    |   1017 |  78.9 |  77.1 |    2% | 269.4 | 260.8 |    3% |    102 |    107 |   -4% |      0 |      0 |    0% |      0 |      0 |    0% |
| random                           |   7976 | 145.4 | 143.0 |    1% | 497.3 | 490.7 |    1% |   2066 |   2063 |    0% |    167 |    117 |   29% |  37461 |  35280 |    5% |
| apache_builds                    |   1988 |  87.6 |  86.8 |    0% | 311.4 | 302.6 |    2% |     97 |    106 |   -9% |      0 |      0 |    0% |      2 |    314 | -15600% |
| citm_catalog                     |  26987 |  84.9 |  84.9 |    0% | 314.5 | 300.3 |    4% |   1752 |   1751 |    0% |   1283 |  11782 | -818% |  89467 |  83534 |    6% |
| gsoc-2018                        |  51997 |  73.4 |  77.3 |   -5% | 169.8 | 164.1 |    3% |  30913 |  30659 |    0% |  53116 |  85110 |  -60% | 168469 | 168193 |    0% |

### Westmere

Westmere improves as well, though not as much:

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| numbers                          |   2345 | 275.2 | 263.9 |    4% | 887.4 | 874.6 |    1% |   2115 |   2229 |   -5% |      0 |      1 |    0% |     21 |   1073 | -5009% |
| marine_ik                        |  46616 | 315.3 | 303.3 |    3% | 1018.5 | 1010.5 |    0% |  52299 |  52630 |    0% | 125616 | 127583 |   -1% | 255840 | 255880 |    0% |
| mesh                             |  11306 | 322.9 | 313.4 |    2% | 1085.5 | 1078.6 |    0% |  10143 |  10293 |   -1% |    282 |    523 |  -85% |  54421 |  54957 |    0% |
| mesh.pretty                      |  24646 | 195.8 | 192.6 |    1% | 671.4 | 668.2 |    0% |  13733 |  13374 |    2% |   7246 |   9717 |  -34% |  85111 |  84373 |    0% |
| citm_catalog                     |  26987 | 110.6 | 109.5 |    0% | 417.3 | 412.2 |    1% |   1820 |   1774 |    2% |   8925 |   8557 |    4% |  85362 |  85908 |    0% |
| canada                           |  35172 | 298.2 | 295.5 |    0% | 1071.2 | 1064.8 |    0% |  18919 |  18776 |    0% |  52826 |  50048 |    5% | 154665 | 154453 |    0% |
| twitterescaped                   |   8787 | 243.8 | 241.6 |    0% | 690.1 | 687.8 |    0% |   4755 |   4765 |    0% |      8 |      5 |   37% |  29491 |  28690 |    2% |
| update-center                    |   8330 | 150.9 | 150.2 |    0% | 501.2 | 497.6 |    0% |   6052 |   5744 |    5% |     10 |      6 |   40% |  30418 |  31903 |   -4% |
| gsoc-2018                        |  51997 | 101.9 | 101.5 |    0% | 293.1 | 293.0 |    0% |  32430 |  31653 |    2% |  68365 |  75101 |   -9% | 168542 | 168426 |    0% |
| twitter                          |   9867 | 125.4 | 125.6 |    0% | 443.2 | 441.2 |    0% |   2825 |   3010 |   -6% |     10 |      9 |   10% |  30634 |  31256 |   -2% |
| github_events                    |   1017 | 110.2 | 110.9 |    0% | 403.3 | 403.5 |    0% |     94 |    114 |  -21% |      0 |      0 |    0% |      0 |      0 |    0% |
| random                           |   7976 | 191.4 | 193.0 |    0% | 709.9 | 712.9 |    0% |   2040 |   2011 |    1% |    118 |     42 |   64% |  35244 |  33807 |    4% |
| apache_builds                    |   1988 | 120.4 | 122.4 |   -1% | 453.2 | 454.1 |    0% |    142 |    135 |    4% |      8 |     11 |  -37% |     49 |    126 | -157% |
| instruments                      |   3442 | 130.6 | 134.1 |   -2% | 499.2 | 507.0 |   -1% |    358 |    539 |  -50% |     10 |      0 |    0% |   3966 |   5033 |  -26% |