### PR TITLE
Split stage 2 in SAX fashion

### DIFF
--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -145,19 +145,15 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
-
-  // If we didn't make it to the end, it's an error
-  if ( next_structural_index != n_structural_indexes ) {
-    logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return TAPE_ERROR;
-  }
-
-  return SUCCESS;
+  doc = &_doc;
+  stage2::tape_builder builder(*doc);
+  return stage2::structural_parser::parse<false>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
+  doc = &_doc;
+  stage2::tape_builder builder(_doc);
+  return stage2::structural_parser::parse<true>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -112,6 +112,7 @@ really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, c
 #include "arm64/stringparsing.h"
 #include "arm64/numberparsing.h"
 #include "generic/stage2/structural_parser.h"
+#include "generic/stage2/tape_builder.h"
 
 //
 // Implementation-specific overrides
@@ -144,7 +145,7 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
+  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
@@ -156,7 +157,7 @@ WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) no
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::parse_structurals<true>(*this, _doc);
+  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -316,12 +316,13 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 #include "fallback/stringparsing.h"
 #include "fallback/numberparsing.h"
 #include "generic/stage2/structural_parser.h"
+#include "generic/stage2/tape_builder.h"
 
 namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
+  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
@@ -333,7 +334,7 @@ WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) no
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::parse_structurals<true>(*this, _doc);
+  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -322,19 +322,15 @@ namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
-
-  // If we didn't make it to the end, it's an error
-  if ( next_structural_index != n_structural_indexes ) {
-    logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return TAPE_ERROR;
-  }
-
-  return SUCCESS;
+  doc = &_doc;
+  stage2::tape_builder builder(*doc);
+  return stage2::structural_parser::parse<false>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
+  doc = &_doc;
+  stage2::tape_builder builder(_doc);
+  return stage2::structural_parser::parse<true>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -7,10 +7,10 @@ namespace logger {
   static constexpr const char * DASHES = "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
 
   static constexpr const bool LOG_ENABLED = false;
-  static constexpr const int LOG_EVENT_LEN = 30;
-  static constexpr const int LOG_BUFFER_LEN = 20;
-  static constexpr const int LOG_DETAIL_LEN = 50;
-  static constexpr const int LOG_INDEX_LEN = 10;
+  static constexpr const int LOG_EVENT_LEN = 20;
+  static constexpr const int LOG_BUFFER_LEN = 10;
+  static constexpr const int LOG_SMALL_BUFFER_LEN = 10;
+  static constexpr const int LOG_INDEX_LEN = 5;
 
   static int log_depth; // Not threadsafe. Log only.
 
@@ -28,8 +28,8 @@ namespace logger {
     if (LOG_ENABLED) {
       log_depth = 0;
       printf("\n");
-      printf("| %-*s | %-*s | %*s | %*s | %*s | %-*s | %-*s | %-*s |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", 4, "Curr", 4, "Next", 5, "Next#", 5, "Tape#", LOG_DETAIL_LEN, "Detail", LOG_INDEX_LEN, "index");
-      printf("|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|%.*s|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, 4+2, DASHES, 4+2, DASHES, 5+2, DASHES, 5+2, DASHES, LOG_DETAIL_LEN+2, DASHES, LOG_INDEX_LEN+2, DASHES);
+      printf("| %-*s | %-*s | %-*s | %-*s | %-*s | Detail |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", LOG_SMALL_BUFFER_LEN, "Next", 5, "Next#", 5, "Tape#");
+      printf("|%.*s|%.*s|%.*s|%.*s|%.*s|--------|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, LOG_SMALL_BUFFER_LEN+2, DASHES, 5+2, DASHES, 5+2, DASHES);
     }
   }
 
@@ -44,22 +44,35 @@ namespace logger {
   static really_inline void log_line(S &structurals, const char *title_prefix, const char *title, const char *detail) {
     if (LOG_ENABLED) {
       printf("| %*s%s%-*s ", log_depth*2, "", title_prefix, LOG_EVENT_LEN - log_depth*2 - int(strlen(title_prefix)), title);
+      auto current_index = structurals.at_beginning() ? nullptr : structurals.next_structural-1;
+      auto next_index = structurals.next_structural;
+      auto current = current_index ? &structurals.buf[*current_index] : (const uint8_t*)"                                                       ";
+      auto next = &structurals.buf[*next_index];
       {
         // Print the next N characters in the buffer.
         printf("| ");
         // Otherwise, print the characters starting from the buffer position.
         // Print spaces for unprintable or newline characters.
         for (int i=0;i<LOG_BUFFER_LEN;i++) {
-          printf("%c", printable_char(structurals.current()[i]));
+          printf("%c", printable_char(current[i]));
+        }
+        printf(" ");
+        // Print the next N characters in the buffer.
+        printf("| ");
+        // Otherwise, print the characters starting from the buffer position.
+        // Print spaces for unprintable or newline characters.
+        for (int i=0;i<LOG_SMALL_BUFFER_LEN;i++) {
+          printf("%c", printable_char(next[i]));
         }
         printf(" ");
       }
-      printf("|    %c ", printable_char(structurals.current_char()));
-      printf("|    %c ", printable_char(structurals.peek_next_char()));
-      printf("| %5u ", structurals.parser.structural_indexes[*(structurals.current_structural+1)]);
-      printf("| %5u ", structurals.next_tape_index());
-      printf("| %-*s ", LOG_DETAIL_LEN, detail);
-      printf("| %*u ", LOG_INDEX_LEN, *structurals.current_structural);
+      if (current_index) {
+        printf("| %*u ", LOG_INDEX_LEN, *current_index);
+      } else {
+        printf("| %-*s ", LOG_INDEX_LEN, "");
+      }
+      printf("| %*u ", LOG_INDEX_LEN, structurals.next_tape_index());
+      printf("| %-s ", detail);
       printf("|\n");
     }
   }

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -28,8 +28,8 @@ namespace logger {
     if (LOG_ENABLED) {
       log_depth = 0;
       printf("\n");
-      printf("| %-*s | %-*s | %-*s | %-*s | %-*s | Detail |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", LOG_SMALL_BUFFER_LEN, "Next", 5, "Next#", 5, "Tape#");
-      printf("|%.*s|%.*s|%.*s|%.*s|%.*s|--------|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, LOG_SMALL_BUFFER_LEN+2, DASHES, 5+2, DASHES, 5+2, DASHES);
+      printf("| %-*s | %-*s | %-*s | %-*s | Detail |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", LOG_SMALL_BUFFER_LEN, "Next", 5, "Next#");
+      printf("|%.*s|%.*s|%.*s|%.*s|--------|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, LOG_SMALL_BUFFER_LEN+2, DASHES, 5+2, DASHES);
     }
   }
 
@@ -71,7 +71,7 @@ namespace logger {
       } else {
         printf("| %-*s ", LOG_INDEX_LEN, "");
       }
-      printf("| %*u ", LOG_INDEX_LEN, structurals.next_tape_index());
+      // printf("| %*u ", LOG_INDEX_LEN, structurals.next_tape_index());
       printf("| %-s ", detail);
       printf("|\n");
     }

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -26,6 +26,10 @@ public:
   really_inline char peek_next_char() {
     return buf[*(current_structural+1)];
   }
+  really_inline const uint8_t* advance() {
+    current_structural++;
+    return &buf[*current_structural];
+  }
   really_inline char advance_char() {
     current_structural++;
     return buf[*current_structural];

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -5,44 +5,45 @@ namespace stage2 {
 class structural_iterator {
 public:
   const uint8_t* const buf;
-  uint32_t *current_structural;
+  uint32_t *next_structural;
   dom_parser_implementation &parser;
 
   // Start a structural 
   really_inline structural_iterator(dom_parser_implementation &_parser, size_t start_structural_index)
     : buf{_parser.buf},
-      current_structural{&_parser.structural_indexes[start_structural_index]},
+      next_structural{&_parser.structural_indexes[start_structural_index]},
       parser{_parser} {
   }
   // Get the buffer position of the current structural character
   really_inline const uint8_t* current() {
-    return &buf[*current_structural];
+    return &buf[*(next_structural-1)];
   }
   // Get the current structural character
   really_inline char current_char() {
-    return buf[*current_structural];
+    return buf[*(next_structural-1)];
   }
   // Get the next structural character without advancing
   really_inline char peek_next_char() {
-    return buf[*(current_structural+1)];
+    return buf[*next_structural];
+  }
+  really_inline const uint8_t* peek() {
+    return &buf[*next_structural];
   }
   really_inline const uint8_t* advance() {
-    current_structural++;
-    return &buf[*current_structural];
+    return &buf[*(next_structural++)];
   }
   really_inline char advance_char() {
-    current_structural++;
-    return buf[*current_structural];
+    return buf[*(next_structural++)];
   }
   really_inline size_t remaining_len() {
-    return parser.len - *current_structural;
+    return parser.len - *(next_structural-1);
   }
 
   really_inline bool at_end() {
-    return current_structural == &parser.structural_indexes[parser.n_structural_indexes];
+    return next_structural == &parser.structural_indexes[parser.n_structural_indexes];
   }
   really_inline bool at_beginning() {
-    return current_structural == parser.structural_indexes.get();
+    return next_structural == parser.structural_indexes.get();
   }
 };
 

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -6,13 +6,13 @@ class structural_iterator {
 public:
   const uint8_t* const buf;
   uint32_t *next_structural;
-  dom_parser_implementation &parser;
+  dom_parser_implementation &dom_parser;
 
   // Start a structural 
-  really_inline structural_iterator(dom_parser_implementation &_parser, size_t start_structural_index)
-    : buf{_parser.buf},
-      next_structural{&_parser.structural_indexes[start_structural_index]},
-      parser{_parser} {
+  really_inline structural_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
+    : buf{_dom_parser.buf},
+      next_structural{&_dom_parser.structural_indexes[start_structural_index]},
+      dom_parser{_dom_parser} {
   }
   // Get the buffer position of the current structural character
   really_inline const uint8_t* current() {
@@ -36,14 +36,14 @@ public:
     return buf[*(next_structural++)];
   }
   really_inline size_t remaining_len() {
-    return parser.len - *(next_structural-1);
+    return dom_parser.len - *(next_structural-1);
   }
 
   really_inline bool at_end() {
-    return next_structural == &parser.structural_indexes[parser.n_structural_indexes];
+    return next_structural == &dom_parser.structural_indexes[dom_parser.n_structural_indexes];
   }
   really_inline bool at_beginning() {
-    return next_structural == parser.structural_indexes.get();
+    return next_structural == dom_parser.structural_indexes.get();
   }
 };
 

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -34,14 +34,6 @@ struct structural_parser : structural_iterator {
     return SUCCESS;
   }
   template<typename T>
-  WARN_UNUSED really_inline error_code start_object(T &builder) {
-    depth++;
-    if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
-    builder.start_object(*this);
-    dom_parser.is_array[depth] = false;
-    return SUCCESS;
-  }
-  template<typename T>
   WARN_UNUSED really_inline error_code start_array(T &builder) {
     depth++;
     if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
@@ -149,7 +141,11 @@ WARN_UNUSED really_inline error_code structural_parser::parse(T &builder) noexce
 // Object parser states
 //
 object_begin: {
-  SIMDJSON_TRY( start_object(builder) );
+  depth++;
+  if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
+  builder.start_object(*this);
+  dom_parser.is_array[depth] = false;
+
   const uint8_t *key = advance();
   if (*key != '"') {
     log_error("Object does not start with a key");
@@ -207,7 +203,11 @@ scope_end: {
 // Array parser states
 //
 array_begin: {
-  SIMDJSON_TRY( start_array(builder) );
+  depth++;
+  if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
+  builder.start_array(*this);
+  dom_parser.is_array[depth] = true;
+
   builder.increment_count(*this);
 } // array_begin:
 

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -43,7 +43,6 @@ struct structural_parser : structural_iterator {
     parser.containing_scope[depth].count = 0;
     tape.skip(); // We don't actually *write* the start element until the end.
     parser.is_array[depth] = false;
-    if (depth >= parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
     return SUCCESS;
   }
 

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -125,12 +125,10 @@ WARN_UNUSED really_inline error_code structural_parser::parse(T &builder) noexce
     switch (*value) {
       case '{': {
         if (empty_object(builder)) { goto document_end; }
-        SIMDJSON_TRY( start_object(builder) );
         goto object_begin;
       }
       case '[': {
         if (empty_array(builder)) { goto document_end; }
-        SIMDJSON_TRY( start_array(builder) );
         // Make sure the outer array is closed before continuing; otherwise, there are ways we could get
         // into memory corruption. See https://github.com/simdjson/simdjson/issues/906
         if (!STREAMING) {
@@ -151,6 +149,7 @@ WARN_UNUSED really_inline error_code structural_parser::parse(T &builder) noexce
 // Object parser states
 //
 object_begin: {
+  SIMDJSON_TRY( start_object(builder) );
   const uint8_t *key = advance();
   if (*key != '"') {
     log_error("Object does not start with a key");
@@ -167,12 +166,10 @@ object_field: {
   switch (*value) {
     case '{': {
       if (empty_object(builder)) { break; };
-      SIMDJSON_TRY( start_object(builder) );
       goto object_begin;
     }
     case '[': {
       if (empty_array(builder)) { break; };
-      SIMDJSON_TRY( start_array(builder) );
       goto array_begin;
     }
     default: {
@@ -210,6 +207,7 @@ scope_end: {
 // Array parser states
 //
 array_begin: {
+  SIMDJSON_TRY( start_array(builder) );
   builder.increment_count(*this);
 } // array_begin:
 
@@ -218,12 +216,10 @@ array_value: {
   switch (*value) {
     case '{': {
       if (empty_object(builder)) { break; };
-      SIMDJSON_TRY( start_object(builder) );
       goto object_begin;
     }
     case '[': {
       if (empty_array(builder)) { break; };
-      SIMDJSON_TRY( start_array(builder) );
       goto array_begin;
     }
     default: {

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -3,103 +3,63 @@
 // We assume the file in which it is include already includes
 // "simdjson/stage2.h" (this simplifies amalgation)
 
-#include "generic/stage2/tape_writer.h"
 #include "generic/stage2/logger.h"
-#include "generic/stage2/atomparsing.h"
 #include "generic/stage2/structural_iterator.h"
 
 namespace { // Make everything here private
 namespace SIMDJSON_IMPLEMENTATION {
 namespace stage2 {
 
+#define SIMDJSON_TRY(EXPR) { auto _err = (EXPR); if (_err) { return _err; } }
+
+template<typename T>
 struct structural_parser : structural_iterator {
-  /** Lets you append to the tape */
-  tape_writer tape;
-  /** Next write location in the string buf for stage 2 parsing */
-  uint8_t *current_string_buf_loc;
+  /** Receiver that actually parses the strings and builds the tape */
+  T builder;
   /** Current depth (nested objects and arrays) */
   uint32_t depth{0};
 
   // For non-streaming, to pass an explicit 0 as next_structural, which enables optimizations
   really_inline structural_parser(dom_parser_implementation &_parser, uint32_t start_structural_index)
     : structural_iterator(_parser, start_structural_index),
-      tape{parser.doc->tape.get()},
-      current_string_buf_loc{parser.doc->string_buf.get()} {
-  }
-
-  WARN_UNUSED really_inline error_code start_scope(bool is_array) {
-    depth++;
-    if (depth >= parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
-    parser.containing_scope[depth].tape_index = next_tape_index();
-    parser.containing_scope[depth].count = 0;
-    tape.skip(); // We don't actually *write* the start element until the end.
-    parser.is_array[depth] = is_array;
-    return SUCCESS;
+      builder{parser.doc->tape.get(), parser.doc->string_buf.get()} {
   }
 
   WARN_UNUSED really_inline error_code start_document() {
-    log_start_value("document");
-    parser.containing_scope[depth].tape_index = next_tape_index();
-    parser.containing_scope[depth].count = 0;
-    tape.skip(); // We don't actually *write* the start element until the end.
+    builder.start_document(*this);
     parser.is_array[depth] = false;
     return SUCCESS;
   }
-
   WARN_UNUSED really_inline error_code start_object() {
-    log_start_value("object");
-    return start_scope(false);
+    depth++;
+    if (depth >= parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
+    builder.start_object(*this);
+    parser.is_array[depth] = false;
+    return SUCCESS;
   }
-
   WARN_UNUSED really_inline error_code start_array() {
-    log_start_value("array");
-    return start_scope(true);
+    depth++;
+    if (depth >= parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
+    builder.start_array(*this);
+    parser.is_array[depth] = true;
+    return SUCCESS;
   }
-
-  // this function is responsible for annotating the start of the scope
-  really_inline void end_scope(internal::tape_type start, internal::tape_type end) noexcept {
-    // SIMDJSON_ASSUME(depth > 0);
-    // Write the ending tape element, pointing at the start location
-    const uint32_t start_tape_index = parser.containing_scope[depth].tape_index;
-    tape.append(start_tape_index, end);
-    // Write the start tape element, pointing at the end location (and including count)
-    // count can overflow if it exceeds 24 bits... so we saturate
-    // the convention being that a cnt of 0xffffff or more is undetermined in value (>=  0xffffff).
-    const uint32_t count = parser.containing_scope[depth].count;
-    const uint32_t cntsat = count > 0xFFFFFF ? 0xFFFFFF : count;
-    tape_writer::write(parser.doc->tape[start_tape_index], next_tape_index() | (uint64_t(cntsat) << 32), start);
+  really_inline void end_object() {
+    builder.end_object(*this);
     depth--;
   }
-
-  really_inline uint32_t next_tape_index() {
-    return uint32_t(tape.next_tape_loc - parser.doc->tape.get());
-  }
-
-  really_inline void end_object() {
-    log_end_value("object");
-    end_scope(internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
-  }
   really_inline void end_array() {
-    log_end_value("array");
-    end_scope(internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+    builder.end_array(*this);
+    depth--;
   }
   really_inline void end_document() {
-    log_end_value("document");
-    constexpr uint32_t start_tape_index = 0;
-    tape.append(start_tape_index, internal::tape_type::ROOT);
-    tape_writer::write(parser.doc->tape[start_tape_index], next_tape_index(), internal::tape_type::ROOT);
+    builder.end_document(*this);
   }
 
-  really_inline void empty_container(internal::tape_type start, internal::tape_type end) {
-    auto start_index = next_tape_index();
-    tape.append(start_index+2, start);
-    tape.append(start_index, end);
-  }
   WARN_UNUSED really_inline bool empty_object() {
     if (peek_next_char() == '}') {
       advance_char();
-      log_value("empty object");
-      empty_container(internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+      builder.empty_object(*this);
       return true;
     }
     return false;
@@ -107,122 +67,45 @@ struct structural_parser : structural_iterator {
   WARN_UNUSED really_inline bool empty_array() {
     if (peek_next_char() == ']') {
       advance_char();
-      log_value("empty array");
-      empty_container(internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+      builder.empty_array(*this);
       return true;
     }
     return false;
   }
 
-  // increment_count increments the count of keys in an object or values in an array.
   really_inline void increment_count() {
-    parser.containing_scope[depth].count++; // we have a key value pair in the object at parser.depth - 1
-  }
-
-  really_inline uint8_t *on_start_string() noexcept {
-    // we advance the point, accounting for the fact that we have a NULL termination
-    tape.append(current_string_buf_loc - parser.doc->string_buf.get(), internal::tape_type::STRING);
-    return current_string_buf_loc + sizeof(uint32_t);
-  }
-
-  really_inline void on_end_string(uint8_t *dst) noexcept {
-    uint32_t str_length = uint32_t(dst - (current_string_buf_loc + sizeof(uint32_t)));
-    // TODO check for overflow in case someone has a crazy string (>=4GB?)
-    // But only add the overflow check when the document itself exceeds 4GB
-    // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
-    memcpy(current_string_buf_loc, &str_length, sizeof(uint32_t));
-    // NULL termination is still handy if you expect all your strings to
-    // be NULL terminated? It comes at a small cost
-    *dst = 0;
-    current_string_buf_loc = dst + 1;
+    builder.increment_count(*this);
   }
 
   WARN_UNUSED really_inline error_code parse_key(const uint8_t *key) {
-    return parse_string(key, true);
+    return builder.parse_key(*this, key);
   }
-  WARN_UNUSED really_inline error_code parse_string(const uint8_t *value, bool key = false) {
-    log_value(key ? "key" : "string");
-    uint8_t *dst = on_start_string();
-    dst = stringparsing::parse_string(value, dst);
-    if (dst == nullptr) {
-      log_error("Invalid escape in string");
-      return STRING_ERROR;
-    }
-    on_end_string(dst);
-    return SUCCESS;
+  WARN_UNUSED really_inline error_code parse_string(const uint8_t *value) {
+    return builder.parse_string(*this, value);
   }
-
   WARN_UNUSED really_inline error_code parse_number(const uint8_t *value) {
-    log_value("number");
-    if (!numberparsing::parse_number(value, tape)) { log_error("Invalid number"); return NUMBER_ERROR; }
-    return SUCCESS;
+    return builder.parse_number(*this, value);
   }
-
-  really_inline error_code parse_root_number(const uint8_t *value) {
-    //
-    // We need to make a copy to make sure that the string is space terminated.
-    // This is not about padding the input, which should already padded up
-    // to len + SIMDJSON_PADDING. However, we have no control at this stage
-    // on how the padding was done. What if the input string was padded with nulls?
-    // It is quite common for an input string to have an extra null character (C string).
-    // We do not want to allow 9\0 (where \0 is the null character) inside a JSON
-    // document, but the string "9\0" by itself is fine. So we make a copy and
-    // pad the input with spaces when we know that there is just one input element.
-    // This copy is relatively expensive, but it will almost never be called in
-    // practice unless you are in the strange scenario where you have many JSON
-    // documents made of single atoms.
-    //
-    uint8_t *copy = static_cast<uint8_t *>(malloc(remaining_len() + SIMDJSON_PADDING));
-    if (copy == nullptr) {
-      return MEMALLOC;
-    }
-    memcpy(copy, value, remaining_len());
-    memset(copy + remaining_len(), ' ', SIMDJSON_PADDING);
-    error_code error = parse_number(copy);
-    free(copy);
-    return error;
+  WARN_UNUSED really_inline error_code parse_root_number(const uint8_t *value) {
+    return builder.parse_root_number(*this, value);
   }
-
   WARN_UNUSED really_inline error_code parse_true_atom(const uint8_t *value) {
-    log_value("true");
-    if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::TRUE_VALUE);
-    return SUCCESS;
+    return builder.parse_true_atom(*this, value);
   }
-
   WARN_UNUSED really_inline error_code parse_root_true_atom(const uint8_t *value) {
-    log_value("true");
-    if (!atomparsing::is_valid_true_atom(value, remaining_len())) { return T_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::TRUE_VALUE);
-    return SUCCESS;
+    return builder.parse_root_true_atom(*this, value);
   }
-
   WARN_UNUSED really_inline error_code parse_false_atom(const uint8_t *value) {
-    log_value("false");
-    if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::FALSE_VALUE);
-    return SUCCESS;
+    return builder.parse_false_atom(*this, value);
   }
-
   WARN_UNUSED really_inline error_code parse_root_false_atom(const uint8_t *value) {
-    log_value("false");
-    if (!atomparsing::is_valid_false_atom(value, remaining_len())) { return F_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::FALSE_VALUE);
-    return SUCCESS;
+    return builder.parse_root_false_atom(*this, value);
   }
-
   WARN_UNUSED really_inline error_code parse_null_atom(const uint8_t *value) {
-    log_value("null");
-    if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::NULL_VALUE);
-    return SUCCESS;
+    return builder.parse_null_atom(*this, value);
   }
-
   WARN_UNUSED really_inline error_code parse_root_null_atom(const uint8_t *value) {
-    log_value("null");
-    if (!atomparsing::is_valid_null_atom(value, remaining_len())) { return N_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::NULL_VALUE);
-    return SUCCESS;
+    return builder.parse_root_null_atom(*this, value);
   }
 
   WARN_UNUSED really_inline error_code start() {
@@ -266,12 +149,20 @@ struct structural_parser : structural_iterator {
   }
 }; // struct structural_parser
 
-#define SIMDJSON_TRY(EXPR) { auto _err = (EXPR); if (_err) { return _err; } }
+} // namespace stage2
+} // namespace SIMDJSON_IMPLEMENTATION
+} // unnamed namespace
+
+#include "generic/stage2/tape_builder.h"
+
+namespace { // Make everything here private
+namespace SIMDJSON_IMPLEMENTATION {
+namespace stage2 {
 
 template<bool STREAMING>
 WARN_UNUSED static really_inline error_code parse_structurals(dom_parser_implementation &dom_parser, dom::document &doc) noexcept {
   dom_parser.doc = &doc;
-  stage2::structural_parser parser(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
+  stage2::structural_parser<stage2::tape_builder> parser(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
   SIMDJSON_TRY( parser.start() );
 
   //

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -171,7 +171,6 @@ object_continue: {
   }
   case '}':
     builder.end_object(*this);
-    depth--;
     goto scope_end;
   default:
     log_error("No comma between object fields");
@@ -180,6 +179,7 @@ object_continue: {
 } // object_continue:
 
 scope_end: {
+  depth--;
   if (depth == 0) { goto document_end; }
   if (dom_parser.is_array[depth]) { goto array_continue; }
   goto object_continue;
@@ -213,7 +213,6 @@ array_continue: {
     goto array_value;
   case ']':
     builder.end_array(*this);
-    depth--;
     goto scope_end;
   default:
     log_error("Missing comma between array values");

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -238,7 +238,7 @@ struct structural_parser : structural_iterator {
 
   WARN_UNUSED really_inline error_code finish() {
     end_document();
-    parser.next_structural_index = uint32_t(current_structural + 1 - &parser.structural_indexes[0]);
+    parser.next_structural_index = uint32_t(next_structural - &parser.structural_indexes[0]);
 
     if (depth != 0) {
       log_error("Unclosed objects or arrays!");
@@ -279,7 +279,7 @@ WARN_UNUSED static really_inline error_code parse_structurals(dom_parser_impleme
   // Read first value
   //
   {
-    switch (parser.current_char()) {
+    switch (parser.advance_char()) {
     case '{': {
       if (parser.empty_object()) { goto document_end; }
       SIMDJSON_TRY( parser.start_object() );

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -279,7 +279,8 @@ WARN_UNUSED static really_inline error_code parse_structurals(dom_parser_impleme
   // Read first value
   //
   {
-    switch (parser.advance_char()) {
+    const uint8_t *value = parser.advance();
+    switch (*value) {
     case '{': {
       if (parser.empty_object()) { goto document_end; }
       SIMDJSON_TRY( parser.start_object() );
@@ -297,14 +298,14 @@ WARN_UNUSED static really_inline error_code parse_structurals(dom_parser_impleme
       }
       goto array_begin;
     }
-    case '"': SIMDJSON_TRY( parser.parse_string(parser.current()) ); goto document_end;
-    case 't': SIMDJSON_TRY( parser.parse_root_true_atom(parser.current()) ); goto document_end;
-    case 'f': SIMDJSON_TRY( parser.parse_root_false_atom(parser.current()) ); goto document_end;
-    case 'n': SIMDJSON_TRY( parser.parse_root_null_atom(parser.current()) ); goto document_end;
+    case '"': SIMDJSON_TRY( parser.parse_string(value) ); goto document_end;
+    case 't': SIMDJSON_TRY( parser.parse_root_true_atom(value) ); goto document_end;
+    case 'f': SIMDJSON_TRY( parser.parse_root_false_atom(value) ); goto document_end;
+    case 'n': SIMDJSON_TRY( parser.parse_root_null_atom(value) ); goto document_end;
     case '-':
     case '0': case '1': case '2': case '3': case '4':
     case '5': case '6': case '7': case '8': case '9':
-      SIMDJSON_TRY( parser.parse_root_number(parser.current()) ); goto document_end;
+      SIMDJSON_TRY( parser.parse_root_number(value) ); goto document_end;
     default:
       parser.log_error("Document starts with a non-value character");
       return TAPE_ERROR;
@@ -327,7 +328,8 @@ object_begin: {
 
 object_field: {
   if (unlikely( parser.advance_char() != ':' )) { parser.log_error("Missing colon after key in object"); return TAPE_ERROR; }
-  switch (parser.advance_char()) {
+  const uint8_t *value = parser.advance();
+  switch (*value) {
     case '{': {
       if (parser.empty_object()) { break; };
       SIMDJSON_TRY( parser.start_object() );
@@ -338,14 +340,14 @@ object_field: {
       SIMDJSON_TRY( parser.start_array() );
       goto array_begin;
     }
-    case '"': SIMDJSON_TRY( parser.parse_string(parser.current()) ); break;
-    case 't': SIMDJSON_TRY( parser.parse_true_atom(parser.current()) ); break;
-    case 'f': SIMDJSON_TRY( parser.parse_false_atom(parser.current()) ); break;
-    case 'n': SIMDJSON_TRY( parser.parse_null_atom(parser.current()) ); break;
+    case '"': SIMDJSON_TRY( parser.parse_string(value) ); break;
+    case 't': SIMDJSON_TRY( parser.parse_true_atom(value) ); break;
+    case 'f': SIMDJSON_TRY( parser.parse_false_atom(value) ); break;
+    case 'n': SIMDJSON_TRY( parser.parse_null_atom(value) ); break;
     case '-':
     case '0': case '1': case '2': case '3': case '4':
     case '5': case '6': case '7': case '8': case '9':
-      SIMDJSON_TRY( parser.parse_number(parser.current()) ); break;
+      SIMDJSON_TRY( parser.parse_number(value) ); break;
     default:
       parser.log_error("Non-value found when value was expected!");
       return TAPE_ERROR;
@@ -384,7 +386,8 @@ array_begin: {
 } // array_begin:
 
 array_value: {
-  switch (parser.advance_char()) {
+  const uint8_t *value = parser.advance();
+  switch (*value) {
     case '{': {
       if (parser.empty_object()) { break; };
       SIMDJSON_TRY( parser.start_object() );
@@ -395,14 +398,14 @@ array_value: {
       SIMDJSON_TRY( parser.start_array() );
       goto array_begin;
     }
-    case '"': SIMDJSON_TRY( parser.parse_string(parser.current()) ); break;
-    case 't': SIMDJSON_TRY( parser.parse_true_atom(parser.current()) ); break;
-    case 'f': SIMDJSON_TRY( parser.parse_false_atom(parser.current()) ); break;
-    case 'n': SIMDJSON_TRY( parser.parse_null_atom(parser.current()) ); break;
+    case '"': SIMDJSON_TRY( parser.parse_string(value) ); break;
+    case 't': SIMDJSON_TRY( parser.parse_true_atom(value) ); break;
+    case 'f': SIMDJSON_TRY( parser.parse_false_atom(value) ); break;
+    case 'n': SIMDJSON_TRY( parser.parse_null_atom(value) ); break;
     case '-':
     case '0': case '1': case '2': case '3': case '4':
     case '5': case '6': case '7': case '8': case '9':
-      SIMDJSON_TRY( parser.parse_number(parser.current()) ); break; 
+      SIMDJSON_TRY( parser.parse_number(value) ); break; 
     default:
       parser.log_error("Non-value found when value was expected!");
       return TAPE_ERROR;

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -19,6 +19,9 @@ struct structural_parser : structural_iterator {
   /** Current depth (nested objects and arrays) */
   uint32_t depth{0};
 
+  template<bool STREAMING>
+  WARN_UNUSED static really_inline error_code parse(dom_parser_implementation &dom_parser, dom::document &doc) noexcept;
+
   // For non-streaming, to pass an explicit 0 as next_structural, which enables optimizations
   really_inline structural_parser(dom_parser_implementation &_parser, uint32_t start_structural_index)
     : structural_iterator(_parser, start_structural_index),
@@ -149,20 +152,11 @@ struct structural_parser : structural_iterator {
   }
 }; // struct structural_parser
 
-} // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
-
-#include "generic/stage2/tape_builder.h"
-
-namespace { // Make everything here private
-namespace SIMDJSON_IMPLEMENTATION {
-namespace stage2 {
-
+template<typename T>
 template<bool STREAMING>
-WARN_UNUSED static really_inline error_code parse_structurals(dom_parser_implementation &dom_parser, dom::document &doc) noexcept {
+WARN_UNUSED really_inline error_code structural_parser<T>::parse(dom_parser_implementation &dom_parser, dom::document &doc) noexcept {
   dom_parser.doc = &doc;
-  stage2::structural_parser<stage2::tape_builder> parser(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
+  stage2::structural_parser<T> parser(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
   SIMDJSON_TRY( parser.start() );
 
   //

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -1,0 +1,195 @@
+#include "generic/stage2/tape_writer.h"
+#include "generic/stage2/atomparsing.h"
+
+namespace {
+namespace SIMDJSON_IMPLEMENTATION {
+namespace stage2 {
+
+struct tape_builder {
+  /** Next location to write to tape */
+  tape_writer tape;
+  /** Next write location in the string buf for stage 2 parsing */
+  uint8_t *current_string_buf_loc;
+
+  really_inline void empty_object(structural_parser<tape_builder> &parser) {
+    parser.log_value("empty object");
+    empty_container(parser, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+  }
+  really_inline void empty_array(structural_parser<tape_builder> &parser) {
+    parser.log_value("empty array");
+    empty_container(parser, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+  }
+
+  really_inline void start_document(structural_parser<tape_builder> &parser) {
+    parser.log_start_value("document");
+    start_container(parser);
+  }
+  really_inline void start_object(structural_parser<tape_builder> &parser) {
+    parser.log_start_value("object");
+    start_container(parser);
+  }
+  really_inline void start_array(structural_parser<tape_builder> &parser) {
+    parser.log_start_value("array");
+    start_container(parser);
+  }
+
+  really_inline void end_object(structural_parser<tape_builder> &parser) {
+    parser.log_end_value("object");
+    end_container(parser, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+  }
+  really_inline void end_array(structural_parser<tape_builder> &parser) {
+    parser.log_end_value("array");
+    end_container(parser, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+  }
+  really_inline void end_document(structural_parser<tape_builder> &parser) {
+    parser.log_end_value("document");
+    constexpr uint32_t start_tape_index = 0;
+    tape.append(start_tape_index, internal::tape_type::ROOT);
+    tape_writer::write(parser.parser.doc->tape[start_tape_index], next_tape_index(parser), internal::tape_type::ROOT);
+  }
+
+  WARN_UNUSED really_inline error_code parse_key(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    return parse_string(parser, value, true);
+  }
+  WARN_UNUSED really_inline error_code parse_string(structural_parser<tape_builder> &parser, const uint8_t *value, bool key = false) {
+    parser.log_value(key ? "key" : "string");
+    uint8_t *dst = on_start_string(parser);
+    dst = stringparsing::parse_string(value, dst);
+    if (dst == nullptr) {
+      parser.log_error("Invalid escape in string");
+      return STRING_ERROR;
+    }
+    on_end_string(dst);
+    return SUCCESS;
+  }
+
+  WARN_UNUSED really_inline error_code parse_number(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    parser.log_value("number");
+    if (!numberparsing::parse_number(value, tape)) { parser.log_error("Invalid number"); return NUMBER_ERROR; }
+    return SUCCESS;
+  }
+
+  really_inline error_code parse_root_number(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    //
+    // We need to make a copy to make sure that the string is space terminated.
+    // This is not about padding the input, which should already padded up
+    // to len + SIMDJSON_PADDING. However, we have no control at this stage
+    // on how the padding was done. What if the input string was padded with nulls?
+    // It is quite common for an input string to have an extra null character (C string).
+    // We do not want to allow 9\0 (where \0 is the null character) inside a JSON
+    // document, but the string "9\0" by itself is fine. So we make a copy and
+    // pad the input with spaces when we know that there is just one input element.
+    // This copy is relatively expensive, but it will almost never be called in
+    // practice unless you are in the strange scenario where you have many JSON
+    // documents made of single atoms.
+    //
+    uint8_t *copy = static_cast<uint8_t *>(malloc(parser.remaining_len() + SIMDJSON_PADDING));
+    if (copy == nullptr) {
+      return MEMALLOC;
+    }
+    memcpy(copy, value, parser.remaining_len());
+    memset(copy + parser.remaining_len(), ' ', SIMDJSON_PADDING);
+    error_code error = parse_number(parser, copy);
+    free(copy);
+    return error;
+  }
+
+  WARN_UNUSED really_inline error_code parse_true_atom(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    parser.log_value("true");
+    if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
+    tape.append(0, internal::tape_type::TRUE_VALUE);
+    return SUCCESS;
+  }
+
+  WARN_UNUSED really_inline error_code parse_root_true_atom(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    parser.log_value("true");
+    if (!atomparsing::is_valid_true_atom(value, parser.remaining_len())) { return T_ATOM_ERROR; }
+    tape.append(0, internal::tape_type::TRUE_VALUE);
+    return SUCCESS;
+  }
+
+  WARN_UNUSED really_inline error_code parse_false_atom(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    parser.log_value("false");
+    if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
+    tape.append(0, internal::tape_type::FALSE_VALUE);
+    return SUCCESS;
+  }
+
+  WARN_UNUSED really_inline error_code parse_root_false_atom(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    parser.log_value("false");
+    if (!atomparsing::is_valid_false_atom(value, parser.remaining_len())) { return F_ATOM_ERROR; }
+    tape.append(0, internal::tape_type::FALSE_VALUE);
+    return SUCCESS;
+  }
+
+  WARN_UNUSED really_inline error_code parse_null_atom(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    parser.log_value("null");
+    if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
+    tape.append(0, internal::tape_type::NULL_VALUE);
+    return SUCCESS;
+  }
+
+  WARN_UNUSED really_inline error_code parse_root_null_atom(structural_parser<tape_builder> &parser, const uint8_t *value) {
+    parser.log_value("null");
+    if (!atomparsing::is_valid_null_atom(value, parser.remaining_len())) { return N_ATOM_ERROR; }
+    tape.append(0, internal::tape_type::NULL_VALUE);
+    return SUCCESS;
+  }
+
+  // increment_count increments the count of keys in an object or values in an array.
+  really_inline void increment_count(structural_parser<tape_builder> &parser) {
+    parser.parser.containing_scope[parser.depth].count++; // we have a key value pair in the object at parser.parser.depth - 1
+  }
+
+// private:
+
+  really_inline uint32_t next_tape_index(structural_parser<tape_builder> &parser) {
+    return uint32_t(tape.next_tape_loc - parser.parser.doc->tape.get());
+  }
+
+  really_inline void empty_container(structural_parser<tape_builder> &parser, internal::tape_type start, internal::tape_type end) {
+    auto start_index = next_tape_index(parser);
+    tape.append(start_index+2, start);
+    tape.append(start_index, end);
+  }
+
+  really_inline void start_container(structural_parser<tape_builder> &parser) {
+    parser.parser.containing_scope[parser.depth].tape_index = next_tape_index(parser);
+    parser.parser.containing_scope[parser.depth].count = 0;
+    tape.skip(); // We don't actually *write* the start element until the end.
+  }
+
+  really_inline void end_container(structural_parser<tape_builder> &parser, internal::tape_type start, internal::tape_type end) noexcept {
+    // Write the ending tape element, pointing at the start location
+    const uint32_t start_tape_index = parser.parser.containing_scope[parser.depth].tape_index;
+    tape.append(start_tape_index, end);
+    // Write the start tape element, pointing at the end location (and including count)
+    // count can overflow if it exceeds 24 bits... so we saturate
+    // the convention being that a cnt of 0xffffff or more is undetermined in value (>=  0xffffff).
+    const uint32_t count = parser.parser.containing_scope[parser.depth].count;
+    const uint32_t cntsat = count > 0xFFFFFF ? 0xFFFFFF : count;
+    tape_writer::write(parser.parser.doc->tape[start_tape_index], next_tape_index(parser) | (uint64_t(cntsat) << 32), start);
+  }
+
+  really_inline uint8_t *on_start_string(structural_parser<tape_builder> &parser) noexcept {
+    // we advance the point, accounting for the fact that we have a NULL termination
+    tape.append(current_string_buf_loc - parser.parser.doc->string_buf.get(), internal::tape_type::STRING);
+    return current_string_buf_loc + sizeof(uint32_t);
+  }
+
+  really_inline void on_end_string(uint8_t *dst) noexcept {
+    uint32_t str_length = uint32_t(dst - (current_string_buf_loc + sizeof(uint32_t)));
+    // TODO check for overflow in case someone has a crazy string (>=4GB?)
+    // But only add the overflow check when the document itself exceeds 4GB
+    // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
+    memcpy(current_string_buf_loc, &str_length, sizeof(uint32_t));
+    // NULL termination is still handy if you expect all your strings to
+    // be NULL terminated? It comes at a small cost
+    *dst = 0;
+    current_string_buf_loc = dst + 1;
+  }
+}; // class tape_builder
+
+} // namespace stage2
+} // namespace SIMDJSON_IMPLEMENTATION
+} // unnamed namespace

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -16,6 +16,36 @@ struct tape_builder {
 private:
   friend struct structural_parser;
 
+  really_inline error_code parse_root_primitive(structural_parser &parser, const uint8_t *value) {
+    switch (*value) {
+      case '"': return parse_string(parser, value);
+      case 't': return parse_root_true_atom(parser, value);
+      case 'f': return parse_root_false_atom(parser, value);
+      case 'n': return parse_root_null_atom(parser, value);
+      case '-':
+      case '0': case '1': case '2': case '3': case '4':
+      case '5': case '6': case '7': case '8': case '9':
+        return parse_root_number(parser, value);
+      default:
+        parser.log_error("Document starts with a non-value character");
+        return TAPE_ERROR;
+    }
+  }
+  really_inline error_code parse_primitive(structural_parser &parser, const uint8_t *value) {
+    switch (*value) {
+      case '"': return parse_string(parser, value);
+      case 't': return parse_true_atom(parser, value);
+      case 'f': return parse_false_atom(parser, value);
+      case 'n': return parse_null_atom(parser, value);
+      case '-':
+      case '0': case '1': case '2': case '3': case '4':
+      case '5': case '6': case '7': case '8': case '9':
+        return parse_number(parser, value);
+      default:
+        parser.log_error("Non-value found when value was expected!");
+        return TAPE_ERROR;
+    }
+  }
   really_inline void empty_object(structural_parser &parser) {
     parser.log_value("empty object");
     empty_container(parser, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -108,19 +108,15 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
-
-  // If we didn't make it to the end, it's an error
-  if ( next_structural_index != n_structural_indexes ) {
-    logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return TAPE_ERROR;
-  }
-
-  return SUCCESS;
+  doc = &_doc;
+  stage2::tape_builder builder(_doc);
+  return stage2::structural_parser::parse<false>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
+  doc = &_doc;
+  stage2::tape_builder builder(_doc);
+  return stage2::structural_parser::parse<true>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -77,6 +77,7 @@ really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, c
 #include "haswell/stringparsing.h"
 #include "haswell/numberparsing.h"
 #include "generic/stage2/structural_parser.h"
+#include "generic/stage2/tape_builder.h"
 
 //
 // Implementation-specific overrides
@@ -107,7 +108,7 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
+  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
@@ -119,7 +120,7 @@ WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) no
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::parse_structurals<true>(*this, _doc);
+  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -82,6 +82,7 @@ really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, c
 #include "westmere/stringparsing.h"
 #include "westmere/numberparsing.h"
 #include "generic/stage2/structural_parser.h"
+#include "generic/stage2/tape_builder.h"
 
 //
 // Implementation-specific overrides
@@ -113,7 +114,7 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::parse_structurals<false>(*this, _doc)) { return error; }
+  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
 
   // If we didn't make it to the end, it's an error
   if ( next_structural_index != n_structural_indexes ) {
@@ -125,7 +126,7 @@ WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) no
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::parse_structurals<true>(*this, _doc);
+  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -114,19 +114,15 @@ WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t len) cons
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  if (auto error = stage2::structural_parser<stage2::tape_builder>::parse<false>(*this, _doc)) { return error; }
-
-  // If we didn't make it to the end, it's an error
-  if ( next_structural_index != n_structural_indexes ) {
-    logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-    return TAPE_ERROR;
-  }
-
-  return SUCCESS;
+  doc = &_doc;
+  stage2::tape_builder builder(*doc);
+  return stage2::structural_parser::parse<false>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  return stage2::structural_parser<stage2::tape_builder>::parse<true>(*this, _doc);
+  doc = &_doc;
+  stage2::tape_builder builder(_doc);
+  return stage2::structural_parser::parse<true>(*this, builder);
 }
 
 WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {


### PR DESCRIPTION
This PR splits stage 2 in half to create a (non-public) SAX interface. The purpose of starting with stage 2 is to ensure we start in a good place performance-wise, rather than building something separate and struggling to match the performance we already have in stage 2. It has a fairly clean separation of concerns, with structural_parser in particular never touching the output document.

* structural_parser handles JSON iteration and array / object / colon / comma matching. It maintains depth, structural_index iteration and is_array[] state. It does not reference or touch the document, tape, string_buf, or count.
* tape_builder handles tape construction and primitive parsing. It maintains tape index, string_buf index, and count. It is passed uint8_t *'s into the buffer, and never references structural indexes or is_array[] state.

structural_parser::parse() is templatized on the tape_builder type, and calls into it with SAX-ish functions such as start_array, end_object, and parse_primitive. These are not final public names; the intent here is to get everything into the right *shape* before committing to a final interface.

The hope here is we can build alternate DOMs by hooking up new tape_builder implementations, as well as use the interface in language bindings, to avoid the intermediate serialization to tape and go straight to the language's types. Additionally, there should be opportunities to write raw unparsed DOMs, JSON pointer, and other things between.

It does some restructuring as well, which both simplify stage 2 and gain back the performance that would be lost (and then some) from a purely naive translation into SAX.

## Performance

In general, the effect of this checkin is positive on haswell. Haven't checked elsewhere yet.

### skylake-x gcc10.2, Relative to parent PR

It has an almost purely positive effect relative to the parent PR (the one where we handle empty objects separately):

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| citm_catalog                     |  26987 |  83.0 |  78.9 |    4% | 300.7 | 293.5 |    2% |   1827 |   1738 |    4% |   1639 |   1539 |    6% |  89439 |  89366 |    0% |
| canada                           |  35172 | 280.9 | 269.7 |    3% | 971.3 | 957.3 |    1% |  18841 |  18936 |    0% |  22517 |  28771 |  -27% | 154731 | 154773 |    0% |
| update-center                    |   8330 | 114.6 | 111.0 |    3% | 331.7 | 334.6 |    0% |   5994 |   5577 |    6% |     13 |     28 | -115% |  30980 |  31500 |   -1% |
| random                           |   7976 | 141.8 | 137.8 |    2% | 489.8 | 493.3 |    0% |   2036 |   1917 |    5% |      4 |     14 | -250% |  37029 |  34567 |    6% |
| apache_builds                    |   1988 |  85.7 |  83.4 |    2% | 302.2 | 303.9 |    0% |    107 |     97 |    9% |      5 |      0 |    0% |    131 |     86 |   34% |
| twitter                          |   9867 |  90.6 |  89.8 |    0% | 287.8 | 287.3 |    0% |   3392 |   3723 |   -9% |     10 |      0 |    0% |  32200 |  31006 |    3% |
| marine_ik                        |  46616 | 276.8 | 275.1 |    0% | 895.9 | 907.0 |   -1% |  53194 |  52758 |    0% | 104849 | 137813 |  -31% | 255984 | 255925 |    0% |
| mesh                             |  11306 | 290.8 | 289.3 |    0% | 977.8 | 994.3 |   -1% |  10051 |   8757 |   12% |    171 |    301 |  -76% |  60156 |  55079 |    8% |
| twitterescaped                   |   8787 | 184.4 | 183.7 |    0% | 491.4 | 494.4 |    0% |   4866 |   4872 |    0% |      1 |      1 |    0% |  27684 |  27962 |   -1% |
| numbers                          |   2345 | 239.4 | 238.5 |    0% | 790.8 | 803.6 |   -1% |   2193 |   2170 |    1% |      0 |      0 |    0% |      3 |     75 | -2400% |
| github_events                    |   1017 |  76.6 |  76.8 |    0% | 260.4 | 262.9 |    0% |     99 |    127 |  -28% |      2 |      0 |    0% |      2 |      0 |    0% |
| mesh.pretty                      |  24646 | 173.7 | 174.4 |    0% | 575.3 | 581.9 |   -1% |  13512 |  13292 |    1% |   1388 |   8533 | -514% |  87994 |  85411 |    2% |
| instruments                      |   3442 | 103.6 | 104.1 |    0% | 374.6 | 376.2 |    0% |    449 |    475 |   -5% |     12 |      6 |   50% |   1772 |   5097 | -187% |
| gsoc-2018                        |  51997 |  71.3 |  75.6 |   -6% | 164.0 | 164.9 |    0% |  30450 |  31266 |   -2% |  45546 |  74131 |  -62% | 168334 | 168489 |    0% |

### skylake-x gcc10.2, relative to master

It has a mixed (but generally positive) effect against master, when you include the mixed effect of the previous PR:

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| random                           |   7976 | 152.4 | 137.8 |    9% | 494.5 | 493.3 |    0% |   2069 |   1917 |    7% |     99 |     14 |   85% |  38598 |  34567 |   10% |
| update-center                    |   8330 | 122.6 | 111.0 |    9% | 343.5 | 334.6 |    2% |   5714 |   5577 |    2% |      5 |     28 | -459% |  30743 |  31500 |   -2% |
| apache_builds                    |   1988 |  90.5 |  83.4 |    7% | 309.6 | 303.9 |    1% |    109 |     97 |   11% |      0 |      0 |    0% |      0 |     86 |    0% |
| twitter                          |   9867 |  97.3 |  89.8 |    7% | 294.2 | 287.3 |    2% |   3571 |   3723 |   -4% |      0 |      0 |    0% |  33569 |  31006 |    7% |
| instruments                      |   3442 | 112.3 | 104.1 |    7% | 369.2 | 376.2 |   -1% |    473 |    475 |    0% |      5 |      6 |  -20% |    802 |   5097 | -535% |
| twitterescaped                   |   8787 | 197.5 | 183.7 |    6% | 512.6 | 494.4 |    3% |   5266 |   4872 |    7% |      5 |      1 |   80% |  29842 |  27962 |    6% |
| github_events                    |   1017 |  81.6 |  76.8 |    5% | 267.0 | 262.9 |    1% |    120 |    127 |   -5% |      0 |      0 |    0% |      0 |      0 |    0% |
| citm_catalog                     |  26987 |  83.6 |  78.9 |    5% | 307.0 | 293.5 |    4% |   1761 |   1738 |    1% |   1254 |   1539 |  -22% |  89395 |  89366 |    0% |
| canada                           |  35172 | 272.3 | 269.7 |    0% | 980.9 | 957.3 |    2% |  18825 |  18936 |    0% |  27293 |  28771 |   -5% | 154812 | 154773 |    0% |
| gsoc-2018                        |  51997 |  76.3 |  75.6 |    0% | 169.1 | 164.9 |    2% |  32178 |  31266 |    2% |  47011 |  74131 |  -57% | 168355 | 168489 |    0% |
| marine_ik                        |  46616 | 266.8 | 275.1 |   -3% | 903.9 | 907.0 |    0% |  52667 |  52758 |    0% | 107442 | 137813 |  -28% | 255891 | 255925 |    0% |
| numbers                          |   2345 | 231.0 | 238.5 |   -3% | 790.8 | 803.6 |   -1% |   2161 |   2170 |    0% |      0 |      0 |    0% |      0 |     75 |    0% |
| mesh.pretty                      |  24646 | 165.7 | 174.4 |   -5% | 579.5 | 581.9 |    0% |  13479 |  13292 |    1% |   1403 |   8533 | -508% |  88042 |  85411 |    2% |
| mesh                             |  11306 | 272.2 | 289.3 |   -6% | 986.9 | 994.3 |    0% |   9743 |   8757 |   10% |     59 |    301 | -410% |  60090 |  55079 |    8% |
