### PR TITLE
Basic SAX interface with benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,5 +1,13 @@
 include_directories( . linux )
-link_libraries(simdjson simdjson-flags simdjson-windows-headers test-data)
+link_libraries(simdjson-windows-headers test-data)
+
+
+if (TARGET benchmark::benchmark)
+  add_executable(bench_sax bench_sax.cpp)
+  target_link_libraries(bench_sax simdjson-internal-flags simdjson-include-source benchmark::benchmark)
+endif (TARGET benchmark::benchmark)
+
+link_libraries(simdjson simdjson-flags)
 add_executable(benchfeatures benchfeatures.cpp)
 add_executable(get_corpus_benchmark get_corpus_benchmark.cpp)
 add_executable(perfdiff perfdiff.cpp)
@@ -14,12 +22,6 @@ target_compile_definitions(parse_nonumberparsing PRIVATE SIMDJSON_SKIPNUMBERPARS
 add_executable(parse_nostringparsing parse.cpp)
 target_compile_definitions(parse_nostringparsing PRIVATE SIMDJSON_SKIPSTRINGPARSING)
 
-if (TARGET benchmark::benchmark)
-  link_libraries(benchmark::benchmark)
-  add_executable(bench_parse_call bench_parse_call.cpp)
-  add_executable(bench_dom_api bench_dom_api.cpp)
-endif()
-
 if (TARGET competition-all)
   add_executable(distinctuseridcompetition distinctuseridcompetition.cpp)
   target_link_libraries(distinctuseridcompetition competition-core)
@@ -32,6 +34,12 @@ if (TARGET competition-all)
   add_executable(allparsingcompetition parsingcompetition.cpp)
   target_link_libraries(allparsingcompetition competition-all)
   target_compile_definitions(allparsingcompetition PRIVATE ALLPARSER)
+endif()
+
+if (TARGET benchmark::benchmark)
+  link_libraries(benchmark::benchmark)
+  add_executable(bench_parse_call bench_parse_call.cpp)
+  add_executable(bench_dom_api bench_dom_api.cpp)
 endif()
 
 include(checkperf.cmake)

--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -22,7 +22,7 @@ static void recover_one_string(State& state) {
       return;
   }
   dom::element doc;
-  if (error = parser.parse(docdata).get(doc)) {
+  if ((error = parser.parse(docdata).get(doc))) {
     cerr << "could not parse string" << error << endl;
     return;
   }
@@ -48,8 +48,7 @@ static void serialize_twitter(State& state) {
       return;
   }
   // we do not want mem. alloc. in the loop.
-  error = parser.allocate(docdata.size());
-  if(error) {
+  if((error = parser.allocate(docdata.size()))) {
       cout << error << endl;
       return;
   }

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -2,6 +2,10 @@
 #define SIMDJSON_IMPLEMENTATION_WESTMERE 0
 #define SIMDJSON_IMPLEMENTATION_AMD64 0
 
+#include <iostream>
+#include <sstream>
+#include <random>
+
 #include "simdjson.h"
 
 SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
@@ -9,7 +13,8 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 SIMDJSON_POP_DISABLE_WARNINGS
 
 #include "simdjson.cpp"
-#include "twitter/sax_tweet_reader.h"
+
+#if SIMDJSON_EXCEPTIONS
 
 using namespace benchmark;
 using namespace simdjson;
@@ -18,6 +23,10 @@ using std::endl;
 
 const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
 const int REPETITIONS = 10;
+
+#if SIMDJSON_IMPLEMENTATION_HASWELL
+
+#include "twitter/sax_tweet_reader.h"
 
 static void sax_tweets(State &state) {
   // Load twitter.json to a buffer
@@ -50,7 +59,9 @@ BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](con
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
 
-#if SIMDJSON_EXCEPTIONS
+#endif // SIMDJSON_IMPLEMENTATION_HASWELL
+
+#include "twitter/tweet.h"
 
 simdjson_really_inline uint64_t nullable_int(dom::element element) {
   if (element.is_null()) { return 0; }
@@ -106,8 +117,6 @@ BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](con
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
 
-#endif // SIMDJSON_EXCEPTIONS
-
 static void dom_parse(State &state) {
   // Load twitter.json to a buffer
   padded_string json;
@@ -132,5 +141,219 @@ static void dom_parse(State &state) {
 BENCHMARK(dom_parse)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
+
+
+/********************
+ * Large file parsing benchmarks:
+ ********************/
+
+static std::string build_json_array(size_t N) {
+  std::default_random_engine e;
+  std::uniform_real_distribution<> dis(0, 1);
+  std::stringstream myss;
+  myss << "[" << std::endl;
+  if(N > 0) {
+    myss << "{ \"x\":" << dis(e) << ",  \"y\":" << dis(e) << ", \"z\":" << dis(e) << "}" << std::endl;
+  }
+  for(size_t i = 1; i < N; i++) {
+    myss << "," << std::endl;
+    myss << "{ \"x\":" << dis(e) << ",  \"y\":" << dis(e) << ", \"z\":" << dis(e) << "}";
+  }
+  myss << std::endl;
+  myss << "]" << std::endl;
+  std::string answer = myss.str();
+  std::cout << "Creating a source file spanning " << (answer.size() + 512) / 1024 << " KB " << std::endl;  
+  return answer;
+}
+
+static const simdjson::padded_string& get_my_json_str() {
+  static simdjson::padded_string s = build_json_array(1000000);
+  return s;
+}
+
+struct my_point {
+  double x;
+  double y;
+  double z;
+};
+
+// ./benchmark/bench_sax --benchmark_filter=largerandom
+
+
+/*** 
+ * We start with the naive DOM-based approach.
+ **/
+static void dom_parse_largerandom(State &state) {
+  // Load twitter.json to a buffer
+  const padded_string& json = get_my_json_str();
+
+  // Allocate
+  dom::parser parser;
+  if (auto error = parser.allocate(json.size())) { cerr << error << endl; return; };
+
+  // Read
+  size_t bytes = 0;
+  simdjson::error_code error;
+  for (SIMDJSON_UNUSED auto _ : state) {
+    std::vector<my_point> container;
+    dom::element doc;
+    if ((error = parser.parse(json).get(doc))) { 
+      std::cerr << "failure: " << error << std::endl;
+      throw "Parsing failed"; 
+    };
+    for (auto p : doc) {
+      container.emplace_back(my_point{p["x"], p["y"], p["z"]});
+    }
+    bytes += json.size();
+    benchmark::DoNotOptimize(container.data());
+
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+}
+
+BENCHMARK(dom_parse_largerandom)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+#if SIMDJSON_IMPLEMENTATION_HASWELL
+
+/*** 
+ * Next we are going to code the SAX approach.
+ **/
+
+SIMDJSON_TARGET_HASWELL
+
+namespace largerandom {
+namespace {
+
+using namespace simdjson;
+using namespace haswell;
+using namespace haswell::stage2;
+struct sax_point_reader_visitor {
+public:
+  sax_point_reader_visitor(std::vector<my_point> &_points) : points(_points) {
+  }
+
+  simdjson_really_inline error_code visit_document_start(json_iterator &) { return SUCCESS; }
+  simdjson_really_inline error_code visit_object_start(json_iterator &) { return SUCCESS; }
+  simdjson_really_inline error_code visit_key(json_iterator &, const uint8_t *key) {
+    switch(key[0]) {
+      case 'x':
+        idx = 0;
+        break;
+      case 'y':
+        idx = 2;
+        break;
+      case 'z':
+        idx = 3;
+        break;  
+    }
+    return SUCCESS; 
+  }
+  simdjson_really_inline error_code visit_primitive(json_iterator &, const uint8_t *value) {
+    return numberparsing::parse_double(value).get(buffer[idx]);
+  }
+  simdjson_really_inline error_code visit_array_start(json_iterator &)  { return SUCCESS; }
+  simdjson_really_inline error_code visit_array_end(json_iterator &) { return SUCCESS; }
+  simdjson_really_inline error_code visit_object_end(json_iterator &)  { return SUCCESS; }
+  simdjson_really_inline error_code visit_document_end(json_iterator &)  { return SUCCESS; }
+  simdjson_really_inline error_code visit_empty_array(json_iterator &)  { return SUCCESS; }
+  simdjson_really_inline error_code visit_empty_object(json_iterator &)  { return SUCCESS; }
+  simdjson_really_inline error_code visit_root_primitive(json_iterator &, const uint8_t *)  { return SUCCESS; }
+  simdjson_really_inline error_code increment_count(json_iterator &) { return SUCCESS; }
+  std::vector<my_point> &points;
+  size_t idx{0};
+  double buffer[3];
+};
+
+struct sax_point_reader {
+  std::vector<my_point> points;
+  std::unique_ptr<uint8_t[]> string_buf;
+  size_t capacity;
+  dom_parser_implementation dom_parser;
+
+  sax_point_reader();
+  error_code set_capacity(size_t new_capacity);
+  error_code read_points(const padded_string &json);
+}; // struct sax_point_reader
+
+sax_point_reader::sax_point_reader() : points{}, string_buf{}, capacity{0}, dom_parser() {
+}
+
+error_code sax_point_reader::set_capacity(size_t new_capacity) {
+  // string_capacity copied from document::allocate
+  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
+  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
+  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
+  if (capacity == 0) { // set max depth the first time only
+    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
+  }
+  capacity = new_capacity;
+  return SUCCESS;
+}
+
+error_code sax_point_reader::read_points(const padded_string &json) {
+  // Allocate capacity if needed
+  points.clear();
+  if (capacity < json.size()) {
+    if (auto error = set_capacity(capacity)) { return error; }
+  }
+
+  // Run stage 1 first.
+  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
+
+  // Then walk the document, parsing the tweets as we go
+  json_iterator iter(dom_parser, 0);
+  sax_point_reader_visitor visitor(points);
+  if (auto error = iter.walk_document<false>(visitor)) { return error; }
+  return SUCCESS;
+}
+
+} // unnamed namespace
+} // namespace largerandom
+
+SIMDJSON_UNTARGET_REGION
+
+
+
+
+
+// ./benchmark/bench_sax --benchmark_filter=largerandom
+static void sax_parse_largerandom(State &state) {
+  // Load twitter.json to a buffer
+  const padded_string& json = get_my_json_str();
+
+  // Allocate
+  largerandom::sax_point_reader reader;
+  if (auto error = reader.set_capacity(json.size())) { throw error; }
+  // warming
+  for(size_t i = 0; i < 10; i++) {
+    if (auto error = reader.read_points(json)) { throw error; }
+  }
+
+  // Read
+  size_t bytes = 0;
+  for (SIMDJSON_UNUSED auto _ : state) {
+    if (auto error = reader.read_points(json)) { throw error; }
+    bytes += json.size();
+    benchmark::DoNotOptimize(reader.points.data());
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+}
+BENCHMARK(sax_parse_largerandom)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+#endif // SIMDJSON_IMPLEMENTATION_HASWELL
+
+#endif // SIMDJSON_EXCEPTIONS
 
 BENCHMARK_MAIN();

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -1,0 +1,264 @@
+#define SIMDJSON_IMPLEMENTATION_FALLBACK 0
+#define SIMDJSON_IMPLEMENTATION_WESTMERE 0
+#define SIMDJSON_IMPLEMENTATION_AMD64 0
+
+#include "simdjson.h"
+#include "simdjson.cpp"
+using namespace simdjson;
+
+using namespace haswell;
+using namespace haswell::stage2;
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+
+#define KEY_IS(KEY, MATCH) (!strncmp((const char *)KEY, "\"" MATCH "\"", strlen("\"" MATCH "\"")))
+
+struct twitter_user {
+  uint64_t id{};
+  std::string_view screen_name{};
+};
+struct tweet {
+  uint64_t id{};
+  std::string_view text{};
+  std::string_view created_at{};
+  uint64_t in_reply_to_status_id{};
+  uint64_t retweet_count{};
+  uint64_t favorite_count{};
+  twitter_user user{};
+};
+struct sax_tweet_reader {
+  std::vector<tweet> tweets;
+  std::unique_ptr<uint8_t[]> string_buf;
+  size_t capacity;
+  dom_parser_implementation dom_parser;
+
+  sax_tweet_reader();
+  error_code set_capacity(size_t new_capacity);
+  error_code read_tweets(padded_string &json);
+}; // struct tweet_reader
+
+} // namespace twitter
+
+namespace twitter {
+
+struct sax_tweet_reader_visitor {
+  bool in_statuses{false};
+  bool in_user{false};
+  std::vector<tweet> &tweets;
+  uint8_t *current_string_buf_loc;
+  uint64_t *expect_int{};
+  std::string_view *expect_string{};
+
+  sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
+
+  simdjson_really_inline error_code visit_document_start(json_iterator &iter);
+  simdjson_really_inline error_code visit_object_start(json_iterator &iter);
+  simdjson_really_inline error_code visit_key(json_iterator &iter, const uint8_t *key);
+  simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value);
+  simdjson_really_inline error_code visit_array_start(json_iterator &iter);
+  simdjson_really_inline error_code visit_array_end(json_iterator &iter);
+  simdjson_really_inline error_code visit_object_end(json_iterator &iter);
+  simdjson_really_inline error_code visit_document_end(json_iterator &iter);
+  simdjson_really_inline error_code visit_empty_array(json_iterator &iter);
+  simdjson_really_inline error_code visit_empty_object(json_iterator &iter);
+  simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value);
+  simdjson_really_inline error_code increment_count(json_iterator &iter);
+}; // sax_tweet_reader_visitor
+
+sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {}
+
+error_code sax_tweet_reader::set_capacity(size_t new_capacity) {
+  // string_capacity copied from document::allocate
+  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
+  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
+  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
+  if (capacity == 0) { // set max depth the first time only
+    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
+  }
+  capacity = new_capacity;
+  return SUCCESS;
+}
+
+// NOTE: this assumes the dom_parser is already allocated
+error_code sax_tweet_reader::read_tweets(padded_string &json) {
+  // Allocate capacity if needed
+  tweets.clear();
+  if (capacity < json.size()) {
+    if (auto error = set_capacity(capacity)) { return error; }
+  }
+
+  // Run stage 1 first.
+  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
+
+  // Then walk the document, parsing the tweets as we go
+  json_iterator iter(dom_parser, 0);
+  sax_tweet_reader_visitor visitor(tweets, string_buf.get());
+  if (auto error = iter.walk_document<false>(visitor)) { return error; }
+  return SUCCESS;
+}
+
+sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf)
+  : tweets{_tweets},
+    current_string_buf_loc{string_buf} {
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
+  iter.log_start_value("document");
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
+  // iter.log_start_value("array");
+  // if we expected an int or string and got an array or object, it's an error
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
+  // iter.log_start_value("object");
+
+  // if we expected an int or string and got an array or object, it's an error
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+
+  // { "statuses": [ {
+  if (in_statuses && iter.depth == 3) {
+    iter.log_start_value("tweet");
+    tweets.push_back({});
+  }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &iter, const uint8_t *key) {
+  // iter.log_value("key");
+  if (in_statuses) {
+    switch (iter.depth) {
+      case 3: // in tweet: { "statuses": [ { <key>
+        // NOTE: the way we're comparing key (fairly naturally) means the caller doesn't have to check " for us at all
+        if (KEY_IS(key, "user")) { iter.log_start_value("user"); in_user = true; }
+
+        else if (KEY_IS(key, "id")) { iter.log_value("id"); expect_int = &tweets.back().id; }
+        else if (KEY_IS(key, "in_reply_to_status_id")) { iter.log_value("in_reply_to_status_id"); expect_int = &tweets.back().in_reply_to_status_id; }
+        else if (KEY_IS(key, "retweet_count")) { iter.log_value("retweet_count"); expect_int = &tweets.back().retweet_count; }
+        else if (KEY_IS(key, "favorite_count")) { iter.log_value("favorite_count"); expect_int = &tweets.back().favorite_count; }
+
+        else if (KEY_IS(key, "text")) { iter.log_value("text"); expect_string = &tweets.back().text; }
+        else if (KEY_IS(key, "created_at")) { iter.log_value("created_at"); expect_string = &tweets.back().created_at; }
+        break;
+      case 4:
+        if (in_user) { // in user: { "statuses": [ { "user": { <key>
+          if (KEY_IS(key, "id")) { iter.log_value("id"); expect_int = &tweets.back().user.id; }
+          else if (KEY_IS(key, "screen_name")) { iter.log_value("screen_name"); expect_string = &tweets.back().user.screen_name; }
+        }
+        break;
+      default: break;
+    }
+  } else {
+    if (iter.depth == 1 && KEY_IS(key, "statuses")) {
+      iter.log_start_value("statuses");
+      in_statuses = true;
+    }
+  }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
+  // iter.log_value("primitive");
+  if (expect_int) {
+    iter.log_value("int");
+    if (auto error = numberparsing::parse_unsigned(value).get(*expect_int)) {
+      // If number parsing failed, check if it's null before returning the error
+      if (!atomparsing::is_valid_null_atom(value)) { iter.log_error("expected number or null"); return error; }
+    }
+    expect_int = nullptr;
+  } else if (expect_string) {
+    iter.log_value("string");
+    // Must be a string!
+    if (value[0] != '"') { iter.log_error("expected string"); return STRING_ERROR; }
+    auto end = stringparsing::parse_string(value, current_string_buf_loc);
+    if (!end) { iter.log_error("error parsing string"); return STRING_ERROR; }
+    *expect_string = std::string_view((const char *)current_string_buf_loc, end-current_string_buf_loc);
+    current_string_buf_loc = end;
+    expect_string = nullptr;
+  }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
+  // iter.log_end_value("array");
+  // When we hit the end of { "statuses": [ ... ], we're done with statuses.
+  if (in_statuses && iter.depth == 2) { iter.log_end_value("statuses"); in_statuses = false; }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
+  // iter.log_end_value("object");
+  // When we hit the end of { "statuses": [ { "user": { ... }, we're done with the user
+  if (in_user && iter.depth == 4) { iter.log_end_value("user"); in_user = false; }
+  if (in_statuses && iter.depth == 3) { iter.log_end_value("tweet"); }
+  return SUCCESS;
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &iter) {
+  iter.log_end_value("document");
+  return SUCCESS;
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &iter) {
+  // if we expected an int or string and got an array or object, it's an error
+  // iter.log_value("empty array");
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &iter) {
+  // if we expected an int or string and got an array or object, it's an error
+  // iter.log_value("empty object");
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
+  // iter.log_value("root primitive");
+  iter.log_error("unexpected root primitive");
+  return TAPE_ERROR;
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
+
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
+#include <benchmark/benchmark.h>
+SIMDJSON_POP_DISABLE_WARNINGS
+
+using namespace benchmark;
+using namespace std;
+
+const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+
+static void sax_tweets(State& state) {
+  // Load twitter.json to a buffer
+  padded_string json;
+  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
+
+  // Allocate
+  twitter::sax_tweet_reader reader;
+  if (auto error = reader.set_capacity(json.size())) { cerr << error << endl; return; }
+
+  // Make the tweet_reader
+  size_t bytes = 0;
+  size_t tweets = 0;
+  for (SIMDJSON_UNUSED auto _ : state) {
+    if (auto error = reader.read_tweets(json)) { throw error; }
+    bytes += json.size();
+    tweets += reader.tweets.size();
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+  state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
+}
+BENCHMARK(sax_tweets)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+BENCHMARK_MAIN();

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -3,237 +3,23 @@
 #define SIMDJSON_IMPLEMENTATION_AMD64 0
 
 #include "simdjson.h"
-#include "simdjson.cpp"
-using namespace simdjson;
-
-using namespace haswell;
-using namespace haswell::stage2;
-
-SIMDJSON_TARGET_HASWELL
-
-namespace twitter {
-
-#define KEY_IS(KEY, MATCH) (!strncmp((const char *)KEY, "\"" MATCH "\"", strlen("\"" MATCH "\"")))
-
-struct twitter_user {
-  uint64_t id{};
-  std::string_view screen_name{};
-};
-struct tweet {
-  uint64_t id{};
-  std::string_view text{};
-  std::string_view created_at{};
-  uint64_t in_reply_to_status_id{};
-  uint64_t retweet_count{};
-  uint64_t favorite_count{};
-  twitter_user user{};
-};
-struct sax_tweet_reader {
-  std::vector<tweet> tweets;
-  std::unique_ptr<uint8_t[]> string_buf;
-  size_t capacity;
-  dom_parser_implementation dom_parser;
-
-  sax_tweet_reader();
-  error_code set_capacity(size_t new_capacity);
-  error_code read_tweets(padded_string &json);
-}; // struct tweet_reader
-
-} // namespace twitter
-
-namespace twitter {
-
-struct sax_tweet_reader_visitor {
-  bool in_statuses{false};
-  bool in_user{false};
-  std::vector<tweet> &tweets;
-  uint8_t *current_string_buf_loc;
-  uint64_t *expect_int{};
-  std::string_view *expect_string{};
-
-  sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
-
-  simdjson_really_inline error_code visit_document_start(json_iterator &iter);
-  simdjson_really_inline error_code visit_object_start(json_iterator &iter);
-  simdjson_really_inline error_code visit_key(json_iterator &iter, const uint8_t *key);
-  simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value);
-  simdjson_really_inline error_code visit_array_start(json_iterator &iter);
-  simdjson_really_inline error_code visit_array_end(json_iterator &iter);
-  simdjson_really_inline error_code visit_object_end(json_iterator &iter);
-  simdjson_really_inline error_code visit_document_end(json_iterator &iter);
-  simdjson_really_inline error_code visit_empty_array(json_iterator &iter);
-  simdjson_really_inline error_code visit_empty_object(json_iterator &iter);
-  simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value);
-  simdjson_really_inline error_code increment_count(json_iterator &iter);
-}; // sax_tweet_reader_visitor
-
-sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {}
-
-error_code sax_tweet_reader::set_capacity(size_t new_capacity) {
-  // string_capacity copied from document::allocate
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
-  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
-  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
-  if (capacity == 0) { // set max depth the first time only
-    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
-  }
-  capacity = new_capacity;
-  return SUCCESS;
-}
-
-// NOTE: this assumes the dom_parser is already allocated
-error_code sax_tweet_reader::read_tweets(padded_string &json) {
-  // Allocate capacity if needed
-  tweets.clear();
-  if (capacity < json.size()) {
-    if (auto error = set_capacity(capacity)) { return error; }
-  }
-
-  // Run stage 1 first.
-  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
-
-  // Then walk the document, parsing the tweets as we go
-  json_iterator iter(dom_parser, 0);
-  sax_tweet_reader_visitor visitor(tweets, string_buf.get());
-  if (auto error = iter.walk_document<false>(visitor)) { return error; }
-  return SUCCESS;
-}
-
-sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf)
-  : tweets{_tweets},
-    current_string_buf_loc{string_buf} {
-}
-
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
-  iter.log_start_value("document");
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
-  // iter.log_start_value("array");
-  // if we expected an int or string and got an array or object, it's an error
-  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
-  // iter.log_start_value("object");
-
-  // if we expected an int or string and got an array or object, it's an error
-  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
-
-  // { "statuses": [ {
-  if (in_statuses && iter.depth == 3) {
-    iter.log_start_value("tweet");
-    tweets.push_back({});
-  }
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &iter, const uint8_t *key) {
-  // iter.log_value("key");
-  if (in_statuses) {
-    switch (iter.depth) {
-      case 3: // in tweet: { "statuses": [ { <key>
-        // NOTE: the way we're comparing key (fairly naturally) means the caller doesn't have to check " for us at all
-        if (KEY_IS(key, "user")) { iter.log_start_value("user"); in_user = true; }
-
-        else if (KEY_IS(key, "id")) { iter.log_value("id"); expect_int = &tweets.back().id; }
-        else if (KEY_IS(key, "in_reply_to_status_id")) { iter.log_value("in_reply_to_status_id"); expect_int = &tweets.back().in_reply_to_status_id; }
-        else if (KEY_IS(key, "retweet_count")) { iter.log_value("retweet_count"); expect_int = &tweets.back().retweet_count; }
-        else if (KEY_IS(key, "favorite_count")) { iter.log_value("favorite_count"); expect_int = &tweets.back().favorite_count; }
-
-        else if (KEY_IS(key, "text")) { iter.log_value("text"); expect_string = &tweets.back().text; }
-        else if (KEY_IS(key, "created_at")) { iter.log_value("created_at"); expect_string = &tweets.back().created_at; }
-        break;
-      case 4:
-        if (in_user) { // in user: { "statuses": [ { "user": { <key>
-          if (KEY_IS(key, "id")) { iter.log_value("id"); expect_int = &tweets.back().user.id; }
-          else if (KEY_IS(key, "screen_name")) { iter.log_value("screen_name"); expect_string = &tweets.back().user.screen_name; }
-        }
-        break;
-      default: break;
-    }
-  } else {
-    if (iter.depth == 1 && KEY_IS(key, "statuses")) {
-      iter.log_start_value("statuses");
-      in_statuses = true;
-    }
-  }
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
-  // iter.log_value("primitive");
-  if (expect_int) {
-    iter.log_value("int");
-    if (auto error = numberparsing::parse_unsigned(value).get(*expect_int)) {
-      // If number parsing failed, check if it's null before returning the error
-      if (!atomparsing::is_valid_null_atom(value)) { iter.log_error("expected number or null"); return error; }
-    }
-    expect_int = nullptr;
-  } else if (expect_string) {
-    iter.log_value("string");
-    // Must be a string!
-    if (value[0] != '"') { iter.log_error("expected string"); return STRING_ERROR; }
-    auto end = stringparsing::parse_string(value, current_string_buf_loc);
-    if (!end) { iter.log_error("error parsing string"); return STRING_ERROR; }
-    *expect_string = std::string_view((const char *)current_string_buf_loc, end-current_string_buf_loc);
-    current_string_buf_loc = end;
-    expect_string = nullptr;
-  }
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
-  // iter.log_end_value("array");
-  // When we hit the end of { "statuses": [ ... ], we're done with statuses.
-  if (in_statuses && iter.depth == 2) { iter.log_end_value("statuses"); in_statuses = false; }
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
-  // iter.log_end_value("object");
-  // When we hit the end of { "statuses": [ { "user": { ... }, we're done with the user
-  if (in_user && iter.depth == 4) { iter.log_end_value("user"); in_user = false; }
-  if (in_statuses && iter.depth == 3) { iter.log_end_value("tweet"); }
-  return SUCCESS;
-}
-
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &iter) {
-  iter.log_end_value("document");
-  return SUCCESS;
-}
-
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &iter) {
-  // if we expected an int or string and got an array or object, it's an error
-  // iter.log_value("empty array");
-  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &iter) {
-  // if we expected an int or string and got an array or object, it's an error
-  // iter.log_value("empty object");
-  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
-  return SUCCESS;
-}
-simdjson_really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
-  // iter.log_value("root primitive");
-  iter.log_error("unexpected root primitive");
-  return TAPE_ERROR;
-}
-
-simdjson_really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
-
-} // namespace twitter
-
-SIMDJSON_UNTARGET_REGION
-
 
 SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
+#include "simdjson.cpp"
+#include "twitter/sax_tweet_reader.h"
+
 using namespace benchmark;
-using namespace std;
+using namespace simdjson;
+using std::cerr;
+using std::endl;
 
 const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+const int REPETITIONS = 10;
 
-static void sax_tweets(State& state) {
+static void sax_tweets(State &state) {
   // Load twitter.json to a buffer
   padded_string json;
   if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
@@ -242,7 +28,10 @@ static void sax_tweets(State& state) {
   twitter::sax_tweet_reader reader;
   if (auto error = reader.set_capacity(json.size())) { cerr << error << endl; return; }
 
-  // Make the tweet_reader
+  // Warm the vector
+  if (auto error = reader.read_tweets(json)) { throw error; }
+
+  // Read tweets
   size_t bytes = 0;
   size_t tweets = 0;
   for (SIMDJSON_UNUSED auto _ : state) {
@@ -257,7 +46,90 @@ static void sax_tweets(State& state) {
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
   state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
 }
-BENCHMARK(sax_tweets)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+#if SIMDJSON_EXCEPTIONS
+
+simdjson_really_inline uint64_t nullable_int(dom::element element) {
+  if (element.is_null()) { return 0; }
+  return element;
+}
+simdjson_really_inline void read_dom_tweets(dom::parser &parser, padded_string &json, std::vector<twitter::tweet> &tweets) {
+  for (dom::element tweet : parser.parse(json)["statuses"]) {
+    auto user = tweet["user"];
+    tweets.push_back(
+      {
+        tweet["id"],
+        tweet["text"],
+        tweet["created_at"],
+        nullable_int(tweet["in_reply_to_status_id"]),
+        tweet["retweet_count"],
+        tweet["favorite_count"],
+        { user["id"], user["screen_name"] }
+      }
+    );
+  }
+}
+
+static void dom_tweets(State &state) {
+  // Load twitter.json to a buffer
+  padded_string json;
+  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
+
+  // Allocate
+  dom::parser parser;
+  if (auto error = parser.allocate(json.size())) { cerr << error << endl; return; };
+
+  // Warm the vector
+  std::vector<twitter::tweet> tweets;
+  read_dom_tweets(parser, json, tweets);
+
+  // Read tweets
+  size_t bytes = 0;
+  size_t num_tweets = 0;
+  for (SIMDJSON_UNUSED auto _ : state) {
+    tweets.clear();
+    read_dom_tweets(parser, json, tweets);
+    bytes += json.size();
+    num_tweets += tweets.size();
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+  state.counters["tweets"] = Counter(double(num_tweets), benchmark::Counter::kIsRate);
+}
+BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+#endif // SIMDJSON_EXCEPTIONS
+
+static void dom_parse(State &state) {
+  // Load twitter.json to a buffer
+  padded_string json;
+  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
+
+  // Allocate
+  dom::parser parser;
+  if (auto error = parser.allocate(json.size())) { cerr << error << endl; return; };
+
+  // Read tweets
+  size_t bytes = 0;
+  for (SIMDJSON_UNUSED auto _ : state) {
+    if (parser.parse(json).error()) { throw "Parsing failed"; };
+    bytes += json.size();
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+}
+BENCHMARK(dom_parse)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
 

--- a/benchmark/twitter/sax_tweet_reader.h
+++ b/benchmark/twitter/sax_tweet_reader.h
@@ -1,0 +1,67 @@
+#ifndef TWITTER_SAX_TWEET_READER_H
+#define TWITTER_SAX_TWEET_READER_H
+
+#include "simdjson.h"
+#include "sax_tweet_reader_visitor.h"
+#include "tweet.h"
+#include <vector>
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+namespace {
+
+using namespace simdjson;
+using namespace haswell;
+using namespace haswell::stage2;
+
+struct sax_tweet_reader {
+  std::vector<tweet> tweets;
+  std::unique_ptr<uint8_t[]> string_buf;
+  size_t capacity;
+  dom_parser_implementation dom_parser;
+
+  sax_tweet_reader();
+  error_code set_capacity(size_t new_capacity);
+  error_code read_tweets(padded_string &json);
+}; // struct tweet_reader
+
+sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {
+}
+
+error_code sax_tweet_reader::set_capacity(size_t new_capacity) {
+  // string_capacity copied from document::allocate
+  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
+  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
+  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
+  if (capacity == 0) { // set max depth the first time only
+    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
+  }
+  capacity = new_capacity;
+  return SUCCESS;
+}
+
+// NOTE: this assumes the dom_parser is already allocated
+error_code sax_tweet_reader::read_tweets(padded_string &json) {
+  // Allocate capacity if needed
+  tweets.clear();
+  if (capacity < json.size()) {
+    if (auto error = set_capacity(capacity)) { return error; }
+  }
+
+  // Run stage 1 first.
+  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
+
+  // Then walk the document, parsing the tweets as we go
+  json_iterator iter(dom_parser, 0);
+  sax_tweet_reader_visitor visitor(tweets, string_buf.get());
+  if (auto error = iter.walk_document<false>(visitor)) { return error; }
+  return SUCCESS;
+}
+
+} // unnamed namespace
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+#endif // TWITTER_SAX_TWEET_READER_H

--- a/benchmark/twitter/sax_tweet_reader_visitor.h
+++ b/benchmark/twitter/sax_tweet_reader_visitor.h
@@ -163,6 +163,7 @@ simdjson_really_inline error_code sax_tweet_reader_visitor::visit_object_start(j
       return INCORRECT_TYPE;
   }
   SIMDJSON_UNREACHABLE();
+  return UNINITIALIZED;
 }
 simdjson_really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &, const uint8_t *key) {
   current_key = key;

--- a/benchmark/twitter/sax_tweet_reader_visitor.h
+++ b/benchmark/twitter/sax_tweet_reader_visitor.h
@@ -1,0 +1,518 @@
+#ifndef TWITTER_SAX_TWEET_READER_VISITOR_H
+#define TWITTER_SAX_TWEET_READER_VISITOR_H
+
+#include "simdjson.h"
+#include "tweet.h"
+#include <vector>
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+
+using namespace simdjson;
+using namespace haswell;
+using namespace haswell::stage2;
+
+struct sax_tweet_reader_visitor {
+public:
+  sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
+
+  simdjson_really_inline error_code visit_document_start(json_iterator &iter);
+  simdjson_really_inline error_code visit_object_start(json_iterator &iter);
+  simdjson_really_inline error_code visit_key(json_iterator &iter, const uint8_t *key);
+  simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value);
+  simdjson_really_inline error_code visit_array_start(json_iterator &iter);
+  simdjson_really_inline error_code visit_array_end(json_iterator &iter);
+  simdjson_really_inline error_code visit_object_end(json_iterator &iter);
+  simdjson_really_inline error_code visit_document_end(json_iterator &iter);
+  simdjson_really_inline error_code visit_empty_array(json_iterator &iter);
+  simdjson_really_inline error_code visit_empty_object(json_iterator &iter);
+  simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value);
+  simdjson_really_inline error_code increment_count(json_iterator &iter);
+
+private:
+  // Since we only care about one thing at each level, we just use depth as the marker for what
+  // object/array we're nested inside.
+  enum class containers {
+    document = 0,   //
+    top_object = 1, // {
+    statuses = 2,   // { "statuses": [
+    tweet = 3,      // { "statuses": [ {
+    user = 4        // { "statuses": [ { "user": {
+  };
+  /**
+   * The largest depth we care about.
+   * There can be things at lower depths.
+   */
+  static constexpr uint32_t MAX_SUPPORTED_DEPTH = uint32_t(containers::user);
+  static constexpr const char *STATE_NAMES[] = {
+    "document",
+    "top object",
+    "statuses",
+    "tweet",
+    "user"
+  };
+  enum class field_type {
+    any,
+    unsigned_integer,
+    string,
+    nullable_unsigned_integer,
+    object,
+    array
+  };
+  struct field {
+    const char * key{};
+    size_t len{0};
+    size_t offset;
+    containers container{containers::document};
+    field_type type{field_type::any};
+  };
+
+  containers container{containers::document};
+  std::vector<tweet> &tweets;
+  uint8_t *current_string_buf_loc;
+  const uint8_t *current_key{};
+
+  simdjson_really_inline bool in_container(json_iterator &iter);
+  simdjson_really_inline bool in_container_child(json_iterator &iter);
+  simdjson_really_inline void start_container(json_iterator &iter);
+  simdjson_really_inline void end_container(json_iterator &iter);
+  simdjson_really_inline error_code parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
+  simdjson_really_inline error_code parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
+  simdjson_really_inline error_code parse_string(json_iterator &iter, const uint8_t *value, const field &f);
+
+  struct field_lookup {
+    field entries[256]{};
+
+    field_lookup();
+    simdjson_really_inline field get(const uint8_t * key, containers container);
+  private:
+    simdjson_really_inline uint8_t hash(const char * key, uint32_t depth);
+    simdjson_really_inline void add(const char * key, size_t len, containers container, field_type type, size_t offset);
+    simdjson_really_inline void neg(const char * const key, uint32_t depth);
+  };
+  static field_lookup fields;
+}; // sax_tweet_reader_visitor
+
+sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf)
+  : tweets{_tweets},
+    current_string_buf_loc{string_buf} {
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
+  start_container(iter);
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
+  // If we're not in a container we care about, don't bother with the rest
+  if (!in_container_child(iter)) { return SUCCESS; }
+
+  // Handle fields first
+  if (current_key) {
+    switch (fields.get(current_key, container).type) {
+      case field_type::array: // { "statuses": [
+        start_container(iter);
+        return SUCCESS;
+      case field_type::any:
+        return SUCCESS;
+      case field_type::object:
+      case field_type::unsigned_integer:
+      case field_type::nullable_unsigned_integer:
+      case field_type::string:
+        iter.log_error("unexpected array field");
+        return INCORRECT_TYPE;
+    }
+  }
+
+  // We're not in a field, so it must be a child of an array. We support any of those.
+  iter.log_error("unexpected array");
+  return INCORRECT_TYPE;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
+  // If we're not in a container we care about, don't bother with the rest
+  if (!in_container_child(iter)) { return SUCCESS; }
+
+  // Handle known fields
+  if (current_key) {
+    auto f = fields.get(current_key, container);
+    switch (f.type) {
+      case field_type::object: // { "statuses": [ { "user": {
+        start_container(iter);
+        return SUCCESS;
+      case field_type::any:
+        return SUCCESS;
+      case field_type::array:
+      case field_type::unsigned_integer:
+      case field_type::nullable_unsigned_integer:
+      case field_type::string:
+        iter.log_error("unexpected object field");
+        return INCORRECT_TYPE;
+    }
+  }
+
+  // It's not a field, so it's a child of an array or document
+  switch (container) {
+    case containers::document: // top_object: {
+    case containers::statuses: // tweet:      { "statuses": [ {
+      start_container(iter);
+      return SUCCESS;
+    case containers::top_object:
+    case containers::tweet:
+    case containers::user:
+      iter.log_error("unexpected object");
+      return INCORRECT_TYPE;
+  }
+  SIMDJSON_UNREACHABLE();
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &, const uint8_t *key) {
+  current_key = key;
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
+  // Don't bother unless we're in a container we care about
+  if (!in_container(iter)) { return SUCCESS; }
+
+  // Handle fields first
+  if (current_key) {
+    auto f = fields.get(current_key, container);
+    switch (f.type) {
+      case field_type::unsigned_integer:
+        return parse_unsigned(iter, value, f);
+      case field_type::nullable_unsigned_integer:
+        return parse_nullable_unsigned(iter, value, f);
+      case field_type::string:
+        return parse_string(iter, value, f);
+      case field_type::any:
+        return SUCCESS;
+      case field_type::array:
+      case field_type::object:
+        iter.log_error("unexpected primitive");
+        return INCORRECT_TYPE;
+    }
+  }
+
+  // If it's not a field, it's a child of an array.
+  // The only array we support is statuses, which must contain objects.
+  iter.log_error("unexpected primitive");
+  return INCORRECT_TYPE;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
+  if (in_container(iter)) { end_container(iter); }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
+  if (in_container(iter)) { end_container(iter); }
+  return SUCCESS;
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &iter) {
+  iter.log_end_value("document");
+  return SUCCESS;
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &) {
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &) {
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
+  iter.log_error("unexpected root primitive");
+  return INCORRECT_TYPE;
+}
+
+simdjson_really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
+
+simdjson_really_inline bool sax_tweet_reader_visitor::in_container(json_iterator &iter) {
+  return iter.depth == uint32_t(container);
+}
+simdjson_really_inline bool sax_tweet_reader_visitor::in_container_child(json_iterator &iter) {
+  return iter.depth == uint32_t(container) + 1;
+}
+simdjson_really_inline void sax_tweet_reader_visitor::start_container(json_iterator &iter) {
+  SIMDJSON_ASSUME(iter.depth <= MAX_SUPPORTED_DEPTH); // Asserts in debug mode
+  container = containers(iter.depth);
+  if (logger::LOG_ENABLED) { iter.log_start_value(STATE_NAMES[iter.depth]); }
+}
+simdjson_really_inline void sax_tweet_reader_visitor::end_container(json_iterator &iter) {
+  if (logger::LOG_ENABLED) { iter.log_end_value(STATE_NAMES[int(container)]); }
+  container = containers(int(container) - 1);
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  if (auto error = numberparsing::parse_unsigned(value).get(*i)) {
+    // If number parsing failed, check if it's null before returning the error
+    if (!atomparsing::is_valid_null_atom(value)) { iter.log_error("expected number or null"); return error; }
+    i = 0;
+  }
+  return SUCCESS;
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  return numberparsing::parse_unsigned(value).get(*i);
+}
+simdjson_really_inline error_code sax_tweet_reader_visitor::parse_string(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto s = reinterpret_cast<std::string_view *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  return stringparsing::parse_string_to_buffer(value, current_string_buf_loc, *s);
+}
+
+sax_tweet_reader_visitor::field_lookup sax_tweet_reader_visitor::fields{};
+
+simdjson_really_inline uint8_t sax_tweet_reader_visitor::field_lookup::hash(const char * key, uint32_t depth) {
+  // These shift numbers were chosen specifically because this yields only 2 collisions between
+  // keys in twitter.json, leaves 0 as a distinct value, and has 0 collisions between keys we
+  // actually care about.
+  return uint8_t((key[0] << 0) ^ (key[1] << 3) ^ (key[2] << 3) ^ (key[3] << 1) ^ depth);
+}
+simdjson_really_inline sax_tweet_reader_visitor::field sax_tweet_reader_visitor::field_lookup::get(const uint8_t * key, containers c) {
+  auto index = hash((const char *)key, uint32_t(c));
+  auto entry = entries[index];
+  // TODO if any key is > SIMDJSON_PADDING, this will access inaccessible memory!
+  if (c != entry.container || memcmp(key, entry.key, entry.len)) { return entries[0]; }
+  return entry;
+}
+simdjson_really_inline void sax_tweet_reader_visitor::field_lookup::add(const char * key, size_t len, containers c, field_type type, size_t offset) {
+  auto index = hash(key, uint32_t(c));
+  if (index == 0) {
+    fprintf(stderr, "%s (depth %d) hashes to zero, which is used as 'missing value'\n", key, int(c));
+    assert(false);
+  }
+  if (entries[index].key) {
+    fprintf(stderr, "%s (depth %d) collides with %s (depth %d) !\n", key, int(c), entries[index].key, int(entries[index].container));
+    assert(false);
+  }
+  entries[index] = { key, len, offset, c, type };
+}
+simdjson_really_inline void sax_tweet_reader_visitor::field_lookup::neg(const char * const key, uint32_t depth) {
+  auto index = hash(key, depth);
+  if (entries[index].key) {
+    fprintf(stderr, "%s (depth %d) conflicts with %s (depth %d) !\n", key, depth, entries[index].key, int(entries[index].container));
+    assert(false);
+  }
+}
+
+sax_tweet_reader_visitor::field_lookup::field_lookup() {
+  add("\"statuses\"", strlen("\"statuses\""), containers::top_object, field_type::array, 0); // { "statuses": [...]
+  #define TWEET_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::tweet, TYPE, offsetof(tweet, KEY));
+  TWEET_FIELD(id, field_type::unsigned_integer);
+  TWEET_FIELD(in_reply_to_status_id, field_type::nullable_unsigned_integer);
+  TWEET_FIELD(retweet_count, field_type::unsigned_integer);
+  TWEET_FIELD(favorite_count, field_type::unsigned_integer);
+  TWEET_FIELD(text, field_type::string);
+  TWEET_FIELD(created_at, field_type::string);
+  TWEET_FIELD(user, field_type::object)
+  #undef TWEET_FIELD
+  #define USER_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::user, TYPE, offsetof(tweet, user)+offsetof(twitter_user, KEY));
+  USER_FIELD(id, field_type::unsigned_integer);
+  USER_FIELD(screen_name, field_type::string);
+  #undef USER_FIELD
+
+  // Check for collisions with other (unused) hash keys in typical twitter JSON
+  #define NEG(key, depth) neg("\"" #key "\"", depth);
+  NEG(display_url, 9);
+  NEG(expanded_url, 9);
+  neg("\"h\":", 9);
+  NEG(indices, 9);
+  NEG(resize, 9);
+  NEG(url, 9);
+  neg("\"w\":", 9);
+  NEG(display_url, 8);
+  NEG(expanded_url, 8);
+  neg("\"h\":", 8);
+  NEG(indices, 8);
+  NEG(large, 8);
+  NEG(medium, 8);
+  NEG(resize, 8);
+  NEG(small, 8);
+  NEG(thumb, 8);
+  NEG(url, 8);
+  neg("\"w\":", 8);
+  NEG(display_url, 7);
+  NEG(expanded_url, 7);
+  NEG(id_str, 7);
+  NEG(id, 7);
+  NEG(indices, 7);
+  NEG(large, 7);
+  NEG(media_url_https, 7);
+  NEG(media_url, 7);
+  NEG(medium, 7);
+  NEG(name, 7);
+  NEG(sizes, 7);
+  NEG(small, 7);
+  NEG(source_status_id_str, 7);
+  NEG(source_status_id, 7);
+  NEG(thumb, 7);
+  NEG(type, 7);
+  NEG(url, 7);
+  NEG(urls, 7);
+  NEG(description, 6);
+  NEG(display_url, 6);
+  NEG(expanded_url, 6);
+  NEG(id_str, 6);
+  NEG(id, 6);
+  NEG(indices, 6);
+  NEG(media_url_https, 6);
+  NEG(media_url, 6);
+  NEG(name, 6);
+  NEG(sizes, 6);
+  NEG(source_status_id_str, 6);
+  NEG(source_status_id, 6);
+  NEG(type, 6);
+  NEG(url, 6);
+  NEG(urls, 6);
+  NEG(contributors_enabled, 5);
+  NEG(default_profile_image, 5);
+  NEG(default_profile, 5);
+  NEG(description, 5);
+  NEG(entities, 5);
+  NEG(favourites_count, 5);
+  NEG(follow_request_sent, 5);
+  NEG(followers_count, 5);
+  NEG(following, 5);
+  NEG(friends_count, 5);
+  NEG(geo_enabled, 5);
+  NEG(hashtags, 5);
+  NEG(id_str, 5);
+  NEG(id, 5);
+  NEG(is_translation_enabled, 5);
+  NEG(is_translator, 5);
+  NEG(iso_language_code, 5);
+  NEG(lang, 5);
+  NEG(listed_count, 5);
+  NEG(location, 5);
+  NEG(media, 5);
+  NEG(name, 5);
+  NEG(notifications, 5);
+  NEG(profile_background_color, 5);
+  NEG(profile_background_image_url_https, 5);
+  NEG(profile_background_image_url, 5);
+  NEG(profile_background_tile, 5);
+  NEG(profile_banner_url, 5);
+  NEG(profile_image_url_https, 5);
+  NEG(profile_image_url, 5);
+  NEG(profile_link_color, 5);
+  NEG(profile_sidebar_border_color, 5);
+  NEG(profile_sidebar_fill_color, 5);
+  NEG(profile_text_color, 5);
+  NEG(profile_use_background_image, 5);
+  NEG(protected, 5);
+  NEG(result_type, 5);
+  NEG(statuses_count, 5);
+  NEG(symbols, 5);
+  NEG(time_zone, 5);
+  NEG(url, 5);
+  NEG(urls, 5);
+  NEG(user_mentions, 5);
+  NEG(utc_offset, 5);
+  NEG(verified, 5);
+  NEG(contributors_enabled, 4);
+  NEG(contributors, 4);
+  NEG(coordinates, 4);
+  NEG(default_profile_image, 4);
+  NEG(default_profile, 4);
+  NEG(description, 4);
+  NEG(entities, 4);
+  NEG(favorited, 4);
+  NEG(favourites_count, 4);
+  NEG(follow_request_sent, 4);
+  NEG(followers_count, 4);
+  NEG(following, 4);
+  NEG(friends_count, 4);
+  NEG(geo_enabled, 4);
+  NEG(geo, 4);
+  NEG(hashtags, 4);
+  NEG(id_str, 4);
+  NEG(in_reply_to_screen_name, 4);
+  NEG(in_reply_to_status_id_str, 4);
+  NEG(in_reply_to_user_id_str, 4);
+  NEG(in_reply_to_user_id, 4);
+  NEG(is_translation_enabled, 4);
+  NEG(is_translator, 4);
+  NEG(iso_language_code, 4);
+  NEG(lang, 4);
+  NEG(listed_count, 4);
+  NEG(location, 4);
+  NEG(media, 4);
+  NEG(metadata, 4);
+  NEG(name, 4);
+  NEG(notifications, 4);
+  NEG(place, 4);
+  NEG(possibly_sensitive, 4);
+  NEG(profile_background_color, 4);
+  NEG(profile_background_image_url_https, 4);
+  NEG(profile_background_image_url, 4);
+  NEG(profile_background_tile, 4);
+  NEG(profile_banner_url, 4);
+  NEG(profile_image_url_https, 4);
+  NEG(profile_image_url, 4);
+  NEG(profile_link_color, 4);
+  NEG(profile_sidebar_border_color, 4);
+  NEG(profile_sidebar_fill_color, 4);
+  NEG(profile_text_color, 4);
+  NEG(profile_use_background_image, 4);
+  NEG(protected, 4);
+  NEG(result_type, 4);
+  NEG(retweeted, 4);
+  NEG(source, 4);
+  NEG(statuses_count, 4);
+  NEG(symbols, 4);
+  NEG(time_zone, 4);
+  NEG(truncated, 4);
+  NEG(url, 4);
+  NEG(urls, 4);
+  NEG(user_mentions, 4);
+  NEG(utc_offset, 4);
+  NEG(verified, 4);
+  NEG(contributors, 3);
+  NEG(coordinates, 3);
+  NEG(entities, 3);
+  NEG(favorited, 3);
+  NEG(geo, 3);
+  NEG(id_str, 3);
+  NEG(in_reply_to_screen_name, 3);
+  NEG(in_reply_to_status_id_str, 3);
+  NEG(in_reply_to_user_id_str, 3);
+  NEG(in_reply_to_user_id, 3);
+  NEG(lang, 3);
+  NEG(metadata, 3);
+  NEG(place, 3);
+  NEG(possibly_sensitive, 3);
+  NEG(retweeted_status, 3);
+  NEG(retweeted, 3);
+  NEG(source, 3);
+  NEG(truncated, 3);
+  NEG(completed_in, 2);
+  NEG(count, 2);
+  NEG(max_id_str, 2);
+  NEG(max_id, 2);
+  NEG(next_results, 2);
+  NEG(query, 2);
+  NEG(refresh_url, 2);
+  NEG(since_id_str, 2);
+  NEG(since_id, 2);
+  NEG(search_metadata, 1);
+  #undef NEG
+}
+
+// sax_tweet_reader_visitor::field_lookup::find_min() {
+//   int min_count = 100000;
+//   for (int a=0;a<4;a++) {
+//     for (int b=0;b<4;b++) {
+//       for (int c=0;c<4;c++) {
+//         twitter::sax_tweet_reader_visitor::field_lookup fields(a,b,c);
+//         if (fields.collision_count) { continue; }
+//         if (fields.zero_emission) { continue; }
+//         if (fields.conflict_count < min_count) { printf("min=%d,%d,%d (%d)", a, b, c, fields.conflict_count); }
+//       }
+//     }
+//   }
+// }
+
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+#endif // TWITTER_SAX_TWEET_READER_VISITOR_H

--- a/benchmark/twitter/tweet.h
+++ b/benchmark/twitter/tweet.h
@@ -1,0 +1,21 @@
+#ifndef TWEET_H
+#define TWEET_H
+
+#include "simdjson.h"
+#include "twitter_user.h"
+
+namespace twitter {
+
+struct tweet {
+  uint64_t id{};
+  std::string_view text{};
+  std::string_view created_at{};
+  uint64_t in_reply_to_status_id{};
+  uint64_t retweet_count{};
+  uint64_t favorite_count{};
+  twitter_user user{};
+};
+
+} // namespace twitter
+
+#endif // TWEET_H

--- a/benchmark/twitter/twitter_user.h
+++ b/benchmark/twitter/twitter_user.h
@@ -1,0 +1,15 @@
+#ifndef TWITTER_USER_H
+#define TWITTER_USER_H
+
+#include "simdjson.h"
+
+namespace twitter {
+
+struct twitter_user {
+  uint64_t id{};
+  std::string_view screen_name{};
+};
+
+} // namespace twitter
+
+#endif // TWITTER_USER_H

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -111,7 +111,6 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
 
 #include "arm64/stringparsing.h"
 #include "arm64/numberparsing.h"
-#include "generic/stage2/structural_parser.h"
 #include "generic/stage2/tape_builder.h"
 
 //
@@ -145,15 +144,11 @@ SIMDJSON_WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t 
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(*doc);
-  return stage2::structural_parser::parse<false>(*this, builder);
+  return stage2::tape_builder::parse_document<false>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(_doc);
-  return stage2::structural_parser::parse<true>(*this, builder);
+  return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -315,22 +315,17 @@ SIMDJSON_WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t 
 //
 #include "fallback/stringparsing.h"
 #include "fallback/numberparsing.h"
-#include "generic/stage2/structural_parser.h"
 #include "generic/stage2/tape_builder.h"
 
 namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(*doc);
-  return stage2::structural_parser::parse<false>(*this, builder);
+  return stage2::tape_builder::parse_document<false>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(_doc);
-  return stage2::structural_parser::parse<true>(*this, builder);
+  return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/generic/dom_parser_implementation.h
+++ b/src/generic/dom_parser_implementation.h
@@ -4,16 +4,18 @@
 namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
-// expectation: sizeof(scope_descriptor) = 64/8.
-struct scope_descriptor {
+// expectation: sizeof(open_container) = 64/8.
+struct open_container {
   uint32_t tape_index; // where, on the tape, does the scope ([,{) begins
   uint32_t count; // how many elements in the scope
-}; // struct scope_descriptor
+}; // struct open_container
+
+static_assert(sizeof(open_container) == 64/8, "Open container must be 64 bits");
 
 class dom_parser_implementation final : public internal::dom_parser_implementation {
 public:
   /** Tape location of each open { or [ */
-  std::unique_ptr<scope_descriptor[]> containing_scope{};
+  std::unique_ptr<open_container[]> open_containers{};
   /** Whether each open container is a [ or { */
   std::unique_ptr<bool[]> is_array{};
   /** Buffer passed to stage 1 */

--- a/src/generic/stage2/allocate.h
+++ b/src/generic/stage2/allocate.h
@@ -7,10 +7,10 @@ namespace allocate {
 // Allocates stage 2 internal state and outputs in the parser
 //
 simdjson_really_inline error_code set_max_depth(dom_parser_implementation &parser, size_t max_depth) {
-  parser.containing_scope.reset(new (std::nothrow) scope_descriptor[max_depth]);
+  parser.open_containers.reset(new (std::nothrow) open_container[max_depth]);
   parser.is_array.reset(new (std::nothrow) bool[max_depth]);
 
-  if (!parser.is_array || !parser.containing_scope) {
+  if (!parser.is_array || !parser.open_containers) {
     return MEMALLOC;
   }
   return SUCCESS;

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -91,7 +91,7 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::walk_docum
   // Start the document
   //
   if (at_end()) { return EMPTY; }
-  visitor.start_document(*this);
+  SIMDJSON_TRY( visitor.start_document(*this) );
 
   //
   // Read first value
@@ -127,7 +127,7 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::walk_docum
 object_begin:
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
-  visitor.start_object(*this);
+  SIMDJSON_TRY( visitor.start_object(*this) );
 
   if (advance() != '"') { log_error("Object does not start with a key"); return TAPE_ERROR; }
   visitor.increment_count(*this);
@@ -149,7 +149,7 @@ object_continue:
       if (simdjson_unlikely( advance() != '"' )) { log_error("Key string missing at beginning of field in object"); return TAPE_ERROR; }
       SIMDJSON_TRY( visitor.key(*this, value) );
       goto object_field;
-    case '}': visitor.end_object(*this); goto scope_end;
+    case '}': SIMDJSON_TRY( visitor.end_object(*this) ); goto scope_end;
     default: log_error("No comma between object fields"); return TAPE_ERROR;
   }
 
@@ -165,7 +165,7 @@ scope_end:
 array_begin:
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
-  visitor.start_array(*this);
+  SIMDJSON_TRY( visitor.start_array(*this) );
   visitor.increment_count(*this);
 
 array_value:
@@ -178,12 +178,12 @@ array_value:
 array_continue:
   switch (advance()) {
     case ',': visitor.increment_count(*this); goto array_value;
-    case ']': visitor.end_array(*this); goto scope_end;
+    case ']': SIMDJSON_TRY( visitor.end_array(*this) ); goto scope_end;
     default: log_error("Missing comma between array values"); return TAPE_ERROR;
   }
 
 document_end:
-  visitor.end_document(*this);
+  SIMDJSON_TRY( visitor.end_document(*this) );
 
   dom_parser.next_structural_index = uint32_t(next_structural - &dom_parser.structural_indexes[0]);
 

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -188,8 +188,6 @@ document_end:
 
   dom_parser.next_structural_index = uint32_t(next_structural - &dom_parser.structural_indexes[0]);
 
-  if (depth != 0) { log_error("Unclosed objects or arrays!"); return TAPE_ERROR; }
-
   // If we didn't make it to the end, it's an error
   if ( !STREAMING && dom_parser.next_structural_index != dom_parser.n_structural_indexes ) {
     log_error("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -1,27 +1,45 @@
-// This file contains the common code every implementation uses for stage2
-// It is intended to be included multiple times and compiled multiple times
-// We assume the file in which it is include already includes
-// "simdjson/stage2.h" (this simplifies amalgation)
-
 #include "generic/stage2/logger.h"
-#include "generic/stage2/structural_iterator.h"
 
-namespace { // Make everything here private
+namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace stage2 {
 
-#define SIMDJSON_TRY(EXPR) { auto _err = (EXPR); if (_err) { return _err; } }
-
-struct structural_parser : structural_iterator {
-  /** Current depth (nested objects and arrays) */
+class json_iterator {
+public:
+  const uint8_t* const buf;
+  uint32_t *next_structural;
+  dom_parser_implementation &dom_parser;
   uint32_t depth{0};
 
   template<bool STREAMING, typename T>
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code walk_document(T &visitor) noexcept;
 
-  // For non-streaming, to pass an explicit 0 as next_structural, which enables optimizations
-  simdjson_really_inline structural_parser(dom_parser_implementation &_dom_parser, uint32_t start_structural_index)
-    : structural_iterator(_dom_parser, start_structural_index) {
+  // Start a structural 
+  simdjson_really_inline json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
+    : buf{_dom_parser.buf},
+      next_structural{&_dom_parser.structural_indexes[start_structural_index]},
+      dom_parser{_dom_parser} {
+  }
+
+  // Get the buffer position of the current structural character
+  simdjson_really_inline char peek_next_char() {
+    return buf[*(next_structural)];
+  }
+  simdjson_really_inline const uint8_t* advance() {
+    return &buf[*(next_structural++)];
+  }
+  simdjson_really_inline char advance_char() {
+    return buf[*(next_structural++)];
+  }
+  simdjson_really_inline size_t remaining_len() {
+    return dom_parser.len - *(next_structural-1);
+  }
+
+  simdjson_really_inline bool at_end() {
+    return next_structural == &dom_parser.structural_indexes[dom_parser.n_structural_indexes];
+  }
+  simdjson_really_inline bool at_beginning() {
+    return next_structural == dom_parser.structural_indexes.get();
   }
 
   template<typename T>
@@ -64,11 +82,11 @@ struct structural_parser : structural_iterator {
   simdjson_really_inline void log_error(const char *error) {
     logger::log_line(*this, "", "ERROR", error);
   }
-}; // struct structural_parser
+};
 
 template<bool STREAMING, typename T>
-SIMDJSON_WARN_UNUSED simdjson_really_inline error_code structural_parser::walk_document(T &visitor) noexcept {
-  const uint8_t *value;
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::walk_document(T &visitor) noexcept {
+  const uint8_t *value; // Used to keep a value around between states
 
   logger::log_start();
 

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -204,7 +204,7 @@ document_end:
 
   // If we didn't make it to the end, it's an error
   if ( !STREAMING && dom_parser.next_structural_index != dom_parser.n_structural_indexes ) {
-    logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
+    log_error("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
     return TAPE_ERROR;
   }
 

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -100,6 +100,11 @@ public:
    * Set ENABLE_LOGGING=true in logger.h to see logging.
    */
   simdjson_really_inline void log_error(const char *error) const noexcept;
+
+  template<typename V>
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_primitive(V &visitor, const uint8_t *value) noexcept;
+  template<typename V>
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_primitive(V &visitor, const uint8_t *value) noexcept;
 };
 
 template<bool STREAMING, typename V>
@@ -270,6 +275,39 @@ simdjson_really_inline void json_iterator::log_end_value(const char *type) const
 
 simdjson_really_inline void json_iterator::log_error(const char *error) const noexcept {
   logger::log_line(*this, "", "ERROR", error);
+}
+
+template<typename V>
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::visit_root_primitive(V &visitor, const uint8_t *value) noexcept {
+  switch (*value) {
+    case '"': return visitor.visit_root_string(*this, value);
+    case 't': return visitor.visit_root_true_atom(*this, value);
+    case 'f': return visitor.visit_root_false_atom(*this, value);
+    case 'n': return visitor.visit_root_null_atom(*this, value);
+    case '-':
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+      return visitor.visit_root_number(*this, value);
+    default:
+      log_error("Document starts with a non-value character");
+      return TAPE_ERROR;
+  }
+}
+template<typename V>
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::visit_primitive(V &visitor, const uint8_t *value) noexcept {
+  switch (*value) {
+    case '"': return visitor.visit_string(*this, value);
+    case 't': return visitor.visit_true_atom(*this, value);
+    case 'f': return visitor.visit_false_atom(*this, value);
+    case 'n': return visitor.visit_null_atom(*this, value);
+    case '-':
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+      return visitor.visit_number(*this, value);
+    default:
+      log_error("Non-value found when value was expected!");
+      return TAPE_ERROR;
+  }
 }
 
 } // namespace stage2

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -78,6 +78,7 @@ object_begin:
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
   SIMDJSON_TRY( visitor.visit_object_start(*this) );
+  dom_parser.is_array[depth] = false;
 
   {
     auto key = advance();
@@ -124,6 +125,7 @@ array_begin:
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
   SIMDJSON_TRY( visitor.visit_array_start(*this) );
+  dom_parser.is_array[depth] = true;
   SIMDJSON_TRY( visitor.increment_count(*this) );
 
 array_value:

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -143,8 +143,8 @@ object_begin:
   log_start_value("object");
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
-  SIMDJSON_TRY( visitor.visit_object_start(*this) );
   dom_parser.is_array[depth] = false;
+  SIMDJSON_TRY( visitor.visit_object_start(*this) );
 
   {
     auto key = advance();
@@ -191,8 +191,8 @@ array_begin:
   log_start_value("array");
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
-  SIMDJSON_TRY( visitor.visit_array_start(*this) );
   dom_parser.is_array[depth] = true;
+  SIMDJSON_TRY( visitor.visit_array_start(*this) );
   SIMDJSON_TRY( visitor.increment_count(*this) );
 
 array_value:

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -10,6 +10,7 @@ public:
   uint32_t *next_structural;
   dom_parser_implementation &dom_parser;
   uint32_t depth{0};
+  const uint8_t *value{}; // Used to keep a value around between states
 
   template<bool STREAMING, typename T>
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code walk_document(T &visitor) noexcept;
@@ -25,11 +26,9 @@ public:
   simdjson_really_inline char peek_next_char() {
     return buf[*(next_structural)];
   }
-  simdjson_really_inline const uint8_t* advance() {
-    return &buf[*(next_structural++)];
-  }
-  simdjson_really_inline char advance_char() {
-    return buf[*(next_structural++)];
+  simdjson_really_inline char advance() {
+    value = &buf[*(next_structural++)];
+    return *value;
   }
   simdjson_really_inline size_t remaining_len() {
     return dom_parser.len - *(next_structural-1);
@@ -45,7 +44,7 @@ public:
   template<typename T>
   SIMDJSON_WARN_UNUSED simdjson_really_inline bool empty_object(T &visitor) {
     if (peek_next_char() == '}') {
-      advance_char();
+      advance();
       visitor.empty_object(*this);
       return true;
     }
@@ -54,7 +53,7 @@ public:
   template<typename T>
   SIMDJSON_WARN_UNUSED simdjson_really_inline bool empty_array(T &visitor) {
     if (peek_next_char() == ']') {
-      advance_char();
+      advance();
       visitor.empty_array(*this);
       return true;
     }
@@ -86,8 +85,6 @@ public:
 
 template<bool STREAMING, typename T>
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::walk_document(T &visitor) noexcept {
-  const uint8_t *value; // Used to keep a value around between states
-
   logger::log_start();
 
   //
@@ -99,7 +96,7 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::walk_docum
   //
   // Read first value
   //
-  value = advance();
+  advance();
 
   // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
   // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
@@ -132,35 +129,28 @@ object_begin:
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
   visitor.start_object(*this);
 
-  value = advance();
-  if (*value != '"') { log_error("Object does not start with a key"); return TAPE_ERROR; }
+  if (advance() != '"') { log_error("Object does not start with a key"); return TAPE_ERROR; }
   visitor.increment_count(*this);
   SIMDJSON_TRY( visitor.key(*this, value) );
   goto object_field;
 
 object_field:
-  if (simdjson_unlikely( advance_char() != ':' )) { log_error("Missing colon after key in object"); return TAPE_ERROR; }
-  switch (*(value = advance())) {
+  if (simdjson_unlikely( advance() != ':' )) { log_error("Missing colon after key in object"); return TAPE_ERROR; }
+  switch (advance()) {
     case '{': if (!empty_object(visitor)) { goto object_begin; }; goto object_continue;
     case '[': if (!empty_array(visitor)) { goto array_begin; }; goto object_continue;
     default: SIMDJSON_TRY( visitor.primitive(*this, value) );
   }
 
 object_continue:
-  switch (advance_char()) {
-  case ',': {
-    visitor.increment_count(*this);
-    value = advance();
-    if (simdjson_unlikely( *value != '"' )) { log_error("Key string missing at beginning of field in object"); return TAPE_ERROR; }
-    SIMDJSON_TRY( visitor.key(*this, value) );
-    goto object_field;
-  }
-  case '}':
-    visitor.end_object(*this);
-    goto scope_end;
-  default:
-    log_error("No comma between object fields");
-    return TAPE_ERROR;
+  switch (advance()) {
+    case ',':
+      visitor.increment_count(*this);
+      if (simdjson_unlikely( advance() != '"' )) { log_error("Key string missing at beginning of field in object"); return TAPE_ERROR; }
+      SIMDJSON_TRY( visitor.key(*this, value) );
+      goto object_field;
+    case '}': visitor.end_object(*this); goto scope_end;
+    default: log_error("No comma between object fields"); return TAPE_ERROR;
   }
 
 scope_end:
@@ -179,14 +169,14 @@ array_begin:
   visitor.increment_count(*this);
 
 array_value:
-  switch (*(value = advance())) {
+  switch (advance()) {
     case '{': if (!empty_object(visitor)) { goto object_begin; }; goto array_continue;
     case '[': if (!empty_array(visitor)) { goto array_begin; }; goto array_continue;
     default: SIMDJSON_TRY( visitor.primitive(*this, value) );
   }
 
 array_continue:
-  switch (advance_char()) {
+  switch (advance()) {
     case ',': visitor.increment_count(*this); goto array_value;
     case ']': visitor.end_array(*this); goto scope_end;
     default: log_error("Missing comma between array values"); return TAPE_ERROR;

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -41,6 +41,25 @@ public:
     return next_structural == dom_parser.structural_indexes.get();
   }
 
+  simdjson_really_inline void log_value(const char *type) {
+    logger::log_line(*this, "", type, "");
+  }
+
+  simdjson_really_inline void log_start_value(const char *type) {
+    logger::log_line(*this, "+", type, "");
+    if (logger::LOG_ENABLED) { logger::log_depth++; }
+  }
+
+  simdjson_really_inline void log_end_value(const char *type) {
+    if (logger::LOG_ENABLED) { logger::log_depth--; }
+    logger::log_line(*this, "-", type, "");
+  }
+
+  simdjson_really_inline void log_error(const char *error) {
+    logger::log_line(*this, "", "ERROR", error);
+  }
+
+private:
   template<typename T>
   SIMDJSON_WARN_UNUSED simdjson_really_inline bool empty_object(T &visitor) {
     if (peek_next_char() == '}') {
@@ -62,24 +81,6 @@ public:
 
   simdjson_really_inline uint8_t last_structural() {
     return buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]];
-  }
-
-  simdjson_really_inline void log_value(const char *type) {
-    logger::log_line(*this, "", type, "");
-  }
-
-  simdjson_really_inline void log_start_value(const char *type) {
-    logger::log_line(*this, "+", type, "");
-    if (logger::LOG_ENABLED) { logger::log_depth++; }
-  }
-
-  simdjson_really_inline void log_end_value(const char *type) {
-    if (logger::LOG_ENABLED) { logger::log_depth--; }
-    logger::log_line(*this, "-", type, "");
-  }
-
-  simdjson_really_inline void log_error(const char *error) {
-    logger::log_line(*this, "", "ERROR", error);
   }
 };
 
@@ -116,10 +117,11 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::walk_docum
   }
 
   switch (*value) {
-    case '{': if (!empty_object(visitor)) { goto object_begin; }; goto document_end;
-    case '[': if (!empty_array(visitor)) { goto array_begin; }; goto document_end;
-    default: SIMDJSON_TRY( visitor.root_primitive(*this, value) ); goto document_end;
+    case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
+    case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
+    default: SIMDJSON_TRY( visitor.root_primitive(*this, value) ); break;
   }
+  goto document_end;
 
 //
 // Object parser states
@@ -132,14 +134,13 @@ object_begin:
   if (advance() != '"') { log_error("Object does not start with a key"); return TAPE_ERROR; }
   visitor.increment_count(*this);
   SIMDJSON_TRY( visitor.key(*this, value) );
-  goto object_field;
 
 object_field:
   if (simdjson_unlikely( advance() != ':' )) { log_error("Missing colon after key in object"); return TAPE_ERROR; }
   switch (advance()) {
-    case '{': if (!empty_object(visitor)) { goto object_begin; }; goto object_continue;
-    case '[': if (!empty_array(visitor)) { goto array_begin; }; goto object_continue;
-    default: SIMDJSON_TRY( visitor.primitive(*this, value) );
+    case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
+    case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
+    default: SIMDJSON_TRY( visitor.primitive(*this, value) ); break;
   }
 
 object_continue:
@@ -170,9 +171,9 @@ array_begin:
 
 array_value:
   switch (advance()) {
-    case '{': if (!empty_object(visitor)) { goto object_begin; }; goto array_continue;
-    case '[': if (!empty_array(visitor)) { goto array_begin; }; goto array_continue;
-    default: SIMDJSON_TRY( visitor.primitive(*this, value) );
+    case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
+    case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
+    default: SIMDJSON_TRY( visitor.primitive(*this, value) ); break;
   }
 
 array_continue:
@@ -187,10 +188,7 @@ document_end:
 
   dom_parser.next_structural_index = uint32_t(next_structural - &dom_parser.structural_indexes[0]);
 
-  if (depth != 0) {
-    log_error("Unclosed objects or arrays!");
-    return TAPE_ERROR;
-  }
+  if (depth != 0) { log_error("Unclosed objects or arrays!"); return TAPE_ERROR; }
 
   // If we didn't make it to the end, it's an error
   if ( !STREAMING && dom_parser.next_structural_index != dom_parser.n_structural_indexes ) {

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -14,52 +14,20 @@ public:
   template<bool STREAMING, typename V>
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code walk_document(V &visitor) noexcept;
 
-  // Start a structural 
-  simdjson_really_inline json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
-    : buf{_dom_parser.buf},
-      next_structural{&_dom_parser.structural_indexes[start_structural_index]},
-      dom_parser{_dom_parser} {
-  }
+  simdjson_really_inline json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index);
 
   // Get the buffer position of the current structural character
-  simdjson_really_inline char peek_next_char() {
-    return buf[*(next_structural)];
-  }
-  simdjson_really_inline const uint8_t *advance() {
-    return &buf[*(next_structural++)];
-  }
-  simdjson_really_inline size_t remaining_len() {
-    return dom_parser.len - *(next_structural-1);
-  }
+  simdjson_really_inline char peek_next_char() const noexcept;
+  simdjson_really_inline const uint8_t *advance() noexcept;
+  simdjson_really_inline size_t remaining_len() const noexcept;
+  simdjson_really_inline bool at_end() const noexcept;
+  simdjson_really_inline bool at_beginning() const noexcept;
+  simdjson_really_inline uint8_t last_structural() const noexcept;
 
-  simdjson_really_inline bool at_end() {
-    return next_structural == &dom_parser.structural_indexes[dom_parser.n_structural_indexes];
-  }
-  simdjson_really_inline bool at_beginning() {
-    return next_structural == dom_parser.structural_indexes.get();
-  }
-
-  simdjson_really_inline void log_value(const char *type) {
-    logger::log_line(*this, "", type, "");
-  }
-
-  simdjson_really_inline void log_start_value(const char *type) {
-    logger::log_line(*this, "+", type, "");
-    if (logger::LOG_ENABLED) { logger::log_depth++; }
-  }
-
-  simdjson_really_inline void log_end_value(const char *type) {
-    if (logger::LOG_ENABLED) { logger::log_depth--; }
-    logger::log_line(*this, "-", type, "");
-  }
-
-  simdjson_really_inline void log_error(const char *error) {
-    logger::log_line(*this, "", "ERROR", error);
-  }
-
-  simdjson_really_inline uint8_t last_structural() {
-    return buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]];
-  }
+  simdjson_really_inline void log_value(const char *type) const noexcept;
+  simdjson_really_inline void log_start_value(const char *type) const noexcept;
+  simdjson_really_inline void log_end_value(const char *type) const noexcept;
+  simdjson_really_inline void log_error(const char *error) const noexcept;
 };
 
 template<bool STREAMING, typename V>
@@ -189,6 +157,50 @@ document_end:
   return SUCCESS;
 
 } // walk_document()
+
+simdjson_really_inline json_iterator::json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
+  : buf{_dom_parser.buf},
+    next_structural{&_dom_parser.structural_indexes[start_structural_index]},
+    dom_parser{_dom_parser} {
+}
+
+simdjson_really_inline char json_iterator::peek_next_char() const noexcept {
+  return buf[*(next_structural)];
+}
+simdjson_really_inline const uint8_t *json_iterator::advance() noexcept {
+  return &buf[*(next_structural++)];
+}
+simdjson_really_inline size_t json_iterator::remaining_len() const noexcept {
+  return dom_parser.len - *(next_structural-1);
+}
+
+simdjson_really_inline bool json_iterator::at_end() const noexcept {
+  return next_structural == &dom_parser.structural_indexes[dom_parser.n_structural_indexes];
+}
+simdjson_really_inline bool json_iterator::at_beginning() const noexcept {
+  return next_structural == dom_parser.structural_indexes.get();
+}
+simdjson_really_inline uint8_t json_iterator::last_structural() const noexcept {
+  return buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]];
+}
+
+simdjson_really_inline void json_iterator::log_value(const char *type) const noexcept {
+  logger::log_line(*this, "", type, "");
+}
+
+simdjson_really_inline void json_iterator::log_start_value(const char *type) const noexcept {
+  logger::log_line(*this, "+", type, "");
+  if (logger::LOG_ENABLED) { logger::log_depth++; }
+}
+
+simdjson_really_inline void json_iterator::log_end_value(const char *type) const noexcept {
+  if (logger::LOG_ENABLED) { logger::log_depth--; }
+  logger::log_line(*this, "-", type, "");
+}
+
+simdjson_really_inline void json_iterator::log_error(const char *error) const noexcept {
+  logger::log_line(*this, "", "ERROR", error);
+}
 
 } // namespace stage2
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -57,26 +57,6 @@ public:
     logger::log_line(*this, "", "ERROR", error);
   }
 
-private:
-  template<typename T>
-  SIMDJSON_WARN_UNUSED simdjson_really_inline bool empty_object(T &visitor) {
-    if (peek_next_char() == '}') {
-      advance();
-      visitor.empty_object(*this);
-      return true;
-    }
-    return false;
-  }
-  template<typename T>
-  SIMDJSON_WARN_UNUSED simdjson_really_inline bool empty_array(T &visitor) {
-    if (peek_next_char() == ']') {
-      advance();
-      visitor.empty_array(*this);
-      return true;
-    }
-    return false;
-  }
-
   simdjson_really_inline uint8_t last_structural() {
     return buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]];
   }
@@ -116,8 +96,8 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::walk_docum
     }
 
     switch (*value) {
-      case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
-      case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
+      case '{': if (peek_next_char() == '}') { advance(); visitor.empty_object(*this); break; } goto object_begin;
+      case '[': if (peek_next_char() == ']') { advance(); visitor.empty_array(*this); break; } goto array_begin;
       default: SIMDJSON_TRY( visitor.root_primitive(*this, value) ); break;
     }
   }
@@ -143,8 +123,8 @@ object_field:
   {
     auto value = advance();
     switch (*value) {
-      case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
-      case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
+      case '{': if (peek_next_char() == '}') { advance(); visitor.empty_object(*this); break; } goto object_begin;
+      case '[': if (peek_next_char() == ']') { advance(); visitor.empty_array(*this); break; } goto array_begin;
       default: SIMDJSON_TRY( visitor.primitive(*this, value) ); break;
     }
   }
@@ -182,8 +162,8 @@ array_value:
   {
     auto value = advance();
     switch (*value) {
-      case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
-      case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
+      case '{': if (peek_next_char() == '}') { advance(); visitor.empty_object(*this); break; } goto object_begin;
+      case '[': if (peek_next_char() == ']') { advance(); visitor.empty_array(*this); break; } goto array_begin;
       default: SIMDJSON_TRY( visitor.primitive(*this, value) ); break;
     }
   }

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -8,7 +8,7 @@ namespace logger {
 
   static constexpr const bool LOG_ENABLED = false;
   static constexpr const int LOG_EVENT_LEN = 20;
-  static constexpr const int LOG_BUFFER_LEN = 10;
+  static constexpr const int LOG_BUFFER_LEN = 30;
   static constexpr const int LOG_SMALL_BUFFER_LEN = 10;
   static constexpr const int LOG_INDEX_LEN = 5;
 

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -33,12 +33,6 @@ namespace logger {
     }
   }
 
-  static simdjson_really_inline void log_string(const char *message) {
-    if (LOG_ENABLED) {
-      printf("%s\n", message);
-    }
-  }
-
   // Logs a single line of 
   template<typename S>
   static simdjson_really_inline void log_line(S &structurals, const char *title_prefix, const char *title, const char *detail) {

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -370,9 +370,12 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
     // 10000000000000000000000000000000000000000000e+308
     // 3.1415926535897932384626433832795028841971693993751
     //
+    // NOTE: This makes a *copy* of the writer and passes it to slow_float_parsing. This happens
+    // because slow_float_parsing is a non-inlined function. If we passed our writer reference to
+    // it, it would force it to be stored in memory, preventing the compiler from picking it apart
+    // and putting into registers. i.e. if we pass it as reference, it gets slow.
+    // This is what forces the skip_double, as well.
     error_code error = slow_float_parsing(src, writer);
-    // The number was already written, but we made a copy of the writer
-    // when we passed it to the parse_large_integer() function, so
     writer.skip_double();
     return error;
   }
@@ -382,9 +385,12 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
   if (simdjson_unlikely(exponent < FASTFLOAT_SMALLEST_POWER) || (exponent > FASTFLOAT_LARGEST_POWER)) {
     // this is almost never going to get called!!!
     // we start anew, going slowly!!!
+    // NOTE: This makes a *copy* of the writer and passes it to slow_float_parsing. This happens
+    // because slow_float_parsing is a non-inlined function. If we passed our writer reference to
+    // it, it would force it to be stored in memory, preventing the compiler from picking it apart
+    // and putting into registers. i.e. if we pass it as reference, it gets slow.
+    // This is what forces the skip_double, as well.
     error_code error = slow_float_parsing(src, writer);
-    // The number was already written, but we made a copy of the writer when we passed it to the
-    // slow_float_parsing() function, so we have to skip those tape spots now that we've returned
     writer.skip_double();
     return error;
   }

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -24,7 +24,7 @@ namespace numberparsing {
 // set to false. This should work *most of the time* (like 99% of the time).
 // We assume that power is in the [FASTFLOAT_SMALLEST_POWER,
 // FASTFLOAT_LARGEST_POWER] interval: the caller is responsible for this check.
-simdjson_really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, bool *success) {
+simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool negative, double &d) {
   // we start with a fast path
   // It was described in
   // Clinger WD. How to read floating point numbers accurately.
@@ -40,7 +40,7 @@ simdjson_really_inline double compute_float_64(int64_t power, uint64_t i, bool n
 #endif
     // convert the integer into a double. This is lossless since
     // 0 <= i <= 2^53 - 1.
-    double d = double(i);
+    d = double(i);
     //
     // The general idea is as follows.
     // If 0 <= s < 2^53 and if 10^0 <= p <= 10^22 then
@@ -59,8 +59,7 @@ simdjson_really_inline double compute_float_64(int64_t power, uint64_t i, bool n
     if (negative) {
       d = -d;
     }
-    *success = true;
-    return d;
+    return true;
   }
   // When 22 < power && power <  22 + 16, we could
   // hope for another, secondary fast path.  It wa
@@ -85,7 +84,8 @@ simdjson_really_inline double compute_float_64(int64_t power, uint64_t i, bool n
   // In the slow path, we need to adjust i so that it is > 1<<63 which is always
   // possible, except if i == 0, so we handle i == 0 separately.
   if(i == 0) {
-    return 0.0;
+    d = 0.0;
+    return true;
   }
 
   // We are going to need to do some 64-bit arithmetic to get a more precise product.
@@ -135,8 +135,7 @@ simdjson_really_inline double compute_float_64(int64_t power, uint64_t i, bool n
     // This does happen, e.g. with 7.3177701707893310e+15.
     if (((product_middle + 1 == 0) && ((product_high & 0x1FF) == 0x1FF) &&
          (product_low + i < product_low))) { // let us be prudent and bail out.
-      *success = false;
-      return 0;
+      return false;
     }
     upper = product_high;
     lower = product_middle;
@@ -157,25 +156,24 @@ simdjson_really_inline double compute_float_64(int64_t power, uint64_t i, bool n
   // floating-point values.
   if (simdjson_unlikely((lower == 0) && ((upper & 0x1FF) == 0) &&
                ((mantissa & 3) == 1))) {
-      // if mantissa & 1 == 1 we might need to round up.
-      //
-      // Scenarios:
-      // 1. We are not in the middle. Then we should round up.
-      //
-      // 2. We are right in the middle. Whether we round up depends
-      // on the last significant bit: if it is "one" then we round
-      // up (round to even) otherwise, we do not.
-      //
-      // So if the last significant bit is 1, we can safely round up.
-      // Hence we only need to bail out if (mantissa & 3) == 1.
-      // Otherwise we may need more accuracy or analysis to determine whether
-      // we are exactly between two floating-point numbers.
-      // It can be triggered with 1e23.
-      // Note: because the factor_mantissa and factor_mantissa_low are
-      // almost always rounded down (except for small positive powers),
-      // almost always should round up.
-      *success = false;
-      return 0;
+    // if mantissa & 1 == 1 we might need to round up.
+    //
+    // Scenarios:
+    // 1. We are not in the middle. Then we should round up.
+    //
+    // 2. We are right in the middle. Whether we round up depends
+    // on the last significant bit: if it is "one" then we round
+    // up (round to even) otherwise, we do not.
+    //
+    // So if the last significant bit is 1, we can safely round up.
+    // Hence we only need to bail out if (mantissa & 3) == 1.
+    // Otherwise we may need more accuracy or analysis to determine whether
+    // we are exactly between two floating-point numbers.
+    // It can be triggered with 1e23.
+    // Note: because the factor_mantissa and factor_mantissa_low are
+    // almost always rounded down (except for small positive powers),
+    // almost always should round up.
+    return false;
   }
 
   mantissa += mantissa & 1;
@@ -193,15 +191,12 @@ simdjson_really_inline double compute_float_64(int64_t power, uint64_t i, bool n
   uint64_t real_exponent = c.exp - lz;
   // we have to check that real_exponent is in range, otherwise we bail out
   if (simdjson_unlikely((real_exponent < 1) || (real_exponent > 2046))) {
-    *success = false;
-    return 0;
+    return false;
   }
   mantissa |= real_exponent << 52;
   mantissa |= (((uint64_t)negative) << 63);
-  double d;
   memcpy(&d, &mantissa, sizeof(d));
-  *success = true;
-  return d;
+  return true;
 }
 
 static bool parse_float_strtod(const uint8_t *ptr, double *outDouble) {
@@ -392,9 +387,8 @@ simdjson_really_inline error_code write_float(const uint8_t *const src, bool neg
     writer.skip_double();
     return error;
   }
-  bool success = true;
-  double d = compute_float_64(exponent, i, negative, &success);
-  if (!success) {
+  double d;
+  if (!compute_float_64(exponent, i, negative, d)) {
     // we are almost never going to get here.
     if (!parse_float_strtod(src, &d)) { return INVALID_NUMBER(src); }
   }
@@ -713,12 +707,10 @@ SIMDJSON_UNUSED simdjson_really_inline simdjson_result<double> parse_double(cons
   //
   // Assemble (or slow-parse) the float
   //
-  if (simdjson_likely(!overflow)) {
-    bool success = true;
-    double d = compute_float_64(exponent, i, negative, &success);
-    if (success) { return d; }
-  }
   double d;
+  if (simdjson_likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
   if (!parse_float_strtod(src-negative, &d)) {
     return NUMBER_ERROR;
   }

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -7,12 +7,12 @@ namespace stage2 {
 namespace numberparsing {
 
 #ifdef JSON_TEST_NUMBERS
-#define INVALID_NUMBER(SRC) (found_invalid_number((SRC)), false)
+#define INVALID_NUMBER(SRC) (found_invalid_number((SRC)), NUMBER_ERROR)
 #define WRITE_INTEGER(VALUE, SRC, WRITER) (found_integer((VALUE), (SRC)), writer.append_s64((VALUE)))
 #define WRITE_UNSIGNED(VALUE, SRC, WRITER) (found_unsigned_integer((VALUE), (SRC)), writer.append_u64((VALUE)))
 #define WRITE_DOUBLE(VALUE, SRC, WRITER) (found_float((VALUE), (SRC)), writer.append_double((VALUE)))
 #else
-#define INVALID_NUMBER(SRC) (false)
+#define INVALID_NUMBER(SRC) (NUMBER_ERROR)
 #define WRITE_INTEGER(VALUE, SRC, WRITER) writer.append_s64((VALUE))
 #define WRITE_UNSIGNED(VALUE, SRC, WRITER) writer.append_u64((VALUE))
 #define WRITE_DOUBLE(VALUE, SRC, WRITER) writer.append_double((VALUE))
@@ -252,11 +252,11 @@ simdjson_really_inline bool is_made_of_eight_digits_fast(const uint8_t *chars) {
 }
 
 template<typename W>
-bool slow_float_parsing(SIMDJSON_UNUSED const uint8_t * src, W writer) {
+error_code slow_float_parsing(SIMDJSON_UNUSED const uint8_t * src, W writer) {
   double d;
   if (parse_float_strtod(src, &d)) {
     WRITE_DOUBLE(d, src, writer);
-    return true;
+    return SUCCESS;
   }
   return INVALID_NUMBER(src);
 }
@@ -273,7 +273,7 @@ simdjson_really_inline bool parse_digit(const uint8_t c, I &i) {
   return true;
 }
 
-simdjson_really_inline bool parse_decimal(SIMDJSON_UNUSED const uint8_t *const src, const uint8_t *&p, uint64_t &i, int64_t &exponent) {
+simdjson_really_inline error_code parse_decimal(SIMDJSON_UNUSED const uint8_t *const src, const uint8_t *&p, uint64_t &i, int64_t &exponent) {
   // we continue with the fiction that we have an integer. If the
   // floating point number is representable as x * 10^z for some integer
   // z that fits in 53 bits, then we will be able to convert back the
@@ -296,10 +296,10 @@ simdjson_really_inline bool parse_decimal(SIMDJSON_UNUSED const uint8_t *const s
   if (exponent == 0) {
     return INVALID_NUMBER(src);
   }
-  return true;
+  return SUCCESS;
 }
 
-simdjson_really_inline bool parse_exponent(SIMDJSON_UNUSED const uint8_t *const src, const uint8_t *&p, int64_t &exponent) {
+simdjson_really_inline error_code parse_exponent(SIMDJSON_UNUSED const uint8_t *const src, const uint8_t *&p, int64_t &exponent) {
   // Exp Sign: -123.456e[-]78
   bool neg_exp = ('-' == *p);
   if (neg_exp || '+' == *p) { p++; } // Skip + as well
@@ -347,11 +347,11 @@ simdjson_really_inline bool parse_exponent(SIMDJSON_UNUSED const uint8_t *const 
   // is bounded in magnitude by the size of the JSON input, we are fine in this universe.
   // To sum it up: the next line should never overflow.
   exponent += (neg_exp ? -exp_number : exp_number);
-  return true;
+  return SUCCESS;
 }
 
 template<typename W>
-simdjson_really_inline bool write_float(const uint8_t *const src, bool negative, uint64_t i, const uint8_t * start_digits, int digit_count, int64_t exponent, W &writer) {
+simdjson_really_inline error_code write_float(const uint8_t *const src, bool negative, uint64_t i, const uint8_t * start_digits, int digit_count, int64_t exponent, W &writer) {
   // If we frequently had to deal with long strings of digits,
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
@@ -373,11 +373,11 @@ simdjson_really_inline bool write_float(const uint8_t *const src, bool negative,
       // 10000000000000000000000000000000000000000000e+308
       // 3.1415926535897932384626433832795028841971693993751
       //
-      bool success = slow_float_parsing(src, writer);
+      error_code error = slow_float_parsing(src, writer);
       // The number was already written, but we made a copy of the writer
       // when we passed it to the parse_large_integer() function, so
       writer.skip_double();
-      return success;
+      return error;
     }
   }
   // NOTE: it's weird that the simdjson_unlikely() only wraps half the if, but it seems to get slower any other
@@ -386,11 +386,11 @@ simdjson_really_inline bool write_float(const uint8_t *const src, bool negative,
   if (simdjson_unlikely(exponent < FASTFLOAT_SMALLEST_POWER) || (exponent > FASTFLOAT_LARGEST_POWER)) {
     // this is almost never going to get called!!!
     // we start anew, going slowly!!!
-    bool success = slow_float_parsing(src, writer);
+    error_code error = slow_float_parsing(src, writer);
     // The number was already written, but we made a copy of the writer when we passed it to the
     // slow_float_parsing() function, so we have to skip those tape spots now that we've returned
     writer.skip_double();
-    return success;
+    return error;
   }
   bool success = true;
   double d = compute_float_64(exponent, i, negative, &success);
@@ -399,16 +399,16 @@ simdjson_really_inline bool write_float(const uint8_t *const src, bool negative,
     if (!parse_float_strtod(src, &d)) { return INVALID_NUMBER(src); }
   }
   WRITE_DOUBLE(d, src, writer);
-  return true;
+  return SUCCESS;
 }
 
 // for performance analysis, it is sometimes  useful to skip parsing
 #ifdef SIMDJSON_SKIPNUMBERPARSING
 
 template<typename W>
-simdjson_really_inline bool parse_number(const uint8_t *const, W &writer) {
+simdjson_really_inline error_code parse_number(const uint8_t *const, W &writer) {
   writer.append_s64(0);        // always write zero
-  return true;                 // always succeeds
+  return SUCCESS;              // always succeeds
 }
 
 #else
@@ -423,7 +423,7 @@ simdjson_really_inline bool parse_number(const uint8_t *const, W &writer) {
 //
 // Our objective is accurate parsing (ULP of 0) at high speed.
 template<typename W>
-simdjson_really_inline bool parse_number(const uint8_t *const src, W &writer) {
+simdjson_really_inline error_code parse_number(const uint8_t *const src, W &writer) {
 
   //
   // Check for minus sign
@@ -451,17 +451,19 @@ simdjson_really_inline bool parse_number(const uint8_t *const src, W &writer) {
   if ('.' == *p) {
     is_float = true;
     ++p;
-    if (!parse_decimal(src, p, i, exponent)) { return false; }
+    SIMDJSON_TRY( parse_decimal(src, p, i, exponent) );
     digit_count = int(p - start_digits); // used later to guard against overflows
   }
   if (('e' == *p) || ('E' == *p)) {
     is_float = true;
     ++p;
-    if (!parse_exponent(src, p, exponent)) { return false; }
+    SIMDJSON_TRY( parse_exponent(src, p, exponent) );
   }
   if (is_float) {
     const bool clean_end = is_structural_or_whitespace(*p);
-    return write_float(src, negative, i, start_digits, digit_count, exponent, writer) && clean_end;
+    SIMDJSON_TRY( write_float(src, negative, i, start_digits, digit_count, exponent, writer) );
+    if (!clean_end) { return INVALID_NUMBER(src); }
+    return SUCCESS;
   }
 
   // The longest negative 64-bit number is 19 digits.
@@ -470,13 +472,12 @@ simdjson_really_inline bool parse_number(const uint8_t *const src, W &writer) {
   int longest_digit_count = negative ? 19 : 20;
   if (digit_count > longest_digit_count) { return INVALID_NUMBER(src); }
   if (digit_count == longest_digit_count) {
-    if(negative) {
+    if (negative) {
       // Anything negative above INT64_MAX+1 is invalid
-      if (i > uint64_t(INT64_MAX)+1) {
-        return INVALID_NUMBER(src); 
-      }
+      if (i > uint64_t(INT64_MAX)+1) { return INVALID_NUMBER(src);  }
       WRITE_INTEGER(~i+1, src, writer);
-      return is_structural_or_whitespace(*p);
+      if (!is_structural_or_whitespace(*p)) { return INVALID_NUMBER(src); }
+      return SUCCESS;
     // Positive overflow check:
     // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
     //   biggest uint64_t.
@@ -498,7 +499,8 @@ simdjson_really_inline bool parse_number(const uint8_t *const src, W &writer) {
   } else {
     WRITE_INTEGER(negative ? (~i+1) : i, src, writer);
   }
-  return is_structural_or_whitespace(*p);
+  if (!is_structural_or_whitespace(*p)) { return INVALID_NUMBER(src); }
+  return SUCCESS;
 }
 
 // SAX functions

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -312,8 +312,8 @@ simdjson_really_inline bool parse_exponent(SIMDJSON_UNUSED const uint8_t *const 
   // In particular, it could overflow to INT64_MIN, and we cannot do - INT64_MIN.
   // Thus we *must* check for possible overflow before we negate exp_number.
 
-  // Performance notes: it may seem like combining the two "unlikely checks" below into
-  // a single unlikely path would be faster. The reasoning is sound, but the compiler may
+  // Performance notes: it may seem like combining the two "simdjson_unlikely checks" below into
+  // a single simdjson_unlikely path would be faster. The reasoning is sound, but the compiler may
   // not oblige and may, in fact, generate two distinct paths in any case. It might be
   // possible to do uint64_t(p - start_exp - 1) >= 18 but it could end up trading off 
   // instructions for a likely branch, an unconclusive gain.
@@ -380,7 +380,7 @@ simdjson_really_inline bool write_float(const uint8_t *const src, bool negative,
       return success;
     }
   }
-  // NOTE: it's weird that the unlikely() only wraps half the if, but it seems to get slower any other
+  // NOTE: it's weird that the simdjson_unlikely() only wraps half the if, but it seems to get slower any other
   // way we've tried: https://github.com/simdjson/simdjson/pull/990#discussion_r448497331
   // To future reader: we'd love if someone found a better way, or at least could explain this result!
   if (simdjson_unlikely(exponent < FASTFLOAT_SMALLEST_POWER) || (exponent > FASTFLOAT_LARGEST_POWER)) {
@@ -502,7 +502,7 @@ simdjson_really_inline bool parse_number(const uint8_t *const src, W &writer) {
 }
 
 // Parse any number from 0 to 18,446,744,073,709,551,615
-simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept {
+SIMDJSON_UNUSED simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept {
   const uint8_t *p = src;
 
   //
@@ -597,7 +597,7 @@ simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * 
 // }
 
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
-simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
+SIMDJSON_UNUSED simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
   //
   // Check for minus sign
   //

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -8,14 +8,14 @@ namespace numberparsing {
 
 #ifdef JSON_TEST_NUMBERS
 #define INVALID_NUMBER(SRC) (found_invalid_number((SRC)), NUMBER_ERROR)
-#define WRITE_INTEGER(VALUE, SRC, WRITER) (found_integer((VALUE), (SRC)), writer.append_s64((VALUE)))
-#define WRITE_UNSIGNED(VALUE, SRC, WRITER) (found_unsigned_integer((VALUE), (SRC)), writer.append_u64((VALUE)))
-#define WRITE_DOUBLE(VALUE, SRC, WRITER) (found_float((VALUE), (SRC)), writer.append_double((VALUE)))
+#define WRITE_INTEGER(VALUE, SRC, WRITER) (found_integer((VALUE), (SRC)), (WRITER).append_s64((VALUE)))
+#define WRITE_UNSIGNED(VALUE, SRC, WRITER) (found_unsigned_integer((VALUE), (SRC)), (WRITER).append_u64((VALUE)))
+#define WRITE_DOUBLE(VALUE, SRC, WRITER) (found_float((VALUE), (SRC)), (WRITER).append_double((VALUE)))
 #else
 #define INVALID_NUMBER(SRC) (NUMBER_ERROR)
-#define WRITE_INTEGER(VALUE, SRC, WRITER) writer.append_s64((VALUE))
-#define WRITE_UNSIGNED(VALUE, SRC, WRITER) writer.append_u64((VALUE))
-#define WRITE_DOUBLE(VALUE, SRC, WRITER) writer.append_double((VALUE))
+#define WRITE_INTEGER(VALUE, SRC, WRITER) (WRITER).append_s64((VALUE))
+#define WRITE_UNSIGNED(VALUE, SRC, WRITER) (WRITER).append_u64((VALUE))
+#define WRITE_DOUBLE(VALUE, SRC, WRITER) (WRITER).append_double((VALUE))
 #endif
 
 // Attempts to compute i * 10^(power) exactly; and if "negative" is
@@ -250,7 +250,7 @@ template<typename W>
 error_code slow_float_parsing(SIMDJSON_UNUSED const uint8_t * src, W writer) {
   double d;
   if (parse_float_strtod(src, &d)) {
-    WRITE_DOUBLE(d, src, writer);
+    writer.append_double(d);
     return SUCCESS;
   }
   return INVALID_NUMBER(src);
@@ -345,35 +345,36 @@ simdjson_really_inline error_code parse_exponent(SIMDJSON_UNUSED const uint8_t *
   return SUCCESS;
 }
 
+simdjson_really_inline int significant_digits(const uint8_t * start_digits, int digit_count) {
+  // It is possible that the integer had an overflow.
+  // We have to handle the case where we have 0.0000somenumber.
+  const uint8_t *start = start_digits;
+  while ((*start == '0') || (*start == '.')) {
+    start++;
+  }
+  // we over-decrement by one when there is a '.'
+  return digit_count - int(start - start_digits);
+}
+
 template<typename W>
 simdjson_really_inline error_code write_float(const uint8_t *const src, bool negative, uint64_t i, const uint8_t * start_digits, int digit_count, int64_t exponent, W &writer) {
   // If we frequently had to deal with long strings of digits,
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
   // digit count is off by 1 because of the decimal (assuming there was one).
-  if (simdjson_unlikely((digit_count-1 >= 19))) { // this is uncommon
-    // It is possible that the integer had an overflow.
-    // We have to handle the case where we have 0.0000somenumber.
-    const uint8_t *start = start_digits;
-    while ((*start == '0') || (*start == '.')) {
-      start++;
-    }
-    // we over-decrement by one when there is a '.'
-    digit_count -= int(start - start_digits);
-    if (digit_count >= 19) {
-      // Ok, chances are good that we had an overflow!
-      // this is almost never going to get called!!!
-      // we start anew, going slowly!!!
-      // This will happen in the following examples:
-      // 10000000000000000000000000000000000000000000e+308
-      // 3.1415926535897932384626433832795028841971693993751
-      //
-      error_code error = slow_float_parsing(src, writer);
-      // The number was already written, but we made a copy of the writer
-      // when we passed it to the parse_large_integer() function, so
-      writer.skip_double();
-      return error;
-    }
+  if (simdjson_unlikely(digit_count-1 >= 19 && significant_digits(start_digits, digit_count) >= 19)) {
+    // Ok, chances are good that we had an overflow!
+    // this is almost never going to get called!!!
+    // we start anew, going slowly!!!
+    // This will happen in the following examples:
+    // 10000000000000000000000000000000000000000000e+308
+    // 3.1415926535897932384626433832795028841971693993751
+    //
+    error_code error = slow_float_parsing(src, writer);
+    // The number was already written, but we made a copy of the writer
+    // when we passed it to the parse_large_integer() function, so
+    writer.skip_double();
+    return error;
   }
   // NOTE: it's weird that the simdjson_unlikely() only wraps half the if, but it seems to get slower any other
   // way we've tried: https://github.com/simdjson/simdjson/pull/990#discussion_r448497331

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -501,6 +501,227 @@ simdjson_really_inline bool parse_number(const uint8_t *const src, W &writer) {
   return is_structural_or_whitespace(*p);
 }
 
+// Parse any number from 0 to 18,446,744,073,709,551,615
+simdjson_really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept {
+  const uint8_t *p = src;
+
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  int digit_count = int(p - start_digits);
+  if (digit_count == 0 || ('0' == *start_digits && digit_count > 1)) { return NUMBER_ERROR; }
+  if (!is_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  if (digit_count > 20) { return NUMBER_ERROR; }
+  if (digit_count == 20) {
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return NUMBER_ERROR; }
+  }
+
+  return i;
+}
+
+// Parse any number from 0 to 18,446,744,073,709,551,615
+// Call this version of the method if you regularly expect 8- or 16-digit numbers.
+// simdjson_really_inline simdjson_result<uint64_t> parse_large_unsigned(const uint8_t * const src) noexcept {
+//   const uint8_t *p = src;
+
+//   //
+//   // Parse the integer part.
+//   //
+//   const uint8_t *const start_digits = p;
+//   uint64_t i = 0;
+//   if (is_made_of_eight_digits_fast(p)) {
+//     i = i * 100000000 + parse_eight_digits_unrolled(p);
+//     p += 8;
+//     if (is_made_of_eight_digits_fast(p)) {
+//       i = i * 100000000 + parse_eight_digits_unrolled(p);
+//       p += 8;
+//       if (parse_digit(*p, i)) { // digit 17
+//         p++;
+//         if (parse_digit(*p, i)) { // digit 18
+//           p++;
+//           if (parse_digit(*p, i)) { // digit 19
+//             p++;
+//             if (parse_digit(*p, i)) { // digit 20
+//               p++;
+//               if (parse_digit(*p, i)) { return NUMBER_ERROR; } // 21 digits is an error
+//               // Positive overflow check:
+//               // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+//               //   biggest uint64_t.
+//               // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+//               //   If we got here, it's a 20 digit number starting with the digit "1".
+//               // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+//               //   than 1,553,255,926,290,448,384.
+//               // - That is smaller than the smallest possible 20-digit number the user could write:
+//               //   10,000,000,000,000,000,000.
+//               // - Therefore, if the number is positive and lower than that, it's overflow.
+//               // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+//               //
+//               if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return NUMBER_ERROR; }
+//             }
+//           }
+//         }
+//       }
+//     } // 16 digits
+//   } else { // 8 digits
+//     // Less than 8 digits can't overflow, simpler logic here.
+//     if (parse_digit(*p, i)) { p++; } else { return NUMBER_ERROR; }
+//     while (parse_digit(*p, i)) { p++; }
+//   }
+
+//   if (!is_structural_or_whitespace(*p, i)) { return NUMBER_ERROR; }
+//   // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+//   int digit_count = int(p - src);
+//   if (digit_count == 0 || ('0' == *src && digit_count > 1)) { return NUMBER_ERROR; }
+//   return i;
+// }
+
+// Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
+simdjson_really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
+  //
+  // Check for minus sign
+  //
+  bool negative = (*src == '-');
+  const uint8_t *p = src + negative;
+
+  //
+  // Parse the integer part.
+  //
+  // PERF NOTE: we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare
+  const uint8_t *const start_digits = p;
+  uint64_t i = 0;
+  while (parse_digit(*p, i)) { p++; }
+
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  int digit_count = int(p - start_digits);
+  if (digit_count == 0 || ('0' == *start_digits && digit_count > 1)) { return NUMBER_ERROR; }
+  if (!is_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+
+  // The longest negative 64-bit number is 19 digits.
+  // The longest positive 64-bit number is 20 digits.
+  // We do it this way so we don't trigger this branch unless we must.
+  int longest_digit_count = negative ? 19 : 20;
+  if (digit_count > longest_digit_count) { return NUMBER_ERROR; }
+  if (digit_count == longest_digit_count) {
+    if(negative) {
+      // Anything negative above INT64_MAX+1 is invalid
+      if (i > uint64_t(INT64_MAX)+1) { return NUMBER_ERROR; }
+      return ~i+1;
+
+    // Positive overflow check:
+    // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+    //   biggest uint64_t.
+    // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+    //   If we got here, it's a 20 digit number starting with the digit "1".
+    // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+    //   than 1,553,255,926,290,448,384.
+    // - That is smaller than the smallest possible 20-digit number the user could write:
+    //   10,000,000,000,000,000,000.
+    // - Therefore, if the number is positive and lower than that, it's overflow.
+    // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+    //
+    } else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return NUMBER_ERROR; }
+  }
+
+  return negative ? (~i+1) : i;
+}
+
+// simdjson_really_inline simdjson_result<double> parse_double(const uint8_t * src) noexcept {
+//   //
+//   // Check for minus sign
+//   //
+//   bool negative = (*src == '-');
+//   src += negative;
+
+//   //
+//   // Parse the integer part.
+//   //
+//   uint64_t i = 0;
+//   const uint8_t *p = src;
+//   p += parse_digit(*p, i);
+//   bool leading_zero = (i == 0);
+//   while (parse_digit(*p, i)) { p++; }
+//   // no integer digits, or 0123 (zero must be solo)
+//   if ( p == src || (leading_zero && p != src+1)) { return NUMBER_ERROR; }
+
+//   //
+//   // Parse the decimal part.
+//   //
+//   int64_t exponent = 0;
+//   bool overflow;
+//   if (likely(*p == '.')) {
+//     p++;
+//     const uint8_t *start_decimal_digits = p;
+//     if (!parse_digit(*p, i)) { return NUMBER_ERROR; } // no decimal digits
+//     p++;
+//     while (parse_digit(*p, i)) { p++; }
+//     exponent = -(p - start_decimal_digits);
+
+//     // Overflow check. 19 digits (minus the decimal) may be overflow.
+//     overflow = p-src-1 >= 19;
+//     if (SIMDJSON_unlikely(overflow && leading_zero)) {
+//       // Skip leading 0.00000 and see if it still overflows
+//       const uint8_t *start_digits = src + 2;
+//       while (*start_digits == '0') { start_digits++; }
+//       overflow = start_digits-src >= 19;
+//     }
+//   } else {
+//     overflow = p-src >= 19;
+//   }
+
+//   //
+//   // Parse the exponent
+//   //
+//   if (*p == 'e' || *p == 'E') {
+//     p++;
+//     bool exp_neg = *p == '-';
+//     p += exp_neg || *p == '+';
+
+//     uint64_t exp = 0;
+//     const uint8_t *start_exp_digits = p;
+//     while (parse_digit(*p, exp)) { p++; }
+//     // no exp digits, or 20+ exp digits
+//     if (p-start_exp_digits == 0 || p-start_exp_digits > 19) { return NUMBER_ERROR; }
+
+//     exponent += exp_neg ? 0-exp : exp;
+//     overflow = overflow || exponent < FASTFLOAT_SMALLEST_POWER || exponent > FASTFLOAT_LARGEST_POWER;
+//   }
+
+//   //
+//   // Assemble (or slow-parse) the float
+//   //
+//   if (likely(!overflow)) {
+//     bool success = false;
+//     double d = compute_float_64(exponent, i, negative, &success);
+//     if (success) { return d; }
+//   }
+//   double d;
+//   if (!parse_float_strtod(src-negative, &d)) {
+//     return NUMBER_ERROR;
+//   }
+//   return d;
+// }
+
 #endif // SIMDJSON_SKIPNUMBERPARSING
 
 } // namespace numberparsing

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -119,6 +119,15 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline uint8_t *parse_string(const uint8_t 
   return nullptr;
 }
 
+SIMDJSON_UNUSED SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_string_to_buffer(const uint8_t *src, uint8_t *&current_string_buf_loc, std::string_view &s) {
+  if (src[0] != '"') { return STRING_ERROR; }
+  auto end = stringparsing::parse_string(src, current_string_buf_loc);
+  if (!end) { return STRING_ERROR; }
+  s = std::string_view((const char *)current_string_buf_loc, end-current_string_buf_loc);
+  current_string_buf_loc = end;
+  return SUCCESS;
+}
+
 } // namespace stringparsing
 } // namespace stage2
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -68,6 +68,8 @@ struct structural_parser : structural_iterator {
 
 template<bool STREAMING, typename T>
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code structural_parser::walk_document(T &visitor) noexcept {
+  const uint8_t *value;
+
   logger::log_start();
 
   //
@@ -79,69 +81,61 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code structural_parser::walk_d
   //
   // Read first value
   //
-  {
-    const uint8_t *value = advance();
+  value = advance();
 
-    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
-    // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
-    if (!STREAMING) {
-      switch (*value) {
-        case '{':
-          if (last_structural() != '}') {
-            return TAPE_ERROR;
-          }
-          break;
-        case '[':
-          if (last_structural() != ']') {
-            return TAPE_ERROR;
-          }
-          break;
-      }
-    }
-
+  // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+  // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
+  if (!STREAMING) {
     switch (*value) {
-      case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
-      case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
-      default: SIMDJSON_TRY( visitor.parse_root_primitive(*this, value) );
+      case '{':
+        if (last_structural() != '}') {
+          return TAPE_ERROR;
+        }
+        break;
+      case '[':
+        if (last_structural() != ']') {
+          return TAPE_ERROR;
+        }
+        break;
     }
-    goto document_end;
   }
+
+  switch (*value) {
+    case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
+    case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
+    default: SIMDJSON_TRY( visitor.parse_root_primitive(*this, value) );
+  }
+  goto document_end;
 
 //
 // Object parser states
 //
-object_begin: {
+object_begin:
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
   visitor.start_object(*this);
 
-  const uint8_t *key = advance();
-  if (*key != '"') {
-    log_error("Object does not start with a key");
-    return TAPE_ERROR;
-  }
+  value = advance();
+  if (*value != '"') { log_error("Object does not start with a key"); return TAPE_ERROR; }
   visitor.increment_count(*this);
-  SIMDJSON_TRY( visitor.parse_key(*this, key) );
+  SIMDJSON_TRY( visitor.parse_key(*this, value) );
   goto object_field;
-} // object_begin:
 
-object_field: {
+object_field:
   if (simdjson_unlikely( advance_char() != ':' )) { log_error("Missing colon after key in object"); return TAPE_ERROR; }
-  const uint8_t *value = advance();
-  switch (*value) {
+  switch (*(value = advance())) {
     case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
     case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
     default: SIMDJSON_TRY( visitor.parse_primitive(*this, value) );
   }
-} // object_field:
 
-object_continue: {
+object_continue:
   switch (advance_char()) {
   case ',': {
     visitor.increment_count(*this);
-    const uint8_t *key = advance();
-    if (simdjson_unlikely( *key != '"' )) { log_error("Key string missing at beginning of field in object"); return TAPE_ERROR; }
-    SIMDJSON_TRY( visitor.parse_key(*this, key) );
+    value = advance();
+    if (simdjson_unlikely( *value != '"' )) { log_error("Key string missing at beginning of field in object"); return TAPE_ERROR; }
+    SIMDJSON_TRY( visitor.parse_key(*this, value) );
     goto object_field;
   }
   case '}':
@@ -151,50 +145,37 @@ object_continue: {
     log_error("No comma between object fields");
     return TAPE_ERROR;
   }
-} // object_continue:
 
-scope_end: {
+scope_end:
   depth--;
   if (depth == 0) { goto document_end; }
   if (dom_parser.is_array[depth]) { goto array_continue; }
   goto object_continue;
-} // scope_end:
 
 //
 // Array parser states
 //
-array_begin: {
+array_begin:
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
   visitor.start_array(*this);
-
   visitor.increment_count(*this);
-} // array_begin:
 
-array_value: {
-  const uint8_t *value = advance();
-  switch (*value) {
+array_value:
+  switch (*(value = advance())) {
     case '{': if (!empty_object(visitor)) { goto object_begin; }; break;
     case '[': if (!empty_array(visitor)) { goto array_begin; }; break;
     default: SIMDJSON_TRY( visitor.parse_primitive(*this, value) );
   }
-} // array_value:
 
-array_continue: {
+array_continue:
   switch (advance_char()) {
-  case ',':
-    visitor.increment_count(*this);
-    goto array_value;
-  case ']':
-    visitor.end_array(*this);
-    goto scope_end;
-  default:
-    log_error("Missing comma between array values");
-    return TAPE_ERROR;
+    case ',': visitor.increment_count(*this); goto array_value;
+    case ']': visitor.end_array(*this); goto scope_end;
+    default: log_error("Missing comma between array values"); return TAPE_ERROR;
   }
-} // array_continue:
 
-document_end: {
+document_end:
   visitor.end_document(*this);
 
   dom_parser.next_structural_index = uint32_t(next_structural - &dom_parser.structural_indexes[0]);
@@ -211,7 +192,6 @@ document_end: {
   }
 
   return SUCCESS;
-} // document_end:
 
 } // parse_structurals()
 

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -17,12 +17,7 @@ struct structural_parser : structural_iterator {
   uint32_t depth{0};
 
   template<bool STREAMING, typename T>
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse(T &builder) noexcept;
-  template<bool STREAMING, typename T>
-  SIMDJSON_WARN_UNUSED static simdjson_really_inline error_code parse(dom_parser_implementation &dom_parser, T &builder) noexcept {
-    structural_parser parser(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
-    return parser.parse<STREAMING>(builder);
-  }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code walk_document(T &builder) noexcept;
 
   // For non-streaming, to pass an explicit 0 as next_structural, which enables optimizations
   simdjson_really_inline structural_parser(dom_parser_implementation &_dom_parser, uint32_t start_structural_index)
@@ -90,7 +85,7 @@ struct structural_parser : structural_iterator {
 }; // struct structural_parser
 
 template<bool STREAMING, typename T>
-SIMDJSON_WARN_UNUSED simdjson_really_inline error_code structural_parser::parse(T &builder) noexcept {
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code structural_parser::walk_document(T &builder) noexcept {
   logger::log_start();
 
   //

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -43,24 +43,6 @@ struct structural_parser : structural_iterator {
     return false;
   }
 
-  template<bool STREAMING>
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code finish() {
-    dom_parser.next_structural_index = uint32_t(next_structural - &dom_parser.structural_indexes[0]);
-
-    if (depth != 0) {
-      log_error("Unclosed objects or arrays!");
-      return TAPE_ERROR;
-    }
-
-    // If we didn't make it to the end, it's an error
-    if ( !STREAMING && dom_parser.next_structural_index != dom_parser.n_structural_indexes ) {
-      logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
-      return TAPE_ERROR;
-    }
-
-    return SUCCESS;
-  }
-
   simdjson_really_inline uint8_t last_structural() {
     return buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]];
   }
@@ -214,7 +196,21 @@ array_continue: {
 
 document_end: {
   visitor.end_document(*this);
-  return finish<STREAMING>();
+
+  dom_parser.next_structural_index = uint32_t(next_structural - &dom_parser.structural_indexes[0]);
+
+  if (depth != 0) {
+    log_error("Unclosed objects or arrays!");
+    return TAPE_ERROR;
+  }
+
+  // If we didn't make it to the end, it's an error
+  if ( !STREAMING && dom_parser.next_structural_index != dom_parser.n_structural_indexes ) {
+    logger::log_string("More than one JSON value at the root of the document, or extra characters at the end of the JSON!");
+    return TAPE_ERROR;
+  }
+
+  return SUCCESS;
 } // document_end:
 
 } // parse_structurals()

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -29,19 +29,6 @@ struct structural_parser : structural_iterator {
     : structural_iterator(_dom_parser, start_structural_index) {
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code start_document() {
-    dom_parser.is_array[depth] = false;
-    return SUCCESS;
-  }
-  template<typename T>
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code start_array(T &builder) {
-    depth++;
-    if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
-    builder.start_array(*this);
-    dom_parser.is_array[depth] = true;
-    return SUCCESS;
-  }
-
   template<typename T>
   SIMDJSON_WARN_UNUSED simdjson_really_inline bool empty_object(T &builder) {
     if (peek_next_char() == '}') {
@@ -110,7 +97,6 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code structural_parser::parse(
   // Start the document
   //
   if (at_end()) { return EMPTY; }
-  SIMDJSON_TRY( start_document() );
   builder.start_document(*this);
 
   //
@@ -151,7 +137,6 @@ object_begin: {
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
   builder.start_object(*this);
-  dom_parser.is_array[depth] = false;
 
   const uint8_t *key = advance();
   if (*key != '"') {
@@ -205,7 +190,6 @@ array_begin: {
   depth++;
   if (depth >= dom_parser.max_depth()) { log_error("Exceeded max depth!"); return DEPTH_ERROR; }
   builder.start_array(*this);
-  dom_parser.is_array[depth] = true;
 
   builder.increment_count(*this);
 } // array_begin:

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -173,7 +173,7 @@ private:
 
   // increment_count increments the count of keys in an object or values in an array.
   simdjson_really_inline void increment_count(structural_parser &parser) {
-    parser.dom_parser.containing_scope[parser.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
+    parser.dom_parser.open_containers[parser.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
   }
 
 // private:
@@ -189,19 +189,19 @@ private:
   }
 
   simdjson_really_inline void start_container(structural_parser &parser) {
-    parser.dom_parser.containing_scope[parser.depth].tape_index = next_tape_index(parser);
-    parser.dom_parser.containing_scope[parser.depth].count = 0;
+    parser.dom_parser.open_containers[parser.depth].tape_index = next_tape_index(parser);
+    parser.dom_parser.open_containers[parser.depth].count = 0;
     tape.skip(); // We don't actually *write* the start element until the end.
   }
 
   simdjson_really_inline void end_container(structural_parser &parser, internal::tape_type start, internal::tape_type end) noexcept {
     // Write the ending tape element, pointing at the start location
-    const uint32_t start_tape_index = parser.dom_parser.containing_scope[parser.depth].tape_index;
+    const uint32_t start_tape_index = parser.dom_parser.open_containers[parser.depth].tape_index;
     tape.append(start_tape_index, end);
     // Write the start tape element, pointing at the end location (and including count)
     // count can overflow if it exceeds 24 bits... so we saturate
     // the convention being that a cnt of 0xffffff or more is undetermined in value (>=  0xffffff).
-    const uint32_t count = parser.dom_parser.containing_scope[parser.depth].count;
+    const uint32_t count = parser.dom_parser.open_containers[parser.depth].count;
     const uint32_t cntsat = count > 0xFFFFFF ? 0xFFFFFF : count;
     tape_writer::write(parser.dom_parser.doc->tape[start_tape_index], next_tape_index(parser) | (uint64_t(cntsat) << 32), start);
   }

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -1,3 +1,4 @@
+#include "generic/stage2/structural_parser.h"
 #include "generic/stage2/tape_writer.h"
 #include "generic/stage2/atomparsing.h"
 
@@ -11,10 +12,20 @@ struct tape_builder {
   /** Next write location in the string buf for stage 2 parsing */
   uint8_t *current_string_buf_loc;
 
-  simdjson_really_inline tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
+  template<bool STREAMING>
+  SIMDJSON_WARN_UNUSED static simdjson_really_inline error_code parse_document(
+      dom_parser_implementation &dom_parser,
+      dom::document &doc) noexcept {
+    dom_parser.doc = &doc;
+    structural_parser iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
+    tape_builder builder(doc);
+    return iter.walk_document<STREAMING>(builder);
+  }
 
 private:
   friend struct structural_parser;
+
+  simdjson_really_inline tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
 
   simdjson_really_inline error_code parse_root_primitive(structural_parser &parser, const uint8_t *value) {
     switch (*value) {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -122,40 +122,32 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_primi
   }
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_empty_object(json_iterator &iter) noexcept {
-  iter.log_value("empty object");
   return empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_empty_array(json_iterator &iter) noexcept {
-  iter.log_value("empty array");
   return empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_document_start(json_iterator &iter) noexcept {
-  iter.log_start_value("document");
   start_container(iter);
   return SUCCESS;
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_object_start(json_iterator &iter) noexcept {
-  iter.log_start_value("object");
   start_container(iter);
   return SUCCESS;
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_array_start(json_iterator &iter) noexcept {
-  iter.log_start_value("array");
   start_container(iter);
   return SUCCESS;
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_object_end(json_iterator &iter) noexcept {
-  iter.log_end_value("object");
   return end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_array_end(json_iterator &iter) noexcept {
-  iter.log_end_value("array");
   return end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_document_end(json_iterator &iter) noexcept {
-  iter.log_end_value("document");
   constexpr uint32_t start_tape_index = 0;
   tape.append(start_tape_index, internal::tape_type::ROOT);
   tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -17,7 +17,7 @@ struct tape_builder {
     return iter.walk_document<STREAMING>(builder);
   }
 
-  simdjson_really_inline error_code root_primitive(json_iterator &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code root_primitive(json_iterator &iter, const uint8_t *value) {
     switch (*value) {
       case '"': return parse_string(iter, value);
       case 't': return parse_root_true_atom(iter, value);
@@ -32,7 +32,7 @@ struct tape_builder {
         return TAPE_ERROR;
     }
   }
-  simdjson_really_inline error_code primitive(json_iterator &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code primitive(json_iterator &iter, const uint8_t *value) {
     switch (*value) {
       case '"': return parse_string(iter, value);
       case 't': return parse_true_atom(iter, value);
@@ -47,13 +47,13 @@ struct tape_builder {
         return TAPE_ERROR;
     }
   }
-  simdjson_really_inline void empty_object(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code empty_object(json_iterator &iter) {
     iter.log_value("empty object");
-    empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+    return empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
   }
-  simdjson_really_inline void empty_array(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code empty_array(json_iterator &iter) {
     iter.log_value("empty array");
-    empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+    return empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
   }
 
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code start_document(json_iterator &iter) {
@@ -95,8 +95,9 @@ struct tape_builder {
   }
 
   // increment_count increments the count of keys in an object or values in an array.
-  simdjson_really_inline void increment_count(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code increment_count(json_iterator &iter) {
     iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
+    return SUCCESS;
   }
   simdjson_really_inline bool in_array(json_iterator &iter) noexcept {
     return iter.dom_parser.is_array[iter.depth];
@@ -128,7 +129,7 @@ private:
     return SUCCESS;
   }
 
-  simdjson_really_inline error_code parse_root_number(json_iterator &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_number(json_iterator &iter, const uint8_t *value) {
     //
     // We need to make a copy to make sure that the string is space terminated.
     // This is not about padding the input, which should already padded up
@@ -201,10 +202,11 @@ private:
     return uint32_t(tape.next_tape_loc - iter.dom_parser.doc->tape.get());
   }
 
-  simdjson_really_inline void empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) {
     auto start_index = next_tape_index(iter);
     tape.append(start_index+2, start);
     tape.append(start_index, end);
+    return SUCCESS;
   }
 
   simdjson_really_inline void start_container(json_iterator &iter) {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -12,21 +12,47 @@ struct tape_builder {
     dom_parser_implementation &dom_parser,
     dom::document &doc) noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_empty_object(json_iterator &iter) noexcept;
+  /** Called when a non-empty document starts. */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_start(json_iterator &iter) noexcept;
+  /** Called when a non-empty document ends without error. */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_end(json_iterator &iter) noexcept;
+
+  /** Called when a non-empty array starts. */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_start(json_iterator &iter) noexcept;
+  /** Called when a non-empty array ends. */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_end(json_iterator &iter) noexcept;
+  /** Called when an empty array is found. */
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_empty_array(json_iterator &iter) noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_start(json_iterator &iter) noexcept;
+  /** Called when a non-empty object starts. */
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_object_start(json_iterator &iter) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_start(json_iterator &iter) noexcept;
-
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_object_end(json_iterator &iter) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_end(json_iterator &iter) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_end(json_iterator &iter) noexcept;
+  /**
+   * Called when a key in a field is encountered.
+   *
+   * primitive, visit_object_start, visit_empty_object, visit_array_start, or visit_empty_array
+   * will be called after this with the field value.
+   */
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_key(json_iterator &iter, const uint8_t *key) noexcept;
+  /** Called when a non-empty object ends. */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_object_end(json_iterator &iter) noexcept;
+  /** Called when an empty object is found. */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_empty_object(json_iterator &iter) noexcept;
 
-  // increment_count increments the count of keys in an object or values in an array.
+  /**
+   * Called when a string, number, boolean or null is found.
+   */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value) noexcept;
+  /**
+   * Called when a string, number, boolean or null is found at the top level of a document (i.e.
+   * when there is no array or object and the entire document is a single string, number, boolean or
+   * null.
+   *
+   * This is separate from primitive() because simdjson's normal primitive parsing routines assume
+   * there is at least one more token after the value, which is only true in an array or object.
+   */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept;
+
+  /** Called each time a new field or element in an array or object is found. */
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code increment_count(json_iterator &iter) noexcept;
 
 private:

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -160,8 +160,7 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("number");
-  if (!numberparsing::parse_number(value, tape)) { iter.log_error("Invalid number"); return NUMBER_ERROR; }
-  return SUCCESS;
+  return numberparsing::parse_number(value, tape);
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -52,26 +52,28 @@ struct tape_builder {
    */
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept;
 
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_string(json_iterator &iter, const uint8_t *value, bool key = false) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_number(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
+
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_string(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_number(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
+
   /** Called each time a new field or element in an array or object is found. */
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code increment_count(json_iterator &iter) noexcept;
 
-private:
   /** Next location to write to tape */
   tape_writer tape;
+private:
   /** Next write location in the string buf for stage 2 parsing */
   uint8_t *current_string_buf_loc;
 
   simdjson_really_inline tape_builder(dom::document &doc) noexcept;
-
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_string(json_iterator &iter, const uint8_t *value, bool key = false) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_number(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_number(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
 
   simdjson_really_inline uint32_t next_tape_index(json_iterator &iter) const noexcept;
   simdjson_really_inline void start_container(json_iterator &iter) noexcept;
@@ -92,34 +94,10 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::parse_docum
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept {
-  switch (*value) {
-    case '"': return visit_string(iter, value);
-    case 't': return visit_root_true_atom(iter, value);
-    case 'f': return visit_root_false_atom(iter, value);
-    case 'n': return visit_root_null_atom(iter, value);
-    case '-':
-    case '0': case '1': case '2': case '3': case '4':
-    case '5': case '6': case '7': case '8': case '9':
-      return visit_root_number(iter, value);
-    default:
-      iter.log_error("Document starts with a non-value character");
-      return TAPE_ERROR;
-  }
+  return iter.visit_root_primitive(*this, value);
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_primitive(json_iterator &iter, const uint8_t *value) noexcept {
-  switch (*value) {
-    case '"': return visit_string(iter, value);
-    case 't': return visit_true_atom(iter, value);
-    case 'f': return visit_false_atom(iter, value);
-    case 'n': return visit_null_atom(iter, value);
-    case '-':
-    case '0': case '1': case '2': case '3': case '4':
-    case '5': case '6': case '7': case '8': case '9':
-      return visit_number(iter, value);
-    default:
-      iter.log_error("Non-value found when value was expected!");
-      return TAPE_ERROR;
-  }
+  return iter.visit_primitive(*this, value);
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_empty_object(json_iterator &iter) noexcept {
   return empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
@@ -174,6 +152,10 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_strin
   }
   on_end_string(dst);
   return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_string(json_iterator &iter, const uint8_t *value) noexcept {
+  return visit_string(iter, value);
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -1,4 +1,4 @@
-#include "generic/stage2/structural_parser.h"
+#include "generic/stage2/json_iterator.h"
 #include "generic/stage2/tape_writer.h"
 #include "generic/stage2/atomparsing.h"
 
@@ -12,12 +12,12 @@ struct tape_builder {
       dom_parser_implementation &dom_parser,
       dom::document &doc) noexcept {
     dom_parser.doc = &doc;
-    structural_parser iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
+    json_iterator iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
     tape_builder builder(doc);
     return iter.walk_document<STREAMING>(builder);
   }
 
-  simdjson_really_inline error_code root_primitive(structural_parser &iter, const uint8_t *value) {
+  simdjson_really_inline error_code root_primitive(json_iterator &iter, const uint8_t *value) {
     switch (*value) {
       case '"': return parse_string(iter, value);
       case 't': return parse_root_true_atom(iter, value);
@@ -32,7 +32,7 @@ struct tape_builder {
         return TAPE_ERROR;
     }
   }
-  simdjson_really_inline error_code primitive(structural_parser &iter, const uint8_t *value) {
+  simdjson_really_inline error_code primitive(json_iterator &iter, const uint8_t *value) {
     switch (*value) {
       case '"': return parse_string(iter, value);
       case 't': return parse_true_atom(iter, value);
@@ -47,54 +47,64 @@ struct tape_builder {
         return TAPE_ERROR;
     }
   }
-  simdjson_really_inline void empty_object(structural_parser &iter) {
+  simdjson_really_inline void empty_object(json_iterator &iter) {
     iter.log_value("empty object");
     empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
   }
-  simdjson_really_inline void empty_array(structural_parser &iter) {
+  simdjson_really_inline void empty_array(json_iterator &iter) {
     iter.log_value("empty array");
     empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
   }
 
-  simdjson_really_inline void start_document(structural_parser &iter) {
+  simdjson_really_inline void start_document(json_iterator &iter) {
     iter.log_start_value("document");
     start_container(iter);
     iter.dom_parser.is_array[iter.depth] = false;
   }
-  simdjson_really_inline void start_object(structural_parser &iter) {
+  simdjson_really_inline void start_object(json_iterator &iter) {
     iter.log_start_value("object");
     start_container(iter);
     iter.dom_parser.is_array[iter.depth] = false;
   }
-  simdjson_really_inline void start_array(structural_parser &iter) {
+  simdjson_really_inline void start_array(json_iterator &iter) {
     iter.log_start_value("array");
     start_container(iter);
     iter.dom_parser.is_array[iter.depth] = true;
   }
 
-  simdjson_really_inline void end_object(structural_parser &iter) {
+  simdjson_really_inline void end_object(json_iterator &iter) {
     iter.log_end_value("object");
     end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
   }
-  simdjson_really_inline void end_array(structural_parser &iter) {
+  simdjson_really_inline void end_array(json_iterator &iter) {
     iter.log_end_value("array");
     end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
   }
-  simdjson_really_inline void end_document(structural_parser &iter) {
+  simdjson_really_inline void end_document(json_iterator &iter) {
     iter.log_end_value("document");
     constexpr uint32_t start_tape_index = 0;
     tape.append(start_tape_index, internal::tape_type::ROOT);
     tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
   }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code key(structural_parser &iter, const uint8_t *key) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code key(json_iterator &iter, const uint8_t *key) {
     return parse_string(iter, key, true);
   }
 
+  // Called after end_object/end_array. Not called after empty_object/empty_array,
+  // as the parent is already known in those cases.
+  //
+  // The object returned from end_container() should support the in_container(),
+  // in_array() and in_object() methods, allowing the iterator to branch to the
+  // correct place.
+  simdjson_really_inline tape_builder &end_container(json_iterator &iter) {
+    iter.depth--;
+    return *this;
+  }
   // increment_count increments the count of keys in an object or values in an array.
-  simdjson_really_inline void increment_count(structural_parser &iter) {
+  simdjson_really_inline void increment_count(json_iterator &iter) {
     iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
   }
-  simdjson_really_inline bool in_array(structural_parser &iter) noexcept {
+  simdjson_really_inline bool in_array(json_iterator &iter) noexcept {
     return iter.dom_parser.is_array[iter.depth];
   }
 
@@ -106,7 +116,7 @@ private:
 
   simdjson_really_inline tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_string(structural_parser &iter, const uint8_t *value, bool key = false) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_string(json_iterator &iter, const uint8_t *value, bool key = false) {
     iter.log_value(key ? "key" : "string");
     uint8_t *dst = on_start_string(iter);
     dst = stringparsing::parse_string(value, dst);
@@ -118,13 +128,13 @@ private:
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_number(structural_parser &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_number(json_iterator &iter, const uint8_t *value) {
     iter.log_value("number");
     if (!numberparsing::parse_number(value, tape)) { iter.log_error("Invalid number"); return NUMBER_ERROR; }
     return SUCCESS;
   }
 
-  simdjson_really_inline error_code parse_root_number(structural_parser &iter, const uint8_t *value) {
+  simdjson_really_inline error_code parse_root_number(json_iterator &iter, const uint8_t *value) {
     //
     // We need to make a copy to make sure that the string is space terminated.
     // This is not about padding the input, which should already padded up
@@ -149,42 +159,42 @@ private:
     return error;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_true_atom(structural_parser &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_true_atom(json_iterator &iter, const uint8_t *value) {
     iter.log_value("true");
     if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
     tape.append(0, internal::tape_type::TRUE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_true_atom(structural_parser &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_true_atom(json_iterator &iter, const uint8_t *value) {
     iter.log_value("true");
     if (!atomparsing::is_valid_true_atom(value, iter.remaining_len())) { return T_ATOM_ERROR; }
     tape.append(0, internal::tape_type::TRUE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_false_atom(structural_parser &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_false_atom(json_iterator &iter, const uint8_t *value) {
     iter.log_value("false");
     if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
     tape.append(0, internal::tape_type::FALSE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_false_atom(structural_parser &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_false_atom(json_iterator &iter, const uint8_t *value) {
     iter.log_value("false");
     if (!atomparsing::is_valid_false_atom(value, iter.remaining_len())) { return F_ATOM_ERROR; }
     tape.append(0, internal::tape_type::FALSE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_null_atom(structural_parser &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_null_atom(json_iterator &iter, const uint8_t *value) {
     iter.log_value("null");
     if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
     tape.append(0, internal::tape_type::NULL_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_null_atom(structural_parser &iter, const uint8_t *value) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_null_atom(json_iterator &iter, const uint8_t *value) {
     iter.log_value("null");
     if (!atomparsing::is_valid_null_atom(value, iter.remaining_len())) { return N_ATOM_ERROR; }
     tape.append(0, internal::tape_type::NULL_VALUE);
@@ -193,23 +203,23 @@ private:
 
 // private:
 
-  simdjson_really_inline uint32_t next_tape_index(structural_parser &iter) {
+  simdjson_really_inline uint32_t next_tape_index(json_iterator &iter) {
     return uint32_t(tape.next_tape_loc - iter.dom_parser.doc->tape.get());
   }
 
-  simdjson_really_inline void empty_container(structural_parser &iter, internal::tape_type start, internal::tape_type end) {
+  simdjson_really_inline void empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) {
     auto start_index = next_tape_index(iter);
     tape.append(start_index+2, start);
     tape.append(start_index, end);
   }
 
-  simdjson_really_inline void start_container(structural_parser &iter) {
+  simdjson_really_inline void start_container(json_iterator &iter) {
     iter.dom_parser.open_containers[iter.depth].tape_index = next_tape_index(iter);
     iter.dom_parser.open_containers[iter.depth].count = 0;
     tape.skip(); // We don't actually *write* the start element until the end.
   }
 
-  simdjson_really_inline void end_container(structural_parser &iter, internal::tape_type start, internal::tape_type end) noexcept {
+  simdjson_really_inline void end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
     // Write the ending tape element, pointing at the start location
     const uint32_t start_tape_index = iter.dom_parser.open_containers[iter.depth].tape_index;
     tape.append(start_tape_index, end);
@@ -221,7 +231,7 @@ private:
     tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter) | (uint64_t(cntsat) << 32), start);
   }
 
-  simdjson_really_inline uint8_t *on_start_string(structural_parser &iter) noexcept {
+  simdjson_really_inline uint8_t *on_start_string(json_iterator &iter) noexcept {
     // we advance the point, accounting for the fact that we have a NULL termination
     tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::STRING);
     return current_string_buf_loc + sizeof(uint32_t);

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -56,50 +56,44 @@ struct tape_builder {
     empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
   }
 
-  simdjson_really_inline void start_document(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code start_document(json_iterator &iter) {
     iter.log_start_value("document");
     start_container(iter);
     iter.dom_parser.is_array[iter.depth] = false;
+    return SUCCESS;
   }
-  simdjson_really_inline void start_object(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code start_object(json_iterator &iter) {
     iter.log_start_value("object");
     start_container(iter);
     iter.dom_parser.is_array[iter.depth] = false;
+    return SUCCESS;
   }
-  simdjson_really_inline void start_array(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code start_array(json_iterator &iter) {
     iter.log_start_value("array");
     start_container(iter);
     iter.dom_parser.is_array[iter.depth] = true;
+    return SUCCESS;
   }
 
-  simdjson_really_inline void end_object(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code end_object(json_iterator &iter) {
     iter.log_end_value("object");
-    end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+    return end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
   }
-  simdjson_really_inline void end_array(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code end_array(json_iterator &iter) {
     iter.log_end_value("array");
-    end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+    return end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
   }
-  simdjson_really_inline void end_document(json_iterator &iter) {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code end_document(json_iterator &iter) {
     iter.log_end_value("document");
     constexpr uint32_t start_tape_index = 0;
     tape.append(start_tape_index, internal::tape_type::ROOT);
     tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
+    return SUCCESS;
   }
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code key(json_iterator &iter, const uint8_t *key) {
     return parse_string(iter, key, true);
   }
 
-  // Called after end_object/end_array. Not called after empty_object/empty_array,
-  // as the parent is already known in those cases.
-  //
-  // The object returned from end_container() should support the in_container(),
-  // in_array() and in_object() methods, allowing the iterator to branch to the
-  // correct place.
-  simdjson_really_inline tape_builder &end_container(json_iterator &iter) {
-    iter.depth--;
-    return *this;
-  }
   // increment_count increments the count of keys in an object or values in an array.
   simdjson_really_inline void increment_count(json_iterator &iter) {
     iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
@@ -219,7 +213,7 @@ private:
     tape.skip(); // We don't actually *write* the start element until the end.
   }
 
-  simdjson_really_inline void end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
     // Write the ending tape element, pointing at the start location
     const uint32_t start_tape_index = iter.dom_parser.open_containers[iter.depth].tape_index;
     tape.append(start_tape_index, end);
@@ -229,6 +223,7 @@ private:
     const uint32_t count = iter.dom_parser.open_containers[iter.depth].count;
     const uint32_t cntsat = count > 0xFFFFFF ? 0xFFFFFF : count;
     tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter) | (uint64_t(cntsat) << 32), start);
+    return SUCCESS;
   }
 
   simdjson_really_inline uint8_t *on_start_string(json_iterator &iter) noexcept {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -28,7 +28,6 @@ struct tape_builder {
 
   // increment_count increments the count of keys in an object or values in an array.
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code increment_count(json_iterator &iter) noexcept;
-  simdjson_really_inline bool in_array(json_iterator &iter) noexcept;
 
 private:
   /** Next location to write to tape */
@@ -108,19 +107,16 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_empty
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_document_start(json_iterator &iter) noexcept {
   iter.log_start_value("document");
   start_container(iter);
-  iter.dom_parser.is_array[iter.depth] = false;
   return SUCCESS;
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_object_start(json_iterator &iter) noexcept {
   iter.log_start_value("object");
   start_container(iter);
-  iter.dom_parser.is_array[iter.depth] = false;
   return SUCCESS;
 }
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_array_start(json_iterator &iter) noexcept {
   iter.log_start_value("array");
   start_container(iter);
-  iter.dom_parser.is_array[iter.depth] = true;
   return SUCCESS;
 }
 
@@ -146,9 +142,6 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_key(j
 SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::increment_count(json_iterator &iter) noexcept {
   iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
   return SUCCESS;
-}
-simdjson_really_inline bool tape_builder::in_array(json_iterator &iter) noexcept {
-  return iter.dom_parser.is_array[iter.depth];
 }
 
 simdjson_really_inline tape_builder::tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -7,11 +7,6 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace stage2 {
 
 struct tape_builder {
-  /** Next location to write to tape */
-  tape_writer tape;
-  /** Next write location in the string buf for stage 2 parsing */
-  uint8_t *current_string_buf_loc;
-
   template<bool STREAMING>
   SIMDJSON_WARN_UNUSED static simdjson_really_inline error_code parse_document(
       dom_parser_implementation &dom_parser,
@@ -22,12 +17,7 @@ struct tape_builder {
     return iter.walk_document<STREAMING>(builder);
   }
 
-private:
-  friend struct structural_parser;
-
-  simdjson_really_inline tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
-
-  simdjson_really_inline error_code parse_root_primitive(structural_parser &iter, const uint8_t *value) {
+  simdjson_really_inline error_code root_primitive(structural_parser &iter, const uint8_t *value) {
     switch (*value) {
       case '"': return parse_string(iter, value);
       case 't': return parse_root_true_atom(iter, value);
@@ -42,7 +32,7 @@ private:
         return TAPE_ERROR;
     }
   }
-  simdjson_really_inline error_code parse_primitive(structural_parser &iter, const uint8_t *value) {
+  simdjson_really_inline error_code primitive(structural_parser &iter, const uint8_t *value) {
     switch (*value) {
       case '"': return parse_string(iter, value);
       case 't': return parse_true_atom(iter, value);
@@ -96,10 +86,26 @@ private:
     tape.append(start_tape_index, internal::tape_type::ROOT);
     tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
   }
-
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_key(structural_parser &iter, const uint8_t *value) {
-    return parse_string(iter, value, true);
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code key(structural_parser &iter, const uint8_t *key) {
+    return parse_string(iter, key, true);
   }
+
+  // increment_count increments the count of keys in an object or values in an array.
+  simdjson_really_inline void increment_count(structural_parser &iter) {
+    iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
+  }
+  simdjson_really_inline bool in_array(structural_parser &iter) noexcept {
+    return iter.dom_parser.is_array[iter.depth];
+  }
+
+private:
+  /** Next location to write to tape */
+  tape_writer tape;
+  /** Next write location in the string buf for stage 2 parsing */
+  uint8_t *current_string_buf_loc;
+
+  simdjson_really_inline tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
+
   SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_string(structural_parser &iter, const uint8_t *value, bool key = false) {
     iter.log_value(key ? "key" : "string");
     uint8_t *dst = on_start_string(iter);
@@ -183,11 +189,6 @@ private:
     if (!atomparsing::is_valid_null_atom(value, iter.remaining_len())) { return N_ATOM_ERROR; }
     tape.append(0, internal::tape_type::NULL_VALUE);
     return SUCCESS;
-  }
-
-  // increment_count increments the count of keys in an object or values in an array.
-  simdjson_really_inline void increment_count(structural_parser &iter) {
-    iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
   }
 
 // private:

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -58,14 +58,17 @@ private:
   simdjson_really_inline void start_document(structural_parser &parser) {
     parser.log_start_value("document");
     start_container(parser);
+    parser.dom_parser.is_array[parser.depth] = false;
   }
   simdjson_really_inline void start_object(structural_parser &parser) {
     parser.log_start_value("object");
     start_container(parser);
+    parser.dom_parser.is_array[parser.depth] = false;
   }
   simdjson_really_inline void start_array(structural_parser &parser) {
     parser.log_start_value("array");
     start_container(parser);
+    parser.dom_parser.is_array[parser.depth] = true;
   }
 
   simdjson_really_inline void end_object(structural_parser &parser) {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -9,99 +9,26 @@ namespace stage2 {
 struct tape_builder {
   template<bool STREAMING>
   SIMDJSON_WARN_UNUSED static simdjson_really_inline error_code parse_document(
-      dom_parser_implementation &dom_parser,
-      dom::document &doc) noexcept {
-    dom_parser.doc = &doc;
-    json_iterator iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
-    tape_builder builder(doc);
-    return iter.walk_document<STREAMING>(builder);
-  }
+    dom_parser_implementation &dom_parser,
+    dom::document &doc) noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value) {
-    switch (*value) {
-      case '"': return visit_string(iter, value);
-      case 't': return visit_root_true_atom(iter, value);
-      case 'f': return visit_root_false_atom(iter, value);
-      case 'n': return visit_root_null_atom(iter, value);
-      case '-':
-      case '0': case '1': case '2': case '3': case '4':
-      case '5': case '6': case '7': case '8': case '9':
-        return visit_root_number(iter, value);
-      default:
-        iter.log_error("Document starts with a non-value character");
-        return TAPE_ERROR;
-    }
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value) {
-    switch (*value) {
-      case '"': return visit_string(iter, value);
-      case 't': return visit_true_atom(iter, value);
-      case 'f': return visit_false_atom(iter, value);
-      case 'n': return visit_null_atom(iter, value);
-      case '-':
-      case '0': case '1': case '2': case '3': case '4':
-      case '5': case '6': case '7': case '8': case '9':
-        return visit_number(iter, value);
-      default:
-        iter.log_error("Non-value found when value was expected!");
-        return TAPE_ERROR;
-    }
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_empty_object(json_iterator &iter) {
-    iter.log_value("empty object");
-    return empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_empty_array(json_iterator &iter) {
-    iter.log_value("empty array");
-    return empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
-  }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_empty_object(json_iterator &iter) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_empty_array(json_iterator &iter) noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_start(json_iterator &iter) {
-    iter.log_start_value("document");
-    start_container(iter);
-    iter.dom_parser.is_array[iter.depth] = false;
-    return SUCCESS;
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_object_start(json_iterator &iter) {
-    iter.log_start_value("object");
-    start_container(iter);
-    iter.dom_parser.is_array[iter.depth] = false;
-    return SUCCESS;
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_start(json_iterator &iter) {
-    iter.log_start_value("array");
-    start_container(iter);
-    iter.dom_parser.is_array[iter.depth] = true;
-    return SUCCESS;
-  }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_start(json_iterator &iter) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_object_start(json_iterator &iter) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_start(json_iterator &iter) noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_object_end(json_iterator &iter) {
-    iter.log_end_value("object");
-    return end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_end(json_iterator &iter) {
-    iter.log_end_value("array");
-    return end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_end(json_iterator &iter) {
-    iter.log_end_value("document");
-    constexpr uint32_t start_tape_index = 0;
-    tape.append(start_tape_index, internal::tape_type::ROOT);
-    tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
-    return SUCCESS;
-  }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_key(json_iterator &iter, const uint8_t *key) {
-    return visit_string(iter, key, true);
-  }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_object_end(json_iterator &iter) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_array_end(json_iterator &iter) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_document_end(json_iterator &iter) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_key(json_iterator &iter, const uint8_t *key) noexcept;
 
   // increment_count increments the count of keys in an object or values in an array.
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code increment_count(json_iterator &iter) {
-    iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
-    return SUCCESS;
-  }
-  simdjson_really_inline bool in_array(json_iterator &iter) noexcept {
-    return iter.dom_parser.is_array[iter.depth];
-  }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code increment_count(json_iterator &iter) noexcept;
+  simdjson_really_inline bool in_array(json_iterator &iter) noexcept;
 
 private:
   /** Next location to write to tape */
@@ -109,143 +36,255 @@ private:
   /** Next write location in the string buf for stage 2 parsing */
   uint8_t *current_string_buf_loc;
 
-  simdjson_really_inline tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
+  simdjson_really_inline tape_builder(dom::document &doc) noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_string(json_iterator &iter, const uint8_t *value, bool key = false) {
-    iter.log_value(key ? "key" : "string");
-    uint8_t *dst = on_start_string(iter);
-    dst = stringparsing::parse_string(value, dst);
-    if (dst == nullptr) {
-      iter.log_error("Invalid escape in string");
-      return STRING_ERROR;
-    }
-    on_end_string(dst);
-    return SUCCESS;
-  }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_string(json_iterator &iter, const uint8_t *value, bool key = false) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_number(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_number(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_number(json_iterator &iter, const uint8_t *value) {
-    iter.log_value("number");
-    if (!numberparsing::parse_number(value, tape)) { iter.log_error("Invalid number"); return NUMBER_ERROR; }
-    return SUCCESS;
-  }
+  simdjson_really_inline uint32_t next_tape_index(json_iterator &iter) const noexcept;
+  simdjson_really_inline void start_container(json_iterator &iter) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept;
+  simdjson_really_inline uint8_t *on_start_string(json_iterator &iter) noexcept;
+  simdjson_really_inline void on_end_string(uint8_t *dst) noexcept;
+}; // class tape_builder
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_number(json_iterator &iter, const uint8_t *value) {
-    //
-    // We need to make a copy to make sure that the string is space terminated.
-    // This is not about padding the input, which should already padded up
-    // to len + SIMDJSON_PADDING. However, we have no control at this stage
-    // on how the padding was done. What if the input string was padded with nulls?
-    // It is quite common for an input string to have an extra null character (C string).
-    // We do not want to allow 9\0 (where \0 is the null character) inside a JSON
-    // document, but the string "9\0" by itself is fine. So we make a copy and
-    // pad the input with spaces when we know that there is just one input element.
-    // This copy is relatively expensive, but it will almost never be called in
-    // practice unless you are in the strange scenario where you have many JSON
-    // documents made of single atoms.
-    //
-    uint8_t *copy = static_cast<uint8_t *>(malloc(iter.remaining_len() + SIMDJSON_PADDING));
-    if (copy == nullptr) {
-      return MEMALLOC;
-    }
-    memcpy(copy, value, iter.remaining_len());
-    memset(copy + iter.remaining_len(), ' ', SIMDJSON_PADDING);
-    error_code error = visit_number(iter, copy);
-    free(copy);
-    return error;
-  }
+template<bool STREAMING>
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::parse_document(
+    dom_parser_implementation &dom_parser,
+    dom::document &doc) noexcept {
+  dom_parser.doc = &doc;
+  json_iterator iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
+  tape_builder builder(doc);
+  return iter.walk_document<STREAMING>(builder);
+}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_true_atom(json_iterator &iter, const uint8_t *value) {
-    iter.log_value("true");
-    if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::TRUE_VALUE);
-    return SUCCESS;
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept {
+  switch (*value) {
+    case '"': return visit_string(iter, value);
+    case 't': return visit_root_true_atom(iter, value);
+    case 'f': return visit_root_false_atom(iter, value);
+    case 'n': return visit_root_null_atom(iter, value);
+    case '-':
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+      return visit_root_number(iter, value);
+    default:
+      iter.log_error("Document starts with a non-value character");
+      return TAPE_ERROR;
   }
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_primitive(json_iterator &iter, const uint8_t *value) noexcept {
+  switch (*value) {
+    case '"': return visit_string(iter, value);
+    case 't': return visit_true_atom(iter, value);
+    case 'f': return visit_false_atom(iter, value);
+    case 'n': return visit_null_atom(iter, value);
+    case '-':
+    case '0': case '1': case '2': case '3': case '4':
+    case '5': case '6': case '7': case '8': case '9':
+      return visit_number(iter, value);
+    default:
+      iter.log_error("Non-value found when value was expected!");
+      return TAPE_ERROR;
+  }
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_empty_object(json_iterator &iter) noexcept {
+  iter.log_value("empty object");
+  return empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_empty_array(json_iterator &iter) noexcept {
+  iter.log_value("empty array");
+  return empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_true_atom(json_iterator &iter, const uint8_t *value) {
-    iter.log_value("true");
-    if (!atomparsing::is_valid_true_atom(value, iter.remaining_len())) { return T_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::TRUE_VALUE);
-    return SUCCESS;
-  }
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_document_start(json_iterator &iter) noexcept {
+  iter.log_start_value("document");
+  start_container(iter);
+  iter.dom_parser.is_array[iter.depth] = false;
+  return SUCCESS;
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_object_start(json_iterator &iter) noexcept {
+  iter.log_start_value("object");
+  start_container(iter);
+  iter.dom_parser.is_array[iter.depth] = false;
+  return SUCCESS;
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_array_start(json_iterator &iter) noexcept {
+  iter.log_start_value("array");
+  start_container(iter);
+  iter.dom_parser.is_array[iter.depth] = true;
+  return SUCCESS;
+}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_false_atom(json_iterator &iter, const uint8_t *value) {
-    iter.log_value("false");
-    if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::FALSE_VALUE);
-    return SUCCESS;
-  }
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_object_end(json_iterator &iter) noexcept {
+  iter.log_end_value("object");
+  return end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_array_end(json_iterator &iter) noexcept {
+  iter.log_end_value("array");
+  return end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_document_end(json_iterator &iter) noexcept {
+  iter.log_end_value("document");
+  constexpr uint32_t start_tape_index = 0;
+  tape.append(start_tape_index, internal::tape_type::ROOT);
+  tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
+  return SUCCESS;
+}
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_key(json_iterator &iter, const uint8_t *key) noexcept {
+  return visit_string(iter, key, true);
+}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_false_atom(json_iterator &iter, const uint8_t *value) {
-    iter.log_value("false");
-    if (!atomparsing::is_valid_false_atom(value, iter.remaining_len())) { return F_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::FALSE_VALUE);
-    return SUCCESS;
-  }
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::increment_count(json_iterator &iter) noexcept {
+  iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
+  return SUCCESS;
+}
+simdjson_really_inline bool tape_builder::in_array(json_iterator &iter) noexcept {
+  return iter.dom_parser.is_array[iter.depth];
+}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_null_atom(json_iterator &iter, const uint8_t *value) {
-    iter.log_value("null");
-    if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::NULL_VALUE);
-    return SUCCESS;
-  }
+simdjson_really_inline tape_builder::tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code visit_root_null_atom(json_iterator &iter, const uint8_t *value) {
-    iter.log_value("null");
-    if (!atomparsing::is_valid_null_atom(value, iter.remaining_len())) { return N_ATOM_ERROR; }
-    tape.append(0, internal::tape_type::NULL_VALUE);
-    return SUCCESS;
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_string(json_iterator &iter, const uint8_t *value, bool key) noexcept {
+  iter.log_value(key ? "key" : "string");
+  uint8_t *dst = on_start_string(iter);
+  dst = stringparsing::parse_string(value, dst);
+  if (dst == nullptr) {
+    iter.log_error("Invalid escape in string");
+    return STRING_ERROR;
   }
+  on_end_string(dst);
+  return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
+  iter.log_value("number");
+  if (!numberparsing::parse_number(value, tape)) { iter.log_error("Invalid number"); return NUMBER_ERROR; }
+  return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {
+  //
+  // We need to make a copy to make sure that the string is space terminated.
+  // This is not about padding the input, which should already padded up
+  // to len + SIMDJSON_PADDING. However, we have no control at this stage
+  // on how the padding was done. What if the input string was padded with nulls?
+  // It is quite common for an input string to have an extra null character (C string).
+  // We do not want to allow 9\0 (where \0 is the null character) inside a JSON
+  // document, but the string "9\0" by itself is fine. So we make a copy and
+  // pad the input with spaces when we know that there is just one input element.
+  // This copy is relatively expensive, but it will almost never be called in
+  // practice unless you are in the strange scenario where you have many JSON
+  // documents made of single atoms.
+  //
+  uint8_t *copy = static_cast<uint8_t *>(malloc(iter.remaining_len() + SIMDJSON_PADDING));
+  if (copy == nullptr) { return MEMALLOC; }
+  memcpy(copy, value, iter.remaining_len());
+  memset(copy + iter.remaining_len(), ' ', SIMDJSON_PADDING);
+  error_code error = visit_number(iter, copy);
+  free(copy);
+  return error;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
+  iter.log_value("true");
+  if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
+  tape.append(0, internal::tape_type::TRUE_VALUE);
+  return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
+  iter.log_value("true");
+  if (!atomparsing::is_valid_true_atom(value, iter.remaining_len())) { return T_ATOM_ERROR; }
+  tape.append(0, internal::tape_type::TRUE_VALUE);
+  return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
+  iter.log_value("false");
+  if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
+  tape.append(0, internal::tape_type::FALSE_VALUE);
+  return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
+  iter.log_value("false");
+  if (!atomparsing::is_valid_false_atom(value, iter.remaining_len())) { return F_ATOM_ERROR; }
+  tape.append(0, internal::tape_type::FALSE_VALUE);
+  return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
+  iter.log_value("null");
+  if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
+  tape.append(0, internal::tape_type::NULL_VALUE);
+  return SUCCESS;
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
+  iter.log_value("null");
+  if (!atomparsing::is_valid_null_atom(value, iter.remaining_len())) { return N_ATOM_ERROR; }
+  tape.append(0, internal::tape_type::NULL_VALUE);
+  return SUCCESS;
+}
 
 // private:
 
-  simdjson_really_inline uint32_t next_tape_index(json_iterator &iter) {
-    return uint32_t(tape.next_tape_loc - iter.dom_parser.doc->tape.get());
-  }
+simdjson_really_inline uint32_t tape_builder::next_tape_index(json_iterator &iter) const noexcept {
+  return uint32_t(tape.next_tape_loc - iter.dom_parser.doc->tape.get());
+}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) {
-    auto start_index = next_tape_index(iter);
-    tape.append(start_index+2, start);
-    tape.append(start_index, end);
-    return SUCCESS;
-  }
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
+  auto start_index = next_tape_index(iter);
+  tape.append(start_index+2, start);
+  tape.append(start_index, end);
+  return SUCCESS;
+}
 
-  simdjson_really_inline void start_container(json_iterator &iter) {
-    iter.dom_parser.open_containers[iter.depth].tape_index = next_tape_index(iter);
-    iter.dom_parser.open_containers[iter.depth].count = 0;
-    tape.skip(); // We don't actually *write* the start element until the end.
-  }
+simdjson_really_inline void tape_builder::start_container(json_iterator &iter) noexcept {
+  iter.dom_parser.open_containers[iter.depth].tape_index = next_tape_index(iter);
+  iter.dom_parser.open_containers[iter.depth].count = 0;
+  tape.skip(); // We don't actually *write* the start element until the end.
+}
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
-    // Write the ending tape element, pointing at the start location
-    const uint32_t start_tape_index = iter.dom_parser.open_containers[iter.depth].tape_index;
-    tape.append(start_tape_index, end);
-    // Write the start tape element, pointing at the end location (and including count)
-    // count can overflow if it exceeds 24 bits... so we saturate
-    // the convention being that a cnt of 0xffffff or more is undetermined in value (>=  0xffffff).
-    const uint32_t count = iter.dom_parser.open_containers[iter.depth].count;
-    const uint32_t cntsat = count > 0xFFFFFF ? 0xFFFFFF : count;
-    tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter) | (uint64_t(cntsat) << 32), start);
-    return SUCCESS;
-  }
+SIMDJSON_WARN_UNUSED simdjson_really_inline error_code tape_builder::end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
+  // Write the ending tape element, pointing at the start location
+  const uint32_t start_tape_index = iter.dom_parser.open_containers[iter.depth].tape_index;
+  tape.append(start_tape_index, end);
+  // Write the start tape element, pointing at the end location (and including count)
+  // count can overflow if it exceeds 24 bits... so we saturate
+  // the convention being that a cnt of 0xffffff or more is undetermined in value (>=  0xffffff).
+  const uint32_t count = iter.dom_parser.open_containers[iter.depth].count;
+  const uint32_t cntsat = count > 0xFFFFFF ? 0xFFFFFF : count;
+  tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter) | (uint64_t(cntsat) << 32), start);
+  return SUCCESS;
+}
 
-  simdjson_really_inline uint8_t *on_start_string(json_iterator &iter) noexcept {
-    // we advance the point, accounting for the fact that we have a NULL termination
-    tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::STRING);
-    return current_string_buf_loc + sizeof(uint32_t);
-  }
+simdjson_really_inline uint8_t *tape_builder::on_start_string(json_iterator &iter) noexcept {
+  // we advance the point, accounting for the fact that we have a NULL termination
+  tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::STRING);
+  return current_string_buf_loc + sizeof(uint32_t);
+}
 
-  simdjson_really_inline void on_end_string(uint8_t *dst) noexcept {
-    uint32_t str_length = uint32_t(dst - (current_string_buf_loc + sizeof(uint32_t)));
-    // TODO check for overflow in case someone has a crazy string (>=4GB?)
-    // But only add the overflow check when the document itself exceeds 4GB
-    // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
-    memcpy(current_string_buf_loc, &str_length, sizeof(uint32_t));
-    // NULL termination is still handy if you expect all your strings to
-    // be NULL terminated? It comes at a small cost
-    *dst = 0;
-    current_string_buf_loc = dst + 1;
-  }
-}; // class tape_builder
+simdjson_really_inline void tape_builder::on_end_string(uint8_t *dst) noexcept {
+  uint32_t str_length = uint32_t(dst - (current_string_buf_loc + sizeof(uint32_t)));
+  // TODO check for overflow in case someone has a crazy string (>=4GB?)
+  // But only add the overflow check when the document itself exceeds 4GB
+  // Currently unneeded because we refuse to parse docs larger or equal to 4GB.
+  memcpy(current_string_buf_loc, &str_length, sizeof(uint32_t));
+  // NULL termination is still handy if you expect all your strings to
+  // be NULL terminated? It comes at a small cost
+  *dst = 0;
+  current_string_buf_loc = dst + 1;
+}
 
 } // namespace stage2
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -27,98 +27,98 @@ private:
 
   simdjson_really_inline tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
 
-  simdjson_really_inline error_code parse_root_primitive(structural_parser &parser, const uint8_t *value) {
+  simdjson_really_inline error_code parse_root_primitive(structural_parser &iter, const uint8_t *value) {
     switch (*value) {
-      case '"': return parse_string(parser, value);
-      case 't': return parse_root_true_atom(parser, value);
-      case 'f': return parse_root_false_atom(parser, value);
-      case 'n': return parse_root_null_atom(parser, value);
+      case '"': return parse_string(iter, value);
+      case 't': return parse_root_true_atom(iter, value);
+      case 'f': return parse_root_false_atom(iter, value);
+      case 'n': return parse_root_null_atom(iter, value);
       case '-':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9':
-        return parse_root_number(parser, value);
+        return parse_root_number(iter, value);
       default:
-        parser.log_error("Document starts with a non-value character");
+        iter.log_error("Document starts with a non-value character");
         return TAPE_ERROR;
     }
   }
-  simdjson_really_inline error_code parse_primitive(structural_parser &parser, const uint8_t *value) {
+  simdjson_really_inline error_code parse_primitive(structural_parser &iter, const uint8_t *value) {
     switch (*value) {
-      case '"': return parse_string(parser, value);
-      case 't': return parse_true_atom(parser, value);
-      case 'f': return parse_false_atom(parser, value);
-      case 'n': return parse_null_atom(parser, value);
+      case '"': return parse_string(iter, value);
+      case 't': return parse_true_atom(iter, value);
+      case 'f': return parse_false_atom(iter, value);
+      case 'n': return parse_null_atom(iter, value);
       case '-':
       case '0': case '1': case '2': case '3': case '4':
       case '5': case '6': case '7': case '8': case '9':
-        return parse_number(parser, value);
+        return parse_number(iter, value);
       default:
-        parser.log_error("Non-value found when value was expected!");
+        iter.log_error("Non-value found when value was expected!");
         return TAPE_ERROR;
     }
   }
-  simdjson_really_inline void empty_object(structural_parser &parser) {
-    parser.log_value("empty object");
-    empty_container(parser, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+  simdjson_really_inline void empty_object(structural_parser &iter) {
+    iter.log_value("empty object");
+    empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
   }
-  simdjson_really_inline void empty_array(structural_parser &parser) {
-    parser.log_value("empty array");
-    empty_container(parser, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
-  }
-
-  simdjson_really_inline void start_document(structural_parser &parser) {
-    parser.log_start_value("document");
-    start_container(parser);
-    parser.dom_parser.is_array[parser.depth] = false;
-  }
-  simdjson_really_inline void start_object(structural_parser &parser) {
-    parser.log_start_value("object");
-    start_container(parser);
-    parser.dom_parser.is_array[parser.depth] = false;
-  }
-  simdjson_really_inline void start_array(structural_parser &parser) {
-    parser.log_start_value("array");
-    start_container(parser);
-    parser.dom_parser.is_array[parser.depth] = true;
+  simdjson_really_inline void empty_array(structural_parser &iter) {
+    iter.log_value("empty array");
+    empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
   }
 
-  simdjson_really_inline void end_object(structural_parser &parser) {
-    parser.log_end_value("object");
-    end_container(parser, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+  simdjson_really_inline void start_document(structural_parser &iter) {
+    iter.log_start_value("document");
+    start_container(iter);
+    iter.dom_parser.is_array[iter.depth] = false;
   }
-  simdjson_really_inline void end_array(structural_parser &parser) {
-    parser.log_end_value("array");
-    end_container(parser, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+  simdjson_really_inline void start_object(structural_parser &iter) {
+    iter.log_start_value("object");
+    start_container(iter);
+    iter.dom_parser.is_array[iter.depth] = false;
   }
-  simdjson_really_inline void end_document(structural_parser &parser) {
-    parser.log_end_value("document");
+  simdjson_really_inline void start_array(structural_parser &iter) {
+    iter.log_start_value("array");
+    start_container(iter);
+    iter.dom_parser.is_array[iter.depth] = true;
+  }
+
+  simdjson_really_inline void end_object(structural_parser &iter) {
+    iter.log_end_value("object");
+    end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
+  }
+  simdjson_really_inline void end_array(structural_parser &iter) {
+    iter.log_end_value("array");
+    end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
+  }
+  simdjson_really_inline void end_document(structural_parser &iter) {
+    iter.log_end_value("document");
     constexpr uint32_t start_tape_index = 0;
     tape.append(start_tape_index, internal::tape_type::ROOT);
-    tape_writer::write(parser.dom_parser.doc->tape[start_tape_index], next_tape_index(parser), internal::tape_type::ROOT);
+    tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_key(structural_parser &parser, const uint8_t *value) {
-    return parse_string(parser, value, true);
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_key(structural_parser &iter, const uint8_t *value) {
+    return parse_string(iter, value, true);
   }
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_string(structural_parser &parser, const uint8_t *value, bool key = false) {
-    parser.log_value(key ? "key" : "string");
-    uint8_t *dst = on_start_string(parser);
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_string(structural_parser &iter, const uint8_t *value, bool key = false) {
+    iter.log_value(key ? "key" : "string");
+    uint8_t *dst = on_start_string(iter);
     dst = stringparsing::parse_string(value, dst);
     if (dst == nullptr) {
-      parser.log_error("Invalid escape in string");
+      iter.log_error("Invalid escape in string");
       return STRING_ERROR;
     }
     on_end_string(dst);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_number(structural_parser &parser, const uint8_t *value) {
-    parser.log_value("number");
-    if (!numberparsing::parse_number(value, tape)) { parser.log_error("Invalid number"); return NUMBER_ERROR; }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_number(structural_parser &iter, const uint8_t *value) {
+    iter.log_value("number");
+    if (!numberparsing::parse_number(value, tape)) { iter.log_error("Invalid number"); return NUMBER_ERROR; }
     return SUCCESS;
   }
 
-  simdjson_really_inline error_code parse_root_number(structural_parser &parser, const uint8_t *value) {
+  simdjson_really_inline error_code parse_root_number(structural_parser &iter, const uint8_t *value) {
     //
     // We need to make a copy to make sure that the string is space terminated.
     // This is not about padding the input, which should already padded up
@@ -132,97 +132,97 @@ private:
     // practice unless you are in the strange scenario where you have many JSON
     // documents made of single atoms.
     //
-    uint8_t *copy = static_cast<uint8_t *>(malloc(parser.remaining_len() + SIMDJSON_PADDING));
+    uint8_t *copy = static_cast<uint8_t *>(malloc(iter.remaining_len() + SIMDJSON_PADDING));
     if (copy == nullptr) {
       return MEMALLOC;
     }
-    memcpy(copy, value, parser.remaining_len());
-    memset(copy + parser.remaining_len(), ' ', SIMDJSON_PADDING);
-    error_code error = parse_number(parser, copy);
+    memcpy(copy, value, iter.remaining_len());
+    memset(copy + iter.remaining_len(), ' ', SIMDJSON_PADDING);
+    error_code error = parse_number(iter, copy);
     free(copy);
     return error;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_true_atom(structural_parser &parser, const uint8_t *value) {
-    parser.log_value("true");
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_true_atom(structural_parser &iter, const uint8_t *value) {
+    iter.log_value("true");
     if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
     tape.append(0, internal::tape_type::TRUE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_true_atom(structural_parser &parser, const uint8_t *value) {
-    parser.log_value("true");
-    if (!atomparsing::is_valid_true_atom(value, parser.remaining_len())) { return T_ATOM_ERROR; }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_true_atom(structural_parser &iter, const uint8_t *value) {
+    iter.log_value("true");
+    if (!atomparsing::is_valid_true_atom(value, iter.remaining_len())) { return T_ATOM_ERROR; }
     tape.append(0, internal::tape_type::TRUE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_false_atom(structural_parser &parser, const uint8_t *value) {
-    parser.log_value("false");
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_false_atom(structural_parser &iter, const uint8_t *value) {
+    iter.log_value("false");
     if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
     tape.append(0, internal::tape_type::FALSE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_false_atom(structural_parser &parser, const uint8_t *value) {
-    parser.log_value("false");
-    if (!atomparsing::is_valid_false_atom(value, parser.remaining_len())) { return F_ATOM_ERROR; }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_false_atom(structural_parser &iter, const uint8_t *value) {
+    iter.log_value("false");
+    if (!atomparsing::is_valid_false_atom(value, iter.remaining_len())) { return F_ATOM_ERROR; }
     tape.append(0, internal::tape_type::FALSE_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_null_atom(structural_parser &parser, const uint8_t *value) {
-    parser.log_value("null");
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_null_atom(structural_parser &iter, const uint8_t *value) {
+    iter.log_value("null");
     if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
     tape.append(0, internal::tape_type::NULL_VALUE);
     return SUCCESS;
   }
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_null_atom(structural_parser &parser, const uint8_t *value) {
-    parser.log_value("null");
-    if (!atomparsing::is_valid_null_atom(value, parser.remaining_len())) { return N_ATOM_ERROR; }
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_root_null_atom(structural_parser &iter, const uint8_t *value) {
+    iter.log_value("null");
+    if (!atomparsing::is_valid_null_atom(value, iter.remaining_len())) { return N_ATOM_ERROR; }
     tape.append(0, internal::tape_type::NULL_VALUE);
     return SUCCESS;
   }
 
   // increment_count increments the count of keys in an object or values in an array.
-  simdjson_really_inline void increment_count(structural_parser &parser) {
-    parser.dom_parser.open_containers[parser.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
+  simdjson_really_inline void increment_count(structural_parser &iter) {
+    iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
   }
 
 // private:
 
-  simdjson_really_inline uint32_t next_tape_index(structural_parser &parser) {
-    return uint32_t(tape.next_tape_loc - parser.dom_parser.doc->tape.get());
+  simdjson_really_inline uint32_t next_tape_index(structural_parser &iter) {
+    return uint32_t(tape.next_tape_loc - iter.dom_parser.doc->tape.get());
   }
 
-  simdjson_really_inline void empty_container(structural_parser &parser, internal::tape_type start, internal::tape_type end) {
-    auto start_index = next_tape_index(parser);
+  simdjson_really_inline void empty_container(structural_parser &iter, internal::tape_type start, internal::tape_type end) {
+    auto start_index = next_tape_index(iter);
     tape.append(start_index+2, start);
     tape.append(start_index, end);
   }
 
-  simdjson_really_inline void start_container(structural_parser &parser) {
-    parser.dom_parser.open_containers[parser.depth].tape_index = next_tape_index(parser);
-    parser.dom_parser.open_containers[parser.depth].count = 0;
+  simdjson_really_inline void start_container(structural_parser &iter) {
+    iter.dom_parser.open_containers[iter.depth].tape_index = next_tape_index(iter);
+    iter.dom_parser.open_containers[iter.depth].count = 0;
     tape.skip(); // We don't actually *write* the start element until the end.
   }
 
-  simdjson_really_inline void end_container(structural_parser &parser, internal::tape_type start, internal::tape_type end) noexcept {
+  simdjson_really_inline void end_container(structural_parser &iter, internal::tape_type start, internal::tape_type end) noexcept {
     // Write the ending tape element, pointing at the start location
-    const uint32_t start_tape_index = parser.dom_parser.open_containers[parser.depth].tape_index;
+    const uint32_t start_tape_index = iter.dom_parser.open_containers[iter.depth].tape_index;
     tape.append(start_tape_index, end);
     // Write the start tape element, pointing at the end location (and including count)
     // count can overflow if it exceeds 24 bits... so we saturate
     // the convention being that a cnt of 0xffffff or more is undetermined in value (>=  0xffffff).
-    const uint32_t count = parser.dom_parser.open_containers[parser.depth].count;
+    const uint32_t count = iter.dom_parser.open_containers[iter.depth].count;
     const uint32_t cntsat = count > 0xFFFFFF ? 0xFFFFFF : count;
-    tape_writer::write(parser.dom_parser.doc->tape[start_tape_index], next_tape_index(parser) | (uint64_t(cntsat) << 32), start);
+    tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter) | (uint64_t(cntsat) << 32), start);
   }
 
-  simdjson_really_inline uint8_t *on_start_string(structural_parser &parser) noexcept {
+  simdjson_really_inline uint8_t *on_start_string(structural_parser &iter) noexcept {
     // we advance the point, accounting for the fact that we have a NULL termination
-    tape.append(current_string_buf_loc - parser.dom_parser.doc->string_buf.get(), internal::tape_type::STRING);
+    tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::STRING);
     return current_string_buf_loc + sizeof(uint32_t);
   }
 

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -80,7 +80,6 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
 //
 #include "haswell/stringparsing.h"
 #include "haswell/numberparsing.h"
-#include "generic/stage2/structural_parser.h"
 #include "generic/stage2/tape_builder.h"
 
 //
@@ -112,15 +111,11 @@ SIMDJSON_WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t 
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(_doc);
-  return stage2::structural_parser::parse<false>(*this, builder);
+  return stage2::tape_builder::parse_document<false>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(_doc);
-  return stage2::structural_parser::parse<true>(*this, builder);
+  return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -4,6 +4,8 @@
 
 #include <initializer_list>
 
+#define SIMDJSON_TRY(EXPR) { auto _err = (EXPR); if (_err) { return _err; } }
+
 // Static array of known implementations. We're hoping these get baked into the executable
 // without requiring a static initializer.
 

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -81,7 +81,6 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
 //
 #include "westmere/stringparsing.h"
 #include "westmere/numberparsing.h"
-#include "generic/stage2/structural_parser.h"
 #include "generic/stage2/tape_builder.h"
 
 //
@@ -114,15 +113,11 @@ SIMDJSON_WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t 
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(*doc);
-  return stage2::structural_parser::parse<false>(*this, builder);
+  return stage2::tape_builder::parse_document<false>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2_next(dom::document &_doc) noexcept {
-  doc = &_doc;
-  stage2::tape_builder builder(_doc);
-  return stage2::structural_parser::parse<true>(*this, builder);
+  return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {


### PR DESCRIPTION
This is as far as I could push the SAX interface without affecting performance. Pretty much moving *any* line seems to be enough to hurt at least some files by 1-5% overall. 

It makes no functional changes. What it does:
* Removes structural_parser and structural_iterator, replacing them with a single, fairly thin json_iterator class. walk_document() was pretty much the only method left in structural_parser.
* Give visitor (tape_builder) methods the opportunity to return error codes
* Move more functionality into the visitor
* Make walk_document a little easier to read (IMO, we'll see what you think :))

What I *really* like, as a non-speculative benefit for our current code in particular, is the clean separation of concerns. `json_iterator` owns everything necessary to iterate (structural iteration, depth and is_array), and `tape_builder` owns everything related to parsing to tape (tape index, container indexes, and the string buffer). Hopefully it helps us when making changes.

There is a little bit of API documentation now, but it's not at full speed.

That makes it a refactor-only change though, which means performance must not suffer!

## Performance

skylake sees mixed impact, with slightly increased instruction count generally:

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |
| numbers                          |   2345 | 266.9 | 251.7 |    5% | 819.3 | 836.4 |   -2% |
| mesh                             |  11306 | 308.9 | 297.4 |    3% | 1009.0 | 1016.0 |    0% |
| marine_ik                        |  46616 | 294.5 | 285.9 |    2% | 919.6 | 921.4 |    0% |
| github_events                    |   1017 |  79.5 |  78.5 |    1% | 264.5 | 264.5 |    0% |
| random                           |   7976 | 141.6 | 139.9 |    1% | 494.6 | 494.5 |    0% |
| instruments                      |   3442 | 105.2 | 104.3 |    0% | 378.5 | 378.6 |    0% |
| update-center                    |   8330 | 112.0 | 111.4 |    0% | 335.5 | 335.5 |    0% |
| apache_builds                    |   1988 |  85.9 |  85.6 |    0% | 304.7 | 304.7 |    0% |
| mesh.pretty                      |  24646 | 179.5 | 178.9 |    0% | 592.0 | 596.0 |    0% |
| twitterescaped                   |   8787 | 184.5 | 185.9 |    0% | 489.9 | 489.9 |    0% |
| twitter                          |   9867 |  91.7 |  92.5 |    0% | 290.2 | 290.2 |    0% |
| citm_catalog                     |  26987 |  80.2 |  81.5 |   -1% | 296.3 | 296.3 |    0% |
| canada                           |  35172 | 288.8 | 294.1 |   -1% | 973.9 | 989.3 |   -1% |
| gsoc-2018                        |  51997 |  71.8 |  73.6 |   -2% | 167.0 | 167.0 |    0% |

ARM (ampere gcc10.2) is essentially unimpacted, with minute instruction count fluctuations:

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |
| marine_ik                        |  46616 | 861.4 | 859.1 |    0% | 968.3 | 966.6 |    0% |
| github_events                    |   1017 | 461.0 | 459.7 |    0% | 357.0 | 357.9 |    0% |
| numbers                          |   2345 | 888.3 | 886.9 |    0% | 873.9 | 869.7 |    0% |
| canada                           |  35172 | 811.2 | 810.3 |    0% | 996.4 | 993.2 |    0% |
| mesh                             |  11306 | 922.5 | 921.6 |    0% | 1047.7 | 1044.8 |    0% |
| apache_builds                    |   1988 | 474.3 | 473.9 |    0% | 411.5 | 412.4 |    0% |
| update-center                    |   8330 | 553.4 | 553.2 |    0% | 455.2 | 456.7 |    0% |
| gsoc-2018                        |  51997 | 359.6 | 359.9 |    0% | 237.6 | 237.9 |    0% |
| instruments                      |   3442 | 489.5 | 490.0 |    0% | 464.5 | 466.1 |    0% |
| twitterescaped                   |   8787 | 739.4 | 740.8 |    0% | 620.1 | 621.5 |    0% |
| twitter                          |   9867 | 491.0 | 491.9 |    0% | 381.9 | 383.1 |    0% |
| mesh.pretty                      |  24646 | 563.9 | 565.3 |    0% | 624.7 | 623.4 |    0% |
| citm_catalog                     |  26987 | 392.5 | 394.3 |    0% | 361.8 | 362.4 |    0% |
| random                           |   7976 | 708.8 | 714.6 |    0% | 636.1 | 638.1 |    0% |

## Things I Didn't Do

For the record, here are the things I wanted to do but couldn't find a way without hurting simdjson core performance:

* **Remove `increment_count()`.** Users should just increment when they receive a primitive() or start_array() call. But moving increment_count() in *any way* kills performance. In particular, moving [this one](https://github.com/simdjson/simdjson/pull/1101/files#diff-73e01dfaa9e28fe806176f82736d91ccR124) literally anywhere else causes a 1-9% performance drop across our test files, and that's the one that we'd really need to move because it's wedged in between several independent tasks. Given that it's basically a completely independent operation, this is super puzzling.

  ![image](https://user-images.githubusercontent.com/654882/89832401-1d8f9780-db14-11ea-8e5e-f623de32451b.png)

  More puzzling, that one can be removed entirely by setting container count to 1 when you first create the open_container in start_object(). Removing it has the same performance effect as moving it (even just removing it and changing nothing else has this effect).
* **Pass key and value together (i.e. `primitive_field(key, value)`).** This is related to the first one, actually. I'd like to keep the key around and pass it along with the value so the user can pump them both into a hashtable in one go. This is related to the first one, actually: if we could move that increment_count around, I think we could safely move key parsing straight into the `object_field` goto. That would also save us some code (at the least, there'd be one key string parsing routine instead of two!).
* **Remove STREAMING template parameter from walk_document.** There are only two statements that respect streaming, one at the beginning and one at the end. Somehow the first one, of the form `if (!STREAMING) { if (last structural == ']') { ... } }`, causes a performance drop even if you just remove `if (!STREAMING)` (a template parameter!). The if (!STREAMING) at the very end can't be moved out of the method without a performance drop, either.
* **Let user consume arrays/objects themselves.** I experimented with a `visit_value()` that is called for any value (including `{` and `[`): you would return either state::handled, state::array or state::object, and the core algorithm would branch from there. This gives you the freedom to skip or even parse specific objects yourself, allowing the tweet reader (for example) to skip all objects and arrays that don't have the stuff it needs, as well as run faster by expecting fields in a specific order instead of hashing. Those benefits are theoretical though, and depend on on-demand parsing working (it's an interplay between them), so I don't feel terrible about waiting on this one. On ARM I got a version that ran a little faster on some files, actually, but on Intel I couldn't keep it from going at least a little negative. I could have been screwed by jitters, but I don't want to chance that just now.
