### PR TITLE
SAX benchmark

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -3,8 +3,10 @@ link_libraries(simdjson-windows-headers test-data)
 
 
 if (TARGET benchmark::benchmark)
-  add_executable(bench_sax bench_sax.cpp)
-  target_link_libraries(bench_sax simdjson-internal-flags simdjson-include-source benchmark::benchmark)
+  if (SIMDJSON_IMPLEMENTATION_HASWELL)
+    add_executable(bench_sax bench_sax.cpp)
+    target_link_libraries(bench_sax simdjson-internal-flags simdjson-include-source benchmark::benchmark)
+  endif (SIMDJSON_IMPLEMENTATION_HASWELL)
 endif (TARGET benchmark::benchmark)
 
 link_libraries(simdjson simdjson-flags)

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,5 +1,13 @@
 include_directories( . linux )
-link_libraries(simdjson simdjson-flags simdjson-windows-headers test-data)
+link_libraries(simdjson-windows-headers test-data)
+
+
+if (TARGET benchmark::benchmark)
+  add_executable(bench_sax bench_sax.cpp)
+  target_link_libraries(bench_sax simdjson-internal-flags simdjson-include-source benchmark::benchmark)
+endif (TARGET benchmark::benchmark)
+
+link_libraries(simdjson simdjson-flags)
 add_executable(benchfeatures benchfeatures.cpp)
 add_executable(get_corpus_benchmark get_corpus_benchmark.cpp)
 add_executable(perfdiff perfdiff.cpp)
@@ -14,12 +22,6 @@ target_compile_definitions(parse_nonumberparsing PRIVATE SIMDJSON_SKIPNUMBERPARS
 add_executable(parse_nostringparsing parse.cpp)
 target_compile_definitions(parse_nostringparsing PRIVATE SIMDJSON_SKIPSTRINGPARSING)
 
-if (TARGET benchmark::benchmark)
-  link_libraries(benchmark::benchmark)
-  add_executable(bench_parse_call bench_parse_call.cpp)
-  add_executable(bench_dom_api bench_dom_api.cpp)
-endif()
-
 if (TARGET competition-all)
   add_executable(distinctuseridcompetition distinctuseridcompetition.cpp)
   target_link_libraries(distinctuseridcompetition competition-core)
@@ -32,6 +34,12 @@ if (TARGET competition-all)
   add_executable(allparsingcompetition parsingcompetition.cpp)
   target_link_libraries(allparsingcompetition competition-all)
   target_compile_definitions(allparsingcompetition PRIVATE ALLPARSER)
+endif()
+
+if (TARGET benchmark::benchmark)
+  link_libraries(benchmark::benchmark)
+  add_executable(bench_parse_call bench_parse_call.cpp)
+  add_executable(bench_dom_api bench_dom_api.cpp)
 endif()
 
 include(checkperf.cmake)

--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -22,7 +22,7 @@ static void recover_one_string(State& state) {
       return;
   }
   dom::element doc;
-  if (error = parser.parse(docdata).get(doc)) {
+  if ((error = parser.parse(docdata).get(doc))) {
     cerr << "could not parse string" << error << endl;
     return;
   }
@@ -48,8 +48,7 @@ static void serialize_twitter(State& state) {
       return;
   }
   // we do not want mem. alloc. in the loop.
-  error = parser.allocate(docdata.size());
-  if(error) {
+  if((error = parser.allocate(docdata.size()))) {
       cout << error << endl;
       return;
   }

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -46,6 +46,11 @@ static void sax_tweets(State &state) {
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
   state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
 }
+BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+#if SIMDJSON_EXCEPTIONS
 
 really_inline uint64_t nullable_int(dom::element element) {
   if (element.is_null()) { return 0; }
@@ -97,6 +102,11 @@ static void dom_tweets(State &state) {
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
   state.counters["tweets"] = Counter(double(num_tweets), benchmark::Counter::kIsRate);
 }
+BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+#endif // SIMDJSON_EXCEPTIONS
 
 static void dom_parse(State &state) {
   // Load twitter.json to a buffer
@@ -119,13 +129,6 @@ static void dom_parse(State &state) {
 	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
 }
-
-BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
-    return *(std::max_element(std::begin(v), std::end(v)));
-  })->DisplayAggregatesOnly(true);
-BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
-    return *(std::max_element(std::begin(v), std::end(v)));
-  })->DisplayAggregatesOnly(true);
 BENCHMARK(dom_parse)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -198,7 +198,7 @@ static void dom_parse_largerandom(State &state) {
       std::cerr << "failure: " << error << std::endl;
       throw "Parsing failed"; 
     };
-    for (auto p : simdjson::dom::array(doc)) {
+    for (auto p : doc) {
       container.emplace_back(my_point{p["x"], p["y"], p["z"]});
     }
     bytes += json.size();

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -1,0 +1,264 @@
+#define SIMDJSON_IMPLEMENTATION_FALLBACK 0
+#define SIMDJSON_IMPLEMENTATION_WESTMERE 0
+#define SIMDJSON_IMPLEMENTATION_AMD64 0
+
+#include "simdjson.h"
+#include "simdjson.cpp"
+using namespace simdjson;
+
+using namespace haswell;
+using namespace haswell::stage2;
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+
+#define KEY_IS(KEY, MATCH) (!strncmp((const char *)KEY, "\"" MATCH "\"", strlen("\"" MATCH "\"")))
+
+struct twitter_user {
+  uint64_t id{};
+  std::string_view screen_name{};
+};
+struct tweet {
+  uint64_t id{};
+  std::string_view text{};
+  std::string_view created_at{};
+  uint64_t in_reply_to_status_id{};
+  uint64_t retweet_count{};
+  uint64_t favorite_count{};
+  twitter_user user{};
+};
+struct sax_tweet_reader {
+  std::vector<tweet> tweets;
+  std::unique_ptr<uint8_t[]> string_buf;
+  size_t capacity;
+  dom_parser_implementation dom_parser;
+
+  sax_tweet_reader();
+  error_code set_capacity(size_t new_capacity);
+  error_code read_tweets(padded_string &json);
+}; // struct tweet_reader
+
+} // namespace twitter
+
+namespace twitter {
+
+struct sax_tweet_reader_visitor {
+  bool in_statuses{false};
+  bool in_user{false};
+  std::vector<tweet> &tweets;
+  uint8_t *current_string_buf_loc;
+  uint64_t *expect_int{};
+  std::string_view *expect_string{};
+
+  sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
+
+  really_inline error_code visit_document_start(json_iterator &iter);
+  really_inline error_code visit_object_start(json_iterator &iter);
+  really_inline error_code visit_key(json_iterator &iter, const uint8_t *key);
+  really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value);
+  really_inline error_code visit_array_start(json_iterator &iter);
+  really_inline error_code visit_array_end(json_iterator &iter);
+  really_inline error_code visit_object_end(json_iterator &iter);
+  really_inline error_code visit_document_end(json_iterator &iter);
+  really_inline error_code visit_empty_array(json_iterator &iter);
+  really_inline error_code visit_empty_object(json_iterator &iter);
+  really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value);
+  really_inline error_code increment_count(json_iterator &iter);
+}; // sax_tweet_reader_visitor
+
+sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {}
+
+error_code sax_tweet_reader::set_capacity(size_t new_capacity) {
+  // string_capacity copied from document::allocate
+  size_t string_capacity = ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
+  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
+  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
+  if (capacity == 0) { // set max depth the first time only
+    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
+  }
+  capacity = new_capacity;
+  return SUCCESS;
+}
+
+// NOTE: this assumes the dom_parser is already allocated
+error_code sax_tweet_reader::read_tweets(padded_string &json) {
+  // Allocate capacity if needed
+  tweets.clear();
+  if (capacity < json.size()) {
+    if (auto error = set_capacity(capacity)) { return error; }
+  }
+
+  // Run stage 1 first.
+  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
+
+  // Then walk the document, parsing the tweets as we go
+  json_iterator iter(dom_parser, 0);
+  sax_tweet_reader_visitor visitor(tweets, string_buf.get());
+  if (auto error = iter.walk_document<false>(visitor)) { return error; }
+  return SUCCESS;
+}
+
+sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf)
+  : tweets{_tweets},
+    current_string_buf_loc{string_buf} {
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
+  iter.log_start_value("document");
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
+  // iter.log_start_value("array");
+  // if we expected an int or string and got an array or object, it's an error
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
+  // iter.log_start_value("object");
+
+  // if we expected an int or string and got an array or object, it's an error
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+
+  // { "statuses": [ {
+  if (in_statuses && iter.depth == 3) {
+    iter.log_start_value("tweet");
+    tweets.push_back({});
+  }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &iter, const uint8_t *key) {
+  // iter.log_value("key");
+  if (in_statuses) {
+    switch (iter.depth) {
+      case 3: // in tweet: { "statuses": [ { <key>
+        // NOTE: the way we're comparing key (fairly naturally) means the caller doesn't have to check " for us at all
+        if (KEY_IS(key, "user")) { iter.log_start_value("user"); in_user = true; }
+
+        else if (KEY_IS(key, "id")) { iter.log_value("id"); expect_int = &tweets.back().id; }
+        else if (KEY_IS(key, "in_reply_to_status_id")) { iter.log_value("in_reply_to_status_id"); expect_int = &tweets.back().in_reply_to_status_id; }
+        else if (KEY_IS(key, "retweet_count")) { iter.log_value("retweet_count"); expect_int = &tweets.back().retweet_count; }
+        else if (KEY_IS(key, "favorite_count")) { iter.log_value("favorite_count"); expect_int = &tweets.back().favorite_count; }
+
+        else if (KEY_IS(key, "text")) { iter.log_value("text"); expect_string = &tweets.back().text; }
+        else if (KEY_IS(key, "created_at")) { iter.log_value("created_at"); expect_string = &tweets.back().created_at; }
+        break;
+      case 4:
+        if (in_user) { // in user: { "statuses": [ { "user": { <key>
+          if (KEY_IS(key, "id")) { iter.log_value("id"); expect_int = &tweets.back().user.id; }
+          else if (KEY_IS(key, "screen_name")) { iter.log_value("screen_name"); expect_string = &tweets.back().user.screen_name; }
+        }
+        break;
+      default: break;
+    }
+  } else {
+    if (iter.depth == 1 && KEY_IS(key, "statuses")) {
+      iter.log_start_value("statuses");
+      in_statuses = true;
+    }
+  }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
+  // iter.log_value("primitive");
+  if (expect_int) {
+    iter.log_value("int");
+    if (auto error = numberparsing::parse_unsigned(value).get(*expect_int)) {
+      // If number parsing failed, check if it's null before returning the error
+      if (!atomparsing::is_valid_null_atom(value)) { iter.log_error("expected number or null"); return error; }
+    }
+    expect_int = nullptr;
+  } else if (expect_string) {
+    iter.log_value("string");
+    // Must be a string!
+    if (value[0] != '"') { iter.log_error("expected string"); return STRING_ERROR; }
+    auto end = stringparsing::parse_string(value, current_string_buf_loc);
+    if (!end) { iter.log_error("error parsing string"); return STRING_ERROR; }
+    *expect_string = std::string_view((const char *)current_string_buf_loc, end-current_string_buf_loc);
+    current_string_buf_loc = end;
+    expect_string = nullptr;
+  }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
+  // iter.log_end_value("array");
+  // When we hit the end of { "statuses": [ ... ], we're done with statuses.
+  if (in_statuses && iter.depth == 2) { iter.log_end_value("statuses"); in_statuses = false; }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
+  // iter.log_end_value("object");
+  // When we hit the end of { "statuses": [ { "user": { ... }, we're done with the user
+  if (in_user && iter.depth == 4) { iter.log_end_value("user"); in_user = false; }
+  if (in_statuses && iter.depth == 3) { iter.log_end_value("tweet"); }
+  return SUCCESS;
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &iter) {
+  iter.log_end_value("document");
+  return SUCCESS;
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &iter) {
+  // if we expected an int or string and got an array or object, it's an error
+  // iter.log_value("empty array");
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &iter) {
+  // if we expected an int or string and got an array or object, it's an error
+  // iter.log_value("empty object");
+  if (expect_int || expect_string) { iter.log_error("expected int/string"); return TAPE_ERROR; }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
+  // iter.log_value("root primitive");
+  iter.log_error("unexpected root primitive");
+  return TAPE_ERROR;
+}
+
+really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
+
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+
+SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
+#include <benchmark/benchmark.h>
+SIMDJSON_POP_DISABLE_WARNINGS
+
+using namespace benchmark;
+using namespace std;
+
+const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+
+static void sax_tweets(State& state) {
+  // Load twitter.json to a buffer
+  padded_string json;
+  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
+
+  // Allocate
+  twitter::sax_tweet_reader reader;
+  if (auto error = reader.set_capacity(json.size())) { cerr << error << endl; return; }
+
+  // Make the tweet_reader
+  size_t bytes = 0;
+  size_t tweets = 0;
+  for (UNUSED auto _ : state) {
+    if (auto error = reader.read_tweets(json)) { throw error; }
+    bytes += json.size();
+    tweets += reader.tweets.size();
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+  state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
+}
+BENCHMARK(sax_tweets)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+BENCHMARK_MAIN();

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -334,24 +334,24 @@ really_inline uint8_t sax_tweet_reader_visitor::field_lookup::hash(const char * 
   // actually care about.
   return uint8_t((key[0] << 0) ^ (key[1] << 3) ^ (key[2] << 3) ^ (key[3] << 1) ^ depth);
 }
-really_inline sax_tweet_reader_visitor::field sax_tweet_reader_visitor::field_lookup::get(const uint8_t * key, containers container) {
-  auto index = hash((const char *)key, uint32_t(container));
+really_inline sax_tweet_reader_visitor::field sax_tweet_reader_visitor::field_lookup::get(const uint8_t * key, containers c) {
+  auto index = hash((const char *)key, uint32_t(c));
   auto entry = entries[index];
   // TODO if any key is > SIMDJSON_PADDING, this will access inaccessible memory!
-  if (container != entry.container || memcmp(key, entry.key, entry.len)) { return entries[0]; }
+  if (c != entry.container || memcmp(key, entry.key, entry.len)) { return entries[0]; }
   return entry;
 }
-really_inline void sax_tweet_reader_visitor::field_lookup::add(const char * key, size_t len, containers container, field_type type, size_t offset) {
-  auto index = hash(key, uint32_t(container));
+really_inline void sax_tweet_reader_visitor::field_lookup::add(const char * key, size_t len, containers c, field_type type, size_t offset) {
+  auto index = hash(key, uint32_t(c));
   if (index == 0) {
-    fprintf(stderr, "%s (depth %d) hashes to zero, which is used as 'missing value'\n", key, int(container));
+    fprintf(stderr, "%s (depth %d) hashes to zero, which is used as 'missing value'\n", key, int(c));
     assert(false);
   }
   if (entries[index].key) {
-    fprintf(stderr, "%s (depth %d) collides with %s (depth %d) !\n", key, int(container), entries[index].key, int(entries[index].container));
+    fprintf(stderr, "%s (depth %d) collides with %s (depth %d) !\n", key, int(c), entries[index].key, int(entries[index].container));
     assert(false);
   }
-  entries[index] = { key, len, offset, container, type };
+  entries[index] = { key, len, offset, c, type };
 }
 really_inline void sax_tweet_reader_visitor::field_lookup::neg(const char * const key, uint32_t depth) {
   auto index = hash(key, depth);
@@ -587,7 +587,8 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 SIMDJSON_POP_DISABLE_WARNINGS
 
 using namespace benchmark;
-using namespace std;
+using std::cerr;
+using std::endl;
 
 const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
 const int REPETITIONS = 10;

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -42,27 +42,7 @@ struct sax_tweet_reader {
 namespace twitter {
 
 struct sax_tweet_reader_visitor {
-  // Since we only care about one thing at each level, we just use depth as the marker for what
-  // object/array we're nested inside.
-  enum class containers {
-    DOCUMENT = 0,   //
-    TOP_OBJECT = 1, // {
-    STATUSES = 2,   // { "statuses": [
-    TWEET = 3,      // { "statuses": [ {
-    USER = 4        // { "statuses": [ { "user": {
-  };
-  static constexpr const char *STATE_NAMES[] = {
-    "document",
-    "top object",
-    "statuses",
-    "tweet",
-    "user"
-  };
-
-  containers container{containers::DOCUMENT};
-  std::vector<tweet> &tweets;
-  uint8_t *current_string_buf_loc;
-  const uint8_t *current_key{};
+public:
   sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
 
   really_inline error_code visit_document_start(json_iterator &iter);
@@ -79,16 +59,71 @@ struct sax_tweet_reader_visitor {
   really_inline error_code increment_count(json_iterator &iter);
 
 private:
+  // Since we only care about one thing at each level, we just use depth as the marker for what
+  // object/array we're nested inside.
+  enum class containers {
+    document = 0,   //
+    top_object = 1, // {
+    statuses = 2,   // { "statuses": [
+    tweet = 3,      // { "statuses": [ {
+    user = 4        // { "statuses": [ { "user": {
+  };
+  /**
+   * The largest depth we care about.
+   * There can be things at lower depths.
+   */
+  static constexpr uint32_t MAX_SUPPORTED_DEPTH = uint32_t(containers::user);
+  static constexpr const char *STATE_NAMES[] = {
+    "document",
+    "top object",
+    "statuses",
+    "tweet",
+    "user"
+  };
+  enum class field_type {
+    any,
+    unsigned_integer,
+    string,
+    nullable_unsigned_integer,
+    object,
+    array
+  };
+  struct field {
+    const char * key{};
+    size_t len{0};
+    size_t offset;
+    containers container{containers::document};
+    field_type type{field_type::any};
+  };
+
+  containers container{containers::document};
+  std::vector<tweet> &tweets;
+  uint8_t *current_string_buf_loc;
+  const uint8_t *current_key{};
+
   really_inline bool in_container(json_iterator &iter);
   really_inline bool in_container_child(json_iterator &iter);
-  really_inline void start_container(json_iterator &iter, containers expected_container);
+  really_inline void start_container(json_iterator &iter);
   really_inline void end_container(json_iterator &iter);
-  really_inline error_code parse_nullable_unsigned(json_iterator &iter, uint64_t &i, const uint8_t *value, const char *name);
-  really_inline error_code parse_unsigned(json_iterator &iter, uint64_t &i, const uint8_t *value, const char *name);
-  really_inline error_code parse_string(json_iterator &iter, std::string_view &s, const uint8_t *value, const char *name);
+  really_inline error_code parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
+  really_inline error_code parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
+  really_inline error_code parse_string(json_iterator &iter, const uint8_t *value, const field &f);
+
+  struct field_lookup {
+    field entries[256]{};
+
+    field_lookup();
+    really_inline field get(const uint8_t * key, containers container);
+  private:
+    really_inline uint8_t hash(const char * key, uint32_t depth);
+    really_inline void add(const char * key, size_t len, containers container, field_type type, size_t offset);
+    really_inline void neg(const char * const key, uint32_t depth);
+  };
+  static field_lookup fields;
 }; // sax_tweet_reader_visitor
 
-sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {}
+sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {
+}
 
 error_code sax_tweet_reader::set_capacity(size_t new_capacity) {
   // string_capacity copied from document::allocate
@@ -128,72 +163,106 @@ sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, 
 }
 
 really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
-  start_container(iter, containers::DOCUMENT);
+  start_container(iter);
   return SUCCESS;
 }
 really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
   iter.dom_parser.is_array[iter.depth] = true;
-  if (in_container_child(iter)) {
-    switch (container) {
-      case containers::TOP_OBJECT: if (KEY_IS("statuses")) { start_container(iter, containers::STATUSES); } break;
 
-      case containers::DOCUMENT: return INCORRECT_TYPE; // Must be an object
-      case containers::STATUSES:
-      case containers::TWEET:
-      case containers::USER:
-        // TODO check for the wrong types for things so we don't skip bad documents!
-        break;
+  // If we're not in a container we care about, don't bother with the rest
+  if (!in_container_child(iter)) { return SUCCESS; }
+
+  // Handle fields first
+  if (current_key) {
+    switch (fields.get(current_key, container).type) {
+      case field_type::array: // { "statuses": [
+        start_container(iter);
+        return SUCCESS;
+      case field_type::any:
+        return SUCCESS;
+      case field_type::object:
+      case field_type::unsigned_integer:
+      case field_type::nullable_unsigned_integer:
+      case field_type::string:
+        iter.log_error("unexpected array field");
+        return INCORRECT_TYPE;
     }
   }
-  return SUCCESS;
+
+  // We're not in a field, so it must be a child of an array. We support any of those.
+  iter.log_error("unexpected array");
+  return INCORRECT_TYPE;
 }
 really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
   // iter.log_start_value("object");
   iter.dom_parser.is_array[iter.depth] = false;
-  if (in_container_child(iter)) {
-    switch (container) {
-      case containers::DOCUMENT: start_container(iter, containers::TOP_OBJECT); break;
-      case containers::STATUSES: start_container(iter, containers::TWEET); tweets.push_back({}); break;
-      case containers::TWEET:    if (KEY_IS("user")) { start_container(iter, containers::USER); }; break;
 
-      case containers::TOP_OBJECT:
-      case containers::USER:
-        break;
+  // If we're not in a container we care about, don't bother with the rest
+  if (!in_container_child(iter)) { return SUCCESS; }
+
+  // Handle known fields
+  if (current_key) {
+    auto f = fields.get(current_key, container);
+    switch (f.type) {
+      case field_type::object: // { "statuses": [ { "user": {
+        start_container(iter);
+        return SUCCESS;
+      case field_type::any:
+        return SUCCESS;
+      case field_type::array:
+      case field_type::unsigned_integer:
+      case field_type::nullable_unsigned_integer:
+      case field_type::string:
+        iter.log_error("unexpected object field");
+        return INCORRECT_TYPE;
     }
   }
-  return SUCCESS;
+
+  // It's not a field, so it's a child of an array or document
+  switch (container) {
+    case containers::document: // top_object: {
+    case containers::statuses: // tweet:      { "statuses": [ {
+      start_container(iter);
+      return SUCCESS;
+    case containers::top_object:
+    case containers::tweet:
+    case containers::user:
+      iter.log_error("unexpected object");
+      return INCORRECT_TYPE;
+  }
+  SIMDJSON_UNREACHABLE();
 }
 really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &, const uint8_t *key) {
   current_key = key;
   return SUCCESS;
 }
 really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
-  if (in_container(iter)) {
-    switch (container) {
-      case containers::TWEET:
-        // If this a field of the tweet itself and not a child like metadata, check the fields.
-        // PERF TODO improve branch prediction with a hash and table lookup--first 4 characters can
-        // be done unconditionally and are unique ("id" is 4 characters)
-        if (KEY_IS("id"))             { return parse_unsigned (iter, tweets.back().id,               value, "id"); }
-        if (KEY_IS("in_reply_to_status_id")) { return parse_nullable_unsigned(iter, tweets.back().in_reply_to_status_id, value, "in_reply_to_status_id"); }
-        if (KEY_IS("retweet_count"))  { return parse_unsigned (iter, tweets.back().retweet_count,    value, "retweet_count"); }
-        if (KEY_IS("favorite_count")) { return parse_unsigned (iter, tweets.back().favorite_count,   value, "favorite_count"); }
-        if (KEY_IS("text"))           { return parse_string   (iter, tweets.back().text,             value, "text"); }
-        if (KEY_IS("created_at"))     { return parse_string   (iter, tweets.back().created_at,       value, "created_at"); }
-        break;
-      case containers::USER:
-        // If this a field of the tweet itself and not a child like metadata, check the fields.
-        if (KEY_IS("id"))             { return parse_unsigned (iter, tweets.back().user.id,          value, "id"); }
-        if (KEY_IS("screen_name"))    { return parse_string   (iter, tweets.back().user.screen_name, value, "screen_name"); }
-        break;
-      case containers::DOCUMENT: // root_primitive would be called if it was a document primitive
-      case containers::TOP_OBJECT:
-      case containers::STATUSES:
-        SIMDJSON_UNREACHABLE(); // We can only be in a container if it was already marked an array
-        break;
+  // Don't bother unless we're in a container we care about
+  if (!in_container(iter)) { return SUCCESS; }
+
+  // Handle fields first
+  if (current_key) {
+    auto f = fields.get(current_key, container);
+    switch (f.type) {
+      case field_type::unsigned_integer:
+        return parse_unsigned(iter, value, f);
+      case field_type::nullable_unsigned_integer:
+        return parse_nullable_unsigned(iter, value, f);
+      case field_type::string:
+        return parse_string(iter, value, f);
+      case field_type::any:
+        return SUCCESS;
+      case field_type::array:
+      case field_type::object:
+        iter.log_error("unexpected primitive");
+        return INCORRECT_TYPE;
     }
   }
-  return SUCCESS;
+
+  // If it's not a field, it's a child of an array.
+  // The only array we support is statuses, which must contain objects.
+  iter.log_error("unexpected primitive");
+  return INCORRECT_TYPE;
 }
 really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
   if (in_container(iter)) { end_container(iter); }
@@ -227,32 +296,284 @@ really_inline bool sax_tweet_reader_visitor::in_container(json_iterator &iter) {
 really_inline bool sax_tweet_reader_visitor::in_container_child(json_iterator &iter) {
   return iter.depth == uint32_t(container) + 1;
 }
-really_inline void sax_tweet_reader_visitor::start_container(json_iterator &iter, containers expected_container) {
-  SIMDJSON_ASSUME(uint32_t(expected_container) == iter.depth); // Asserts in debug mode
-  container = expected_container;
-  if (logger::LOG_ENABLED) { iter.log_start_value(STATE_NAMES[int(expected_container)]); }
+really_inline void sax_tweet_reader_visitor::start_container(json_iterator &iter) {
+  SIMDJSON_ASSUME(iter.depth <= MAX_SUPPORTED_DEPTH); // Asserts in debug mode
+  container = containers(iter.depth);
+  if (logger::LOG_ENABLED) { iter.log_start_value(STATE_NAMES[iter.depth]); }
 }
 really_inline void sax_tweet_reader_visitor::end_container(json_iterator &iter) {
   if (logger::LOG_ENABLED) { iter.log_end_value(STATE_NAMES[int(container)]); }
   container = containers(int(container) - 1);
 }
-really_inline error_code sax_tweet_reader_visitor::parse_nullable_unsigned(json_iterator &iter, uint64_t &i, const uint8_t *value, const char *name) {
-  iter.log_value(name);
-  if (auto error = numberparsing::parse_unsigned(value).get(i)) {
+really_inline error_code sax_tweet_reader_visitor::parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  if (auto error = numberparsing::parse_unsigned(value).get(*i)) {
     // If number parsing failed, check if it's null before returning the error
     if (!atomparsing::is_valid_null_atom(value)) { iter.log_error("expected number or null"); return error; }
     i = 0;
   }
   return SUCCESS;
 }
-really_inline error_code sax_tweet_reader_visitor::parse_unsigned(json_iterator &iter, uint64_t &i, const uint8_t *value, const char *name) {
-  iter.log_value(name);
-  return numberparsing::parse_unsigned(value).get(i);
+really_inline error_code sax_tweet_reader_visitor::parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  return numberparsing::parse_unsigned(value).get(*i);
 }
-really_inline error_code sax_tweet_reader_visitor::parse_string(json_iterator &iter, std::string_view &s, const uint8_t *value, const char *name) {
-  iter.log_value(name);
-  return stringparsing::parse_string_to_buffer(value, current_string_buf_loc, s);
+really_inline error_code sax_tweet_reader_visitor::parse_string(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto s = reinterpret_cast<std::string_view *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  return stringparsing::parse_string_to_buffer(value, current_string_buf_loc, *s);
 }
+
+sax_tweet_reader_visitor::field_lookup sax_tweet_reader_visitor::fields{};
+
+really_inline uint8_t sax_tweet_reader_visitor::field_lookup::hash(const char * key, uint32_t depth) {
+  // These shift numbers were chosen specifically because this yields only 2 collisions between
+  // keys in twitter.json, leaves 0 as a distinct value, and has 0 collisions between keys we
+  // actually care about.
+  return uint8_t((key[0] << 0) ^ (key[1] << 3) ^ (key[2] << 3) ^ (key[3] << 1) ^ depth);
+}
+really_inline sax_tweet_reader_visitor::field sax_tweet_reader_visitor::field_lookup::get(const uint8_t * key, containers container) {
+  auto index = hash((const char *)key, uint32_t(container));
+  auto entry = entries[index];
+  // TODO if any key is > SIMDJSON_PADDING, this will access inaccessible memory!
+  if (container != entry.container || memcmp(key, entry.key, entry.len)) { return entries[0]; }
+  return entry;
+}
+really_inline void sax_tweet_reader_visitor::field_lookup::add(const char * key, size_t len, containers container, field_type type, size_t offset) {
+  auto index = hash(key, uint32_t(container));
+  if (index == 0) {
+    fprintf(stderr, "%s (depth %d) hashes to zero, which is used as 'missing value'\n", key, int(container));
+    assert(false);
+  }
+  if (entries[index].key) {
+    fprintf(stderr, "%s (depth %d) collides with %s (depth %d) !\n", key, int(container), entries[index].key, int(entries[index].container));
+    assert(false);
+  }
+  entries[index] = { key, len, offset, container, type };
+}
+really_inline void sax_tweet_reader_visitor::field_lookup::neg(const char * const key, uint32_t depth) {
+  auto index = hash(key, depth);
+  if (entries[index].key) {
+    fprintf(stderr, "%s (depth %d) conflicts with %s (depth %d) !\n", key, depth, entries[index].key, int(entries[index].container));
+    assert(false);
+  }
+}
+
+sax_tweet_reader_visitor::field_lookup::field_lookup() {
+  #define ADD(key, container, type, offset) add("\"" #key "\"", strlen("\"" #key "\""), container, type, offset);
+  ADD(statuses, containers::top_object, field_type::array, 0);
+  ADD(id, containers::tweet, field_type::unsigned_integer, offsetof(tweet, id));
+  ADD(in_reply_to_status_id, containers::tweet, field_type::nullable_unsigned_integer, offsetof(tweet, in_reply_to_status_id));
+  ADD(retweet_count, containers::tweet, field_type::unsigned_integer, offsetof(tweet, retweet_count));
+  ADD(favorite_count, containers::tweet, field_type::unsigned_integer, offsetof(tweet, favorite_count));
+  ADD(text, containers::tweet, field_type::string, offsetof(tweet, text));
+  ADD(created_at, containers::tweet, field_type::string, offsetof(tweet, created_at)); // TODO this could be more constrainted
+  ADD(user, containers::tweet, field_type::object, offsetof(tweet, user));
+  ADD(id, containers::user, field_type::unsigned_integer, offsetof(tweet, user)+offsetof(twitter_user, id));
+  ADD(screen_name, containers::user, field_type::string, offsetof(tweet, user)+offsetof(twitter_user, screen_name));
+  #undef ADD
+
+  #define NEG(key, depth) neg("\"" #key "\"", depth);
+  NEG(display_url, 9);
+  NEG(expanded_url, 9);
+  neg("\"h\":", 9);
+  NEG(indices, 9);
+  NEG(resize, 9);
+  NEG(url, 9);
+  neg("\"w\":", 9);
+  NEG(display_url, 8);
+  NEG(expanded_url, 8);
+  neg("\"h\":", 8);
+  NEG(indices, 8);
+  NEG(large, 8);
+  NEG(medium, 8);
+  NEG(resize, 8);
+  NEG(small, 8);
+  NEG(thumb, 8);
+  NEG(url, 8);
+  neg("\"w\":", 8);
+  NEG(display_url, 7);
+  NEG(expanded_url, 7);
+  NEG(id_str, 7);
+  NEG(id, 7);
+  NEG(indices, 7);
+  NEG(large, 7);
+  NEG(media_url_https, 7);
+  NEG(media_url, 7);
+  NEG(medium, 7);
+  NEG(name, 7);
+  NEG(sizes, 7);
+  NEG(small, 7);
+  NEG(source_status_id_str, 7);
+  NEG(source_status_id, 7);
+  NEG(thumb, 7);
+  NEG(type, 7);
+  NEG(url, 7);
+  NEG(urls, 7);
+  NEG(description, 6);
+  NEG(display_url, 6);
+  NEG(expanded_url, 6);
+  NEG(id_str, 6);
+  NEG(id, 6);
+  NEG(indices, 6);
+  NEG(media_url_https, 6);
+  NEG(media_url, 6);
+  NEG(name, 6);
+  NEG(sizes, 6);
+  NEG(source_status_id_str, 6);
+  NEG(source_status_id, 6);
+  NEG(type, 6);
+  NEG(url, 6);
+  NEG(urls, 6);
+  NEG(contributors_enabled, 5);
+  NEG(default_profile_image, 5);
+  NEG(default_profile, 5);
+  NEG(description, 5);
+  NEG(entities, 5);
+  NEG(favourites_count, 5);
+  NEG(follow_request_sent, 5);
+  NEG(followers_count, 5);
+  NEG(following, 5);
+  NEG(friends_count, 5);
+  NEG(geo_enabled, 5);
+  NEG(hashtags, 5);
+  NEG(id_str, 5);
+  NEG(id, 5);
+  NEG(is_translation_enabled, 5);
+  NEG(is_translator, 5);
+  NEG(iso_language_code, 5);
+  NEG(lang, 5);
+  NEG(listed_count, 5);
+  NEG(location, 5);
+  NEG(media, 5);
+  NEG(name, 5);
+  NEG(notifications, 5);
+  NEG(profile_background_color, 5);
+  NEG(profile_background_image_url_https, 5);
+  NEG(profile_background_image_url, 5);
+  NEG(profile_background_tile, 5);
+  NEG(profile_banner_url, 5);
+  NEG(profile_image_url_https, 5);
+  NEG(profile_image_url, 5);
+  NEG(profile_link_color, 5);
+  NEG(profile_sidebar_border_color, 5);
+  NEG(profile_sidebar_fill_color, 5);
+  NEG(profile_text_color, 5);
+  NEG(profile_use_background_image, 5);
+  NEG(protected, 5);
+  NEG(result_type, 5);
+  NEG(statuses_count, 5);
+  NEG(symbols, 5);
+  NEG(time_zone, 5);
+  NEG(url, 5);
+  NEG(urls, 5);
+  NEG(user_mentions, 5);
+  NEG(utc_offset, 5);
+  NEG(verified, 5);
+  NEG(contributors_enabled, 4);
+  NEG(contributors, 4);
+  NEG(coordinates, 4);
+  NEG(default_profile_image, 4);
+  NEG(default_profile, 4);
+  NEG(description, 4);
+  NEG(entities, 4);
+  NEG(favorited, 4);
+  NEG(favourites_count, 4);
+  NEG(follow_request_sent, 4);
+  NEG(followers_count, 4);
+  NEG(following, 4);
+  NEG(friends_count, 4);
+  NEG(geo_enabled, 4);
+  NEG(geo, 4);
+  NEG(hashtags, 4);
+  NEG(id_str, 4);
+  NEG(in_reply_to_screen_name, 4);
+  NEG(in_reply_to_status_id_str, 4);
+  NEG(in_reply_to_user_id_str, 4);
+  NEG(in_reply_to_user_id, 4);
+  NEG(is_translation_enabled, 4);
+  NEG(is_translator, 4);
+  NEG(iso_language_code, 4);
+  NEG(lang, 4);
+  NEG(listed_count, 4);
+  NEG(location, 4);
+  NEG(media, 4);
+  NEG(metadata, 4);
+  NEG(name, 4);
+  NEG(notifications, 4);
+  NEG(place, 4);
+  NEG(possibly_sensitive, 4);
+  NEG(profile_background_color, 4);
+  NEG(profile_background_image_url_https, 4);
+  NEG(profile_background_image_url, 4);
+  NEG(profile_background_tile, 4);
+  NEG(profile_banner_url, 4);
+  NEG(profile_image_url_https, 4);
+  NEG(profile_image_url, 4);
+  NEG(profile_link_color, 4);
+  NEG(profile_sidebar_border_color, 4);
+  NEG(profile_sidebar_fill_color, 4);
+  NEG(profile_text_color, 4);
+  NEG(profile_use_background_image, 4);
+  NEG(protected, 4);
+  NEG(result_type, 4);
+  NEG(retweeted, 4);
+  NEG(source, 4);
+  NEG(statuses_count, 4);
+  NEG(symbols, 4);
+  NEG(time_zone, 4);
+  NEG(truncated, 4);
+  NEG(url, 4);
+  NEG(urls, 4);
+  NEG(user_mentions, 4);
+  NEG(utc_offset, 4);
+  NEG(verified, 4);
+  NEG(contributors, 3);
+  NEG(coordinates, 3);
+  NEG(entities, 3);
+  NEG(favorited, 3);
+  NEG(geo, 3);
+  NEG(id_str, 3);
+  NEG(in_reply_to_screen_name, 3);
+  NEG(in_reply_to_status_id_str, 3);
+  NEG(in_reply_to_user_id_str, 3);
+  NEG(in_reply_to_user_id, 3);
+  NEG(lang, 3);
+  NEG(metadata, 3);
+  NEG(place, 3);
+  NEG(possibly_sensitive, 3);
+  NEG(retweeted_status, 3);
+  NEG(retweeted, 3);
+  NEG(source, 3);
+  NEG(truncated, 3);
+  NEG(completed_in, 2);
+  NEG(count, 2);
+  NEG(max_id_str, 2);
+  NEG(max_id, 2);
+  NEG(next_results, 2);
+  NEG(query, 2);
+  NEG(refresh_url, 2);
+  NEG(since_id_str, 2);
+  NEG(since_id, 2);
+  NEG(search_metadata, 1);
+  #undef NEG
+}
+
+// sax_tweet_reader_visitor::field_lookup::find_min() {
+//   int min_count = 100000;
+//   for (int a=0;a<4;a++) {
+//     for (int b=0;b<4;b++) {
+//       for (int c=0;c<4;c++) {
+//         twitter::sax_tweet_reader_visitor::field_lookup fields(a,b,c);
+//         if (fields.collision_count) { continue; }
+//         if (fields.zero_emission) { continue; }
+//         if (fields.conflict_count < min_count) { printf("min=%d,%d,%d (%d)", a, b, c, fields.conflict_count); }
+//       }
+//     }
+//   }
+// }
 
 #undef KEY_IS
 

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -3,619 +3,21 @@
 #define SIMDJSON_IMPLEMENTATION_AMD64 0
 
 #include "simdjson.h"
-#include "simdjson.cpp"
-using namespace simdjson;
-
-using namespace haswell;
-using namespace haswell::stage2;
-
-SIMDJSON_TARGET_HASWELL
-
-namespace twitter {
-
-struct twitter_user {
-  uint64_t id{};
-  std::string_view screen_name{};
-};
-struct tweet {
-  uint64_t id{};
-  std::string_view text{};
-  std::string_view created_at{};
-  uint64_t in_reply_to_status_id{};
-  uint64_t retweet_count{};
-  uint64_t favorite_count{};
-  twitter_user user{};
-};
-struct sax_tweet_reader {
-  std::vector<tweet> tweets;
-  std::unique_ptr<uint8_t[]> string_buf;
-  size_t capacity;
-  dom_parser_implementation dom_parser;
-
-  sax_tweet_reader();
-  error_code set_capacity(size_t new_capacity);
-  error_code read_tweets(padded_string &json);
-}; // struct tweet_reader
-
-} // namespace twitter
-
-namespace twitter {
-
-struct sax_tweet_reader_visitor {
-public:
-  sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
-
-  really_inline error_code visit_document_start(json_iterator &iter);
-  really_inline error_code visit_object_start(json_iterator &iter);
-  really_inline error_code visit_key(json_iterator &iter, const uint8_t *key);
-  really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value);
-  really_inline error_code visit_array_start(json_iterator &iter);
-  really_inline error_code visit_array_end(json_iterator &iter);
-  really_inline error_code visit_object_end(json_iterator &iter);
-  really_inline error_code visit_document_end(json_iterator &iter);
-  really_inline error_code visit_empty_array(json_iterator &iter);
-  really_inline error_code visit_empty_object(json_iterator &iter);
-  really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value);
-  really_inline error_code increment_count(json_iterator &iter);
-
-private:
-  // Since we only care about one thing at each level, we just use depth as the marker for what
-  // object/array we're nested inside.
-  enum class containers {
-    document = 0,   //
-    top_object = 1, // {
-    statuses = 2,   // { "statuses": [
-    tweet = 3,      // { "statuses": [ {
-    user = 4        // { "statuses": [ { "user": {
-  };
-  /**
-   * The largest depth we care about.
-   * There can be things at lower depths.
-   */
-  static constexpr uint32_t MAX_SUPPORTED_DEPTH = uint32_t(containers::user);
-  static constexpr const char *STATE_NAMES[] = {
-    "document",
-    "top object",
-    "statuses",
-    "tweet",
-    "user"
-  };
-  enum class field_type {
-    any,
-    unsigned_integer,
-    string,
-    nullable_unsigned_integer,
-    object,
-    array
-  };
-  struct field {
-    const char * key{};
-    size_t len{0};
-    size_t offset;
-    containers container{containers::document};
-    field_type type{field_type::any};
-  };
-
-  containers container{containers::document};
-  std::vector<tweet> &tweets;
-  uint8_t *current_string_buf_loc;
-  const uint8_t *current_key{};
-
-  really_inline bool in_container(json_iterator &iter);
-  really_inline bool in_container_child(json_iterator &iter);
-  really_inline void start_container(json_iterator &iter);
-  really_inline void end_container(json_iterator &iter);
-  really_inline error_code parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
-  really_inline error_code parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
-  really_inline error_code parse_string(json_iterator &iter, const uint8_t *value, const field &f);
-
-  struct field_lookup {
-    field entries[256]{};
-
-    field_lookup();
-    really_inline field get(const uint8_t * key, containers container);
-  private:
-    really_inline uint8_t hash(const char * key, uint32_t depth);
-    really_inline void add(const char * key, size_t len, containers container, field_type type, size_t offset);
-    really_inline void neg(const char * const key, uint32_t depth);
-  };
-  static field_lookup fields;
-}; // sax_tweet_reader_visitor
-
-sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {
-}
-
-error_code sax_tweet_reader::set_capacity(size_t new_capacity) {
-  // string_capacity copied from document::allocate
-  size_t string_capacity = ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
-  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
-  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
-  if (capacity == 0) { // set max depth the first time only
-    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
-  }
-  capacity = new_capacity;
-  return SUCCESS;
-}
-
-// NOTE: this assumes the dom_parser is already allocated
-error_code sax_tweet_reader::read_tweets(padded_string &json) {
-  // Allocate capacity if needed
-  tweets.clear();
-  if (capacity < json.size()) {
-    if (auto error = set_capacity(capacity)) { return error; }
-  }
-
-  // Run stage 1 first.
-  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
-
-  // Then walk the document, parsing the tweets as we go
-  json_iterator iter(dom_parser, 0);
-  sax_tweet_reader_visitor visitor(tweets, string_buf.get());
-  if (auto error = iter.walk_document<false>(visitor)) { return error; }
-  return SUCCESS;
-}
-
-#define KEY_IS(MATCH) (!strncmp((const char *)current_key, "\"" MATCH "\"", strlen("\"" MATCH "\"")))
-
-sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf)
-  : tweets{_tweets},
-    current_string_buf_loc{string_buf} {
-}
-
-really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
-  start_container(iter);
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
-  iter.dom_parser.is_array[iter.depth] = true;
-
-  // If we're not in a container we care about, don't bother with the rest
-  if (!in_container_child(iter)) { return SUCCESS; }
-
-  // Handle fields first
-  if (current_key) {
-    switch (fields.get(current_key, container).type) {
-      case field_type::array: // { "statuses": [
-        start_container(iter);
-        return SUCCESS;
-      case field_type::any:
-        return SUCCESS;
-      case field_type::object:
-      case field_type::unsigned_integer:
-      case field_type::nullable_unsigned_integer:
-      case field_type::string:
-        iter.log_error("unexpected array field");
-        return INCORRECT_TYPE;
-    }
-  }
-
-  // We're not in a field, so it must be a child of an array. We support any of those.
-  iter.log_error("unexpected array");
-  return INCORRECT_TYPE;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
-  // iter.log_start_value("object");
-  iter.dom_parser.is_array[iter.depth] = false;
-
-  // If we're not in a container we care about, don't bother with the rest
-  if (!in_container_child(iter)) { return SUCCESS; }
-
-  // Handle known fields
-  if (current_key) {
-    auto f = fields.get(current_key, container);
-    switch (f.type) {
-      case field_type::object: // { "statuses": [ { "user": {
-        start_container(iter);
-        return SUCCESS;
-      case field_type::any:
-        return SUCCESS;
-      case field_type::array:
-      case field_type::unsigned_integer:
-      case field_type::nullable_unsigned_integer:
-      case field_type::string:
-        iter.log_error("unexpected object field");
-        return INCORRECT_TYPE;
-    }
-  }
-
-  // It's not a field, so it's a child of an array or document
-  switch (container) {
-    case containers::document: // top_object: {
-    case containers::statuses: // tweet:      { "statuses": [ {
-      start_container(iter);
-      return SUCCESS;
-    case containers::top_object:
-    case containers::tweet:
-    case containers::user:
-      iter.log_error("unexpected object");
-      return INCORRECT_TYPE;
-  }
-  SIMDJSON_UNREACHABLE();
-}
-really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &, const uint8_t *key) {
-  current_key = key;
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
-  // Don't bother unless we're in a container we care about
-  if (!in_container(iter)) { return SUCCESS; }
-
-  // Handle fields first
-  if (current_key) {
-    auto f = fields.get(current_key, container);
-    switch (f.type) {
-      case field_type::unsigned_integer:
-        return parse_unsigned(iter, value, f);
-      case field_type::nullable_unsigned_integer:
-        return parse_nullable_unsigned(iter, value, f);
-      case field_type::string:
-        return parse_string(iter, value, f);
-      case field_type::any:
-        return SUCCESS;
-      case field_type::array:
-      case field_type::object:
-        iter.log_error("unexpected primitive");
-        return INCORRECT_TYPE;
-    }
-  }
-
-  // If it's not a field, it's a child of an array.
-  // The only array we support is statuses, which must contain objects.
-  iter.log_error("unexpected primitive");
-  return INCORRECT_TYPE;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
-  if (in_container(iter)) { end_container(iter); }
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
-  if (in_container(iter)) { end_container(iter); }
-  return SUCCESS;
-}
-
-really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &) {
-  return SUCCESS;
-}
-
-really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &) {
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &) {
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
-  iter.log_error("unexpected root primitive");
-  return INCORRECT_TYPE;
-}
-
-really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
-
-really_inline bool sax_tweet_reader_visitor::in_container(json_iterator &iter) {
-  return iter.depth == uint32_t(container);
-}
-really_inline bool sax_tweet_reader_visitor::in_container_child(json_iterator &iter) {
-  return iter.depth == uint32_t(container) + 1;
-}
-really_inline void sax_tweet_reader_visitor::start_container(json_iterator &iter) {
-  SIMDJSON_ASSUME(iter.depth <= MAX_SUPPORTED_DEPTH); // Asserts in debug mode
-  container = containers(iter.depth);
-  if (logger::LOG_ENABLED) { iter.log_start_value(STATE_NAMES[iter.depth]); }
-}
-really_inline void sax_tweet_reader_visitor::end_container(json_iterator &iter) {
-  if (logger::LOG_ENABLED) { iter.log_end_value(STATE_NAMES[int(container)]); }
-  container = containers(int(container) - 1);
-}
-really_inline error_code sax_tweet_reader_visitor::parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
-  iter.log_value(f.key);
-  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
-  if (auto error = numberparsing::parse_unsigned(value).get(*i)) {
-    // If number parsing failed, check if it's null before returning the error
-    if (!atomparsing::is_valid_null_atom(value)) { iter.log_error("expected number or null"); return error; }
-    i = 0;
-  }
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
-  iter.log_value(f.key);
-  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
-  return numberparsing::parse_unsigned(value).get(*i);
-}
-really_inline error_code sax_tweet_reader_visitor::parse_string(json_iterator &iter, const uint8_t *value, const field &f) {
-  iter.log_value(f.key);
-  auto s = reinterpret_cast<std::string_view *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
-  return stringparsing::parse_string_to_buffer(value, current_string_buf_loc, *s);
-}
-
-sax_tweet_reader_visitor::field_lookup sax_tweet_reader_visitor::fields{};
-
-really_inline uint8_t sax_tweet_reader_visitor::field_lookup::hash(const char * key, uint32_t depth) {
-  // These shift numbers were chosen specifically because this yields only 2 collisions between
-  // keys in twitter.json, leaves 0 as a distinct value, and has 0 collisions between keys we
-  // actually care about.
-  return uint8_t((key[0] << 0) ^ (key[1] << 3) ^ (key[2] << 3) ^ (key[3] << 1) ^ depth);
-}
-really_inline sax_tweet_reader_visitor::field sax_tweet_reader_visitor::field_lookup::get(const uint8_t * key, containers c) {
-  auto index = hash((const char *)key, uint32_t(c));
-  auto entry = entries[index];
-  // TODO if any key is > SIMDJSON_PADDING, this will access inaccessible memory!
-  if (c != entry.container || memcmp(key, entry.key, entry.len)) { return entries[0]; }
-  return entry;
-}
-really_inline void sax_tweet_reader_visitor::field_lookup::add(const char * key, size_t len, containers c, field_type type, size_t offset) {
-  auto index = hash(key, uint32_t(c));
-  if (index == 0) {
-    fprintf(stderr, "%s (depth %d) hashes to zero, which is used as 'missing value'\n", key, int(c));
-    assert(false);
-  }
-  if (entries[index].key) {
-    fprintf(stderr, "%s (depth %d) collides with %s (depth %d) !\n", key, int(c), entries[index].key, int(entries[index].container));
-    assert(false);
-  }
-  entries[index] = { key, len, offset, c, type };
-}
-really_inline void sax_tweet_reader_visitor::field_lookup::neg(const char * const key, uint32_t depth) {
-  auto index = hash(key, depth);
-  if (entries[index].key) {
-    fprintf(stderr, "%s (depth %d) conflicts with %s (depth %d) !\n", key, depth, entries[index].key, int(entries[index].container));
-    assert(false);
-  }
-}
-
-sax_tweet_reader_visitor::field_lookup::field_lookup() {
-  add("\"statuses\"", strlen("\"statuses\""), containers::top_object, field_type::array, 0); // { "statuses": [...]
-  #define TWEET_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::tweet, TYPE, offsetof(tweet, KEY));
-  TWEET_FIELD(id, field_type::unsigned_integer);
-  TWEET_FIELD(in_reply_to_status_id, field_type::nullable_unsigned_integer);
-  TWEET_FIELD(retweet_count, field_type::unsigned_integer);
-  TWEET_FIELD(favorite_count, field_type::unsigned_integer);
-  TWEET_FIELD(text, field_type::string);
-  TWEET_FIELD(created_at, field_type::string);
-  TWEET_FIELD(user, field_type::object)
-  #undef TWEET_FIELD
-  #define USER_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::user, TYPE, offsetof(tweet, user)+offsetof(twitter_user, KEY));
-  USER_FIELD(id, field_type::unsigned_integer);
-  USER_FIELD(screen_name, field_type::string);
-  #undef USER_FIELD
-
-  // Check for collisions with other (unused) hash keys in typical twitter JSON
-  #define NEG(key, depth) neg("\"" #key "\"", depth);
-  NEG(display_url, 9);
-  NEG(expanded_url, 9);
-  neg("\"h\":", 9);
-  NEG(indices, 9);
-  NEG(resize, 9);
-  NEG(url, 9);
-  neg("\"w\":", 9);
-  NEG(display_url, 8);
-  NEG(expanded_url, 8);
-  neg("\"h\":", 8);
-  NEG(indices, 8);
-  NEG(large, 8);
-  NEG(medium, 8);
-  NEG(resize, 8);
-  NEG(small, 8);
-  NEG(thumb, 8);
-  NEG(url, 8);
-  neg("\"w\":", 8);
-  NEG(display_url, 7);
-  NEG(expanded_url, 7);
-  NEG(id_str, 7);
-  NEG(id, 7);
-  NEG(indices, 7);
-  NEG(large, 7);
-  NEG(media_url_https, 7);
-  NEG(media_url, 7);
-  NEG(medium, 7);
-  NEG(name, 7);
-  NEG(sizes, 7);
-  NEG(small, 7);
-  NEG(source_status_id_str, 7);
-  NEG(source_status_id, 7);
-  NEG(thumb, 7);
-  NEG(type, 7);
-  NEG(url, 7);
-  NEG(urls, 7);
-  NEG(description, 6);
-  NEG(display_url, 6);
-  NEG(expanded_url, 6);
-  NEG(id_str, 6);
-  NEG(id, 6);
-  NEG(indices, 6);
-  NEG(media_url_https, 6);
-  NEG(media_url, 6);
-  NEG(name, 6);
-  NEG(sizes, 6);
-  NEG(source_status_id_str, 6);
-  NEG(source_status_id, 6);
-  NEG(type, 6);
-  NEG(url, 6);
-  NEG(urls, 6);
-  NEG(contributors_enabled, 5);
-  NEG(default_profile_image, 5);
-  NEG(default_profile, 5);
-  NEG(description, 5);
-  NEG(entities, 5);
-  NEG(favourites_count, 5);
-  NEG(follow_request_sent, 5);
-  NEG(followers_count, 5);
-  NEG(following, 5);
-  NEG(friends_count, 5);
-  NEG(geo_enabled, 5);
-  NEG(hashtags, 5);
-  NEG(id_str, 5);
-  NEG(id, 5);
-  NEG(is_translation_enabled, 5);
-  NEG(is_translator, 5);
-  NEG(iso_language_code, 5);
-  NEG(lang, 5);
-  NEG(listed_count, 5);
-  NEG(location, 5);
-  NEG(media, 5);
-  NEG(name, 5);
-  NEG(notifications, 5);
-  NEG(profile_background_color, 5);
-  NEG(profile_background_image_url_https, 5);
-  NEG(profile_background_image_url, 5);
-  NEG(profile_background_tile, 5);
-  NEG(profile_banner_url, 5);
-  NEG(profile_image_url_https, 5);
-  NEG(profile_image_url, 5);
-  NEG(profile_link_color, 5);
-  NEG(profile_sidebar_border_color, 5);
-  NEG(profile_sidebar_fill_color, 5);
-  NEG(profile_text_color, 5);
-  NEG(profile_use_background_image, 5);
-  NEG(protected, 5);
-  NEG(result_type, 5);
-  NEG(statuses_count, 5);
-  NEG(symbols, 5);
-  NEG(time_zone, 5);
-  NEG(url, 5);
-  NEG(urls, 5);
-  NEG(user_mentions, 5);
-  NEG(utc_offset, 5);
-  NEG(verified, 5);
-  NEG(contributors_enabled, 4);
-  NEG(contributors, 4);
-  NEG(coordinates, 4);
-  NEG(default_profile_image, 4);
-  NEG(default_profile, 4);
-  NEG(description, 4);
-  NEG(entities, 4);
-  NEG(favorited, 4);
-  NEG(favourites_count, 4);
-  NEG(follow_request_sent, 4);
-  NEG(followers_count, 4);
-  NEG(following, 4);
-  NEG(friends_count, 4);
-  NEG(geo_enabled, 4);
-  NEG(geo, 4);
-  NEG(hashtags, 4);
-  NEG(id_str, 4);
-  NEG(in_reply_to_screen_name, 4);
-  NEG(in_reply_to_status_id_str, 4);
-  NEG(in_reply_to_user_id_str, 4);
-  NEG(in_reply_to_user_id, 4);
-  NEG(is_translation_enabled, 4);
-  NEG(is_translator, 4);
-  NEG(iso_language_code, 4);
-  NEG(lang, 4);
-  NEG(listed_count, 4);
-  NEG(location, 4);
-  NEG(media, 4);
-  NEG(metadata, 4);
-  NEG(name, 4);
-  NEG(notifications, 4);
-  NEG(place, 4);
-  NEG(possibly_sensitive, 4);
-  NEG(profile_background_color, 4);
-  NEG(profile_background_image_url_https, 4);
-  NEG(profile_background_image_url, 4);
-  NEG(profile_background_tile, 4);
-  NEG(profile_banner_url, 4);
-  NEG(profile_image_url_https, 4);
-  NEG(profile_image_url, 4);
-  NEG(profile_link_color, 4);
-  NEG(profile_sidebar_border_color, 4);
-  NEG(profile_sidebar_fill_color, 4);
-  NEG(profile_text_color, 4);
-  NEG(profile_use_background_image, 4);
-  NEG(protected, 4);
-  NEG(result_type, 4);
-  NEG(retweeted, 4);
-  NEG(source, 4);
-  NEG(statuses_count, 4);
-  NEG(symbols, 4);
-  NEG(time_zone, 4);
-  NEG(truncated, 4);
-  NEG(url, 4);
-  NEG(urls, 4);
-  NEG(user_mentions, 4);
-  NEG(utc_offset, 4);
-  NEG(verified, 4);
-  NEG(contributors, 3);
-  NEG(coordinates, 3);
-  NEG(entities, 3);
-  NEG(favorited, 3);
-  NEG(geo, 3);
-  NEG(id_str, 3);
-  NEG(in_reply_to_screen_name, 3);
-  NEG(in_reply_to_status_id_str, 3);
-  NEG(in_reply_to_user_id_str, 3);
-  NEG(in_reply_to_user_id, 3);
-  NEG(lang, 3);
-  NEG(metadata, 3);
-  NEG(place, 3);
-  NEG(possibly_sensitive, 3);
-  NEG(retweeted_status, 3);
-  NEG(retweeted, 3);
-  NEG(source, 3);
-  NEG(truncated, 3);
-  NEG(completed_in, 2);
-  NEG(count, 2);
-  NEG(max_id_str, 2);
-  NEG(max_id, 2);
-  NEG(next_results, 2);
-  NEG(query, 2);
-  NEG(refresh_url, 2);
-  NEG(since_id_str, 2);
-  NEG(since_id, 2);
-  NEG(search_metadata, 1);
-  #undef NEG
-}
-
-// sax_tweet_reader_visitor::field_lookup::find_min() {
-//   int min_count = 100000;
-//   for (int a=0;a<4;a++) {
-//     for (int b=0;b<4;b++) {
-//       for (int c=0;c<4;c++) {
-//         twitter::sax_tweet_reader_visitor::field_lookup fields(a,b,c);
-//         if (fields.collision_count) { continue; }
-//         if (fields.zero_emission) { continue; }
-//         if (fields.conflict_count < min_count) { printf("min=%d,%d,%d (%d)", a, b, c, fields.conflict_count); }
-//       }
-//     }
-//   }
-// }
-
-#undef KEY_IS
-
-} // namespace twitter
-
-SIMDJSON_UNTARGET_REGION
-
 
 SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
+#include "simdjson.cpp"
+#include "twitter/sax_tweet_reader.h"
+
 using namespace benchmark;
+using namespace simdjson;
 using std::cerr;
 using std::endl;
 
 const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
 const int REPETITIONS = 10;
-
-really_inline uint64_t nullable_int(dom::element element) {
-  if (element.is_null()) { return 0; }
-  return element;
-}
-really_inline void read_dom_tweets(dom::parser &parser, padded_string &json, std::vector<twitter::tweet> &tweets) {
-  for (dom::element tweet : parser.parse(json)["statuses"]) {
-    auto user = tweet["user"];
-    tweets.push_back(
-      {
-        tweet["id"],
-        tweet["text"],
-        tweet["created_at"],
-        nullable_int(tweet["in_reply_to_status_id"]),
-        tweet["retweet_count"],
-        tweet["favorite_count"],
-        { user["id"], user["screen_name"] }
-      }
-    );
-  }
-}
 
 static void sax_tweets(State &state) {
   // Load twitter.json to a buffer
@@ -644,9 +46,27 @@ static void sax_tweets(State &state) {
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
   state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
 }
-BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
-    return *(std::max_element(std::begin(v), std::end(v)));
-  })->DisplayAggregatesOnly(true);
+
+really_inline uint64_t nullable_int(dom::element element) {
+  if (element.is_null()) { return 0; }
+  return element;
+}
+really_inline void read_dom_tweets(dom::parser &parser, padded_string &json, std::vector<twitter::tweet> &tweets) {
+  for (dom::element tweet : parser.parse(json)["statuses"]) {
+    auto user = tweet["user"];
+    tweets.push_back(
+      {
+        tweet["id"],
+        tweet["text"],
+        tweet["created_at"],
+        nullable_int(tweet["in_reply_to_status_id"]),
+        tweet["retweet_count"],
+        tweet["favorite_count"],
+        { user["id"], user["screen_name"] }
+      }
+    );
+  }
+}
 
 static void dom_tweets(State &state) {
   // Load twitter.json to a buffer
@@ -677,9 +97,6 @@ static void dom_tweets(State &state) {
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
   state.counters["tweets"] = Counter(double(num_tweets), benchmark::Counter::kIsRate);
 }
-BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
-    return *(std::max_element(std::begin(v), std::end(v)));
-  })->DisplayAggregatesOnly(true);
 
 static void dom_parse(State &state) {
   // Load twitter.json to a buffer
@@ -702,6 +119,13 @@ static void dom_parse(State &state) {
 	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
 }
+
+BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
 BENCHMARK(dom_parse)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -2,6 +2,10 @@
 #define SIMDJSON_IMPLEMENTATION_WESTMERE 0
 #define SIMDJSON_IMPLEMENTATION_AMD64 0
 
+#include <iostream>
+#include <sstream>
+#include <random>
+
 #include "simdjson.h"
 
 SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
@@ -132,5 +136,231 @@ static void dom_parse(State &state) {
 BENCHMARK(dom_parse)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
+
+
+
+
+/********************
+ * Large file parsing benchmarks:
+ ********************/
+
+static std::string build_json_array(size_t N) {
+  std::default_random_engine e;
+  std::uniform_real_distribution<> dis(0, 1);
+  std::stringstream myss;
+  myss << "[" << std::endl;
+  if(N > 0) {
+    myss << "{ \"x\":" << dis(e) << ",  \"y\":" << dis(e) << ", \"z\":" << dis(e) << "}" << std::endl;
+  }
+  for(size_t i = 1; i < N; i++) {
+    myss << "," << std::endl;
+    myss << "{ \"x\":" << dis(e) << ",  \"y\":" << dis(e) << ", \"z\":" << dis(e) << "}";
+  }
+  myss << std::endl;
+  myss << "]" << std::endl;
+  std::string answer = myss.str();
+  std::cout << "Creating a source file spanning " << (answer.size() + 512) / 1024 << " KB " << std::endl;  
+  return answer;
+}
+
+static const simdjson::padded_string& get_my_json_str() {
+  static simdjson::padded_string s = build_json_array(1000000);
+  return s;
+}
+
+struct my_point {
+  double x;
+  double y;
+  double z;
+};
+
+// ./benchmark/bench_sax --benchmark_filter=largerandom
+
+
+/*** 
+ * We start with the naive DOM-based approach.
+ **/
+static void dom_parse_largerandom(State &state) {
+  // Load twitter.json to a buffer
+  const padded_string& json = get_my_json_str();
+
+  // Allocate
+  dom::parser parser;
+  if (auto error = parser.allocate(json.size())) { cerr << error << endl; return; };
+
+  // Read
+  size_t bytes = 0;
+  simdjson::error_code error;
+  for (UNUSED auto _ : state) {
+    std::vector<my_point> container;
+    dom::element doc;
+    if ((error = parser.parse(json).get(doc))) { 
+      std::cerr << "failure: " << error << std::endl;
+      throw "Parsing failed"; 
+    };
+    for (auto p : simdjson::dom::array(doc)) {
+      container.emplace_back(my_point{p["x"], p["y"], p["z"]});
+    }
+    bytes += json.size();
+    benchmark::DoNotOptimize(container.data());
+
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+}
+
+BENCHMARK(dom_parse_largerandom)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+
+/*** 
+ * Next we are going to code the SAX approach.
+ **/
+
+SIMDJSON_TARGET_HASWELL
+
+namespace largerandom {
+namespace {
+
+using namespace simdjson;
+using namespace haswell;
+using namespace haswell::stage2;
+struct sax_point_reader_visitor {
+public:
+  sax_point_reader_visitor(std::vector<my_point> &_points) : points(_points) {
+  }
+
+  really_inline error_code visit_document_start(json_iterator &) { return SUCCESS; }
+  really_inline error_code visit_object_start(json_iterator &) { return SUCCESS; }
+  really_inline error_code visit_key(json_iterator &, const uint8_t *key) {
+    switch(key[0]) {
+      case 'x':
+        idx = 0;
+        break;
+      case 'y':
+        idx = 2;
+        break;
+      case 'z':
+        idx = 3;
+        break;  
+    }
+    return SUCCESS; 
+  }
+  really_inline error_code visit_primitive(json_iterator &, const uint8_t *value) {
+    return numberparsing::parse_double(value).get(buffer[idx]);
+  }
+  really_inline error_code visit_array_start(json_iterator &)  { return SUCCESS; }
+  really_inline error_code visit_array_end(json_iterator &) { return SUCCESS; }
+  really_inline error_code visit_object_end(json_iterator &)  { return SUCCESS; }
+  really_inline error_code visit_document_end(json_iterator &)  { return SUCCESS; }
+  really_inline error_code visit_empty_array(json_iterator &)  { return SUCCESS; }
+  really_inline error_code visit_empty_object(json_iterator &)  { return SUCCESS; }
+  really_inline error_code visit_root_primitive(json_iterator &, const uint8_t *)  { return SUCCESS; }
+  really_inline error_code increment_count(json_iterator &) { return SUCCESS; }
+  std::vector<my_point> &points;
+  size_t idx{0};
+  double buffer[3];
+};
+
+struct sax_point_reader {
+  std::vector<my_point> points;
+  std::unique_ptr<uint8_t[]> string_buf;
+  size_t capacity;
+  dom_parser_implementation dom_parser;
+
+  sax_point_reader();
+  error_code set_capacity(size_t new_capacity);
+  error_code read_points(const padded_string &json);
+}; // struct sax_point_reader
+
+sax_point_reader::sax_point_reader() : points{}, string_buf{}, capacity{0}, dom_parser() {
+}
+
+error_code sax_point_reader::set_capacity(size_t new_capacity) {
+  // string_capacity copied from document::allocate
+  size_t string_capacity = ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
+  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
+  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
+  if (capacity == 0) { // set max depth the first time only
+    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
+  }
+  capacity = new_capacity;
+  return SUCCESS;
+}
+
+error_code sax_point_reader::read_points(const padded_string &json) {
+  // Allocate capacity if needed
+  points.clear();
+  if (capacity < json.size()) {
+    if (auto error = set_capacity(capacity)) { return error; }
+  }
+
+  // Run stage 1 first.
+  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
+
+  // Then walk the document, parsing the tweets as we go
+  json_iterator iter(dom_parser, 0);
+  sax_point_reader_visitor visitor(points);
+  if (auto error = iter.walk_document<false>(visitor)) { return error; }
+  return SUCCESS;
+}
+
+} // unnamed namespace
+} // namespace largerandom
+
+SIMDJSON_UNTARGET_REGION
+
+
+
+
+
+// ./benchmark/bench_sax --benchmark_filter=largerandom
+static void sax_parse_largerandom(State &state) {
+  // Load twitter.json to a buffer
+  const padded_string& json = get_my_json_str();
+
+  // Allocate
+  largerandom::sax_point_reader reader;
+  reader.set_capacity(json.size());
+  // warming
+  for(size_t i = 0; i < 10; i++) {
+    reader.read_points(json);
+  }
+
+  // Read
+  size_t bytes = 0;
+  for (UNUSED auto _ : state) {
+    reader.read_points(json);
+    bytes += json.size();
+    benchmark::DoNotOptimize(reader.points.data());
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+}
+BENCHMARK(sax_parse_largerandom)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 BENCHMARK_MAIN();

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -232,8 +232,63 @@ using namespace benchmark;
 using namespace std;
 
 const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+const int REPETITIONS = 20;
 
-static void sax_tweets(State& state) {
+really_inline uint64_t nullable_int(dom::element element) {
+  if (element.is_null()) { return 0; }
+  return element;
+}
+really_inline void read_dom_tweets(dom::parser &parser, padded_string &json, std::vector<twitter::tweet> &tweets) {
+  for (dom::element tweet : parser.parse(json)["statuses"]) {
+    auto user = tweet["user"];
+    tweets.push_back(
+      {
+        tweet["id"],
+        tweet["text"],
+        tweet["created_at"],
+        nullable_int(tweet["in_reply_to_status_id"]),
+        nullable_int(tweet["retweet_count"]),
+        nullable_int(tweet["favorite_count"]),
+        { user["id"], user["screen_name"] }
+      }
+    );
+  }
+}
+
+static void dom_tweets(State &state) {
+  // Load twitter.json to a buffer
+  padded_string json;
+  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
+
+  // Allocate
+  dom::parser parser;
+  if (auto error = parser.allocate(json.size())) { cerr << error << endl; return; };
+
+  // Warm the vector
+  std::vector<twitter::tweet> tweets;
+  read_dom_tweets(parser, json, tweets);
+
+  // Read tweets
+  size_t bytes = 0;
+  size_t num_tweets = 0;
+  for (UNUSED auto _ : state) {
+    tweets.clear();
+    read_dom_tweets(parser, json, tweets);
+    bytes += json.size();
+    num_tweets += tweets.size();
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+  state.counters["tweets"] = Counter(double(num_tweets), benchmark::Counter::kIsRate);
+}
+BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void sax_tweets(State &state) {
   // Load twitter.json to a buffer
   padded_string json;
   if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
@@ -242,7 +297,10 @@ static void sax_tweets(State& state) {
   twitter::sax_tweet_reader reader;
   if (auto error = reader.set_capacity(json.size())) { cerr << error << endl; return; }
 
-  // Make the tweet_reader
+  // Warm the vector
+  if (auto error = reader.read_tweets(json)) { throw error; }
+
+  // Read tweets
   size_t bytes = 0;
   size_t tweets = 0;
   for (UNUSED auto _ : state) {
@@ -257,7 +315,7 @@ static void sax_tweets(State& state) {
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
   state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
 }
-BENCHMARK(sax_tweets)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
 

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -13,8 +13,6 @@ SIMDJSON_TARGET_HASWELL
 
 namespace twitter {
 
-#define KEY_IS(KEY, MATCH) (!strncmp((const char *)KEY, "\"" MATCH "\"", strlen("\"" MATCH "\"")))
-
 struct twitter_user {
   uint64_t id{};
   std::string_view screen_name{};
@@ -44,12 +42,27 @@ struct sax_tweet_reader {
 namespace twitter {
 
 struct sax_tweet_reader_visitor {
-  bool in_statuses{false};
-  bool in_user{false};
+  // Since we only care about one thing at each level, we just use depth as the marker for what
+  // object/array we're nested inside.
+  enum class containers {
+    DOCUMENT = 0,   //
+    TOP_OBJECT = 1, // {
+    STATUSES = 2,   // { "statuses": [
+    TWEET = 3,      // { "statuses": [ {
+    USER = 4        // { "statuses": [ { "user": {
+  };
+  static constexpr const char *STATE_NAMES[] = {
+    "document",
+    "top object",
+    "statuses",
+    "tweet",
+    "user"
+  };
+
+  containers container{containers::DOCUMENT};
   std::vector<tweet> &tweets;
   uint8_t *current_string_buf_loc;
   const uint8_t *current_key{};
-
   sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
 
   really_inline error_code visit_document_start(json_iterator &iter);
@@ -66,6 +79,10 @@ struct sax_tweet_reader_visitor {
   really_inline error_code increment_count(json_iterator &iter);
 
 private:
+  really_inline bool in_container(json_iterator &iter);
+  really_inline bool in_container_child(json_iterator &iter);
+  really_inline void start_container(json_iterator &iter, containers expected_container);
+  really_inline void end_container(json_iterator &iter);
   really_inline error_code parse_nullable_unsigned(json_iterator &iter, uint64_t &i, const uint8_t *value, const char *name);
   really_inline error_code parse_unsigned(json_iterator &iter, uint64_t &i, const uint8_t *value, const char *name);
   really_inline error_code parse_string(json_iterator &iter, std::string_view &s, const uint8_t *value, const char *name);
@@ -103,33 +120,45 @@ error_code sax_tweet_reader::read_tweets(padded_string &json) {
   return SUCCESS;
 }
 
+#define KEY_IS(MATCH) (!strncmp((const char *)current_key, "\"" MATCH "\"", strlen("\"" MATCH "\"")))
+
 sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf)
   : tweets{_tweets},
     current_string_buf_loc{string_buf} {
 }
 
-really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &) {
+really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
+  start_container(iter, containers::DOCUMENT);
   return SUCCESS;
 }
 really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
-  // if we expected an int or string and got an array or object, it's an error
-  if (iter.depth == 2 && KEY_IS(current_key, "statuses")) {
-    iter.log_start_value("statuses");
-    in_statuses = true;
+  iter.dom_parser.is_array[iter.depth] = true;
+  if (in_container_child(iter)) {
+    switch (container) {
+      case containers::TOP_OBJECT: if (KEY_IS("statuses")) { start_container(iter, containers::STATUSES); } break;
+
+      case containers::DOCUMENT: return INCORRECT_TYPE; // Must be an object
+      case containers::STATUSES:
+      case containers::TWEET:
+      case containers::USER:
+        // TODO check for the wrong types for things so we don't skip bad documents!
+        break;
+    }
   }
   return SUCCESS;
 }
 really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
-  // { "statuses": [ {
-  if (in_statuses) {
-    switch (iter.depth) {
-      case 3:
-        iter.log_start_value("tweet");
-        tweets.push_back({});
+  // iter.log_start_value("object");
+  iter.dom_parser.is_array[iter.depth] = false;
+  if (in_container_child(iter)) {
+    switch (container) {
+      case containers::DOCUMENT: start_container(iter, containers::TOP_OBJECT); break;
+      case containers::STATUSES: start_container(iter, containers::TWEET); tweets.push_back({}); break;
+      case containers::TWEET:    if (KEY_IS("user")) { start_container(iter, containers::USER); }; break;
+
+      case containers::TOP_OBJECT:
+      case containers::USER:
         break;
-      case 4:
-        // NOTE: the way we're comparing key (fairly naturally) means the caller doesn't have to check " for us at all
-        if (KEY_IS(current_key, "user")) { iter.log_start_value("user"); in_user = true; }
     }
   }
   return SUCCESS;
@@ -137,6 +166,75 @@ really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_itera
 really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &, const uint8_t *key) {
   current_key = key;
   return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
+  if (in_container(iter)) {
+    switch (container) {
+      case containers::TWEET:
+        // If this a field of the tweet itself and not a child like metadata, check the fields.
+        // PERF TODO improve branch prediction with a hash and table lookup--first 4 characters can
+        // be done unconditionally and are unique ("id" is 4 characters)
+        if (KEY_IS("id"))             { return parse_unsigned (iter, tweets.back().id,               value, "id"); }
+        if (KEY_IS("in_reply_to_status_id")) { return parse_nullable_unsigned(iter, tweets.back().in_reply_to_status_id, value, "in_reply_to_status_id"); }
+        if (KEY_IS("retweet_count"))  { return parse_unsigned (iter, tweets.back().retweet_count,    value, "retweet_count"); }
+        if (KEY_IS("favorite_count")) { return parse_unsigned (iter, tweets.back().favorite_count,   value, "favorite_count"); }
+        if (KEY_IS("text"))           { return parse_string   (iter, tweets.back().text,             value, "text"); }
+        if (KEY_IS("created_at"))     { return parse_string   (iter, tweets.back().created_at,       value, "created_at"); }
+        break;
+      case containers::USER:
+        // If this a field of the tweet itself and not a child like metadata, check the fields.
+        if (KEY_IS("id"))             { return parse_unsigned (iter, tweets.back().user.id,          value, "id"); }
+        if (KEY_IS("screen_name"))    { return parse_string   (iter, tweets.back().user.screen_name, value, "screen_name"); }
+        break;
+      case containers::DOCUMENT: // root_primitive would be called if it was a document primitive
+      case containers::TOP_OBJECT:
+      case containers::STATUSES:
+        SIMDJSON_UNREACHABLE(); // We can only be in a container if it was already marked an array
+        break;
+    }
+  }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
+  if (in_container(iter)) { end_container(iter); }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
+  if (in_container(iter)) { end_container(iter); }
+  return SUCCESS;
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &) {
+  return SUCCESS;
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &) {
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &) {
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
+  iter.log_error("unexpected root primitive");
+  return INCORRECT_TYPE;
+}
+
+really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
+
+really_inline bool sax_tweet_reader_visitor::in_container(json_iterator &iter) {
+  return iter.depth == uint32_t(container);
+}
+really_inline bool sax_tweet_reader_visitor::in_container_child(json_iterator &iter) {
+  return iter.depth == uint32_t(container) + 1;
+}
+really_inline void sax_tweet_reader_visitor::start_container(json_iterator &iter, containers expected_container) {
+  SIMDJSON_ASSUME(uint32_t(expected_container) == iter.depth); // Asserts in debug mode
+  container = expected_container;
+  if (logger::LOG_ENABLED) { iter.log_start_value(STATE_NAMES[int(expected_container)]); }
+}
+really_inline void sax_tweet_reader_visitor::end_container(json_iterator &iter) {
+  if (logger::LOG_ENABLED) { iter.log_end_value(STATE_NAMES[int(container)]); }
+  container = containers(int(container) - 1);
 }
 really_inline error_code sax_tweet_reader_visitor::parse_nullable_unsigned(json_iterator &iter, uint64_t &i, const uint8_t *value, const char *name) {
   iter.log_value(name);
@@ -153,66 +251,10 @@ really_inline error_code sax_tweet_reader_visitor::parse_unsigned(json_iterator 
 }
 really_inline error_code sax_tweet_reader_visitor::parse_string(json_iterator &iter, std::string_view &s, const uint8_t *value, const char *name) {
   iter.log_value(name);
-  // Must be a string!
-  if (value[0] != '"') { iter.log_error("expected string"); return STRING_ERROR; }
-  auto end = stringparsing::parse_string(value, current_string_buf_loc);
-  if (!end) { iter.log_error("error parsing string"); return STRING_ERROR; }
-  s = std::string_view((const char *)current_string_buf_loc, end-current_string_buf_loc);
-  current_string_buf_loc = end;
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
-  // iter.log_value("primitive");
-  // iter.log_value("key");
-  if (in_statuses) {
-    switch (iter.depth) {
-      case 3: // in tweet: { "statuses": [ { <key>
-        if (KEY_IS(current_key, "id")) { return parse_unsigned(iter, tweets.back().id, value, "id"); }
-        else if (KEY_IS(current_key, "in_reply_to_status_id")) { return parse_nullable_unsigned(iter, tweets.back().in_reply_to_status_id, value, "in_reply_to_status_id"); }
-        else if (KEY_IS(current_key, "retweet_count")) { return parse_unsigned(iter, tweets.back().retweet_count, value, "retweet_count"); }
-        else if (KEY_IS(current_key, "favorite_count")) { return parse_unsigned(iter, tweets.back().favorite_count, value, "favorite_count"); }
-        else if (KEY_IS(current_key, "text")) { return parse_string(iter, tweets.back().text, value, "text"); }
-        else if (KEY_IS(current_key, "created_at")) { return parse_string(iter, tweets.back().created_at, value, "created_at"); }
-        break;
-      case 4:
-        if (in_user) { // in user: { "statuses": [ { "user": { <key>
-          if (KEY_IS(current_key, "id")) { return parse_unsigned(iter, tweets.back().user.id, value, "id"); }
-          else if (KEY_IS(current_key, "screen_name")) { { return parse_string(iter, tweets.back().user.screen_name, value, "screen_name"); } }
-        }
-        break;
-      default: break;
-    }
-  }
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
-  // When we hit the end of { "statuses": [ ... ], we're done with statuses.
-  if (in_statuses && iter.depth == 2) { iter.log_end_value("statuses"); in_statuses = false; }
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
-  // When we hit the end of { "statuses": [ { "user": { ... }, we're done with the user
-  if (in_user && iter.depth == 4) { iter.log_end_value("user"); in_user = false; }
-  if (in_statuses && iter.depth == 3) { iter.log_end_value("tweet"); }
-  return SUCCESS;
+  return stringparsing::parse_string_to_buffer(value, current_string_buf_loc, s);
 }
 
-really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &) {
-  return SUCCESS;
-}
-
-really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &) {
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &) {
-  return SUCCESS;
-}
-really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
-  iter.log_error("unexpected root primitive");
-  return TAPE_ERROR;
-}
-
-really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
+#undef KEY_IS
 
 } // namespace twitter
 
@@ -227,7 +269,7 @@ using namespace benchmark;
 using namespace std;
 
 const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
-const int REPETITIONS = 20;
+const int REPETITIONS = 10;
 
 really_inline uint64_t nullable_int(dom::element element) {
   if (element.is_null()) { return 0; }
@@ -242,13 +284,44 @@ really_inline void read_dom_tweets(dom::parser &parser, padded_string &json, std
         tweet["text"],
         tweet["created_at"],
         nullable_int(tweet["in_reply_to_status_id"]),
-        nullable_int(tweet["retweet_count"]),
-        nullable_int(tweet["favorite_count"]),
+        tweet["retweet_count"],
+        tweet["favorite_count"],
         { user["id"], user["screen_name"] }
       }
     );
   }
 }
+
+static void sax_tweets(State &state) {
+  // Load twitter.json to a buffer
+  padded_string json;
+  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
+
+  // Allocate
+  twitter::sax_tweet_reader reader;
+  if (auto error = reader.set_capacity(json.size())) { cerr << error << endl; return; }
+
+  // Warm the vector
+  if (auto error = reader.read_tweets(json)) { throw error; }
+
+  // Read tweets
+  size_t bytes = 0;
+  size_t tweets = 0;
+  for (UNUSED auto _ : state) {
+    if (auto error = reader.read_tweets(json)) { throw error; }
+    bytes += json.size();
+    tweets += reader.tweets.size();
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+  state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
+}
+BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
 
 static void dom_tweets(State &state) {
   // Load twitter.json to a buffer
@@ -280,37 +353,6 @@ static void dom_tweets(State &state) {
   state.counters["tweets"] = Counter(double(num_tweets), benchmark::Counter::kIsRate);
 }
 BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
-    return *(std::max_element(std::begin(v), std::end(v)));
-  })->DisplayAggregatesOnly(true);
-
-static void sax_tweets(State &state) {
-  // Load twitter.json to a buffer
-  padded_string json;
-  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
-
-  // Allocate
-  twitter::sax_tweet_reader reader;
-  if (auto error = reader.set_capacity(json.size())) { cerr << error << endl; return; }
-
-  // Warm the vector
-  if (auto error = reader.read_tweets(json)) { throw error; }
-
-  // Read tweets
-  size_t bytes = 0;
-  size_t tweets = 0;
-  for (UNUSED auto _ : state) {
-    if (auto error = reader.read_tweets(json)) { throw error; }
-    bytes += json.size();
-    tweets += reader.tweets.size();
-  }
-  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
-  state.counters["Gigabytes"] = benchmark::Counter(
-	        double(bytes), benchmark::Counter::kIsRate,
-	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
-  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
-  state.counters["tweets"] = Counter(double(tweets), benchmark::Counter::kIsRate);
-}
-BENCHMARK(sax_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
 

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -325,16 +325,16 @@ static void sax_parse_largerandom(State &state) {
 
   // Allocate
   largerandom::sax_point_reader reader;
-  reader.set_capacity(json.size());
+  if (auto error = reader.set_capacity(json.size())) { throw error; }
   // warming
   for(size_t i = 0; i < 10; i++) {
-    reader.read_points(json);
+    if (auto error = reader.read_points(json)) { throw error; }
   }
 
   // Read
   size_t bytes = 0;
   for (UNUSED auto _ : state) {
-    reader.read_points(json);
+    if (auto error = reader.read_points(json)) { throw error; }
     bytes += json.size();
     benchmark::DoNotOptimize(reader.points.data());
   }

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -362,19 +362,22 @@ really_inline void sax_tweet_reader_visitor::field_lookup::neg(const char * cons
 }
 
 sax_tweet_reader_visitor::field_lookup::field_lookup() {
-  #define ADD(key, container, type, offset) add("\"" #key "\"", strlen("\"" #key "\""), container, type, offset);
-  ADD(statuses, containers::top_object, field_type::array, 0);
-  ADD(id, containers::tweet, field_type::unsigned_integer, offsetof(tweet, id));
-  ADD(in_reply_to_status_id, containers::tweet, field_type::nullable_unsigned_integer, offsetof(tweet, in_reply_to_status_id));
-  ADD(retweet_count, containers::tweet, field_type::unsigned_integer, offsetof(tweet, retweet_count));
-  ADD(favorite_count, containers::tweet, field_type::unsigned_integer, offsetof(tweet, favorite_count));
-  ADD(text, containers::tweet, field_type::string, offsetof(tweet, text));
-  ADD(created_at, containers::tweet, field_type::string, offsetof(tweet, created_at)); // TODO this could be more constrainted
-  ADD(user, containers::tweet, field_type::object, offsetof(tweet, user));
-  ADD(id, containers::user, field_type::unsigned_integer, offsetof(tweet, user)+offsetof(twitter_user, id));
-  ADD(screen_name, containers::user, field_type::string, offsetof(tweet, user)+offsetof(twitter_user, screen_name));
-  #undef ADD
+  add("\"statuses\"", strlen("\"statuses\""), containers::top_object, field_type::array, 0); // { "statuses": [...]
+  #define TWEET_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::tweet, TYPE, offsetof(tweet, KEY));
+  TWEET_FIELD(id, field_type::unsigned_integer);
+  TWEET_FIELD(in_reply_to_status_id, field_type::nullable_unsigned_integer);
+  TWEET_FIELD(retweet_count, field_type::unsigned_integer);
+  TWEET_FIELD(favorite_count, field_type::unsigned_integer);
+  TWEET_FIELD(text, field_type::string);
+  TWEET_FIELD(created_at, field_type::string);
+  TWEET_FIELD(user, field_type::object)
+  #undef TWEET_FIELD
+  #define USER_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::user, TYPE, offsetof(tweet, user)+offsetof(twitter_user, KEY));
+  USER_FIELD(id, field_type::unsigned_integer);
+  USER_FIELD(screen_name, field_type::string);
+  #undef USER_FIELD
 
+  // Check for collisions with other (unused) hash keys in typical twitter JSON
   #define NEG(key, depth) neg("\"" #key "\"", depth);
   NEG(display_url, 9);
   NEG(expanded_url, 9);

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -356,4 +356,29 @@ BENCHMARK(dom_tweets)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](con
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
 
+static void dom_parse(State &state) {
+  // Load twitter.json to a buffer
+  padded_string json;
+  if (auto error = padded_string::load(TWITTER_JSON).get(json)) { cerr << error << endl; return; }
+
+  // Allocate
+  dom::parser parser;
+  if (auto error = parser.allocate(json.size())) { cerr << error << endl; return; };
+
+  // Read tweets
+  size_t bytes = 0;
+  for (UNUSED auto _ : state) {
+    if (parser.parse(json).error()) { throw "Parsing failed"; };
+    bytes += json.size();
+  }
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+	        double(bytes), benchmark::Counter::kIsRate,
+	        benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+  state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
+}
+BENCHMARK(dom_parse)->Repetitions(REPETITIONS)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
 BENCHMARK_MAIN();

--- a/benchmark/twitter/sax_tweet_reader.h
+++ b/benchmark/twitter/sax_tweet_reader.h
@@ -1,0 +1,67 @@
+#ifndef TWITTER_SAX_TWEET_READER_H
+#define TWITTER_SAX_TWEET_READER_H
+
+#include "simdjson.h"
+#include "sax_tweet_reader_visitor.h"
+#include "tweet.h"
+#include <vector>
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+namespace {
+
+using namespace simdjson;
+using namespace haswell;
+using namespace haswell::stage2;
+
+struct sax_tweet_reader {
+  std::vector<tweet> tweets;
+  std::unique_ptr<uint8_t[]> string_buf;
+  size_t capacity;
+  dom_parser_implementation dom_parser;
+
+  sax_tweet_reader();
+  error_code set_capacity(size_t new_capacity);
+  error_code read_tweets(padded_string &json);
+}; // struct tweet_reader
+
+sax_tweet_reader::sax_tweet_reader() : tweets{}, string_buf{}, capacity{0}, dom_parser() {
+}
+
+error_code sax_tweet_reader::set_capacity(size_t new_capacity) {
+  // string_capacity copied from document::allocate
+  size_t string_capacity = ROUNDUP_N(5 * new_capacity / 3 + 32, 64);
+  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
+  if (auto error = dom_parser.set_capacity(new_capacity)) { return error; }
+  if (capacity == 0) { // set max depth the first time only
+    if (auto error = dom_parser.set_max_depth(DEFAULT_MAX_DEPTH)) { return error; }
+  }
+  capacity = new_capacity;
+  return SUCCESS;
+}
+
+// NOTE: this assumes the dom_parser is already allocated
+error_code sax_tweet_reader::read_tweets(padded_string &json) {
+  // Allocate capacity if needed
+  tweets.clear();
+  if (capacity < json.size()) {
+    if (auto error = set_capacity(capacity)) { return error; }
+  }
+
+  // Run stage 1 first.
+  if (auto error = dom_parser.stage1((uint8_t *)json.data(), json.size(), false)) { return error; }
+
+  // Then walk the document, parsing the tweets as we go
+  json_iterator iter(dom_parser, 0);
+  sax_tweet_reader_visitor visitor(tweets, string_buf.get());
+  if (auto error = iter.walk_document<false>(visitor)) { return error; }
+  return SUCCESS;
+}
+
+} // unnamed namespace
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+#endif // TWITTER_SAX_TWEET_READER_H

--- a/benchmark/twitter/sax_tweet_reader_visitor.h
+++ b/benchmark/twitter/sax_tweet_reader_visitor.h
@@ -1,0 +1,518 @@
+#ifndef TWITTER_SAX_TWEET_READER_VISITOR_H
+#define TWITTER_SAX_TWEET_READER_VISITOR_H
+
+#include "simdjson.h"
+#include "tweet.h"
+#include <vector>
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+
+using namespace simdjson;
+using namespace haswell;
+using namespace haswell::stage2;
+
+struct sax_tweet_reader_visitor {
+public:
+  sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf);
+
+  really_inline error_code visit_document_start(json_iterator &iter);
+  really_inline error_code visit_object_start(json_iterator &iter);
+  really_inline error_code visit_key(json_iterator &iter, const uint8_t *key);
+  really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value);
+  really_inline error_code visit_array_start(json_iterator &iter);
+  really_inline error_code visit_array_end(json_iterator &iter);
+  really_inline error_code visit_object_end(json_iterator &iter);
+  really_inline error_code visit_document_end(json_iterator &iter);
+  really_inline error_code visit_empty_array(json_iterator &iter);
+  really_inline error_code visit_empty_object(json_iterator &iter);
+  really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value);
+  really_inline error_code increment_count(json_iterator &iter);
+
+private:
+  // Since we only care about one thing at each level, we just use depth as the marker for what
+  // object/array we're nested inside.
+  enum class containers {
+    document = 0,   //
+    top_object = 1, // {
+    statuses = 2,   // { "statuses": [
+    tweet = 3,      // { "statuses": [ {
+    user = 4        // { "statuses": [ { "user": {
+  };
+  /**
+   * The largest depth we care about.
+   * There can be things at lower depths.
+   */
+  static constexpr uint32_t MAX_SUPPORTED_DEPTH = uint32_t(containers::user);
+  static constexpr const char *STATE_NAMES[] = {
+    "document",
+    "top object",
+    "statuses",
+    "tweet",
+    "user"
+  };
+  enum class field_type {
+    any,
+    unsigned_integer,
+    string,
+    nullable_unsigned_integer,
+    object,
+    array
+  };
+  struct field {
+    const char * key{};
+    size_t len{0};
+    size_t offset;
+    containers container{containers::document};
+    field_type type{field_type::any};
+  };
+
+  containers container{containers::document};
+  std::vector<tweet> &tweets;
+  uint8_t *current_string_buf_loc;
+  const uint8_t *current_key{};
+
+  really_inline bool in_container(json_iterator &iter);
+  really_inline bool in_container_child(json_iterator &iter);
+  really_inline void start_container(json_iterator &iter);
+  really_inline void end_container(json_iterator &iter);
+  really_inline error_code parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
+  really_inline error_code parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f);
+  really_inline error_code parse_string(json_iterator &iter, const uint8_t *value, const field &f);
+
+  struct field_lookup {
+    field entries[256]{};
+
+    field_lookup();
+    really_inline field get(const uint8_t * key, containers container);
+  private:
+    really_inline uint8_t hash(const char * key, uint32_t depth);
+    really_inline void add(const char * key, size_t len, containers container, field_type type, size_t offset);
+    really_inline void neg(const char * const key, uint32_t depth);
+  };
+  static field_lookup fields;
+}; // sax_tweet_reader_visitor
+
+sax_tweet_reader_visitor::sax_tweet_reader_visitor(std::vector<tweet> &_tweets, uint8_t *string_buf)
+  : tweets{_tweets},
+    current_string_buf_loc{string_buf} {
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_document_start(json_iterator &iter) {
+  start_container(iter);
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_array_start(json_iterator &iter) {
+  // If we're not in a container we care about, don't bother with the rest
+  if (!in_container_child(iter)) { return SUCCESS; }
+
+  // Handle fields first
+  if (current_key) {
+    switch (fields.get(current_key, container).type) {
+      case field_type::array: // { "statuses": [
+        start_container(iter);
+        return SUCCESS;
+      case field_type::any:
+        return SUCCESS;
+      case field_type::object:
+      case field_type::unsigned_integer:
+      case field_type::nullable_unsigned_integer:
+      case field_type::string:
+        iter.log_error("unexpected array field");
+        return INCORRECT_TYPE;
+    }
+  }
+
+  // We're not in a field, so it must be a child of an array. We support any of those.
+  iter.log_error("unexpected array");
+  return INCORRECT_TYPE;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_object_start(json_iterator &iter) {
+  // If we're not in a container we care about, don't bother with the rest
+  if (!in_container_child(iter)) { return SUCCESS; }
+
+  // Handle known fields
+  if (current_key) {
+    auto f = fields.get(current_key, container);
+    switch (f.type) {
+      case field_type::object: // { "statuses": [ { "user": {
+        start_container(iter);
+        return SUCCESS;
+      case field_type::any:
+        return SUCCESS;
+      case field_type::array:
+      case field_type::unsigned_integer:
+      case field_type::nullable_unsigned_integer:
+      case field_type::string:
+        iter.log_error("unexpected object field");
+        return INCORRECT_TYPE;
+    }
+  }
+
+  // It's not a field, so it's a child of an array or document
+  switch (container) {
+    case containers::document: // top_object: {
+    case containers::statuses: // tweet:      { "statuses": [ {
+      start_container(iter);
+      return SUCCESS;
+    case containers::top_object:
+    case containers::tweet:
+    case containers::user:
+      iter.log_error("unexpected object");
+      return INCORRECT_TYPE;
+  }
+  SIMDJSON_UNREACHABLE();
+}
+really_inline error_code sax_tweet_reader_visitor::visit_key(json_iterator &, const uint8_t *key) {
+  current_key = key;
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_primitive(json_iterator &iter, const uint8_t *value) {
+  // Don't bother unless we're in a container we care about
+  if (!in_container(iter)) { return SUCCESS; }
+
+  // Handle fields first
+  if (current_key) {
+    auto f = fields.get(current_key, container);
+    switch (f.type) {
+      case field_type::unsigned_integer:
+        return parse_unsigned(iter, value, f);
+      case field_type::nullable_unsigned_integer:
+        return parse_nullable_unsigned(iter, value, f);
+      case field_type::string:
+        return parse_string(iter, value, f);
+      case field_type::any:
+        return SUCCESS;
+      case field_type::array:
+      case field_type::object:
+        iter.log_error("unexpected primitive");
+        return INCORRECT_TYPE;
+    }
+  }
+
+  // If it's not a field, it's a child of an array.
+  // The only array we support is statuses, which must contain objects.
+  iter.log_error("unexpected primitive");
+  return INCORRECT_TYPE;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_array_end(json_iterator &iter) {
+  if (in_container(iter)) { end_container(iter); }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_object_end(json_iterator &iter) {
+  if (in_container(iter)) { end_container(iter); }
+  return SUCCESS;
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_document_end(json_iterator &iter) {
+  iter.log_end_value("document");
+  return SUCCESS;
+}
+
+really_inline error_code sax_tweet_reader_visitor::visit_empty_array(json_iterator &) {
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_empty_object(json_iterator &) {
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::visit_root_primitive(json_iterator &iter, const uint8_t *) {
+  iter.log_error("unexpected root primitive");
+  return INCORRECT_TYPE;
+}
+
+really_inline error_code sax_tweet_reader_visitor::increment_count(json_iterator &) { return SUCCESS; }
+
+really_inline bool sax_tweet_reader_visitor::in_container(json_iterator &iter) {
+  return iter.depth == uint32_t(container);
+}
+really_inline bool sax_tweet_reader_visitor::in_container_child(json_iterator &iter) {
+  return iter.depth == uint32_t(container) + 1;
+}
+really_inline void sax_tweet_reader_visitor::start_container(json_iterator &iter) {
+  SIMDJSON_ASSUME(iter.depth <= MAX_SUPPORTED_DEPTH); // Asserts in debug mode
+  container = containers(iter.depth);
+  if (logger::LOG_ENABLED) { iter.log_start_value(STATE_NAMES[iter.depth]); }
+}
+really_inline void sax_tweet_reader_visitor::end_container(json_iterator &iter) {
+  if (logger::LOG_ENABLED) { iter.log_end_value(STATE_NAMES[int(container)]); }
+  container = containers(int(container) - 1);
+}
+really_inline error_code sax_tweet_reader_visitor::parse_nullable_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  if (auto error = numberparsing::parse_unsigned(value).get(*i)) {
+    // If number parsing failed, check if it's null before returning the error
+    if (!atomparsing::is_valid_null_atom(value)) { iter.log_error("expected number or null"); return error; }
+    i = 0;
+  }
+  return SUCCESS;
+}
+really_inline error_code sax_tweet_reader_visitor::parse_unsigned(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto i = reinterpret_cast<uint64_t *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  return numberparsing::parse_unsigned(value).get(*i);
+}
+really_inline error_code sax_tweet_reader_visitor::parse_string(json_iterator &iter, const uint8_t *value, const field &f) {
+  iter.log_value(f.key);
+  auto s = reinterpret_cast<std::string_view *>(reinterpret_cast<char *>(&tweets.back() + f.offset));
+  return stringparsing::parse_string_to_buffer(value, current_string_buf_loc, *s);
+}
+
+sax_tweet_reader_visitor::field_lookup sax_tweet_reader_visitor::fields{};
+
+really_inline uint8_t sax_tweet_reader_visitor::field_lookup::hash(const char * key, uint32_t depth) {
+  // These shift numbers were chosen specifically because this yields only 2 collisions between
+  // keys in twitter.json, leaves 0 as a distinct value, and has 0 collisions between keys we
+  // actually care about.
+  return uint8_t((key[0] << 0) ^ (key[1] << 3) ^ (key[2] << 3) ^ (key[3] << 1) ^ depth);
+}
+really_inline sax_tweet_reader_visitor::field sax_tweet_reader_visitor::field_lookup::get(const uint8_t * key, containers c) {
+  auto index = hash((const char *)key, uint32_t(c));
+  auto entry = entries[index];
+  // TODO if any key is > SIMDJSON_PADDING, this will access inaccessible memory!
+  if (c != entry.container || memcmp(key, entry.key, entry.len)) { return entries[0]; }
+  return entry;
+}
+really_inline void sax_tweet_reader_visitor::field_lookup::add(const char * key, size_t len, containers c, field_type type, size_t offset) {
+  auto index = hash(key, uint32_t(c));
+  if (index == 0) {
+    fprintf(stderr, "%s (depth %d) hashes to zero, which is used as 'missing value'\n", key, int(c));
+    assert(false);
+  }
+  if (entries[index].key) {
+    fprintf(stderr, "%s (depth %d) collides with %s (depth %d) !\n", key, int(c), entries[index].key, int(entries[index].container));
+    assert(false);
+  }
+  entries[index] = { key, len, offset, c, type };
+}
+really_inline void sax_tweet_reader_visitor::field_lookup::neg(const char * const key, uint32_t depth) {
+  auto index = hash(key, depth);
+  if (entries[index].key) {
+    fprintf(stderr, "%s (depth %d) conflicts with %s (depth %d) !\n", key, depth, entries[index].key, int(entries[index].container));
+    assert(false);
+  }
+}
+
+sax_tweet_reader_visitor::field_lookup::field_lookup() {
+  add("\"statuses\"", strlen("\"statuses\""), containers::top_object, field_type::array, 0); // { "statuses": [...]
+  #define TWEET_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::tweet, TYPE, offsetof(tweet, KEY));
+  TWEET_FIELD(id, field_type::unsigned_integer);
+  TWEET_FIELD(in_reply_to_status_id, field_type::nullable_unsigned_integer);
+  TWEET_FIELD(retweet_count, field_type::unsigned_integer);
+  TWEET_FIELD(favorite_count, field_type::unsigned_integer);
+  TWEET_FIELD(text, field_type::string);
+  TWEET_FIELD(created_at, field_type::string);
+  TWEET_FIELD(user, field_type::object)
+  #undef TWEET_FIELD
+  #define USER_FIELD(KEY, TYPE) add("\"" #KEY "\"", strlen("\"" #KEY "\""), containers::user, TYPE, offsetof(tweet, user)+offsetof(twitter_user, KEY));
+  USER_FIELD(id, field_type::unsigned_integer);
+  USER_FIELD(screen_name, field_type::string);
+  #undef USER_FIELD
+
+  // Check for collisions with other (unused) hash keys in typical twitter JSON
+  #define NEG(key, depth) neg("\"" #key "\"", depth);
+  NEG(display_url, 9);
+  NEG(expanded_url, 9);
+  neg("\"h\":", 9);
+  NEG(indices, 9);
+  NEG(resize, 9);
+  NEG(url, 9);
+  neg("\"w\":", 9);
+  NEG(display_url, 8);
+  NEG(expanded_url, 8);
+  neg("\"h\":", 8);
+  NEG(indices, 8);
+  NEG(large, 8);
+  NEG(medium, 8);
+  NEG(resize, 8);
+  NEG(small, 8);
+  NEG(thumb, 8);
+  NEG(url, 8);
+  neg("\"w\":", 8);
+  NEG(display_url, 7);
+  NEG(expanded_url, 7);
+  NEG(id_str, 7);
+  NEG(id, 7);
+  NEG(indices, 7);
+  NEG(large, 7);
+  NEG(media_url_https, 7);
+  NEG(media_url, 7);
+  NEG(medium, 7);
+  NEG(name, 7);
+  NEG(sizes, 7);
+  NEG(small, 7);
+  NEG(source_status_id_str, 7);
+  NEG(source_status_id, 7);
+  NEG(thumb, 7);
+  NEG(type, 7);
+  NEG(url, 7);
+  NEG(urls, 7);
+  NEG(description, 6);
+  NEG(display_url, 6);
+  NEG(expanded_url, 6);
+  NEG(id_str, 6);
+  NEG(id, 6);
+  NEG(indices, 6);
+  NEG(media_url_https, 6);
+  NEG(media_url, 6);
+  NEG(name, 6);
+  NEG(sizes, 6);
+  NEG(source_status_id_str, 6);
+  NEG(source_status_id, 6);
+  NEG(type, 6);
+  NEG(url, 6);
+  NEG(urls, 6);
+  NEG(contributors_enabled, 5);
+  NEG(default_profile_image, 5);
+  NEG(default_profile, 5);
+  NEG(description, 5);
+  NEG(entities, 5);
+  NEG(favourites_count, 5);
+  NEG(follow_request_sent, 5);
+  NEG(followers_count, 5);
+  NEG(following, 5);
+  NEG(friends_count, 5);
+  NEG(geo_enabled, 5);
+  NEG(hashtags, 5);
+  NEG(id_str, 5);
+  NEG(id, 5);
+  NEG(is_translation_enabled, 5);
+  NEG(is_translator, 5);
+  NEG(iso_language_code, 5);
+  NEG(lang, 5);
+  NEG(listed_count, 5);
+  NEG(location, 5);
+  NEG(media, 5);
+  NEG(name, 5);
+  NEG(notifications, 5);
+  NEG(profile_background_color, 5);
+  NEG(profile_background_image_url_https, 5);
+  NEG(profile_background_image_url, 5);
+  NEG(profile_background_tile, 5);
+  NEG(profile_banner_url, 5);
+  NEG(profile_image_url_https, 5);
+  NEG(profile_image_url, 5);
+  NEG(profile_link_color, 5);
+  NEG(profile_sidebar_border_color, 5);
+  NEG(profile_sidebar_fill_color, 5);
+  NEG(profile_text_color, 5);
+  NEG(profile_use_background_image, 5);
+  NEG(protected, 5);
+  NEG(result_type, 5);
+  NEG(statuses_count, 5);
+  NEG(symbols, 5);
+  NEG(time_zone, 5);
+  NEG(url, 5);
+  NEG(urls, 5);
+  NEG(user_mentions, 5);
+  NEG(utc_offset, 5);
+  NEG(verified, 5);
+  NEG(contributors_enabled, 4);
+  NEG(contributors, 4);
+  NEG(coordinates, 4);
+  NEG(default_profile_image, 4);
+  NEG(default_profile, 4);
+  NEG(description, 4);
+  NEG(entities, 4);
+  NEG(favorited, 4);
+  NEG(favourites_count, 4);
+  NEG(follow_request_sent, 4);
+  NEG(followers_count, 4);
+  NEG(following, 4);
+  NEG(friends_count, 4);
+  NEG(geo_enabled, 4);
+  NEG(geo, 4);
+  NEG(hashtags, 4);
+  NEG(id_str, 4);
+  NEG(in_reply_to_screen_name, 4);
+  NEG(in_reply_to_status_id_str, 4);
+  NEG(in_reply_to_user_id_str, 4);
+  NEG(in_reply_to_user_id, 4);
+  NEG(is_translation_enabled, 4);
+  NEG(is_translator, 4);
+  NEG(iso_language_code, 4);
+  NEG(lang, 4);
+  NEG(listed_count, 4);
+  NEG(location, 4);
+  NEG(media, 4);
+  NEG(metadata, 4);
+  NEG(name, 4);
+  NEG(notifications, 4);
+  NEG(place, 4);
+  NEG(possibly_sensitive, 4);
+  NEG(profile_background_color, 4);
+  NEG(profile_background_image_url_https, 4);
+  NEG(profile_background_image_url, 4);
+  NEG(profile_background_tile, 4);
+  NEG(profile_banner_url, 4);
+  NEG(profile_image_url_https, 4);
+  NEG(profile_image_url, 4);
+  NEG(profile_link_color, 4);
+  NEG(profile_sidebar_border_color, 4);
+  NEG(profile_sidebar_fill_color, 4);
+  NEG(profile_text_color, 4);
+  NEG(profile_use_background_image, 4);
+  NEG(protected, 4);
+  NEG(result_type, 4);
+  NEG(retweeted, 4);
+  NEG(source, 4);
+  NEG(statuses_count, 4);
+  NEG(symbols, 4);
+  NEG(time_zone, 4);
+  NEG(truncated, 4);
+  NEG(url, 4);
+  NEG(urls, 4);
+  NEG(user_mentions, 4);
+  NEG(utc_offset, 4);
+  NEG(verified, 4);
+  NEG(contributors, 3);
+  NEG(coordinates, 3);
+  NEG(entities, 3);
+  NEG(favorited, 3);
+  NEG(geo, 3);
+  NEG(id_str, 3);
+  NEG(in_reply_to_screen_name, 3);
+  NEG(in_reply_to_status_id_str, 3);
+  NEG(in_reply_to_user_id_str, 3);
+  NEG(in_reply_to_user_id, 3);
+  NEG(lang, 3);
+  NEG(metadata, 3);
+  NEG(place, 3);
+  NEG(possibly_sensitive, 3);
+  NEG(retweeted_status, 3);
+  NEG(retweeted, 3);
+  NEG(source, 3);
+  NEG(truncated, 3);
+  NEG(completed_in, 2);
+  NEG(count, 2);
+  NEG(max_id_str, 2);
+  NEG(max_id, 2);
+  NEG(next_results, 2);
+  NEG(query, 2);
+  NEG(refresh_url, 2);
+  NEG(since_id_str, 2);
+  NEG(since_id, 2);
+  NEG(search_metadata, 1);
+  #undef NEG
+}
+
+// sax_tweet_reader_visitor::field_lookup::find_min() {
+//   int min_count = 100000;
+//   for (int a=0;a<4;a++) {
+//     for (int b=0;b<4;b++) {
+//       for (int c=0;c<4;c++) {
+//         twitter::sax_tweet_reader_visitor::field_lookup fields(a,b,c);
+//         if (fields.collision_count) { continue; }
+//         if (fields.zero_emission) { continue; }
+//         if (fields.conflict_count < min_count) { printf("min=%d,%d,%d (%d)", a, b, c, fields.conflict_count); }
+//       }
+//     }
+//   }
+// }
+
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+#endif // TWITTER_SAX_TWEET_READER_VISITOR_H

--- a/benchmark/twitter/tweet.h
+++ b/benchmark/twitter/tweet.h
@@ -1,0 +1,25 @@
+#ifndef TWEET_H
+#define TWEET_H
+
+#include "simdjson.h"
+#include "twitter_user.h"
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+
+struct tweet {
+  uint64_t id{};
+  std::string_view text{};
+  std::string_view created_at{};
+  uint64_t in_reply_to_status_id{};
+  uint64_t retweet_count{};
+  uint64_t favorite_count{};
+  twitter_user user{};
+};
+
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+#endif // TWEET_H

--- a/benchmark/twitter/tweet.h
+++ b/benchmark/twitter/tweet.h
@@ -4,8 +4,6 @@
 #include "simdjson.h"
 #include "twitter_user.h"
 
-SIMDJSON_TARGET_HASWELL
-
 namespace twitter {
 
 struct tweet {
@@ -19,7 +17,5 @@ struct tweet {
 };
 
 } // namespace twitter
-
-SIMDJSON_UNTARGET_REGION
 
 #endif // TWEET_H

--- a/benchmark/twitter/twitter_user.h
+++ b/benchmark/twitter/twitter_user.h
@@ -1,0 +1,19 @@
+#ifndef TWITTER_USER_H
+#define TWITTER_USER_H
+
+#include "simdjson.h"
+
+SIMDJSON_TARGET_HASWELL
+
+namespace twitter {
+
+struct twitter_user {
+  uint64_t id{};
+  std::string_view screen_name{};
+};
+
+} // namespace twitter
+
+SIMDJSON_UNTARGET_REGION
+
+#endif // TWITTER_USER_H

--- a/benchmark/twitter/twitter_user.h
+++ b/benchmark/twitter/twitter_user.h
@@ -3,8 +3,6 @@
 
 #include "simdjson.h"
 
-SIMDJSON_TARGET_HASWELL
-
 namespace twitter {
 
 struct twitter_user {
@@ -13,7 +11,5 @@ struct twitter_user {
 };
 
 } // namespace twitter
-
-SIMDJSON_UNTARGET_REGION
 
 #endif // TWITTER_USER_H

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -8,7 +8,7 @@ namespace logger {
 
   static constexpr const bool LOG_ENABLED = false;
   static constexpr const int LOG_EVENT_LEN = 20;
-  static constexpr const int LOG_BUFFER_LEN = 10;
+  static constexpr const int LOG_BUFFER_LEN = 30;
   static constexpr const int LOG_SMALL_BUFFER_LEN = 10;
   static constexpr const int LOG_INDEX_LEN = 5;
 

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -497,6 +497,7 @@ really_inline error_code parse_number(const uint8_t *const src, V &visitor) {
   return SUCCESS;
 }
 
+// SAX functions
 namespace {
 // Parse any number from 0 to 18,446,744,073,709,551,615
 UNUSED really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept {
@@ -539,7 +540,7 @@ UNUSED really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * co
 
 // Parse any number from 0 to 18,446,744,073,709,551,615
 // Call this version of the method if you regularly expect 8- or 16-digit numbers.
-really_inline simdjson_result<uint64_t> parse_large_unsigned(const uint8_t * const src) noexcept {
+UNUSED really_inline simdjson_result<uint64_t> parse_large_unsigned(const uint8_t * const src) noexcept {
   const uint8_t *p = src;
 
   //
@@ -642,7 +643,7 @@ UNUSED really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) 
   return negative ? (~i+1) : i;
 }
 
-really_inline simdjson_result<double> parse_double(const uint8_t * src) noexcept {
+UNUSED really_inline simdjson_result<double> parse_double(const uint8_t * src) noexcept {
   //
   // Check for minus sign
   //

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -498,7 +498,7 @@ really_inline error_code parse_number(const uint8_t *const src, V &visitor) {
 }
 
 // Parse any number from 0 to 18,446,744,073,709,551,615
-really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept {
+UNUSED really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept {
   const uint8_t *p = src;
 
   //
@@ -593,7 +593,7 @@ really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src
 // }
 
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
-really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
+UNUSED really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
   //
   // Check for minus sign
   //

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -497,6 +497,7 @@ really_inline error_code parse_number(const uint8_t *const src, V &visitor) {
   return SUCCESS;
 }
 
+namespace {
 // Parse any number from 0 to 18,446,744,073,709,551,615
 UNUSED really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept {
   const uint8_t *p = src;
@@ -538,59 +539,58 @@ UNUSED really_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * co
 
 // Parse any number from 0 to 18,446,744,073,709,551,615
 // Call this version of the method if you regularly expect 8- or 16-digit numbers.
-// really_inline simdjson_result<uint64_t> parse_large_unsigned(const uint8_t * const src) noexcept {
-//   const uint8_t *p = src;
+really_inline simdjson_result<uint64_t> parse_large_unsigned(const uint8_t * const src) noexcept {
+  const uint8_t *p = src;
 
-//   //
-//   // Parse the integer part.
-//   //
-//   const uint8_t *const start_digits = p;
-//   uint64_t i = 0;
-//   if (is_made_of_eight_digits_fast(p)) {
-//     i = i * 100000000 + parse_eight_digits_unrolled(p);
-//     p += 8;
-//     if (is_made_of_eight_digits_fast(p)) {
-//       i = i * 100000000 + parse_eight_digits_unrolled(p);
-//       p += 8;
-//       if (parse_digit(*p, i)) { // digit 17
-//         p++;
-//         if (parse_digit(*p, i)) { // digit 18
-//           p++;
-//           if (parse_digit(*p, i)) { // digit 19
-//             p++;
-//             if (parse_digit(*p, i)) { // digit 20
-//               p++;
-//               if (parse_digit(*p, i)) { return NUMBER_ERROR; } // 21 digits is an error
-//               // Positive overflow check:
-//               // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
-//               //   biggest uint64_t.
-//               // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
-//               //   If we got here, it's a 20 digit number starting with the digit "1".
-//               // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
-//               //   than 1,553,255,926,290,448,384.
-//               // - That is smaller than the smallest possible 20-digit number the user could write:
-//               //   10,000,000,000,000,000,000.
-//               // - Therefore, if the number is positive and lower than that, it's overflow.
-//               // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
-//               //
-//               if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return NUMBER_ERROR; }
-//             }
-//           }
-//         }
-//       }
-//     } // 16 digits
-//   } else { // 8 digits
-//     // Less than 8 digits can't overflow, simpler logic here.
-//     if (parse_digit(*p, i)) { p++; } else { return NUMBER_ERROR; }
-//     while (parse_digit(*p, i)) { p++; }
-//   }
+  //
+  // Parse the integer part.
+  //
+  uint64_t i = 0;
+  if (is_made_of_eight_digits_fast(p)) {
+    i = i * 100000000 + parse_eight_digits_unrolled(p);
+    p += 8;
+    if (is_made_of_eight_digits_fast(p)) {
+      i = i * 100000000 + parse_eight_digits_unrolled(p);
+      p += 8;
+      if (parse_digit(*p, i)) { // digit 17
+        p++;
+        if (parse_digit(*p, i)) { // digit 18
+          p++;
+          if (parse_digit(*p, i)) { // digit 19
+            p++;
+            if (parse_digit(*p, i)) { // digit 20
+              p++;
+              if (parse_digit(*p, i)) { return NUMBER_ERROR; } // 21 digits is an error
+              // Positive overflow check:
+              // - A 20 digit number starting with 2-9 is overflow, because 18,446,744,073,709,551,615 is the
+              //   biggest uint64_t.
+              // - A 20 digit number starting with 1 is overflow if it is less than INT64_MAX.
+              //   If we got here, it's a 20 digit number starting with the digit "1".
+              // - If a 20 digit number starting with 1 overflowed (i*10+digit), the result will be smaller
+              //   than 1,553,255,926,290,448,384.
+              // - That is smaller than the smallest possible 20-digit number the user could write:
+              //   10,000,000,000,000,000,000.
+              // - Therefore, if the number is positive and lower than that, it's overflow.
+              // - The value we are looking at is less than or equal to 9,223,372,036,854,775,808 (INT64_MAX).
+              //
+              if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return NUMBER_ERROR; }
+            }
+          }
+        }
+      }
+    } // 16 digits
+  } else { // 8 digits
+    // Less than 8 digits can't overflow, simpler logic here.
+    if (parse_digit(*p, i)) { p++; } else { return NUMBER_ERROR; }
+    while (parse_digit(*p, i)) { p++; }
+  }
 
-//   if (!is_structural_or_whitespace(*p, i)) { return NUMBER_ERROR; }
-//   // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
-//   int digit_count = int(p - src);
-//   if (digit_count == 0 || ('0' == *src && digit_count > 1)) { return NUMBER_ERROR; }
-//   return i;
-// }
+  if (!is_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
+  // If there were no digits, or if the integer starts with 0 and has more than one digit, it's an error.
+  int digit_count = int(p - src);
+  if (digit_count == 0 || ('0' == *src && digit_count > 1)) { return NUMBER_ERROR; }
+  return i;
+}
 
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807
 UNUSED really_inline simdjson_result<int64_t> parse_integer(const uint8_t *src) noexcept {
@@ -715,7 +715,7 @@ really_inline simdjson_result<double> parse_double(const uint8_t * src) noexcept
   }
   return d;
 }
-
+} //namespace {}
 #endif // SIMDJSON_SKIPNUMBERPARSING
 
 } // namespace numberparsing

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -119,6 +119,15 @@ WARN_UNUSED really_inline uint8_t *parse_string(const uint8_t *src, uint8_t *dst
   return nullptr;
 }
 
+WARN_UNUSED really_inline error_code parse_string_to_buffer(const uint8_t *src, uint8_t *&current_string_buf_loc, std::string_view &s) {
+  if (src[0] != '"') { return STRING_ERROR; }
+  auto end = stringparsing::parse_string(src, current_string_buf_loc);
+  if (!end) { return STRING_ERROR; }
+  s = std::string_view((const char *)current_string_buf_loc, end-current_string_buf_loc);
+  current_string_buf_loc = end;
+  return SUCCESS;
+}
+
 } // namespace stringparsing
 } // namespace stage2
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -119,7 +119,7 @@ WARN_UNUSED really_inline uint8_t *parse_string(const uint8_t *src, uint8_t *dst
   return nullptr;
 }
 
-WARN_UNUSED really_inline error_code parse_string_to_buffer(const uint8_t *src, uint8_t *&current_string_buf_loc, std::string_view &s) {
+UNUSED WARN_UNUSED really_inline error_code parse_string_to_buffer(const uint8_t *src, uint8_t *&current_string_buf_loc, std::string_view &s) {
   if (src[0] != '"') { return STRING_ERROR; }
   auto end = stringparsing::parse_string(src, current_string_buf_loc);
   if (!end) { return STRING_ERROR; }


### PR DESCRIPTION
I wrote a benchmark that selectively deserializes twitter.json, gets the tweet ID, text, timestamp, user ID, screen name, # favorites, # retweets, and ID of the tweet it's replying to (if any).

Relevant design points:
* Primitive values we don't care about are not parsed or validated. Structure (objects and arrays) is fully validated, however.
* It keeps track of the `container` you are in (root, top object, statuses, tweet, user). There are other sub-object or sub-sub-objects we don't care about (twitter.json has a depth of 9)--we let the depth float and decide whether we're directly *in* a tweet or user by checking if depth == 3 or 4.
* Fields we care about are described in a static hash from [key+depth] -> [type, binary offset into tweet]. Types are unsigned, nullable unsigned, and string.
* When a primitive field is found, we look up field descriptor, switch on the type, parse the value and store it at the given binary offset in the tweet struct. This way we can handle all fields of the same type in a single branch.

## Performance

This blows normal parsing out of the water, as one would hope:

| Benchmark | Throughput |
|---|---|
| SAX | 3.7 GB/s |
| Parse Only | 2.3 GB/s |
| DOM | 2.1 GB/s |


Branchiness is *absolutely* a big deal with SAX, since callbacks aren't context dependent (you have to use if statements to figure out where you are in the file). It has run through several iterations that demonstrate this:

* The original implementation (see the first commit) ran at the same speed as the DOM implementation (2.1GB/s).
* Reducing the number of branches by removing the key -> type indirection pulled it ahead (2.3GB/s).
* Simplifying and reducing the branchiness of the "what object / array am I in" checks you have to do on every value bought another small win (2.4GB/s).
* Removing the terrible miss time (it strncmps every single key) as well as branchiness of the field name comparison with a hash absolutely smashed through the performance barrier (3.7GB/s)

```
sax_tweets/repeats:10_mean       170498 ns       170493 ns           10 Gigabytes=3.70406G/s docs=5.86536k/s tweets=0/s
sax_tweets/repeats:10_median     170513 ns       170511 ns           10 Gigabytes=3.70366G/s docs=5.86472k/s tweets=0/s
sax_tweets/repeats:10_stddev        125 ns          125 ns           10 Gigabytes=2.72247M/s docs=4.31101/s tweets=0/s
sax_tweets/repeats:10_max        170740 ns       170739 ns           10 Gigabytes=3.70752G/s docs=5.87083k/s tweets=0/s

dom_tweets/repeats:10_mean       297737 ns       297726 ns           10 Gigabytes=2.12113G/s docs=3.3588k/s tweets=335.88k/s
dom_tweets/repeats:10_median     297683 ns       297673 ns           10 Gigabytes=2.12151G/s docs=3.3594k/s tweets=335.94k/s
dom_tweets/repeats:10_stddev        234 ns          233 ns           10 Gigabytes=1.65781M/s docs=2.62513/s tweets=262.513/s
dom_tweets/repeats:10_max        298085 ns       298081 ns           10 Gigabytes=2.12327G/s docs=3.36219k/s tweets=336.219k/s

dom_parse/repeats:10_mean        278354 ns       278346 ns           10 Gigabytes=2.26882G/s docs=3.59265k/s
dom_parse/repeats:10_median      278424 ns       278413 ns           10 Gigabytes=2.26827G/s docs=3.59178k/s
dom_parse/repeats:10_stddev         322 ns          322 ns           10 Gigabytes=2.63048M/s docs=4.16534/s
dom_parse/repeats:10_max         278717 ns       278708 ns           10 Gigabytes=2.27389G/s docs=3.60068k/s
```

These are decent results.

* The DOM implementation deserializes *the entire twitter file,* while the SAX implementation deserializes nothing at all. It then *copies* the values, while SAX generates the values in place. There is no way to overcome this limitation.
* The DOM implementation also has a very inefficient object key lookup algorithm that crawls the whole object each time, which could be fixed or made better.
* The SAX implementation can be improved several ways: its key matching algorithm could be made nearly branchless with some simple hashing.
* Maximum key length you care about must be less than SIMDJSON_PADDING. Right now, it doesn't bother length checking when checking if the key is the correct one with memcmp.

On the other hand, the DOM implementation is 20 lines, and the SAX implementation is pushing 200.

The SAX implementation also does not check or error when things it expects to be primitives turn out to be objects or arrays (i.e. `"id": [1,2]`), or vice versa. This is extra code that has to be added to match the DOM implementation (and remain safe).

## On-Demand

On-demand parsing should be able to match and exceed this, eliminating the frustrating "where am I" checks on every callback. It should also be able to match the DOM's 20 line ease-of-reading.