### PR TITLE
Fix potential buffer overrun with heavily customized input and padding

### DIFF
--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -114,18 +114,27 @@ WARN_UNUSED really_inline error_code structural_parser::parse(T &builder) noexce
   //
   {
     const uint8_t *value = advance();
-    switch (*value) {
-      case '{': if (!empty_object(builder)) { goto object_begin; }; break;
-      case '[': {
-        // Make sure the outer array is closed before continuing; otherwise, there are ways we could get
-        // into memory corruption. See https://github.com/simdjson/simdjson/issues/906
-        if (!STREAMING) {
+
+    // Make sure the outer hash or array is closed before continuing; otherwise, there are ways we
+    // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
+    if (!STREAMING) {
+      switch (*value) {
+        case '{':
+          if (buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]] != '}') {
+            return TAPE_ERROR;
+          }
+          break;
+        case '[':
           if (buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]] != ']') {
             return TAPE_ERROR;
           }
-        }
-        if (!empty_array(builder)) { goto array_begin; }; break;
+          break;
       }
+    }
+
+    switch (*value) {
+      case '{': if (!empty_object(builder)) { goto object_begin; }; break;
+      case '[': if (!empty_array(builder)) { goto array_begin; }; break;
       default: SIMDJSON_TRY( builder.parse_root_primitive(*this, value) );
     }
     goto document_end;

--- a/src/generic/stage2/structural_parser.h
+++ b/src/generic/stage2/structural_parser.h
@@ -79,6 +79,10 @@ struct structural_parser : structural_iterator {
     return SUCCESS;
   }
 
+  really_inline uint8_t last_structural() {
+    return buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]];
+  }
+
   really_inline void log_value(const char *type) {
     logger::log_line(*this, "", type, "");
   }
@@ -120,12 +124,12 @@ WARN_UNUSED really_inline error_code structural_parser::parse(T &builder) noexce
     if (!STREAMING) {
       switch (*value) {
         case '{':
-          if (buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]] != '}') {
+          if (last_structural() != '}') {
             return TAPE_ERROR;
           }
           break;
         case '[':
-          if (buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]] != ']') {
+          if (last_structural() != ']') {
             return TAPE_ERROR;
           }
           break;

--- a/tests/errortests.cpp
+++ b/tests/errortests.cpp
@@ -145,6 +145,49 @@ namespace parser_load {
   }
 }
 
+namespace adversarial {
+  #define PADDING_FILLED_WITH_NUMBERS "222222222222222222222222222222222"
+  bool number_overrun_at_root() {
+    TEST_START();
+    constexpr const char *json = "1" PADDING_FILLED_WITH_NUMBERS ",";
+    constexpr size_t len = 1; // strlen("1");
+
+    dom::parser parser;
+    uint64_t foo;
+    ASSERT_SUCCESS( parser.parse(json, len).get(foo) ); // Parse just the first digit
+    ASSERT_EQUAL( foo, 1 );
+    TEST_SUCCEED();
+  }
+  bool number_overrun_in_array() {
+    TEST_START();
+    constexpr const char *json = "[1" PADDING_FILLED_WITH_NUMBERS "]";
+    constexpr size_t len = 2; // strlen("[1");
+
+    dom::parser parser;
+    uint64_t foo;
+    ASSERT_ERROR( parser.parse(json, len).get(foo), TAPE_ERROR ); // Parse just the first digit
+    TEST_SUCCEED();
+  }
+  bool number_overrun_in_object() {
+    TEST_START();
+    constexpr const char *json = "{\"key\":1" PADDING_FILLED_WITH_NUMBERS "}";
+    constexpr size_t len = 8; // strlen("{\"key\":1");
+
+    dom::parser parser;
+    uint64_t foo;
+    ASSERT_ERROR( parser.parse(json, len).get(foo), TAPE_ERROR ); // Parse just the first digit
+    TEST_SUCCEED();
+  }
+  bool run() {
+    static_assert(33 > SIMDJSON_PADDING, "corruption test doesn't have enough padding"); // 33 = strlen(PADDING_FILLED_WITH_NUMBERS)
+    return true
+      && number_overrun_at_root()
+      && number_overrun_in_array()
+      && number_overrun_in_object()
+    ;
+  }
+}
+
 int main() {
   // this is put here deliberately to check that the documentation is correct (README),
   // should this fail to compile, you should update the documentation:
@@ -152,7 +195,10 @@ int main() {
     printf("unsupported CPU\n"); 
   }
   std::cout << "Running error tests." << std::endl;
-  if (!parser_load::run()) {
+  if (!(true
+        && parser_load::run()
+        && adversarial::run()
+  )) {
     return EXIT_FAILURE;
   }
   std::cout << "Error tests are ok." << std::endl;


### PR DESCRIPTION
Because number parsing will keep going as long as it can find new numbers, there is a case where it could trail off past SIMDJSON_PADDING:

```c++
const char *json = "{\"key\":122222222222222222222222222222222222222222222}";
parser.parse(json, strlen("{\"key\":1"));
```

We fix this for numbers we find at the root by copying the buffer and adding spaces; we fix it for arrays by checking if the array is closed. But we don't check if hashes are closed, so we can get into this situation still.

To make this a corruption bug, you just have to cut the array off after SIMDJSON_PADDING digits.

This closes off all possible corruption bugs where non-root primitives assume there is a structural or whitespace after them, I believe.

## Performance

Incredibly and inexplicably, this PR improves performance and reduces instruction counts on skylake:

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |
| numbers                          |   2345 | 266.9 | 242.1 |    9% | 819.3 | 810.8 |    1% |
| mesh                             |  11306 | 308.9 | 302.2 |    2% | 1009.0 | 1010.5 |    0% |
| github_events                    |   1017 |  79.5 |  78.3 |    1% | 264.5 | 262.9 |    0% |
| canada                           |  35172 | 288.8 | 285.7 |    1% | 973.9 | 980.2 |    0% |
| random                           |   7976 | 141.6 | 140.2 |    1% | 494.6 | 491.8 |    0% |
| twitter                          |   9867 |  91.7 |  90.8 |    1% | 290.2 | 288.2 |    0% |
| update-center                    |   8330 | 112.0 | 111.0 |    0% | 335.5 | 332.4 |    0% |
| gsoc-2018                        |  51997 |  71.8 |  71.6 |    0% | 167.0 | 166.4 |    0% |
| apache_builds                    |   1988 |  85.9 |  85.8 |    0% | 304.7 | 302.9 |    0% |
| twitterescaped                   |   8787 | 184.5 | 184.4 |    0% | 489.9 | 487.7 |    0% |
| citm_catalog                     |  26987 |  80.2 |  80.3 |    0% | 296.3 | 296.3 |    0% |
| mesh.pretty                      |  24646 | 179.5 | 179.7 |    0% | 592.0 | 592.6 |    0% |
| instruments                      |   3442 | 105.2 | 105.9 |    0% | 378.5 | 378.3 |    0% |
| marine_ik                        |  46616 | 294.5 | 297.6 |   -1% | 919.6 | 917.5 |    0% |