### PR TITLE
Number refactorings with positive effects

### DIFF
--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -8,14 +8,14 @@ namespace numberparsing {
 
 #ifdef JSON_TEST_NUMBERS
 #define INVALID_NUMBER(SRC) (found_invalid_number((SRC)), NUMBER_ERROR)
-#define WRITE_INTEGER(VALUE, SRC, WRITER) (found_integer((VALUE), (SRC)), writer.append_s64((VALUE)))
-#define WRITE_UNSIGNED(VALUE, SRC, WRITER) (found_unsigned_integer((VALUE), (SRC)), writer.append_u64((VALUE)))
-#define WRITE_DOUBLE(VALUE, SRC, WRITER) (found_float((VALUE), (SRC)), writer.append_double((VALUE)))
+#define WRITE_INTEGER(VALUE, SRC, WRITER) (found_integer((VALUE), (SRC)), (WRITER).append_s64((VALUE)))
+#define WRITE_UNSIGNED(VALUE, SRC, WRITER) (found_unsigned_integer((VALUE), (SRC)), (WRITER).append_u64((VALUE)))
+#define WRITE_DOUBLE(VALUE, SRC, WRITER) (found_float((VALUE), (SRC)), (WRITER).append_double((VALUE)))
 #else
 #define INVALID_NUMBER(SRC) (NUMBER_ERROR)
-#define WRITE_INTEGER(VALUE, SRC, WRITER) writer.append_s64((VALUE))
-#define WRITE_UNSIGNED(VALUE, SRC, WRITER) writer.append_u64((VALUE))
-#define WRITE_DOUBLE(VALUE, SRC, WRITER) writer.append_double((VALUE))
+#define WRITE_INTEGER(VALUE, SRC, WRITER) (WRITER).append_s64((VALUE))
+#define WRITE_UNSIGNED(VALUE, SRC, WRITER) (WRITER).append_u64((VALUE))
+#define WRITE_DOUBLE(VALUE, SRC, WRITER) (WRITER).append_double((VALUE))
 #endif
 
 // Attempts to compute i * 10^(power) exactly; and if "negative" is
@@ -250,7 +250,7 @@ template<typename W>
 error_code slow_float_parsing(UNUSED const uint8_t * src, W writer) {
   double d;
   if (parse_float_strtod(src, &d)) {
-    WRITE_DOUBLE(d, src, writer);
+    writer.append_double(d);
     return SUCCESS;
   }
   return INVALID_NUMBER(src);
@@ -345,35 +345,36 @@ really_inline error_code parse_exponent(UNUSED const uint8_t *const src, const u
   return SUCCESS;
 }
 
+really_inline int significant_digits(const uint8_t * start_digits, int digit_count) {
+  // It is possible that the integer had an overflow.
+  // We have to handle the case where we have 0.0000somenumber.
+  const uint8_t *start = start_digits;
+  while ((*start == '0') || (*start == '.')) {
+    start++;
+  }
+  // we over-decrement by one when there is a '.'
+  return digit_count - int(start - start_digits);
+}
+
 template<typename W>
 really_inline error_code write_float(const uint8_t *const src, bool negative, uint64_t i, const uint8_t * start_digits, int digit_count, int64_t exponent, W &writer) {
   // If we frequently had to deal with long strings of digits,
   // we could extend our code by using a 128-bit integer instead
   // of a 64-bit integer. However, this is uncommon in practice.
   // digit count is off by 1 because of the decimal (assuming there was one).
-  if (unlikely((digit_count-1 >= 19))) { // this is uncommon
-    // It is possible that the integer had an overflow.
-    // We have to handle the case where we have 0.0000somenumber.
-    const uint8_t *start = start_digits;
-    while ((*start == '0') || (*start == '.')) {
-      start++;
-    }
-    // we over-decrement by one when there is a '.'
-    digit_count -= int(start - start_digits);
-    if (digit_count >= 19) {
-      // Ok, chances are good that we had an overflow!
-      // this is almost never going to get called!!!
-      // we start anew, going slowly!!!
-      // This will happen in the following examples:
-      // 10000000000000000000000000000000000000000000e+308
-      // 3.1415926535897932384626433832795028841971693993751
-      //
-      error_code error = slow_float_parsing(src, writer);
-      // The number was already written, but we made a copy of the writer
-      // when we passed it to the parse_large_integer() function, so
-      writer.skip_double();
-      return error;
-    }
+  if (unlikely(digit_count-1 >= 19 && significant_digits(start_digits, digit_count) >= 19)) {
+    // Ok, chances are good that we had an overflow!
+    // this is almost never going to get called!!!
+    // we start anew, going slowly!!!
+    // This will happen in the following examples:
+    // 10000000000000000000000000000000000000000000e+308
+    // 3.1415926535897932384626433832795028841971693993751
+    //
+    error_code error = slow_float_parsing(src, writer);
+    // The number was already written, but we made a copy of the writer
+    // when we passed it to the parse_large_integer() function, so
+    writer.skip_double();
+    return error;
   }
   // NOTE: it's weird that the unlikely() only wraps half the if, but it seems to get slower any other
   // way we've tried: https://github.com/simdjson/simdjson/pull/990#discussion_r448497331

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -370,9 +370,12 @@ really_inline error_code write_float(const uint8_t *const src, bool negative, ui
     // 10000000000000000000000000000000000000000000e+308
     // 3.1415926535897932384626433832795028841971693993751
     //
+    // NOTE: This makes a *copy* of the writer and passes it to slow_float_parsing. This happens
+    // because slow_float_parsing is a non-inlined function. If we passed our writer reference to
+    // it, it would force it to be stored in memory, preventing the compiler from picking it apart
+    // and putting into registers. i.e. if we pass it as reference, it gets slow.
+    // This is what forces the skip_double, as well.
     error_code error = slow_float_parsing(src, writer);
-    // The number was already written, but we made a copy of the writer
-    // when we passed it to the parse_large_integer() function, so
     writer.skip_double();
     return error;
   }
@@ -382,9 +385,12 @@ really_inline error_code write_float(const uint8_t *const src, bool negative, ui
   if (unlikely(exponent < FASTFLOAT_SMALLEST_POWER) || (exponent > FASTFLOAT_LARGEST_POWER)) {
     // this is almost never going to get called!!!
     // we start anew, going slowly!!!
+    // NOTE: This makes a *copy* of the writer and passes it to slow_float_parsing. This happens
+    // because slow_float_parsing is a non-inlined function. If we passed our writer reference to
+    // it, it would force it to be stored in memory, preventing the compiler from picking it apart
+    // and putting into registers. i.e. if we pass it as reference, it gets slow.
+    // This is what forces the skip_double, as well.
     error_code error = slow_float_parsing(src, writer);
-    // The number was already written, but we made a copy of the writer when we passed it to the
-    // slow_float_parsing() function, so we have to skip those tape spots now that we've returned
     writer.skip_double();
     return error;
   }

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -24,7 +24,7 @@ namespace numberparsing {
 // set to false. This should work *most of the time* (like 99% of the time).
 // We assume that power is in the [FASTFLOAT_SMALLEST_POWER,
 // FASTFLOAT_LARGEST_POWER] interval: the caller is responsible for this check.
-really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, bool *success) {
+really_inline bool compute_float_64(int64_t power, uint64_t i, bool negative, double &d) {
   // we start with a fast path
   // It was described in
   // Clinger WD. How to read floating point numbers accurately.
@@ -40,7 +40,7 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, 
 #endif
     // convert the integer into a double. This is lossless since
     // 0 <= i <= 2^53 - 1.
-    double d = double(i);
+    d = double(i);
     //
     // The general idea is as follows.
     // If 0 <= s < 2^53 and if 10^0 <= p <= 10^22 then
@@ -59,8 +59,7 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, 
     if (negative) {
       d = -d;
     }
-    *success = true;
-    return d;
+    return true;
   }
   // When 22 < power && power <  22 + 16, we could
   // hope for another, secondary fast path.  It wa
@@ -85,7 +84,8 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, 
   // In the slow path, we need to adjust i so that it is > 1<<63 which is always
   // possible, except if i == 0, so we handle i == 0 separately.
   if(i == 0) {
-    return 0.0;
+    d = 0.0;
+    return true;
   }
 
   // We are going to need to do some 64-bit arithmetic to get a more precise product.
@@ -135,8 +135,7 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, 
     // This does happen, e.g. with 7.3177701707893310e+15.
     if (((product_middle + 1 == 0) && ((product_high & 0x1FF) == 0x1FF) &&
          (product_low + i < product_low))) { // let us be prudent and bail out.
-      *success = false;
-      return 0;
+      return false;
     }
     upper = product_high;
     lower = product_middle;
@@ -157,25 +156,24 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, 
   // floating-point values.
   if (unlikely((lower == 0) && ((upper & 0x1FF) == 0) &&
                ((mantissa & 3) == 1))) {
-      // if mantissa & 1 == 1 we might need to round up.
-      //
-      // Scenarios:
-      // 1. We are not in the middle. Then we should round up.
-      //
-      // 2. We are right in the middle. Whether we round up depends
-      // on the last significant bit: if it is "one" then we round
-      // up (round to even) otherwise, we do not.
-      //
-      // So if the last significant bit is 1, we can safely round up.
-      // Hence we only need to bail out if (mantissa & 3) == 1.
-      // Otherwise we may need more accuracy or analysis to determine whether
-      // we are exactly between two floating-point numbers.
-      // It can be triggered with 1e23.
-      // Note: because the factor_mantissa and factor_mantissa_low are
-      // almost always rounded down (except for small positive powers),
-      // almost always should round up.
-      *success = false;
-      return 0;
+    // if mantissa & 1 == 1 we might need to round up.
+    //
+    // Scenarios:
+    // 1. We are not in the middle. Then we should round up.
+    //
+    // 2. We are right in the middle. Whether we round up depends
+    // on the last significant bit: if it is "one" then we round
+    // up (round to even) otherwise, we do not.
+    //
+    // So if the last significant bit is 1, we can safely round up.
+    // Hence we only need to bail out if (mantissa & 3) == 1.
+    // Otherwise we may need more accuracy or analysis to determine whether
+    // we are exactly between two floating-point numbers.
+    // It can be triggered with 1e23.
+    // Note: because the factor_mantissa and factor_mantissa_low are
+    // almost always rounded down (except for small positive powers),
+    // almost always should round up.
+    return false;
   }
 
   mantissa += mantissa & 1;
@@ -193,15 +191,12 @@ really_inline double compute_float_64(int64_t power, uint64_t i, bool negative, 
   uint64_t real_exponent = c.exp - lz;
   // we have to check that real_exponent is in range, otherwise we bail out
   if (unlikely((real_exponent < 1) || (real_exponent > 2046))) {
-    *success = false;
-    return 0;
+    return false;
   }
   mantissa |= real_exponent << 52;
   mantissa |= (((uint64_t)negative) << 63);
-  double d;
   memcpy(&d, &mantissa, sizeof(d));
-  *success = true;
-  return d;
+  return true;
 }
 
 static bool parse_float_strtod(const uint8_t *ptr, double *outDouble) {
@@ -392,9 +387,8 @@ really_inline error_code write_float(const uint8_t *const src, bool negative, ui
     writer.skip_double();
     return error;
   }
-  bool success = true;
-  double d = compute_float_64(exponent, i, negative, &success);
-  if (!success) {
+  double d;
+  if (!compute_float_64(exponent, i, negative, d)) {
     // we are almost never going to get here.
     if (!parse_float_strtod(src, &d)) { return INVALID_NUMBER(src); }
   }
@@ -713,12 +707,10 @@ UNUSED really_inline simdjson_result<double> parse_double(const uint8_t * src) n
   //
   // Assemble (or slow-parse) the float
   //
-  if (likely(!overflow)) {
-    bool success = true;
-    double d = compute_float_64(exponent, i, negative, &success);
-    if (success) { return d; }
-  }
   double d;
+  if (likely(!overflow)) {
+    if (compute_float_64(exponent, i, negative, d)) { return d; }
+  }
   if (!parse_float_strtod(src-negative, &d)) {
     return NUMBER_ERROR;
   }

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -160,8 +160,7 @@ WARN_UNUSED really_inline error_code tape_builder::visit_root_string(json_iterat
 
 WARN_UNUSED really_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("number");
-  if (!numberparsing::parse_number(value, tape)) { iter.log_error("Invalid number"); return NUMBER_ERROR; }
-  return SUCCESS;
+  return numberparsing::parse_number(value, tape);
 }
 
 WARN_UNUSED really_inline error_code tape_builder::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {


### PR DESCRIPTION
I spent some time factoring number parsing, to get rid of the need to pass the writer to a function ... I haven't succeeded in that yet, but the small changes here seem to change some stuff so I thought I'd send it up. IMO it makes the flow a little clearer, which is the main reason to do it.

* Return error codes from parse_double(): this was actually the biggest jump. Now that we're just passing error codes all the way down to the caller, we get some savings!
* Make compute_float_64 return bool (and write to `double &d`): this simplifies our control flow usage a bit. This also gets rid of a "not quite bug" where one of the paths in compute_float_64 forgot to assign success = true, so you are forced to pre-assign it to true before calling.
* Collapses the code to remove leading zeroes into its own function (significant_digits()).

## Performance

This appears to make things better for files like canada.json, which has lots of numbers dispersed across many different arrays (it's an array of points), and worse for files like numbers.json, which has one massive array.  These numbers are vs. master, but note that this PR is relative to #1101 .

It also results in a general, seemingly significant, drop in branch misses on ARM for most files.

ARM gcc10.2 (ampere):

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| canada                           |  35172 | 811.2 | 781.4 |    3% | 996.4 | 987.7 |    0% |  48499 |  44052 |    9% |  91719 |  91769 |    0% | 5088797 | 5097982 |    0% |
| update-center                    |   8330 | 553.4 | 540.1 |    2% | 455.2 | 455.3 |    0% |  13610 |  13558 |    0% |  20787 |  20814 |    0% | 1008397 | 1021905 |   -1% |
| mesh.pretty                      |  24646 | 563.9 | 556.8 |    1% | 624.7 | 622.6 |    0% |  24094 |  23485 |    2% |  59090 |  59084 |    0% | 1971915 | 1974519 |    0% |
| random                           |   7976 | 708.8 | 702.1 |    0% | 636.1 | 636.1 |    0% |   7126 |   8713 |  -22% |  21598 |  21598 |    0% | 1235929 | 1242282 |    0% |
| apache_builds                    |   1988 | 474.3 | 470.8 |    0% | 411.5 | 411.5 |    0% |    730 |    717 |    1% |   4832 |   4822 |    0% | 201044 | 200786 |    0% |
| twitter                          |   9867 | 491.0 | 488.0 |    0% | 381.9 | 381.9 |    0% |  16676 |  16396 |    1% |  23394 |  23385 |    0% | 856794 | 857169 |    0% |
| citm_catalog                     |  26987 | 392.5 | 391.3 |    0% | 361.8 | 361.8 |    0% |   9374 |   8868 |    5% |  62694 |  62674 |    0% | 1818343 | 1816310 |    0% |
| gsoc-2018                        |  51997 | 359.6 | 358.9 |    0% | 237.6 | 237.6 |    0% |  38316 |  39331 |   -2% | 109503 | 109527 |    0% | 2739706 | 2752278 |    0% |
| twitterescaped                   |   8787 | 739.4 | 738.7 |    0% | 620.1 | 620.1 |    0% |  19863 |  19676 |    0% |  21319 |  21336 |    0% | 1562384 | 1560415 |    0% |
| github_events                    |   1017 | 461.0 | 461.1 |    0% | 357.0 | 357.0 |    0% |   1530 |   1505 |    1% |   2406 |   2401 |    0% |  87753 |  87173 |    0% |
| instruments                      |   3442 | 489.5 | 491.0 |    0% | 464.5 | 464.5 |    0% |   4318 |   4468 |   -3% |   8675 |   8670 |    0% | 340896 | 341213 |    0% |
| mesh                             |  11306 | 922.5 | 929.6 |    0% | 1047.7 | 1049.1 |    0% |  21104 |  18051 |   14% |  32339 |  32347 |    0% | 1648614 | 1649047 |    0% |
| marine_ik                        |  46616 | 861.4 | 868.9 |    0% | 968.3 | 969.4 |    0% |  95052 |  92301 |    2% | 134047 | 133978 |    0% | 7538697 | 7571395 |    0% |
| numbers                          |   2345 | 888.3 | 909.5 |   -2% | 873.9 | 878.2 |    0% |   3148 |   3239 |   -2% |   6021 |   6017 |    0% | 258282 | 258396 |    0% |

Haswell gcc9.2 (skylake):

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. | master Branch Misses | PR Branch Misses | -Branch Misses | master Cache Misses | PR Cache Misses | -Cache Misses | master Cache Refs | PR Cache Refs | -Cache Refs |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |    --: |    --: |   --: |
| canada                           |  35172 | 288.8 | 273.2 |    5% | 973.9 | 965.4 |    0% |  19401 |  18932 |    2% |  74999 |  69317 |    7% | 343822 | 345134 |    0% |
| marine_ik                        |  46616 | 294.5 | 281.3 |    4% | 919.6 | 921.7 |    0% |  52315 |  51872 |    0% | 224627 | 258374 |  -15% | 570302 | 575376 |    0% |
| mesh                             |  11306 | 308.9 | 297.5 |    3% | 1009.0 | 1010.8 |    0% |  10039 |  10142 |   -1% |      0 |      0 |    0% | 136713 | 136863 |    0% |
| mesh.pretty                      |  24646 | 179.5 | 175.2 |    2% | 592.0 | 589.8 |    0% |  13921 |  13507 |    2% |   1496 |   1783 |  -19% | 194445 | 194803 |    0% |
| update-center                    |   8330 | 112.0 | 109.4 |    2% | 335.5 | 335.5 |    0% |   5702 |   5549 |    2% |      0 |      0 |    0% |  84324 |  84109 |    0% |
| numbers                          |   2345 | 266.9 | 261.2 |    2% | 819.3 | 823.6 |    0% |   2138 |   2204 |   -3% |      0 |      0 |    0% |  18414 |  18258 |    0% |
| instruments                      |   3442 | 105.2 | 103.3 |    1% | 378.5 | 380.0 |    0% |    459 |    536 |  -16% |      0 |      0 |    0% |  30156 |  30633 |   -1% |
| random                           |   7976 | 141.6 | 139.1 |    1% | 494.6 | 495.2 |    0% |   2040 |   1970 |    3% |      0 |      0 |    0% |  91854 |  91713 |    0% |
| twitter                          |   9867 |  91.7 |  90.3 |    1% | 290.2 | 290.5 |    0% |   3712 |   3622 |    2% |      0 |      0 |    0% |  83239 |  83090 |    0% |
| gsoc-2018                        |  51997 |  71.8 |  70.9 |    1% | 167.0 | 167.0 |    0% |  30701 |  31347 |   -2% |  86086 | 129569 |  -50% | 362910 | 366977 |   -1% |
| apache_builds                    |   1988 |  85.9 |  84.9 |    1% | 304.7 | 304.7 |    0% |    108 |    106 |    1% |      0 |      0 |    0% |  13691 |  14007 |   -2% |
| github_events                    |   1017 |  79.5 |  78.7 |    1% | 264.5 | 264.6 |    0% |    115 |    137 |  -19% |      0 |      0 |    0% |   4565 |   3515 |   23% |
| twitterescaped                   |   8787 | 184.5 | 184.3 |    0% | 489.9 | 490.2 |    0% |   5017 |   5197 |   -3% |      0 |      0 |    0% |  79442 |  79276 |    0% |
| citm_catalog                     |  26987 |  80.2 |  80.4 |    0% | 296.3 | 296.8 |    0% |   1735 |   1730 |    0% |   2830 |   4712 |  -66% | 193900 | 194843 |    0% |