### PR TITLE
This improves our documentation.

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -46,28 +46,47 @@ c++ myproject.cpp simdjson.cpp
 ```
 
 Note:
-- Users on macOS and other platforms were default compilers do not provide C++11 compliant by default should request it with the appropriate flag (e.g., `c++ myproject.cpp simdjson.cpp`).
+- Users on macOS and other platforms were default compilers do not provide C++11 compliant by default should request it with the appropriate flag (e.g., `c++ -std=c++17 myproject.cpp simdjson.cpp`).
 - Visual Studio users should compile with the `_CRT_SECURE_NO_WARNINGS` flag to avoid warnings with respect to our use of standard C functions such as `fopen`.
+
+
+Using simdjson with package managers
+------------------
+
+You can install the simdjson library on your system or in your project using multiple package managers such as  MSYS2, the conan package manager, vcpkg, brew, the apt package manager (debian-based Linux systems), the FreeBSD package manager (FreeBSD), and so on. [Visit our wiki for more details](https://github.com/simdjson/simdjson/wiki/Installing-simdjson-with-a-package-manager).
 
 Using simdjson as a CMake dependency
 ------------------
 
-You can include the  simdjson repository as a folder in your CMake project. In the parent
-`CMakeLists.txt`, include the following lines:
+You can include the  simdjson as a CMake dependency by including the following lines in your `CMakeLists.txt`:
 
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  simdjson
+  GIT_REPOSITORY https://github.com/simdjson/simdjson.git
+  GIT_TAG  v0.4.7
+  GIT_SHALLOW TRUE)
+
+set(SIMDJSON_JUST_LIBRARY ON CACHE INTERNAL "")
+set(SIMDJSON_BUILD_STATIC ON CACHE INTERNAL "")
+
+FetchContent_MakeAvailable(simdjson)
 ```
-set(SIMDJSON_JUST_LIBRARY ON CACHE STRING "Build just the library, nothing else." FORCE)
-add_subdirectory(simdjson EXCLUDE_FROM_ALL)
-```
+
+You should replace `GIT_TAG  v0.4.7` by the version you need (e.g., `GIT_TAG  v0.5.0`). If you omit `GIT_TAG  v0.5.0`, you will work from the main branch of simdjson: we recommend that if you are working on production code, 
 
 Elsewhere in your project, you can  declare dependencies on simdjson with lines such as these:
 
-```
+```cmake
 add_executable(myprogram myprogram.cpp)
 target_link_libraries(myprogram simdjson)
 ```
 
-See [our CMake demonstration](https://github.com/simdjson/cmakedemo).
+See [our CMake demonstration](https://github.com/simdjson/cmake_demo_single_file). It works under Linux, FreeBSD, macOS and Windows (including Visual Studio).
+
+
 
 The CMake build in simdjson can be taylored with a few variables. You can see the available variables and their default values by entering the `cmake -LA` command.
 

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -84,6 +84,8 @@ add_executable(myprogram myprogram.cpp)
 target_link_libraries(myprogram simdjson)
 ```
 
+We recommend CMake version 3.15 or better.
+
 See [our CMake demonstration](https://github.com/simdjson/cmake_demo_single_file). It works under Linux, FreeBSD, macOS and Windows (including Visual Studio).
 
 

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -65,6 +65,8 @@ add_executable(myprogram myprogram.cpp)
 target_link_libraries(myprogram simdjson)
 ```
 
+We recommend CMake version 3.15 or better.
+
 See [our CMake demonstration](https://github.com/simdjson/cmake_demo_single_file). It works under Linux, FreeBSD, macOS and Windows (including Visual Studio).
 
 The CMake build in simdjson can be taylored with a few variables. You can see the available variables and their default values by entering the `cmake -LA` command.

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -41,7 +41,7 @@ Using simdjson as a CMake dependency
 
 You can include the  simdjson as a CMake dependency by including the following lines in your `CMakeLists.txt`:
 
-```cmake
+```
 include(FetchContent)
 
 FetchContent_Declare(
@@ -60,7 +60,7 @@ You should replace `GIT_TAG  v0.4.7` by the version you need (e.g., `GIT_TAG  v0
 
 Elsewhere in your project, you can  declare dependencies on simdjson with lines such as these:
 
-```cmake
+```
 add_executable(myprogram myprogram.cpp)
 target_link_libraries(myprogram simdjson)
 ```

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -28,28 +28,48 @@ c++ myproject.cpp simdjson.cpp
 ```
 
 Note:
-- Users on macOS and other platforms were default compilers do not provide C++11 compliant by default should request it with the appropriate flag (e.g., `c++ myproject.cpp simdjson.cpp`).
+- Users on macOS and other platforms were default compilers do not provide C++11 compliant by default should request it with the appropriate flag (e.g., `c++  -std=c++17 myproject.cpp simdjson.cpp`).
 - Visual Studio users should compile with the `_CRT_SECURE_NO_WARNINGS` flag to avoid warnings with respect to our use of standard C functions such as `fopen`.
+
+Using simdjson with package managers
+------------------
+
+You can install the simdjson library on your system or in your project using multiple package managers such as  MSYS2, the conan package manager, vcpkg, brew, the apt package manager (debian-based Linux systems), the FreeBSD package manager (FreeBSD), and so on. [Visit our wiki for more details](https://github.com/simdjson/simdjson/wiki/Installing-simdjson-with-a-package-manager).
 
 Using simdjson as a CMake dependency
 ------------------
 
-You can include the  simdjson repository as a folder in your CMake project. In the parent
-`CMakeLists.txt`, include the following lines:
+You can include the  simdjson as a CMake dependency by including the following lines in your `CMakeLists.txt`:
 
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(
+  simdjson
+  GIT_REPOSITORY https://github.com/simdjson/simdjson.git
+  GIT_TAG  v0.4.7
+  GIT_SHALLOW TRUE)
+
+set(SIMDJSON_JUST_LIBRARY ON CACHE INTERNAL "")
+set(SIMDJSON_BUILD_STATIC ON CACHE INTERNAL "")
+
+FetchContent_MakeAvailable(simdjson)
 ```
-set(SIMDJSON_JUST_LIBRARY ON CACHE STRING "Build just the library, nothing else." FORCE)
-add_subdirectory(simdjson EXCLUDE_FROM_ALL)
-```
+
+You should replace `GIT_TAG  v0.4.7` by the version you need (e.g., `GIT_TAG  v0.5.0`). If you omit `GIT_TAG  v0.5.0`, you will work from the main branch of simdjson: we recommend that if you are working on production code, 
 
 Elsewhere in your project, you can  declare dependencies on simdjson with lines such as these:
 
-```
+```cmake
 add_executable(myprogram myprogram.cpp)
 target_link_libraries(myprogram simdjson)
 ```
 
-See [our CMake demonstration](https://github.com/simdjson/cmakedemo).
+See [our CMake demonstration](https://github.com/simdjson/cmake_demo_single_file). It works under Linux, FreeBSD, macOS and Windows (including Visual Studio).
+
+The CMake build in simdjson can be taylored with a few variables. You can see the available variables and their default values by entering the `cmake -LA` command.
+
+
 
 The Basics: Loading and Parsing JSON Documents
 ----------------------------------------------


### PR DESCRIPTION
There is nothing specific to Visual Studio per se, but it covers package managers, and it points at how one can build a simdjson-dependent project using CMake with Visual Studio. The CMake instructions for Windows/Visual Studio used to be more complicated but now that Visual Studio 2019 defaults on x64 (on 64-bit Windows), it is pretty much as easy as under any other platform.

For package managers, we point at the wiki since these are things that are likely to change quickly over time (more packages, instructions that evolve, and so forth).

I really like the new CMake instructions. It is very neat.

Fixes https://github.com/simdjson/simdjson/issues/750