### PR TITLE
Adding test for issue 1133 and improving documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
       - run: |
           cd build &&
           cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination .. &&
-          make $BUILD_FLAGS all
+          cmake $BUILD_FLAGS --build .
 
   cmake_test:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,9 +75,8 @@ commands:
     steps:
       - cmake_prep
       - run: |
-          cd build &&
-          cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination .. &&
-          cmake $BUILD_FLAGS --build . --verbose
+          cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination -B build . &&
+          cmake $BUILD_FLAGS --build build --verbose
 
   cmake_test:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
       - cmake_prep
       - run: |
           cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination -B build . &&
-          cmake $BUILD_FLAGS --build build --verbose
+          cmake $BUILD_FLAGS --build build
 
   cmake_test:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,12 +71,15 @@ commands:
       - checkout
       - run: mkdir -p build
 
-  cmake_build:
+  cmake_build_cache:
     steps:
       - cmake_prep
-      - run: |
-          cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination -B build . &&
-          cmake $BUILD_FLAGS --build build
+      - run: cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination -B build . 
+
+  cmake_build:
+    steps:
+      - cmake_build_cache
+      - run: cmake --build build
 
   cmake_test:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+
+# We constantly run out of memory so please do not use parallelism (-j, -j4). 
+
 # Reusable image / compiler definitions
 executors:
   gcc8:
@@ -8,8 +11,8 @@ executors:
         environment:
           CXX: g++-8
           CC: gcc-8
-          BUILD_FLAGS: # we constantly run out of memory so removing -j
-          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
+          BUILD_FLAGS: 
+          CTEST_FLAGS: --output-on-failure
 
   gcc9:
     docker:
@@ -17,8 +20,8 @@ executors:
         environment:
           CXX: g++-9
           CC: gcc-9
-          BUILD_FLAGS: # we constantly run out of memory so removing -j
-          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
+          BUILD_FLAGS:
+          CTEST_FLAGS: --output-on-failure
 
   gcc10:
     docker:
@@ -26,8 +29,8 @@ executors:
         environment:
           CXX: g++-10
           CC: gcc-10
-          BUILD_FLAGS: # we constantly run out of memory so removing -j
-          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
+          BUILD_FLAGS:
+          CTEST_FLAGS: --output-on-failure
 
   clang10:
     docker:
@@ -35,8 +38,8 @@ executors:
         environment:
           CXX: clang++-10
           CC: clang-10
-          BUILD_FLAGS: # we constantly run out of memory so removing -j
-          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
+          BUILD_FLAGS:
+          CTEST_FLAGS: --output-on-failure
 
   clang9:
     docker:
@@ -44,8 +47,8 @@ executors:
         environment:
           CXX: clang++-9
           CC: clang-9
-          BUILD_FLAGS: # we constantly run out of memory so removing -j
-          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
+          BUILD_FLAGS:
+          CTEST_FLAGS: --output-on-failure 
 
   clang6:
     docker:
@@ -53,8 +56,8 @@ executors:
         environment:
           CXX: clang++-6.0
           CC: clang-6.0
-          BUILD_FLAGS: # we constantly run out of memory so removing -j
-          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
+          BUILD_FLAGS:
+          CTEST_FLAGS: --output-on-failure
 
 # Reusable test commands (and initializer for clang 6)
 commands:
@@ -138,12 +141,12 @@ jobs:
   sanitize-gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake sanitize build
     executor: gcc10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -E checkperf } # we constantly run out of memory so removing -j4 
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -E checkperf }
     steps: [ cmake_test ]
   sanitize-clang10:
     description: Build and run tests on clang 10 and AVX 2 with a cmake sanitize build
     executor: clang10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: --output-on-failure -E checkperf }  # we constantly run out of memory so removing -j4
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: --output-on-failure -E checkperf }
     steps: [ cmake_test ]
 
   # dynamic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,12 +138,12 @@ jobs:
   sanitize-gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake sanitize build
     executor: gcc10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: # we constantly run out of memory so removing -j4 --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -E checkperf } # we constantly run out of memory so removing -j4 
     steps: [ cmake_test ]
   sanitize-clang10:
     description: Build and run tests on clang 10 and AVX 2 with a cmake sanitize build
     executor: clang10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: # we constantly run out of memory so removing -j4 --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: --output-on-failure -E checkperf }  # we constantly run out of memory so removing -j4
     steps: [ cmake_test ]
 
   # dynamic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
       - run: |
           cd build &&
           cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination .. &&
-          cmake $BUILD_FLAGS --build .
+          cmake $BUILD_FLAGS --build . --verbose
 
   cmake_test:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ executors:
         environment:
           CXX: g++-8
           CC: gcc-8
-          BUILD_FLAGS: -j
-          CTEST_FLAGS: -j4 --output-on-failure
+          BUILD_FLAGS: # we constantly run out of memory so removing -j
+          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
 
   gcc9:
     docker:
@@ -17,8 +17,8 @@ executors:
         environment:
           CXX: g++-9
           CC: gcc-9
-          BUILD_FLAGS: -j
-          CTEST_FLAGS: -j4 --output-on-failure
+          BUILD_FLAGS: # we constantly run out of memory so removing -j
+          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
 
   gcc10:
     docker:
@@ -26,8 +26,8 @@ executors:
         environment:
           CXX: g++-10
           CC: gcc-10
-          BUILD_FLAGS: -j
-          CTEST_FLAGS: -j4 --output-on-failure
+          BUILD_FLAGS: # we constantly run out of memory so removing -j
+          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
 
   clang10:
     docker:
@@ -35,8 +35,8 @@ executors:
         environment:
           CXX: clang++-10
           CC: clang-10
-          BUILD_FLAGS: -j
-          CTEST_FLAGS: -j4 --output-on-failure
+          BUILD_FLAGS: # we constantly run out of memory so removing -j
+          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
 
   clang9:
     docker:
@@ -44,8 +44,8 @@ executors:
         environment:
           CXX: clang++-9
           CC: clang-9
-          BUILD_FLAGS: -j
-          CTEST_FLAGS: -j4 --output-on-failure
+          BUILD_FLAGS: # we constantly run out of memory so removing -j
+          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
 
   clang6:
     docker:
@@ -53,8 +53,8 @@ executors:
         environment:
           CXX: clang++-6.0
           CC: clang-6.0
-          BUILD_FLAGS: -j
-          CTEST_FLAGS: -j4 --output-on-failure
+          BUILD_FLAGS: # we constantly run out of memory so removing -j
+          CTEST_FLAGS: --output-on-failure # we constantly run out of memory so removing -j4 
 
 # Reusable test commands (and initializer for clang 6)
 commands:
@@ -138,12 +138,12 @@ jobs:
   sanitize-gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake sanitize build
     executor: gcc10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: -j4 --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: # we constantly run out of memory so removing -j4 --output-on-failure -E checkperf }
     steps: [ cmake_test ]
   sanitize-clang10:
     description: Build and run tests on clang 10 and AVX 2 with a cmake sanitize build
     executor: clang10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: -j4 --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: # we constantly run out of memory so removing -j4 --output-on-failure -E checkperf }
     steps: [ cmake_test ]
 
   # dynamic

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -592,14 +592,37 @@ Here is a simple example, given "x.json" with this content:
 
 ```c++
 dom::parser parser;
-dom::document_stream docs = parser.load_many(filename);
+dom::document_stream docs = parser.load_many("x.json");
 for (dom::element doc : docs) {
   cout << doc["foo"] << endl;
 }
 // Prints 1 2 3
 ```
 
-In-memory ndjson strings can be parsed as well, with `parser.parse_many(string)`.
+In-memory ndjson strings can be parsed as well, with `parser.parse_many(string)`: 
+
+
+```c++
+dom::parser parser;
+  auto json = R"({ "foo": 1 }
+{ "foo": 2 }
+{ "foo": 3 })";
+dom::document_stream docs = parser.parse_many(json);
+for (dom::element doc : docs) {
+  cout << doc["foo"] << endl;
+}
+// Prints 1 2 3
+```
+
+
+Unlike `parser.parse`, both `parser.load_many(filename)` and `parser.parse_many(string)` may parse
+"on demand" (lazily). That is, no parsing may have been done before you enter the loop 
+`for (dom::element doc : docs) {` and you should expect the parser to only ever fully parse one JSON
+document at a time.
+
+1. When calling `parser.load_many(filename)`, the file's content is loaded up in a memory buffer owned by the `parser`'s instance. Thus the file can be safely deleted after calling `parser.load_many(filename)` as the parser instance owns all of the data.
+2. When calling  `parser.parse_many(string)`, no copy is made of the provided string input. The provided memory buffer may be accessed each time a JSON document is parsed.  Calling `parser.parse_many(string)` on a  temporary string buffer (e.g., `docs = parser.parse_many("[1,2,3]"_padded)`) is unsafe because the  `document_stream` instance needs access to the buffer to return the JSON documents. In constrast, calling `doc = parser.parse("[1,2,3]"_padded)` is safe because `parser.parse` eagerly parses the input.
+
 
 Both `load_many` and `parse_many` take an optional parameter `size_t batch_size` which defines the window processing size. It is set by default to a large value (`1000000` corresponding to 1 MB). None of your JSON documents should exceed this window size, or else you will get  the error `simdjson::CAPACITY`. You cannot set this window size larger than 4 GB: you will get  the error `simdjson::CAPACITY`. The smaller the window size is, the less memory the function will use. Setting the window size too small (e.g., less than 100 kB) may also impact performance negatively. Leaving it to 1 MB is expected to be a good choice, unless you have some larger documents.
 

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -606,7 +606,7 @@ In-memory ndjson strings can be parsed as well, with `parser.parse_many(string)`
 dom::parser parser;
   auto json = R"({ "foo": 1 }
 { "foo": 2 }
-{ "foo": 3 })";
+{ "foo": 3 })"_padded;
 dom::document_stream docs = parser.parse_many(json);
 for (dom::element doc : docs) {
   cout << doc["foo"] << endl;

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -587,7 +587,7 @@ In-memory ndjson strings can be parsed as well, with `parser.parse_many(string)`
 dom::parser parser;
   auto json = R"({ "foo": 1 }
 { "foo": 2 }
-{ "foo": 3 })";
+{ "foo": 3 })"_padded;
 dom::document_stream docs = parser.parse_many(json);
 for (dom::element doc : docs) {
   cout << doc["foo"] << endl;

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -564,7 +564,7 @@ than 4GB), though each individual document must be no larger than 4 GB.
 
 Here is a simple example, given "x.json" with this content:
 
-```json
+```
 { "foo": 1 }
 { "foo": 2 }
 { "foo": 3 }
@@ -572,14 +572,37 @@ Here is a simple example, given "x.json" with this content:
 
 ```
 dom::parser parser;
-dom::document_stream docs = parser.load_many(filename);
+dom::document_stream docs = parser.load_many("x.json");
 for (dom::element doc : docs) {
   cout << doc["foo"] << endl;
 }
 // Prints 1 2 3
 ```
 
-In-memory ndjson strings can be parsed as well, with `parser.parse_many(string)`.
+
+In-memory ndjson strings can be parsed as well, with `parser.parse_many(string)`: 
+
+
+```
+dom::parser parser;
+  auto json = R"({ "foo": 1 }
+{ "foo": 2 }
+{ "foo": 3 })";
+dom::document_stream docs = parser.parse_many(json);
+for (dom::element doc : docs) {
+  cout << doc["foo"] << endl;
+}
+// Prints 1 2 3
+```
+
+
+Unlike `parser.parse`, both `parser.load_many(filename)` and `parser.parse_many(string)` may parse
+"on demand" (lazily). That is, no parsing may have been done before you enter the loop 
+`for (dom::element doc : docs) {` and you should expect the parser to only ever fully parse one JSON
+document at a time.
+
+1. When calling `parser.load_many(filename)`, the file's content is loaded up in a memory buffer owned by the `parser`'s instance. Thus the file can be safely deleted after calling `parser.load_many(filename)` as the parser instance owns all of the data.
+2. When calling  `parser.parse_many(string)`, no copy is made of the provided string input. The provided memory buffer may be accessed each time a JSON document is parsed.  Calling `parser.parse_many(string)` on a  temporary string buffer (e.g., `docs = parser.parse_many("[1,2,3]"_padded)`) is unsafe because the  `document_stream` instance needs access to the buffer to return the JSON documents. In constrast, calling `doc = parser.parse("[1,2,3]"_padded)` is safe because `parser.parse` eagerly parses the input.
 
 Both `load_many` and `parse_many` take an optional parameter `size_t batch_size` which defines the window processing size. It is set by default to a large value (`1000000` corresponding to 1 MB). None of your JSON documents should exceed this window size, or else you will get  the error `simdjson::CAPACITY`. You cannot set this window size larger than 4 GB: you will get  the error `simdjson::CAPACITY`. The smaller the window size is, the less memory the function will use. Setting the window size too small (e.g., less than 100 kB) may also impact performance negatively. Leaving it to 1 MB is expected to be a good choice, unless you have some larger documents.
 

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -70,6 +70,33 @@ namespace document_stream_tests {
     return true;
   }
 
+  bool single_document() {
+    std::cout << "Running " << __func__ << std::endl;
+    simdjson::dom::parser parser;
+    auto json = R"({"hello": "world"})"_padded;
+    simdjson::dom::document_stream stream;
+    ASSERT_SUCCESS(parser.parse_many(json).get(stream));
+    size_t count = 0;
+    for (simdjson::dom::element doc : stream) {
+        std::cout << doc << std::endl;
+        count += 1;
+    }
+    return count == 1;
+  }
+#if SIMDJSON_EXCEPTIONS
+  bool single_document_exceptions() {
+    std::cout << "Running " << __func__ << std::endl;
+    simdjson::dom::parser parser;
+    auto json = R"({"hello": "world"})"_padded;
+    size_t count = 0;
+    for (auto doc : parser.parse_many(json)) {
+        std::cout << doc << std::endl;
+        count += 1;
+    }
+    return count == 1;
+  }
+#endif
+
   bool small_window() {
     std::cout << "Running " << __func__ << std::endl;
     auto json = R"({"error":[],"result":{"token":"xxx"}}{"error":[],"result":{"token":"xxx"}})"_padded;
@@ -247,7 +274,11 @@ namespace document_stream_tests {
   }
 
   bool run() {
-    return test_current_index() &&
+    return test_current_index()  && 
+           single_document() &&
+#if SIMDJSON_EXCEPTIONS
+           single_document_exceptions() &&
+#endif
 #ifdef SIMDJSON_THREADS_ENABLED
            threaded_disabled() &&
 #endif

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -77,7 +77,7 @@ namespace document_stream_tests {
     simdjson::dom::document_stream stream;
     ASSERT_SUCCESS(parser.parse_many(json).get(stream));
     size_t count = 0;
-    for (simdjson::dom::element doc : stream) {
+    for (auto doc : stream) {
         std::cout << doc << std::endl;
         count += 1;
     }

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -82,9 +82,12 @@ namespace document_stream_tests {
           return false;
         }
         std::string expected = R"({"hello":"world"})";
-        std::string answer = simdjson::minify(doc.value());
+        simdjson::dom::element this_document;
+        ASSERT_SUCCESS(doc.get(this_document));
+
+        std::string answer = simdjson::minify(this_document);
         if(answer != expected) {
-          std::cout << doc.value() << std::endl;
+          std::cout << this_document << std::endl;
           return false;
         }
         count += 1;

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -69,7 +69,7 @@ namespace document_stream_tests {
     }
     return true;
   }
-
+#if SIMDJSON_EXCEPTIONS
   bool single_document() {
     std::cout << "Running " << __func__ << std::endl;
     simdjson::dom::parser parser;
@@ -83,7 +83,6 @@ namespace document_stream_tests {
     }
     return count == 1;
   }
-#if SIMDJSON_EXCEPTIONS
   bool single_document_exceptions() {
     std::cout << "Running " << __func__ << std::endl;
     simdjson::dom::parser parser;
@@ -275,8 +274,8 @@ namespace document_stream_tests {
 
   bool run() {
     return test_current_index()  && 
-           single_document() &&
 #if SIMDJSON_EXCEPTIONS
+           single_document() &&
            single_document_exceptions() &&
 #endif
 #ifdef SIMDJSON_THREADS_ENABLED

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -128,7 +128,6 @@ namespace document_stream_tests {
     }
     return count == 1;
   }
-
 #endif
 
   bool small_window() {

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -179,6 +179,16 @@ void basics_ndjson() {
   // Prints 1 2 3
 }
 
+void basics_ndjson_parse_many() {
+  dom::parser parser;
+  auto json = R"({ "foo": 1 }
+{ "foo": 2 }
+{ "foo": 3 })";
+  dom::document_stream docs = parser.parse_many(json);
+  for (dom::element doc : docs) {
+    cout << doc["foo"] << endl;
+  }
+}
 void implementation_selection_1() {
   cout << "simdjson v" << STRINGIFY(SIMDJSON_VERSION) << endl;
   cout << "Detected the best implementation for your machine: " << simdjson::active_implementation->name();

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -183,7 +183,7 @@ void basics_ndjson_parse_many() {
   dom::parser parser;
   auto json = R"({ "foo": 1 }
 { "foo": 2 }
-{ "foo": 3 })";
+{ "foo": 3 })"_padded;
   dom::document_stream docs = parser.parse_many(json);
   for (dom::element doc : docs) {
     cout << doc["foo"] << endl;


### PR DESCRIPTION
When using `parse_many`, we do not copy the string input, and yet we parse several documents, going back to the input. If the user mistakenly provides us with a temporary memory buffer, they can be doing something unsafe.

This PR is a documentation update (with some added tests). We want to very clearly explain how to use safely the library. It would be nicer if the parser always took ownership of the data, but as long as you allow people to pass a pointer (something we want to allow), it is just not feasible for us to do so.

I have also simplified the circle CI tests. They keep randomly failing lately and I have to restart them. It gets on my nerve. Looking at the logs, it seems to have to do with memory failures. Well. Obviously, a parallel build will use more memory, so I think we will get more reliable build by using single-threaded builds.

https://github.com/simdjson/simdjson/issues/1133