### PR TITLE
Add API lifetime safety to on-demand parsing

### DIFF
--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -48,7 +48,7 @@ simdjson_really_inline twitter::twitter_user read_user(ondemand::object && user)
 }
 simdjson_really_inline void read_tweets(ondemand::parser &parser, padded_string &json, std::vector<twitter::tweet> &tweets) {
   // Walk the document, parsing the tweets as we go
-  auto doc = parser.parse(json);
+  auto doc = parser.iterate(json);
   auto root = doc.get_object();
   ondemand::array statuses = root["statuses"];
   for (ondemand::object tweet : statuses) {
@@ -111,8 +111,7 @@ simdjson_really_inline void read_tweets(ondemand::parser &parser, padded_string 
   // Walk the document, parsing the tweets as we go
 
   // { "statuses": 
-  auto doc = parser.parse(json);
-  ondemand::json_iterator &iter = doc.iterate();
+  auto iter = parser.iterate_raw(json).value();
   if (!iter.start_object()   || !iter.find_field_raw("statuses")) { throw; }
   // { "statuses": [
   if (!iter.start_array()) { throw; }
@@ -411,7 +410,7 @@ static void ondemand_largerandom(State &state) {
   size_t points = 0;
   for (SIMDJSON_UNUSED auto _ : state) {
     std::vector<my_point> container;
-    auto doc = parser.parse(json);
+    auto doc = parser.iterate(json).value();
     ondemand::array array = doc.get_array();
     for (ondemand::object point_object : array) {
       auto point = point_object.begin();
@@ -465,8 +464,7 @@ static void iter_largerandom(State &state) {
   size_t points = 0;
   for (SIMDJSON_UNUSED auto _ : state) {
     std::vector<my_point> container;
-    auto doc = parser.parse(json);
-    ondemand::json_iterator &iter = doc.iterate();
+    auto iter = parser.iterate_raw(json).value();
     if (iter.start_array()) {
       do {
         container.emplace_back(my_point{first_double(iter), next_double(iter), next_double(iter)});

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -121,13 +121,13 @@ simdjson_really_inline void read_tweets(ondemand::parser &parser, padded_string 
     twitter::tweet tweet;
 
     if (!iter.start_object()   || !iter.find_field_raw("created_at")) { throw; }
-    tweet.created_at = iter.get_raw_json_string().value().unescape(parser);
+    tweet.created_at = iter.get_raw_json_string().value().unescape(iter);
 
     if (!iter.has_next_field() || !iter.find_field_raw("id")) { throw; }
     tweet.id = iter.get_uint64();
 
     if (!iter.has_next_field() || !iter.find_field_raw("text")) { throw; }
-    tweet.text = iter.get_raw_json_string().value().unescape(parser);
+    tweet.text = iter.get_raw_json_string().value().unescape(iter);
 
     if (!iter.has_next_field() || !iter.find_field_raw("in_reply_to_status_id")) { throw; }
     if (!iter.is_null()) {
@@ -140,7 +140,7 @@ simdjson_really_inline void read_tweets(ondemand::parser &parser, padded_string 
       tweet.user.id = iter.get_uint64();
 
       if (!iter.has_next_field() || !iter.find_field_raw("screen_name")) { throw; }
-      tweet.user.screen_name = iter.get_raw_json_string().value().unescape(parser);
+      tweet.user.screen_name = iter.get_raw_json_string().value().unescape(iter);
 
       iter.skip_container(); // Skip the rest of the user object
     }

--- a/benchmark/twitter/sax_tweet_reader_visitor.h
+++ b/benchmark/twitter/sax_tweet_reader_visitor.h
@@ -295,7 +295,6 @@ simdjson_really_inline void sax_tweet_reader_visitor::field_lookup::neg(const ch
   auto index = hash(key, depth);
   if (entries[index].key) {
     fprintf(stderr, "%s (depth %d) conflicts with %s (depth %d) !\n", key, depth, entries[index].key, int(entries[index].container));
-    assert(false);
   }
 }
 

--- a/doc/ondemand.md
+++ b/doc/ondemand.md
@@ -1,0 +1,315 @@
+I'll write a few of the design features / innovations here:
+
+## Classes
+
+In general, simdjson's parser classes are divided into two categories:
+
+* Persistent State:
+  - Generally persisted through multiple algorithm runs.
+  - Intended to be stored in memory.
+  - We try not to access members of these structs repeatedly if we can avoid it.
+  - We limit mallocs to these classes so they can be reused.
+  - Examples: dom::parser, ondemand::parser, dom_parser_implementation
+* Inline Algorithm Context:
+  - Context and counters for a single hot-loop algorithm (stage 1, stage 2, etc.).
+  - Member variables intended to be broken up and stored in registers where possible.
+  - We try to store as few things as we can manage to avoid register pressure.
+  - We never copy these (except perhaps during construction).
+  - We *only* pass references / pointers to really_inline functions, expecting the
+    compiler to eliminate the indirection.
+  - Examples: stage2::structural_parser, stage1::json_structural_indexer
+
+In ondemand, `ondemand::parser` and `dom_parser_implementation` are used to store persistent state,
+and all other classes are inline algorithm context.
+
+### ondemand::parser / dom_parser_implementation
+
+On-demand parsing has several primary classes that keep the main state:
+
+* `ondemand::parser`: Holds resources for parsing.
+  - Persistent State.
+  - `parser.parse()` calls stage 1 and then returns `ondemand::document` for you to iterate.
+  - `structural_indexes`: Buffer for structural indexes for stage 1.
+  - `string_buf`: Allocates string buffer for fast string parsing.
+  - `buf`, `len`: cached pointer to JSON buffer (and length) being parsed.
+  - `current_string_buf_loc`: The current append position in string_buf (see string parsing, later).
+    Like buf and len, this is reset on every parse.
+* `json_iterator`: Low-level iteration over JSON structurals from stage 1.
+  - Not user-facing (though you can call doc.iterate() to get it right now, I don't think we want to
+    expose that API unless we absolutely must).
+  - Inline Algorithm Context. Stored internally in `document`.
+  - `buf`: Pointer to JSON buffer, intended to be stored in a register since it's used so much.
+    (This is also in dom_parser_implementation, but that's stored in memory and we're avoiding
+    indirection here.)
+  - `index`: Pointer to next structural index.
+  - NOTE: probably *should* have a cached (or primary) copy of current_string_buf_loc for registerness.
+
+### Value
+
+value represents an value whose type is not yet known. The On Demand philosophy is to let the *user*
+tell us what type the value is by asking us to convert it, and *then* check the type. A value can
+be converted to an array or object, parsed to string, double, uint64_t, int64_t, or bool, or checked
+for is_null().
+
+* **Arrays** can be used with get_array(). More on that in the array section.
+* **Objects** can be used with get_object(). More on that in the object section.
+* **Strings** are parsed with get_string(), which parses the string, appending the unescaped value
+  into a buffer allocated by the parser, and returning a `std::string_view` pointing at the buffer
+  and telling you the location. We append a terminating `\0` in case you end up using these values
+  with routines designed for C strings (the string_view's length of course does not include that
+  `\0').
+  
+  These string_views *will be invalidated on the next parse,* so if you want to persist a copy,
+  you'll need to allocate your own actual strings. This case is designed to be fast in the
+  server-like scenario, where you parse a document, use the values, and only then move on to parse
+  another one.
+
+  Optionally, get_raw_json_string() gives you a pointer to the raw, unescaped JSON, allowing you to
+  work with strings efficiently in cases where your format disallows escaping--for example,
+  enumeration values and GUIDs.
+* **Numbers** can be parsed with get_double(), get_uint64() and get_int64(), each of which is a separate,
+battle-tested parser specifically targeted to the type. The algorithms give exact answers, even for
+floating-point numbers, and check for overflow or invalid characters.
+* **true, false and null** are parsed through get_bool() and is_null(). simdjson checks these quickly by
+read the next 4 characters as a 32-bit integer and comparing that to true, fals, or null. Then it
+checks the extra "e" in false, and ensures that the next character is either whitespace, or a JSON
+operator (, : ] or }).
+
+### Document
+
+document represents the top level value in the document, behaving much like a value but also does
+double duty, storing iteration state. It can be converted to an array or object, parsed to
+string, double, uint64_t, int64_t, bool, or checked for is_null().
+
+The document *must* be kept around during iteration, as all other iterator classes rely on it to
+provide iterator state. 
+
+If the document itself is a single number, boolean, or null, the parsing algorithm is very slightly
+different from the value parsers, which rely on there being more JSON after the value. To
+accomodate, simdjson copies the number or atom into a small buffer, places a space after it, and
+then runs the normal algorithm. Strings, arrays and objects at the root all use exactly the same
+stuff. (NOTE: I haven't implemented this difference yet.)
+
+### Array
+
+The `ondemand::array` object lets you iterate the values of an array in a forward-only manner:
+
+```c++
+for (object tweet : doc["tweets"].get_array()) {
+  ...
+}
+```
+
+This is equivalent to:
+
+```c++
+array tweets = doc["tweets"].get_array();
+array::iterator iter = tweets.begin();
+array::iterator end = tweets.end();
+while (iter != end) {
+  object tweet = *iter;
+  ...
+  iter++;
+}
+```
+
+The way you *parse* an array is somewhat split into pieces by the iterator. Here is how we section
+the work to parse and validate the array:
+
+1. `get_array()`:
+   - Validates that this is an array (starts with `[`). Returns INCORRECT_TYPE if not.
+   - If the array is empty (followed by `]`), advances the iterator past the `]` and returns an
+     array with finished == true.
+   - If the array is not empty, returns an array with finished == false. Iterator remains pointed
+     at the first value (the token just after `[`).
+2. `tweets.begin()`, `tweets.end()`: Returns an `array::iterator`, which just points back at the
+   array object.
+3. `while (iter != end)`: Stops if finished == true.
+4. `*iter`: Yields the value (or error).
+   - If there is an error, returns it and sets finished == true.
+   - Returns a value object, advancing the iterator just past the value token (if it is `[`, `{`,
+     etc. then that will be handled when the value is converted to an array/object).
+5. `iter++`: Expects the iterator to have finished with the previous array value, and looks for `,` or `]`.
+   - Advances the iterator and gets the JSON `]` or `,`.
+   - If the array just ended (there is a `]`), sets finished == true.
+   - If the array continues (`,`), does nothing.
+   - If anything else is there (`true`, `:`, `}`, etc.), sets error = TAPE_ERROR.
+   - #3 gets run next.
+
+### Array
+
+The `ondemand::array` object lets you iterate the values of an array in a forward-only manner:
+
+```c++
+for (object tweet : doc["tweets"].get_array()) {
+  ...
+}
+```
+
+This is equivalent to:
+
+```c++
+array tweets = doc["tweets"].get_array();
+array::iterator iter = tweets.begin();
+array::iterator end = tweets.end();
+while (iter != end) {
+  object tweet = *iter;
+  ...
+  iter++;
+}
+```
+
+The way you *parse* an array is somewhat split into pieces by the iterator. Here is how we section
+the work to parse and validate the array:
+
+1. `get_array()`:
+   - Validates that this is an array (starts with `[`). Returns INCORRECT_TYPE if not.
+   - If the array is empty (followed by `]`), advances the iterator past the `]` and returns an
+     array with finished == true.
+   - If the array is not empty, returns an array with finished == false. Iterator remains pointed
+     at the first value (the token just after `[`).
+2. `tweets.begin()`, `tweets.end()`: Returns an `array::iterator`, which just points back at the
+   array object.
+3. `while (iter != end)`: Stops if finished == true.
+4. `*iter`: Yields the value (or error).
+   - If there is an error, returns it and sets finished == true.
+   - Returns a value object, advancing the iterator just past the value token (if it is `[`, `{`,
+     etc. then that will be handled when the value is converted to an array/object).
+5. `iter++`: Expects the iterator to have finished with the previous array value, and looks for `,` or `]`.
+   - Advances the iterator and gets the JSON `]` or `,`.
+   - If the array just ended (there is a `]`), sets finished == true.
+   - If the array continues (`,`), does nothing.
+   - If anything else is there (`true`, `:`, `}`, etc.), sets error = TAPE_ERROR.
+   - #3 gets run next.
+
+#### Error Chaining
+
+When you iterate over an array or object with an error, the error is yielded in the loop
+
+#### Error Chaining
+
+
+* `document`: Represents the root value of the document, as well as iteration state.
+  - Inline Algorithm Context. MUST be kept around for the duration of the algorithm.
+  - `iter`: The `json_iterator`, which handles low-level iteration.
+  - `parser`: A pointer to the parser to get at persistent state.
+  - Can be converted to `value` (and by proxy, to array/object/string/number/bool/null).
+  - Can be iterated (like `value`, assumes it is an array).
+  - Safety: can only be converted to `value` once. This prevents double iteration of arrays/objects
+    (which will cause inconsistent iterator state) or double-unescaping strings (which could cause
+    memory overruns if done too much). NOTE: this is actually not ideal; it means you can't do
+    `if (document.parse_double().error() == INCORRECT_TYPE) { document.parse_string(); }`
+
+The `value` class is expected to be temporary (NOT kept around), used to check the type of a value
+and parse it to another type. It can convert to array or object, and has helpers to parse string,
+double, int64, uint64, boolean and is_null().
+
+`value` does not check the type of the value ahead of time. Instead, when you ask for a value of a
+given type, it tries to parse as that type, treating a parser error as INCORRECT_TYPE. For example,
+if you call get_int64() on the JSON string `"123"`, it will fail because it is looking for either a
+`-` or digit at the front. The philosophy here is "proceed AS IF the JSON has the desired type, and
+have an unlikely error branch if not." Since most files have well-known types, this avoids
+unnecessary branchiness and extra checks for the value type.
+
+It does preemptively advance the iterator and store the pointer to the JSON, allowing you to attempt
+to parse more than one type. This is how you do nullable ints, for example: check is_null() and
+then get_int64(). If we didn't store the JSON, and instead did `iter.advance()` during is_null(),
+you would get garbage if you then did get_int64().
+
+## 
+
+until it's asked to convert, in which case it proceeds
+    *expecting* the value is of the given type, treating an error in parsing as "it must be some
+    other type." This saves the extra explicit type check in the common case where you already know
+    saving the if/switch statement
+    and . We find out it's not a double
+    when the double parser says "I couldn't find any digits and I don't understand what this `t`
+    character is for."
+  - The iterator has already been advanced past the value token. If it's { or [, the iterator is just
+    after the open brace.
+  - Can be parsed as a string, double, int, unsigned, boolean, or `is_null()`, in which case a parser is run
+    and the value is returned.
+  - Can be converted to array or object iterator.
+* `object`: Represents an object iteration.
+  - `doc`: A pointer to the document (and the iterator).
+  - `at_start`: boolean saying whether we're at the start of the object, used for `[]`.
+  - Can do order-sensitive field lookups.
+  - Can iterate over key/value pairs.
+* `array`: Represents an array iteration.
+  - `doc`: A pointer to the document (and the iterator).
+  
+
+    
+  - Can be returned as a `raw_json_string`, so that people who want to check JSON strings without
+    unescaping can do so.
+  - Can be converted to array or object
+     and keep member variables in the same registers.
+    In fact, , and . Usually based on whether they are persistent--i.e. we intend them
+to be stored in memory--or algorithmic--
+(which generally means we intend to persist them), or algorithm-lifetime, possibly
+
+- persistent classes
+- non-persistent 
+`ondemand::parser` is the equivalent of `dom::parser`, and . 
+`json_iterator` handles all iteration state.
+
+### json_iterator / document
+
+`document` owns the json_iterator and the . I'm considering moving this into the json_iterator so there's one
+less class that requires persistent ownership, however.
+
+### String unescaping
+
+When the user requests strings, we unescape them to a single string_buf (much like the DOM parser)
+so that users enjoy the same string performance as the core simdjson. The current_string_buf_loc is
+presently stored in the 
+
+We do not write the length to the string buffer, however; that is stored in the string_view we
+return to the user, and immediately forgotten.
+
+Presently, we use the `char string_buf[]` to write
+
+ The top-level document stores a json_iterator inside, which 
+
+It is illegal to move the document after it has been iterated (otherwise, pointers would be
+invalidated). Note: I need to check that the current code actually checks this.
+
+If it's stored in a `simdjson_result<document>` (as it would be in `auto doc = parser.parse(json)`),
+the document pointed to by children is the one inside the simdjson_result, and the simdjson_result,
+therefore, can't be moved either.
+
+### Object Iteration
+
+Because the C++ iterator contract requires iterators to be const-assignable and const-constructable,
+object and array iterators are separate classes from the object/array itself, and have an interior
+mutable reference to it.
+
+### Array Iteration
+
+### Iteration Safety
+
+  - If the value fails to be parsed as one type, you can try to parse it as something else until you
+    succeed.
+  - Safety: If the value succeeds in being parsed or converted to a type, you cannot try again. (It
+    sets `json` to null, so you will segfault.) This prevents double iteration of an array (which
+    will cause inconsistent iterator state) or double-unescaping a string (which could cause memory
+    overruns if done too much).
+  - Guaranteed Iteration: If you discard a value without using it--perhaps you just wanted to know
+    if it was null but didn't care what the actual value was--it will iterate. See 
+
+This is an area I'm chomping at the bit for Rust, actually ... a whole lot of this would be safer if
+we had compiler-enforced borrowing.
+
+### Raw Key Lookup
+
+### Skip Algorithm
+
+### Root Scalar Parsing Without Malloc
+
+The malloc when we parse the number / atoms at the root of the document has always bothered me a little, so I wrote alternate routines that use a stack-based buffer instead, based on the type in question. Atoms require no more than 6 bytes; integers no more than 21; and floats ... well, I [wanted your opinion on that, actually.](https://github.com/simdjson/simdjson/pull/947/files#diff-979f6706620f56f5d6a45ca3bf511669R166). I wanted to set a limit on the biggest possible float, and came up with:
+
+> Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of fractional digits needed to distinguish any two doubles (including zeroes and significant digits). Add 8 more digits for the other stuff (`-0.<fraction>e-308`) -- and you get 1082.
+
+Technically, people could add an arbitrary number of digits after that ... but we could actually scan for that and ignore, if we wanted. I know it's a lot of convolutions to avoid malloc / free, but I think there are really good reasons to have a 100% malloc-free library (well, we have integration points that malloc, but they are predictable and could easily be swapped out.
+
+I considered just using separate algorithms, and I think for numbers in particular there is probably a way to do that without having two separate functions, but I haven't figured out the *clean* way yet.

--- a/include/simdjson/error-inl.h
+++ b/include/simdjson/error-inl.h
@@ -67,9 +67,14 @@ simdjson_really_inline error_code simdjson_result_base<T>::error() const noexcep
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline T& simdjson_result_base<T>::value() noexcept(false) {
+simdjson_really_inline T& simdjson_result_base<T>::value() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return this->first;
+}
+
+template<typename T>
+simdjson_really_inline T&& simdjson_result_base<T>::value() && noexcept(false) {
+  return std::forward<simdjson_result_base<T>>(*this).take_value();
 }
 
 template<typename T>
@@ -122,8 +127,13 @@ simdjson_really_inline error_code simdjson_result<T>::error() const noexcept {
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline T& simdjson_result<T>::value() noexcept(false) {
+simdjson_really_inline T& simdjson_result<T>::value() & noexcept(false) {
   return internal::simdjson_result_base<T>::value();
+}
+
+template<typename T>
+simdjson_really_inline T&& simdjson_result<T>::value() && noexcept(false) {
+  return std::forward<internal::simdjson_result_base<T>>(*this).value();
 }
 
 template<typename T>

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -146,7 +146,14 @@ struct simdjson_result_base : public std::pair<T, error_code> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T& value() noexcept(false);
+  simdjson_really_inline T& value() & noexcept(false);
+
+  /**
+   * Take the result value (move it).
+   *
+   * @throw simdjson_error if there was an error.
+   */
+  simdjson_really_inline T&& value() && noexcept(false);
 
   /**
    * Take the result value (move it).
@@ -218,7 +225,14 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T& value() noexcept(false);
+  simdjson_really_inline T& value() & noexcept(false);
+
+  /**
+   * Take the result value (move it).
+   *
+   * @throw simdjson_error if there was an error.
+   */
+  simdjson_really_inline T&& value() && noexcept(false);
 
   /**
    * Take the result value (move it).

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -108,6 +108,7 @@ simdjson_really_inline bool array::iterator::operator!=(const array::iterator &)
 simdjson_really_inline array::iterator &array::iterator::operator++() noexcept {
   if (a->error) { return *this; }
   a->error = a->iter->has_next_element().get(a->has_next); // If there's an error, has_next stays true.
+  if (!a->has_next) { a->iter.release(); }
   return *this;
 }
 
@@ -177,7 +178,7 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array:
 }
 
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator>::operator*() noexcept {
-  if (error()) { return error(); }
+  if (error()) { second = SUCCESS; return error(); }
   return *first;
 }
 // Assumes it's being compared with the end. true if depth < iter->depth.

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -41,18 +41,18 @@ namespace ondemand {
 //
 
 simdjson_really_inline array::array() noexcept = default;
-simdjson_really_inline array::array(json_iterator *_iter, bool has_value) noexcept
-  : iter{_iter}, has_next{has_value}, error{SUCCESS}
+simdjson_really_inline array::array(json_iterator_ref &&_iter, bool has_value) noexcept
+  : iter{std::forward<json_iterator_ref>(_iter)}, has_next{has_value}, error{SUCCESS}
 {
 }
 simdjson_really_inline array::array(array &&other) noexcept
-  : iter{other.iter}, has_next{other.has_next}, error{other.error}
+  : iter{std::forward<array>(other).iter}, has_next{other.has_next}, error{other.error}
 {
   // Terminate the other iterator
   other.has_next = false;
 }
 simdjson_really_inline array &array::operator=(array &&other) noexcept {
-  iter = other.iter;
+  iter = std::forward<array>(other).iter;
   has_next = other.has_next;
   error = other.error;
   // Terminate the other iterator
@@ -67,13 +67,13 @@ simdjson_really_inline array::~array() noexcept {
   }
 }
 
-simdjson_really_inline simdjson_result<array> array::start(json_iterator *iter) noexcept {
+simdjson_really_inline simdjson_result<array> array::start(json_iterator_ref &&iter) noexcept {
   bool has_value;
   SIMDJSON_TRY( iter->start_array().get(has_value) );
-  return array(iter, has_value);
+  return array(std::forward<json_iterator_ref>(iter), has_value);
 }
-simdjson_really_inline array array::started(json_iterator *iter) noexcept {
-  return array(iter, iter->started_array());
+simdjson_really_inline array array::started(json_iterator_ref &&iter) noexcept {
+  return array(std::forward<json_iterator_ref>(iter), iter->started_array());
 }
 simdjson_really_inline array::iterator array::begin() noexcept {
   return *this;
@@ -96,7 +96,7 @@ simdjson_really_inline array::iterator &array::iterator::operator=(const array::
 
 simdjson_really_inline simdjson_result<value> array::iterator::operator*() noexcept {
   if (a->error) { return a->report_error(); }
-  return value::start(a->iter);
+  return value::start(a->iter.borrow());
 }
 simdjson_really_inline bool array::iterator::operator==(const array::iterator &) noexcept {
   return !a->has_next;

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -5,54 +5,54 @@ namespace ondemand {
 //
 // ### Live States
 //
-// While iterating or looking up values, depth >= doc->iter.depth. at_start may vary. Error is
+// While iterating or looking up values, depth >= iter->depth. at_start may vary. Error is
 // always SUCCESS:
 //
 // - Start: This is the state when the array is first found and the iterator is just past the `{`.
 //   In this state, at_start == true.
 // - Next: After we hand a scalar value to the user, or an array/object which they then fully
 //   iterate over, the iterator is at the `,` before the next value (or `]`). In this state,
-//   depth == doc->iter.depth, at_start == false, and error == SUCCESS.
+//   depth == iter->depth, at_start == false, and error == SUCCESS.
 // - Unfinished Business: When we hand an array/object to the user which they do not fully
 //   iterate over, we need to finish that iteration by skipping child values until we reach the
-//   Next state. In this state, depth > doc->iter.depth, at_start == false, and error == SUCCESS.
+//   Next state. In this state, depth > iter->depth, at_start == false, and error == SUCCESS.
 //
 // ## Error States
 // 
-// In error states, we will yield exactly one more value before stopping. doc->iter.depth == depth
+// In error states, we will yield exactly one more value before stopping. iter->depth == depth
 // and at_start is always false. We decrement after yielding the error, moving to the Finished
 // state.
 //
 // - Chained Error: When the array iterator is part of an error chain--for example, in
 //   `for (auto tweet : doc["tweets"])`, where the tweet element may be missing or not be an
 //   array--we yield that error in the loop, exactly once. In this state, error != SUCCESS and
-//   doc->iter.depth == depth, and at_start == false. We decrement depth when we yield the error.
+//   iter->depth == depth, and at_start == false. We decrement depth when we yield the error.
 // - Missing Comma Error: When the iterator ++ method discovers there is no comma between elements,
 //   we flag that as an error and treat it exactly the same as a Chained Error. In this state,
-//   error == TAPE_ERROR, doc->iter.depth == depth, and at_start == false.
+//   error == TAPE_ERROR, iter->depth == depth, and at_start == false.
 //
 // ## Terminal State
 //
-// The terminal state has doc->iter.depth < depth. at_start is always false.
+// The terminal state has iter->depth < depth. at_start is always false.
 //
 // - Finished: When we have reached a `]` or have reported an error, we are finished. We signal this
-//   by decrementing depth. In this state, doc->iter.depth < depth, at_start == false, and
+//   by decrementing depth. In this state, iter->depth < depth, at_start == false, and
 //   error == SUCCESS.
 //
 
 simdjson_really_inline array::array() noexcept = default;
-simdjson_really_inline array::array(document *_doc, bool has_value) noexcept
-  : doc{_doc}, has_next{has_value}, error{SUCCESS}
+simdjson_really_inline array::array(json_iterator *_iter, bool has_value) noexcept
+  : iter{_iter}, has_next{has_value}, error{SUCCESS}
 {
 }
 simdjson_really_inline array::array(array &&other) noexcept
-  : doc{other.doc}, has_next{other.has_next}, error{other.error}
+  : iter{other.iter}, has_next{other.has_next}, error{other.error}
 {
   // Terminate the other iterator
   other.has_next = false;
 }
 simdjson_really_inline array &array::operator=(array &&other) noexcept {
-  doc = other.doc;
+  iter = other.iter;
   has_next = other.has_next;
   error = other.error;
   // Terminate the other iterator
@@ -62,18 +62,18 @@ simdjson_really_inline array &array::operator=(array &&other) noexcept {
 
 simdjson_really_inline array::~array() noexcept {
   if (!error && has_next) {
-    logger::log_event(doc->iter, "unfinished", "array");
-    doc->iter.skip_container();
+    logger::log_event(*iter, "unfinished", "array");
+    iter->skip_container();
   }
 }
 
-simdjson_really_inline simdjson_result<array> array::start(document *doc) noexcept {
+simdjson_really_inline simdjson_result<array> array::start(json_iterator *iter) noexcept {
   bool has_value;
-  SIMDJSON_TRY( doc->iter.start_array().get(has_value) );
-  return array(doc, has_value);
+  SIMDJSON_TRY( iter->start_array().get(has_value) );
+  return array(iter, has_value);
 }
-simdjson_really_inline array array::started(document *doc) noexcept {
-  return array(doc, doc->iter.started_array());
+simdjson_really_inline array array::started(json_iterator *iter) noexcept {
+  return array(iter, iter->started_array());
 }
 simdjson_really_inline array::iterator array::begin() noexcept {
   return *this;
@@ -96,7 +96,7 @@ simdjson_really_inline array::iterator &array::iterator::operator=(const array::
 
 simdjson_really_inline simdjson_result<value> array::iterator::operator*() noexcept {
   if (a->error) { return a->report_error(); }
-  return value::start(a->doc);
+  return value::start(a->iter);
 }
 simdjson_really_inline bool array::iterator::operator==(const array::iterator &) noexcept {
   return !a->has_next;
@@ -106,7 +106,7 @@ simdjson_really_inline bool array::iterator::operator!=(const array::iterator &)
 }
 simdjson_really_inline array::iterator &array::iterator::operator++() noexcept {
   if (a->error) { return *this; }
-  a->error = a->doc->iter.has_next_element().get(a->has_next); // If there's an error, has_next stays true.
+  a->error = a->iter->has_next_element().get(a->has_next); // If there's an error, has_next stays true.
   return *this;
 }
 
@@ -179,12 +179,12 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
   if (error()) { return error(); }
   return *first;
 }
-// Assumes it's being compared with the end. true if depth < doc->iter.depth.
+// Assumes it's being compared with the end. true if depth < iter->depth.
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> &other) noexcept {
   if (error()) { return true; }
   return first == other.first;
 }
-// Assumes it's being compared with the end. true if depth >= doc->iter.depth.
+// Assumes it's being compared with the end. true if depth >= iter->depth.
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> &other) noexcept {
   if (error()) { return false; }
   return first != other.first;

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -45,15 +45,8 @@ simdjson_really_inline array::array(json_iterator_ref &&_iter) noexcept
   : iter{std::forward<json_iterator_ref>(_iter)}, error{SUCCESS}
 {
 }
-simdjson_really_inline array::array(array &&other) noexcept
-  : iter{std::forward<array>(other).iter}, error{other.error}
-{
-}
-simdjson_really_inline array &array::operator=(array &&other) noexcept {
-  iter = std::forward<array>(other).iter;
-  error = other.error;
-  return *this;
-}
+simdjson_really_inline array::array(array &&other) noexcept = default;
+simdjson_really_inline array &array::operator=(array &&other) noexcept = default;
 
 simdjson_really_inline array::~array() noexcept {
   if (iter.is_alive()) {

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -61,9 +61,10 @@ simdjson_really_inline array &array::operator=(array &&other) noexcept {
 }
 
 simdjson_really_inline array::~array() noexcept {
-  if (!error && has_next) {
+  if (!error && has_next && iter.is_alive()) {
     logger::log_event(*iter, "unfinished", "array");
     iter->skip_container();
+    iter.release();
   }
 }
 

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -48,15 +48,11 @@ simdjson_really_inline array::array(json_iterator_ref &&_iter, bool has_value) n
 simdjson_really_inline array::array(array &&other) noexcept
   : iter{std::forward<array>(other).iter}, has_next{other.has_next}, error{other.error}
 {
-  // Terminate the other iterator
-  other.has_next = false;
 }
 simdjson_really_inline array &array::operator=(array &&other) noexcept {
   iter = std::forward<array>(other).iter;
   has_next = other.has_next;
   error = other.error;
-  // Terminate the other iterator
-  other.has_next = false;
   return *this;
 }
 
@@ -99,16 +95,15 @@ simdjson_really_inline simdjson_result<value> array::iterator::operator*() noexc
   if (a->error) { return a->report_error(); }
   return value::start(a->iter.borrow());
 }
-simdjson_really_inline bool array::iterator::operator==(const array::iterator &) noexcept {
-  return !a->has_next;
+simdjson_really_inline bool array::iterator::operator==(const array::iterator &other) noexcept {
+  return !(*this != other);
 }
 simdjson_really_inline bool array::iterator::operator!=(const array::iterator &) noexcept {
   return a->has_next;
 }
 simdjson_really_inline array::iterator &array::iterator::operator++() noexcept {
-  if (a->error) { return *this; }
   a->error = a->iter->has_next_element().get(a->has_next); // If there's an error, has_next stays true.
-  if (!a->has_next) { a->iter.release(); }
+  if (!a->error && !a->has_next) { a->iter.release(); }
   return *this;
 }
 

--- a/src/generic/ondemand/array.h
+++ b/src/generic/ondemand/array.h
@@ -53,13 +53,13 @@ protected:
    * @param doc The document containing the array.
    * @error INCORRECT_TYPE if the iterator is not at [.
    */
-  static simdjson_really_inline simdjson_result<array> start(json_iterator *iter) noexcept;
+  static simdjson_really_inline simdjson_result<array> start(json_iterator_ref &&iter) noexcept;
   /**
    * Begin array iteration.
    *
    * @param doc The document containing the array. The iterator must be just after the opening `[`.
    */
-  static simdjson_really_inline array started(json_iterator *iter) noexcept;
+  static simdjson_really_inline array started(json_iterator_ref &&iter) noexcept;
 
   /**
    * Report the current error and set finished so it won't be reported again.
@@ -73,7 +73,7 @@ protected:
    *            reflect the array's depth. The iterator must be just after the opening `[`.
    * @param has_value Whether the array has a value (false means empty array).
    */
-  simdjson_really_inline array(json_iterator *iter, bool has_value) noexcept;
+  simdjson_really_inline array(json_iterator_ref &&iter, bool has_value) noexcept;
 
   /**
    * Document containing this array.
@@ -81,7 +81,7 @@ protected:
    * PERF NOTE: expected to be elided in favor of the parent document: this is set when the array
    * is first used, and never changes afterwards.
    */
-  json_iterator *iter{};
+  json_iterator_ref iter{};
   /**
    * Whether we have anything to yield.
    *

--- a/src/generic/ondemand/array.h
+++ b/src/generic/ondemand/array.h
@@ -62,18 +62,12 @@ protected:
   static simdjson_really_inline array started(json_iterator_ref &&iter) noexcept;
 
   /**
-   * Report the current error and set finished so it won't be reported again.
-   */
-  simdjson_really_inline error_code report_error() noexcept;
-
-  /**
    * Internal array creation. Call array::start() or array::started() instead of this.
    *
    * @param doc The document containing the array. iter->depth must already be incremented to
    *            reflect the array's depth. The iterator must be just after the opening `[`.
-   * @param has_value Whether the array has a value (false means empty array).
    */
-  simdjson_really_inline array(json_iterator_ref &&iter, bool has_value) noexcept;
+  simdjson_really_inline array(json_iterator_ref &&iter) noexcept;
 
   /**
    * Document containing this array.
@@ -82,14 +76,6 @@ protected:
    * is first used, and never changes afterwards.
    */
   json_iterator_ref iter{};
-  /**
-   * Whether we have anything to yield.
-   *
-   * PERF NOTE: we hope this will be elided into inline control flow, as it is true for all
-   * iterations except the last, and compilers with SSA optimization can sometimes do last-iteration
-   * optimization.
-   */
-  bool has_next{};
   /**
    * Error, if there is one. Errors are only yielded once.
    *

--- a/src/generic/ondemand/array.h
+++ b/src/generic/ondemand/array.h
@@ -31,9 +31,9 @@ public:
 
     // Reads key and value, yielding them to the user.
     simdjson_really_inline simdjson_result<value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-    // Assumes it's being compared with the end. true if depth < doc->iter.depth.
+    // Assumes it's being compared with the end. true if depth < iter->depth.
     simdjson_really_inline bool operator==(const array::iterator &) noexcept;
-    // Assumes it's being compared with the end. true if depth >= doc->iter.depth.
+    // Assumes it's being compared with the end. true if depth >= iter->depth.
     simdjson_really_inline bool operator!=(const array::iterator &) noexcept;
     // Checks for ']' and ','
     simdjson_really_inline array::iterator &operator++() noexcept;
@@ -53,13 +53,13 @@ protected:
    * @param doc The document containing the array.
    * @error INCORRECT_TYPE if the iterator is not at [.
    */
-  static simdjson_really_inline simdjson_result<array> start(document *doc) noexcept;
+  static simdjson_really_inline simdjson_result<array> start(json_iterator *iter) noexcept;
   /**
    * Begin array iteration.
    *
    * @param doc The document containing the array. The iterator must be just after the opening `[`.
    */
-  static simdjson_really_inline array started(document *doc) noexcept;
+  static simdjson_really_inline array started(json_iterator *iter) noexcept;
 
   /**
    * Report the current error and set finished so it won't be reported again.
@@ -69,11 +69,11 @@ protected:
   /**
    * Internal array creation. Call array::start() or array::started() instead of this.
    *
-   * @param doc The document containing the array. doc->iter.depth must already be incremented to
+   * @param doc The document containing the array. iter->depth must already be incremented to
    *            reflect the array's depth. The iterator must be just after the opening `[`.
    * @param has_value Whether the array has a value (false means empty array).
    */
-  simdjson_really_inline array(document *_doc, bool has_value) noexcept;
+  simdjson_really_inline array(json_iterator *iter, bool has_value) noexcept;
 
   /**
    * Document containing this array.
@@ -81,7 +81,7 @@ protected:
    * PERF NOTE: expected to be elided in favor of the parent document: this is set when the array
    * is first used, and never changes afterwards.
    */
-  document *doc{};
+  json_iterator *iter{};
   /**
    * Whether we have anything to yield.
    *
@@ -136,9 +136,9 @@ public:
 
   // Reads key and value, yielding them to the user.
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-  // Assumes it's being compared with the end. true if depth < doc->iter.depth.
+  // Assumes it's being compared with the end. true if depth < iter->depth.
   simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> &) noexcept;
-  // Assumes it's being compared with the end. true if depth >= doc->iter.depth.
+  // Assumes it's being compared with the end. true if depth >= iter->depth.
   simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> &) noexcept;
   // Checks for ']' and ','
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> &operator++() noexcept;

--- a/src/generic/ondemand/document-inl.h
+++ b/src/generic/ondemand/document-inl.h
@@ -4,7 +4,7 @@ namespace ondemand {
 
 simdjson_really_inline document::document(document &&other) noexcept = default;
 simdjson_really_inline document &document::operator=(document &&other) noexcept = default;
-simdjson_really_inline document::document(ondemand::json_iterator && _iter) noexcept
+simdjson_really_inline document::document(ondemand::json_iterator &&_iter) noexcept
   : iter(std::forward<json_iterator>(_iter))
 {
   logger::log_start_value(iter, "document");
@@ -20,7 +20,7 @@ simdjson_really_inline value document::as_value() noexcept {
     logger::log_error(iter, "Document value can only be used once! ondemand::document is a forward-only input iterator.");
     abort(); // TODO is there anything softer we can do? I'd rather not make this a simdjson_result just for user error.
   }
-  return value::start(&iter);
+  return value::start(iter.borrow());
 }
 
 simdjson_really_inline simdjson_result<array> document::get_array() & noexcept { return as_value().get_array(); }

--- a/src/generic/ondemand/document-inl.h
+++ b/src/generic/ondemand/document-inl.h
@@ -44,7 +44,9 @@ simdjson_really_inline document::operator raw_json_string() & noexcept(false) { 
 simdjson_really_inline document::operator bool() noexcept(false) { return as_value(); }
 #endif
 
-simdjson_really_inline simdjson_result<array::iterator> document::begin() & noexcept { return as_value().begin(); }
+simdjson_really_inline simdjson_result<array::iterator> document::begin() & noexcept {
+  return as_value().get_array().begin();
+}
 simdjson_really_inline simdjson_result<array::iterator> document::end() & noexcept { return {}; }
 simdjson_really_inline simdjson_result<value> document::operator[](std::string_view key) & noexcept { return as_value()[key]; }
 

--- a/src/generic/ondemand/document-inl.h
+++ b/src/generic/ondemand/document-inl.h
@@ -4,8 +4,8 @@ namespace ondemand {
 
 simdjson_really_inline document::document(document &&other) noexcept = default;
 simdjson_really_inline document &document::operator=(document &&other) noexcept = default;
-simdjson_really_inline document::document(ondemand::parser *_parser) noexcept
-  : iter(_parser)
+simdjson_really_inline document::document(ondemand::json_iterator && _iter) noexcept
+  : iter(std::forward<json_iterator>(_iter))
 {
   logger::log_start_value(iter, "document");
 }
@@ -21,13 +21,6 @@ simdjson_really_inline value document::as_value() noexcept {
     abort(); // TODO is there anything softer we can do? I'd rather not make this a simdjson_result just for user error.
   }
   return value::start(&iter);
-}
-simdjson_really_inline json_iterator &document::iterate() & noexcept {
-  if (!iter.at_start()) {
-    logger::log_error(iter, "Document value can only be used once! ondemand::document is a forward-only input iterator.");
-    abort(); // TODO is there anything softer we can do? I'd rather not make this a simdjson_result just for user error.
-  }
-  return iter;
 }
 
 simdjson_really_inline simdjson_result<array> document::get_array() & noexcept { return as_value().get_array(); }
@@ -70,11 +63,9 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::docume
 {
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::simdjson_result(
-  SIMDJSON_IMPLEMENTATION::ondemand::document &&value,
   error_code error
 ) noexcept :
     internal::simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document>(
-      std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document>(value),
       error
     )
 {
@@ -92,9 +83,6 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator[](const char *key) & noexcept {
   return as_value()[key];
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator&> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::iterate() noexcept {
-  return { first.iterate(), error() };
 }
 
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_array() & noexcept { return as_value().get_array(); }

--- a/src/generic/ondemand/document.h
+++ b/src/generic/ondemand/document.h
@@ -52,10 +52,8 @@ public:
   simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
   simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
 
-  simdjson_really_inline json_iterator &iterate() & noexcept;
-
 protected:
-  simdjson_really_inline document(ondemand::parser *parser) noexcept;
+  simdjson_really_inline document(ondemand::json_iterator &&iter) noexcept;
   simdjson_really_inline const uint8_t *text(uint32_t idx) const noexcept;
 
   json_iterator iter{}; ///< Current position in the document
@@ -81,7 +79,7 @@ template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> : public internal::simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document> {
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document &&value, error_code error) noexcept; ///< @private
+  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
@@ -108,8 +106,6 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> end() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
-
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator&> iterate() noexcept;
 
 protected:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> as_value() noexcept;

--- a/src/generic/ondemand/document.h
+++ b/src/generic/ondemand/document.h
@@ -58,11 +58,9 @@ protected:
   simdjson_really_inline document(ondemand::parser *parser) noexcept;
   simdjson_really_inline const uint8_t *text(uint32_t idx) const noexcept;
 
-  json_iterator iter; ///< Current position in the document
-  ondemand::parser *parser;
+  json_iterator iter{}; ///< Current position in the document
 
   simdjson_really_inline value as_value() noexcept;
-  simdjson_really_inline bool at_start() const noexcept;
 
   friend struct simdjson_result<document>;
   friend class value;

--- a/src/generic/ondemand/field-inl.h
+++ b/src/generic/ondemand/field-inl.h
@@ -12,15 +12,15 @@ simdjson_really_inline field::field(raw_json_string key, ondemand::value &&value
 {
 }
 
-simdjson_really_inline simdjson_result<field> field::start(document *doc) noexcept {
+simdjson_really_inline simdjson_result<field> field::start(json_iterator *iter) noexcept {
   raw_json_string key;
-  SIMDJSON_TRY( doc->iter.field_key().get(key) );
-  SIMDJSON_TRY( doc->iter.field_value() );
-  return field::start(doc, key);
+  SIMDJSON_TRY( iter->field_key().get(key) );
+  SIMDJSON_TRY( iter->field_value() );
+  return field::start(iter, key);
 }
 
-simdjson_really_inline simdjson_result<field> field::start(document *doc, raw_json_string key) noexcept {
-    return field(key, value::start(doc));
+simdjson_really_inline simdjson_result<field> field::start(json_iterator *iter, raw_json_string key) noexcept {
+    return field(key, value::start(iter));
 }
 
 simdjson_really_inline raw_json_string field::key() const noexcept {

--- a/src/generic/ondemand/field-inl.h
+++ b/src/generic/ondemand/field-inl.h
@@ -12,15 +12,15 @@ simdjson_really_inline field::field(raw_json_string key, ondemand::value &&value
 {
 }
 
-simdjson_really_inline simdjson_result<field> field::start(json_iterator *iter) noexcept {
+simdjson_really_inline simdjson_result<field> field::start(json_iterator_ref &&iter) noexcept {
   raw_json_string key;
   SIMDJSON_TRY( iter->field_key().get(key) );
   SIMDJSON_TRY( iter->field_value() );
-  return field::start(iter, key);
+  return field::start(std::forward<json_iterator_ref>(iter), key);
 }
 
-simdjson_really_inline simdjson_result<field> field::start(json_iterator *iter, raw_json_string key) noexcept {
-    return field(key, value::start(iter));
+simdjson_really_inline simdjson_result<field> field::start(json_iterator_ref &&iter, raw_json_string key) noexcept {
+    return field(key, value::start(std::forward<json_iterator_ref>(iter)));
 }
 
 simdjson_really_inline raw_json_string field::key() const noexcept {

--- a/src/generic/ondemand/field.h
+++ b/src/generic/ondemand/field.h
@@ -19,8 +19,8 @@ public:
   simdjson_really_inline ondemand::value &value() noexcept;
 protected:
   simdjson_really_inline field(raw_json_string key, ondemand::value &&value) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(json_iterator *iter) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(json_iterator *iter, raw_json_string key) noexcept;
+  static simdjson_really_inline simdjson_result<field> start(json_iterator_ref &&iter) noexcept;
+  static simdjson_really_inline simdjson_result<field> start(json_iterator_ref &&iter, raw_json_string key) noexcept;
   friend struct simdjson_result<field>;
   friend class object;
 };

--- a/src/generic/ondemand/field.h
+++ b/src/generic/ondemand/field.h
@@ -19,8 +19,8 @@ public:
   simdjson_really_inline ondemand::value &value() noexcept;
 protected:
   simdjson_really_inline field(raw_json_string key, ondemand::value &&value) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(document *doc) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(document *doc, raw_json_string key) noexcept;
+  static simdjson_really_inline simdjson_result<field> start(json_iterator *iter) noexcept;
+  static simdjson_really_inline simdjson_result<field> start(json_iterator *iter, raw_json_string key) noexcept;
   friend struct simdjson_result<field>;
   friend class object;
 };

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -5,7 +5,8 @@ namespace ondemand {
 simdjson_really_inline json_iterator::json_iterator() noexcept = default;
 simdjson_really_inline json_iterator::json_iterator(json_iterator &&other) noexcept
   : token_iterator(std::forward<token_iterator>(other)),
-    parser{other.parser}
+    parser{other.parser},
+    current_string_buf_loc{other.current_string_buf_loc}
 {
   other.parser = nullptr;
 }
@@ -13,6 +14,7 @@ simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&o
   buf = other.buf;
   index = other.index;
   parser = other.parser;
+  current_string_buf_loc = other.current_string_buf_loc;
   other.parser = nullptr;
   return *this;
 }
@@ -21,13 +23,9 @@ simdjson_really_inline json_iterator::json_iterator(ondemand::parser *_parser) n
 {
   // Release the string buf so it can be reused by the next document
   logger::log_headers();
-  parser->current_string_buf_loc = parser->string_buf.get();
+  current_string_buf_loc = parser->string_buf.get();
 }
-simdjson_really_inline json_iterator::~json_iterator() noexcept {
-  if (parser) {
-    parser->current_string_buf_loc = nullptr;
-  }
-}
+simdjson_really_inline json_iterator::~json_iterator() noexcept = default;
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> json_iterator::start_object() noexcept {
   if (*advance() != '{') { logger::log_error(*this, "Not an object"); return INCORRECT_TYPE; }

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -27,7 +27,10 @@ simdjson_really_inline json_iterator::json_iterator(ondemand::parser *_parser) n
   // Release the string buf so it can be reused by the next document
   logger::log_headers();
 }
-simdjson_really_inline json_iterator::~json_iterator() noexcept = default;
+simdjson_really_inline json_iterator::~json_iterator() noexcept {
+  // If we have any leases out when we die, it's an error
+  SIMDJSON_ASSUME(active_lease_depth == 0);
+}
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> json_iterator::start_object() noexcept {
   if (*advance() != '{') { logger::log_error(*this, "Not an object"); return INCORRECT_TYPE; }

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -260,6 +260,41 @@ simdjson_really_inline bool json_iterator::is_alive() const noexcept {
   return parser;
 }
 
+simdjson_really_inline json_iterator_ref json_iterator::borrow() noexcept {
+  return json_iterator_ref(this);
+}
+
+//
+// json_iterator_ref
+//
+simdjson_really_inline json_iterator_ref::json_iterator_ref() noexcept = default;
+simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator_ref &&other) noexcept = default;
+simdjson_really_inline json_iterator_ref &json_iterator_ref::operator=(json_iterator_ref &&other) noexcept = default;
+simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator *_iter) noexcept
+  : iter{_iter}
+{
+}
+simdjson_really_inline json_iterator_ref::~json_iterator_ref() noexcept = default;
+
+simdjson_really_inline json_iterator_ref json_iterator_ref::borrow() noexcept {
+  return json_iterator_ref(iter);
+}
+
+simdjson_really_inline json_iterator *json_iterator_ref::operator->() noexcept {
+  return iter;
+}
+simdjson_really_inline json_iterator &json_iterator_ref::operator*() noexcept {
+  return *iter;
+}
+simdjson_really_inline const json_iterator &json_iterator_ref::operator*() const noexcept {
+  return *iter;
+}
+
+simdjson_really_inline bool json_iterator_ref::is_alive() const noexcept {
+  return iter != nullptr;
+}
+
+
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace {

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -282,7 +282,10 @@ simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator *_iter
   : iter{_iter}
 {
 }
-simdjson_really_inline json_iterator_ref::~json_iterator_ref() noexcept = default;
+simdjson_really_inline json_iterator_ref::~json_iterator_ref() noexcept {
+  // The caller MUST consume their value and release the iterator before they die
+  SIMDJSON_ASSUME(!iter);
+}
 
 simdjson_really_inline json_iterator_ref json_iterator_ref::borrow() noexcept {
   return json_iterator_ref(iter);

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -287,14 +287,21 @@ simdjson_really_inline json_iterator_ref::~json_iterator_ref() noexcept = defaul
 simdjson_really_inline json_iterator_ref json_iterator_ref::borrow() noexcept {
   return json_iterator_ref(iter);
 }
+simdjson_really_inline void json_iterator_ref::release() noexcept {
+  SIMDJSON_ASSUME(is_alive());
+  iter = nullptr;
+}
 
 simdjson_really_inline json_iterator *json_iterator_ref::operator->() noexcept {
+  SIMDJSON_ASSUME(is_alive());
   return iter;
 }
 simdjson_really_inline json_iterator &json_iterator_ref::operator*() noexcept {
+  SIMDJSON_ASSUME(is_alive());
   return *iter;
 }
 simdjson_really_inline const json_iterator &json_iterator_ref::operator*() const noexcept {
+  SIMDJSON_ASSUME(is_alive());
   return *iter;
 }
 

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -277,14 +277,16 @@ simdjson_really_inline json_iterator_ref json_iterator::borrow() noexcept {
 //
 simdjson_really_inline json_iterator_ref::json_iterator_ref() noexcept = default;
 simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator_ref &&other) noexcept
-  : iter{std::exchange(other.iter, nullptr)},
+  : iter{other.iter},
     lease_depth{other.lease_depth}
 {
+  other.iter = nullptr;
 }
 simdjson_really_inline json_iterator_ref &json_iterator_ref::operator=(json_iterator_ref &&other) noexcept {
   SIMDJSON_ASSUME(!is_active());
-  iter = std::exchange(other.iter, nullptr);
+  iter = other.iter;
   lease_depth = other.lease_depth;
+  other.iter = nullptr;
   return *this;
 }
 simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator *_iter, uint32_t _lease_depth) noexcept

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -19,11 +19,13 @@ simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&o
   return *this;
 }
 simdjson_really_inline json_iterator::json_iterator(ondemand::parser *_parser) noexcept
-  : token_iterator(_parser->dom_parser.buf, _parser->dom_parser.structural_indexes.get()), parser{_parser}
+  : token_iterator(_parser->dom_parser.buf, _parser->dom_parser.structural_indexes.get()),
+    parser{_parser},
+    current_string_buf_loc{parser->string_buf.get()},
+    active_lease_depth{0}
 {
   // Release the string buf so it can be reused by the next document
   logger::log_headers();
-  current_string_buf_loc = parser->string_buf.get();
 }
 simdjson_really_inline json_iterator::~json_iterator() noexcept = default;
 
@@ -261,7 +263,10 @@ simdjson_really_inline bool json_iterator::is_alive() const noexcept {
 }
 
 simdjson_really_inline json_iterator_ref json_iterator::borrow() noexcept {
-  return json_iterator_ref(this);
+  SIMDJSON_ASSUME(active_lease_depth == 0);
+  const uint32_t child_depth = 1;
+  active_lease_depth = child_depth;
+  return json_iterator_ref(this, child_depth);
 }
 
 //
@@ -269,47 +274,57 @@ simdjson_really_inline json_iterator_ref json_iterator::borrow() noexcept {
 //
 simdjson_really_inline json_iterator_ref::json_iterator_ref() noexcept = default;
 simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator_ref &&other) noexcept
-  : iter{std::forward<json_iterator_ref>(other).iter}
+  : iter{std::exchange(other.iter, nullptr)},
+    lease_depth{other.lease_depth}
 {
-  other.iter = nullptr;
 }
 simdjson_really_inline json_iterator_ref &json_iterator_ref::operator=(json_iterator_ref &&other) noexcept {
-  iter = std::forward<json_iterator_ref>(other).iter;
-  other.iter = nullptr;
+  SIMDJSON_ASSUME(!is_active());
+  iter = std::exchange(other.iter, nullptr);
+  lease_depth = other.lease_depth;
   return *this;
 }
-simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator *_iter) noexcept
-  : iter{_iter}
+simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator *_iter, uint32_t _lease_depth) noexcept
+  : iter{_iter},
+    lease_depth{_lease_depth}
 {
+  SIMDJSON_ASSUME(is_active());
 }
 simdjson_really_inline json_iterator_ref::~json_iterator_ref() noexcept {
   // The caller MUST consume their value and release the iterator before they die
-  SIMDJSON_ASSUME(!iter);
+  SIMDJSON_ASSUME(!is_alive());
 }
 
 simdjson_really_inline json_iterator_ref json_iterator_ref::borrow() noexcept {
-  return json_iterator_ref(iter);
+  SIMDJSON_ASSUME(is_active());
+  const uint32_t child_depth = lease_depth + 1;
+  iter->active_lease_depth = child_depth;
+  return json_iterator_ref(iter, child_depth);
 }
 simdjson_really_inline void json_iterator_ref::release() noexcept {
-  SIMDJSON_ASSUME(is_alive());
+  SIMDJSON_ASSUME(is_active());
+  iter->active_lease_depth = lease_depth - 1;
   iter = nullptr;
 }
 
 simdjson_really_inline json_iterator *json_iterator_ref::operator->() noexcept {
-  SIMDJSON_ASSUME(is_alive());
+  SIMDJSON_ASSUME(is_active());
   return iter;
 }
 simdjson_really_inline json_iterator &json_iterator_ref::operator*() noexcept {
-  SIMDJSON_ASSUME(is_alive());
+  SIMDJSON_ASSUME(is_active());
   return *iter;
 }
 simdjson_really_inline const json_iterator &json_iterator_ref::operator*() const noexcept {
-  SIMDJSON_ASSUME(is_alive());
+  SIMDJSON_ASSUME(is_active());
   return *iter;
 }
 
 simdjson_really_inline bool json_iterator_ref::is_alive() const noexcept {
   return iter != nullptr;
+}
+simdjson_really_inline bool json_iterator_ref::is_active() const noexcept {
+  return is_alive() && lease_depth == iter->active_lease_depth;
 }
 
 

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -268,8 +268,16 @@ simdjson_really_inline json_iterator_ref json_iterator::borrow() noexcept {
 // json_iterator_ref
 //
 simdjson_really_inline json_iterator_ref::json_iterator_ref() noexcept = default;
-simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator_ref &&other) noexcept = default;
-simdjson_really_inline json_iterator_ref &json_iterator_ref::operator=(json_iterator_ref &&other) noexcept = default;
+simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator_ref &&other) noexcept
+  : iter{std::forward<json_iterator_ref>(other).iter}
+{
+  other.iter = nullptr;
+}
+simdjson_really_inline json_iterator_ref &json_iterator_ref::operator=(json_iterator_ref &&other) noexcept {
+  iter = std::forward<json_iterator_ref>(other).iter;
+  other.iter = nullptr;
+  return *this;
+}
 simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator *_iter) noexcept
   : iter{_iter}
 {

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -145,6 +145,7 @@ protected:
   friend class array;
   friend class value;
   friend class raw_json_string;
+  friend class parser;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
 };
 

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -134,6 +134,7 @@ public:
   simdjson_really_inline bool is_alive() const noexcept;
 protected:
   ondemand::parser *parser{};
+  uint8_t *current_string_buf_loc{};
 
   simdjson_really_inline json_iterator(ondemand::parser *parser) noexcept;
   template<int N>
@@ -143,6 +144,7 @@ protected:
   friend class object;
   friend class array;
   friend class value;
+  friend class raw_json_string;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
 };
 

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -2,6 +2,8 @@ namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
+class json_iterator_ref;
+
 /**
  * Iterates through JSON, with structure-sensitive algorithms.
  * 
@@ -140,6 +142,8 @@ protected:
   template<int N>
   SIMDJSON_WARN_UNUSED simdjson_really_inline bool advance_to_buffer(uint8_t (&buf)[N]) noexcept;
 
+  simdjson_really_inline json_iterator_ref borrow() noexcept;
+
   friend class document;
   friend class object;
   friend class array;
@@ -147,7 +151,31 @@ protected:
   friend class raw_json_string;
   friend class parser;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
-};
+}; // json_iterator
+
+class json_iterator_ref {
+public:
+  simdjson_really_inline json_iterator_ref() noexcept;
+  simdjson_really_inline json_iterator_ref(json_iterator_ref &&other) noexcept;
+  simdjson_really_inline json_iterator_ref &operator=(json_iterator_ref &&other) noexcept;
+  simdjson_really_inline json_iterator_ref(const json_iterator_ref &other) noexcept = delete;
+  simdjson_really_inline json_iterator_ref &operator=(const json_iterator_ref &other) noexcept = delete;
+  simdjson_really_inline ~json_iterator_ref() noexcept;
+
+  simdjson_really_inline json_iterator_ref borrow() noexcept;
+
+  simdjson_really_inline json_iterator *operator->() noexcept;
+  simdjson_really_inline json_iterator &operator*() noexcept;
+  simdjson_really_inline const json_iterator &operator*() const noexcept;
+
+  simdjson_really_inline bool is_alive() const noexcept;
+
+private:
+  simdjson_really_inline json_iterator_ref(json_iterator *iter) noexcept;
+  json_iterator *iter;
+
+  friend class json_iterator;
+}; // class json_iterator_ref
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -137,6 +137,7 @@ public:
 protected:
   ondemand::parser *parser{};
   uint8_t *current_string_buf_loc{};
+  uint32_t active_lease_depth{};
 
   simdjson_really_inline json_iterator(ondemand::parser *parser) noexcept;
   template<int N>
@@ -150,6 +151,7 @@ protected:
   friend class value;
   friend class raw_json_string;
   friend class parser;
+  friend class json_iterator_ref;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
 }; // json_iterator
 
@@ -170,10 +172,12 @@ public:
   simdjson_really_inline const json_iterator &operator*() const noexcept;
 
   simdjson_really_inline bool is_alive() const noexcept;
+  simdjson_really_inline bool is_active() const noexcept;
 
 private:
-  simdjson_really_inline json_iterator_ref(json_iterator *iter) noexcept;
-  json_iterator *iter;
+  simdjson_really_inline json_iterator_ref(json_iterator *iter, uint32_t lease_depth) noexcept;
+  json_iterator *iter{};
+  uint32_t lease_depth{};
 
   friend class json_iterator;
 }; // class json_iterator_ref

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -163,6 +163,7 @@ public:
   simdjson_really_inline ~json_iterator_ref() noexcept;
 
   simdjson_really_inline json_iterator_ref borrow() noexcept;
+  simdjson_really_inline void release() noexcept;
 
   simdjson_really_inline json_iterator *operator->() noexcept;
   simdjson_really_inline json_iterator &operator*() noexcept;

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -14,6 +14,7 @@ public:
   simdjson_really_inline json_iterator &operator=(json_iterator &&other) noexcept;
   simdjson_really_inline json_iterator(const json_iterator &other) noexcept = delete;
   simdjson_really_inline json_iterator &operator=(const json_iterator &other) noexcept = delete;
+  simdjson_really_inline ~json_iterator() noexcept;
 
   /**
    * Check for an opening { and start an object iteration.
@@ -117,8 +118,24 @@ public:
    */
   simdjson_really_inline bool skip_container() noexcept;
 
+  /**
+   * Tell whether the iterator is still at the start
+   */
+  simdjson_really_inline bool at_start() const noexcept;
+
+  /**
+   * Tell whether the iterator has reached EOF
+   */
+  simdjson_really_inline bool at_eof() const noexcept;
+
+  /**
+   * Tell whether the iterator is live (has not been moved).
+   */
+  simdjson_really_inline bool is_alive() const noexcept;
 protected:
-  simdjson_really_inline json_iterator(const uint8_t *buf, uint32_t *index) noexcept;
+  ondemand::parser *parser{};
+
+  simdjson_really_inline json_iterator(ondemand::parser *parser) noexcept;
   template<int N>
   SIMDJSON_WARN_UNUSED simdjson_really_inline bool advance_to_buffer(uint8_t (&buf)[N]) noexcept;
 

--- a/src/generic/ondemand/object-inl.h
+++ b/src/generic/ondemand/object-inl.h
@@ -45,19 +45,13 @@ namespace ondemand {
 
 simdjson_really_inline object::object() noexcept = default;
 simdjson_really_inline object::object(json_iterator_ref &&_iter) noexcept
-  : iter{std::forward<json_iterator_ref>(_iter)}, at_start{true}, error{SUCCESS}
+  : iter{std::forward<json_iterator_ref>(_iter)},
+    at_start{true},
+    error{SUCCESS}
 {
 }
-simdjson_really_inline object::object(object &&other) noexcept
-  : iter{std::forward<object>(other).iter}, at_start{other.at_start}, error{other.error}
-{
-}
-simdjson_really_inline object &object::operator=(object &&other) noexcept {
-  iter = std::forward<object>(other).iter;
-  at_start = other.at_start;
-  error = other.error;
-  return *this;
-}
+simdjson_really_inline object::object(object &&other) noexcept = default;
+simdjson_really_inline object &object::operator=(object &&other) noexcept = default;
 
 simdjson_really_inline object::~object() noexcept {
   if (iter.is_alive()) {

--- a/src/generic/ondemand/object-inl.h
+++ b/src/generic/ondemand/object-inl.h
@@ -5,31 +5,31 @@ namespace ondemand {
 //
 // ### Live States
 //
-// While iterating or looking up values, depth >= doc->iter.depth. at_start may vary. Error is
+// While iterating or looking up values, depth >= iter->depth. at_start may vary. Error is
 // always SUCCESS:
 //
 // - Start: This is the state when the object is first found and the iterator is just past the {.
 //   In this state, at_start == true.
 // - Next: After we hand a scalar value to the user, or an array/object which they then fully
 //   iterate over, the iterator is at the , or } before the next value. In this state,
-//   depth == doc->iter.depth, at_start == false, and error == SUCCESS.
+//   depth == iter->depth, at_start == false, and error == SUCCESS.
 // - Unfinished Business: When we hand an array/object to the user which they do not fully
 //   iterate over, we need to finish that iteration by skipping child values until we reach the
-//   Next state. In this state, depth > doc->iter.depth, at_start == false, and error == SUCCESS.
+//   Next state. In this state, depth > iter->depth, at_start == false, and error == SUCCESS.
 //
 // ## Error States
 // 
-// In error states, we will yield exactly one more value before stopping. doc->iter.depth == depth
+// In error states, we will yield exactly one more value before stopping. iter->depth == depth
 // and at_start is always false. We decrement after yielding the error, moving to the Finished
 // state.
 //
 // - Chained Error: When the object iterator is part of an error chain--for example, in
 //   `for (auto tweet : doc["tweets"])`, where the tweet field may be missing or not be an
 //   object--we yield that error in the loop, exactly once. In this state, error != SUCCESS and
-//   doc->iter.depth == depth, and at_start == false. We decrement depth when we yield the error.
+//   iter->depth == depth, and at_start == false. We decrement depth when we yield the error.
 // - Missing Comma Error: When the iterator ++ method discovers there is no comma between fields,
 //   we flag that as an error and treat it exactly the same as a Chained Error. In this state,
-//   error == TAPE_ERROR, doc->iter.depth == depth, and at_start == false.
+//   error == TAPE_ERROR, iter->depth == depth, and at_start == false.
 //
 // Errors that occur while reading a field to give to the user (such as when the key is not a
 // string or the field is missing a colon) are yielded immediately. Depth is then decremented,
@@ -37,25 +37,25 @@ namespace ondemand {
 //
 // ## Terminal State
 //
-// The terminal state has doc->iter.depth < depth. at_start is always false.
+// The terminal state has iter->depth < depth. at_start is always false.
 //
 // - Finished: When we have reached a }, we are finished. We signal this by decrementing depth.
-//   In this state, doc->iter.depth < depth, at_start == false, and error == SUCCESS.
+//   In this state, iter->depth < depth, at_start == false, and error == SUCCESS.
 //
 
 simdjson_really_inline object::object() noexcept = default;
-simdjson_really_inline object::object(document *_doc, bool _has_value) noexcept
-  : doc{_doc}, has_next{_has_value}, at_start{true}, error{SUCCESS}
+simdjson_really_inline object::object(json_iterator *_iter, bool _has_value) noexcept
+  : iter{_iter}, has_next{_has_value}, at_start{true}, error{SUCCESS}
 {
 }
 simdjson_really_inline object::object(object &&other) noexcept
-  : doc{other.doc}, has_next{other.has_next}, at_start{other.at_start}, error{other.error}
+  : iter{other.iter}, has_next{other.has_next}, at_start{other.at_start}, error{other.error}
 {
   // Terminate the other iterator
   other.has_next = false;
 }
 simdjson_really_inline object &object::operator=(object &&other) noexcept {
-  doc = other.doc;
+  iter = other.iter;
   has_next = other.has_next;
   at_start = other.at_start;
   error = other.error;
@@ -66,8 +66,8 @@ simdjson_really_inline object &object::operator=(object &&other) noexcept {
 
 simdjson_really_inline object::~object() noexcept {
   if (!error && has_next) {
-    logger::log_event(doc->iter, "unfinished", "object");
-    doc->iter.skip_container();
+    logger::log_event(*iter, "unfinished", "object");
+    iter->skip_container();
   }
 }
 
@@ -79,36 +79,36 @@ simdjson_really_inline simdjson_result<value> object::operator[](const std::stri
     if (at_start) {
       at_start = false;
     } else {
-      if ((error = doc->iter.has_next_field().get(has_next) )) { return report_error(); }
+      if ((error = iter->has_next_field().get(has_next) )) { return report_error(); }
     }
   }
   while (has_next) {
     // Get the key
     raw_json_string actual_key;
-    if ((error = doc->iter.field_key().get(actual_key) )) { return report_error(); };
-    if ((error = doc->iter.field_value() )) { return report_error(); }
+    if ((error = iter->field_key().get(actual_key) )) { return report_error(); };
+    if ((error = iter->field_value() )) { return report_error(); }
 
     // Check if it matches
     if (actual_key == key) {
-      logger::log_event(doc->iter, "match", key, -2);
-      return value::start(doc);
+      logger::log_event(*iter, "match", key, -2);
+      return value::start(iter);
     }
-    logger::log_event(doc->iter, "no match", key, -2);
-    doc->iter.skip(); // Skip the value entirely
-    if ((error = doc->iter.has_next_field().get(has_next) )) { return report_error(); }
+    logger::log_event(*iter, "no match", key, -2);
+    iter->skip(); // Skip the value entirely
+    if ((error = iter->has_next_field().get(has_next) )) { return report_error(); }
   }
 
   // If the loop ended, we're out of fields to look at.
   return NO_SUCH_FIELD;
 }
 
-simdjson_really_inline simdjson_result<object> object::start(document *doc) noexcept {
+simdjson_really_inline simdjson_result<object> object::start(json_iterator *iter) noexcept {
   bool has_value;
-  SIMDJSON_TRY( doc->iter.start_object().get(has_value) );
-  return object(doc, has_value);
+  SIMDJSON_TRY( iter->start_object().get(has_value) );
+  return object(iter, has_value);
 }
-simdjson_really_inline object object::started(document *doc) noexcept {
-  return object(doc, doc->iter.started_object());
+simdjson_really_inline object object::started(json_iterator *iter) noexcept {
+  return object(iter, iter->started_object());
 }
 simdjson_really_inline object::iterator object::begin() noexcept {
   return *this;
@@ -135,7 +135,7 @@ simdjson_really_inline object::iterator &object::iterator::operator=(const objec
 simdjson_really_inline simdjson_result<field> object::iterator::operator*() noexcept {
   if (o->error) { return o->report_error(); }
   if (o->at_start) { o->at_start = false; }
-  return field::start(o->doc);
+  return field::start(o->iter);
 }
 simdjson_really_inline bool object::iterator::operator==(const object::iterator &) noexcept {
   return !o->has_next;
@@ -145,7 +145,7 @@ simdjson_really_inline bool object::iterator::operator!=(const object::iterator 
 }
 simdjson_really_inline object::iterator &object::iterator::operator++() noexcept {
   if (o->error) { return *this; }
-  o->error = o->doc->iter.has_next_element().get(o->has_next); // If there's an error, has_next stays true.
+  o->error = o->iter->has_next_element().get(o->has_next); // If there's an error, has_next stays true.
   return *this;
 }
 
@@ -212,12 +212,12 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>
   if (error()) { return error(); }
   return *first;
 }
-// Assumes it's being compared with the end. true if depth < doc->iter.depth.
+// Assumes it's being compared with the end. true if depth < iter->depth.
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object::iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object::iterator> &other) noexcept {
   if (error()) { return true; }
   return first == other.first;
 }
-// Assumes it's being compared with the end. true if depth >= doc->iter.depth.
+// Assumes it's being compared with the end. true if depth >= iter->depth.
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object::iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object::iterator> &other) noexcept {
   if (error()) { return false; }
   return first != other.first;

--- a/src/generic/ondemand/object-inl.h
+++ b/src/generic/ondemand/object-inl.h
@@ -65,9 +65,10 @@ simdjson_really_inline object &object::operator=(object &&other) noexcept {
 }
 
 simdjson_really_inline object::~object() noexcept {
-  if (!error && has_next) {
+  if (!error && has_next && iter.is_alive()) {
     logger::log_event(*iter, "unfinished", "object");
     iter->skip_container();
+    iter.release();
   }
 }
 

--- a/src/generic/ondemand/object.h
+++ b/src/generic/ondemand/object.h
@@ -28,9 +28,9 @@ public:
 
     // Reads key and value, yielding them to the user.
     simdjson_really_inline simdjson_result<field> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-    // Assumes it's being compared with the end. true if depth < doc->iter.depth.
+    // Assumes it's being compared with the end. true if depth < iter->depth.
     simdjson_really_inline bool operator==(const object::iterator &) noexcept;
-    // Assumes it's being compared with the end. true if depth >= doc->iter.depth.
+    // Assumes it's being compared with the end. true if depth >= iter->depth.
     simdjson_really_inline bool operator!=(const object::iterator &) noexcept;
     // Checks for ']' and ','
     simdjson_really_inline object::iterator &operator++() noexcept;
@@ -51,8 +51,8 @@ protected:
    * @param doc The document containing the object. The iterator must be just after the opening `{`.
    * @param error If this is not SUCCESS, creates an error chained object.
    */
-  static simdjson_really_inline simdjson_result<object> start(document *doc) noexcept;
-  static simdjson_really_inline object started(document *doc) noexcept;
+  static simdjson_really_inline simdjson_result<object> start(json_iterator *iter) noexcept;
+  static simdjson_really_inline object started(json_iterator *iter) noexcept;
 
   /**
    * Internal object creation. Call object::begin(doc) instead of this.
@@ -62,7 +62,7 @@ protected:
    * @param is_empty Whether this container is empty or not.
    * @param error The error to report. If the error is not SUCCESS, this is an error chained object.
    */
-  simdjson_really_inline object(document *_doc, bool is_empty) noexcept;
+  simdjson_really_inline object(json_iterator *_iter, bool is_empty) noexcept;
 
   simdjson_really_inline error_code report_error() noexcept;
 
@@ -72,7 +72,7 @@ protected:
    * PERF NOTE: expected to be elided in favor of the parent document: this is set when the object
    * is first used, and never changes afterwards.
    */
-  document *doc{};
+  json_iterator *iter{};
   /**
    * Whether we have anything to yield.
    *
@@ -135,9 +135,9 @@ public:
 
   // Reads key and value, yielding them to the user.
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-  // Assumes it's being compared with the end. true if depth < doc->iter.depth.
+  // Assumes it's being compared with the end. true if depth < iter->depth.
   simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object::iterator> &) noexcept;
-  // Assumes it's being compared with the end. true if depth >= doc->iter.depth.
+  // Assumes it's being compared with the end. true if depth >= iter->depth.
   simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object::iterator> &) noexcept;
   // Checks for ']' and ','
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object::iterator> &operator++() noexcept;

--- a/src/generic/ondemand/object.h
+++ b/src/generic/ondemand/object.h
@@ -59,10 +59,8 @@ protected:
    *
    * @param doc The document containing the object. doc->depth must already be incremented to
    *            reflect the object's depth. The iterator must be just after the opening `{`.
-   * @param is_empty Whether this container is empty or not.
-   * @param error The error to report. If the error is not SUCCESS, this is an error chained object.
    */
-  simdjson_really_inline object(json_iterator_ref &&_iter, bool is_empty) noexcept;
+  simdjson_really_inline object(json_iterator_ref &&_iter) noexcept;
 
   simdjson_really_inline error_code report_error() noexcept;
 
@@ -73,14 +71,6 @@ protected:
    * is first used, and never changes afterwards.
    */
   json_iterator_ref iter{};
-  /**
-   * Whether we have anything to yield.
-   *
-   * PERF NOTE: we hope this will be elided into inline control flow, as it is true for all
-   * iterations except the last, and compilers with SSA optimization can sometimes do last-iteration
-   * optimization.
-   */
-  bool has_next{};
   /**
    * Whether we are at the start.
    * 

--- a/src/generic/ondemand/object.h
+++ b/src/generic/ondemand/object.h
@@ -51,8 +51,8 @@ protected:
    * @param doc The document containing the object. The iterator must be just after the opening `{`.
    * @param error If this is not SUCCESS, creates an error chained object.
    */
-  static simdjson_really_inline simdjson_result<object> start(json_iterator *iter) noexcept;
-  static simdjson_really_inline object started(json_iterator *iter) noexcept;
+  static simdjson_really_inline simdjson_result<object> start(json_iterator_ref &&iter) noexcept;
+  static simdjson_really_inline object started(json_iterator_ref &&iter) noexcept;
 
   /**
    * Internal object creation. Call object::begin(doc) instead of this.
@@ -62,7 +62,7 @@ protected:
    * @param is_empty Whether this container is empty or not.
    * @param error The error to report. If the error is not SUCCESS, this is an error chained object.
    */
-  simdjson_really_inline object(json_iterator *_iter, bool is_empty) noexcept;
+  simdjson_really_inline object(json_iterator_ref &&_iter, bool is_empty) noexcept;
 
   simdjson_really_inline error_code report_error() noexcept;
 
@@ -72,7 +72,7 @@ protected:
    * PERF NOTE: expected to be elided in favor of the parent document: this is set when the object
    * is first used, and never changes afterwards.
    */
-  json_iterator *iter{};
+  json_iterator_ref iter{};
   /**
    * Whether we have anything to yield.
    *

--- a/src/generic/ondemand/parser-inl.h
+++ b/src/generic/ondemand/parser-inl.h
@@ -19,10 +19,6 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parser::allocate(size_t n
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<document> parser::parse(const padded_string &buf) noexcept {
-  if (current_string_buf_loc) {
-    return { this, PARSER_IN_USE };
-  }
-
   // Allocate if needed
   error_code error;
   if (_capacity < buf.size()) {

--- a/src/generic/ondemand/parser-inl.h
+++ b/src/generic/ondemand/parser-inl.h
@@ -19,7 +19,14 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parser::allocate(size_t n
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<document> parser::iterate(const padded_string &buf) noexcept {
-  return document(iterate_raw(buf));
+  // Allocate if needed
+  if (_capacity < buf.size()) {
+    SIMDJSON_TRY( allocate(buf.size(), _max_depth) );
+  }
+
+  // Run stage 1.
+  SIMDJSON_TRY( dom_parser.stage1((const uint8_t *)buf.data(), buf.size(), false) );  
+  return document(this);
 }
 
 SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<json_iterator> parser::iterate_raw(const padded_string &buf) noexcept {

--- a/src/generic/ondemand/parser-inl.h
+++ b/src/generic/ondemand/parser-inl.h
@@ -18,19 +18,19 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parser::allocate(size_t n
   return SUCCESS;
 }
 
-SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<document> parser::parse(const padded_string &buf) noexcept {
+SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<document> parser::iterate(const padded_string &buf) noexcept {
+  return document(iterate_raw(buf));
+}
+
+SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<json_iterator> parser::iterate_raw(const padded_string &buf) noexcept {
   // Allocate if needed
-  error_code error;
   if (_capacity < buf.size()) {
-    error = allocate(buf.size(), _max_depth);
-    if (error) {
-      return { this, error };
-    }
+    SIMDJSON_TRY( allocate(buf.size(), _max_depth) );
   }
 
   // Run stage 1.
-  error = dom_parser.stage1((const uint8_t *)buf.data(), buf.size(), false);  
-  return { this, error };
+  SIMDJSON_TRY( dom_parser.stage1((const uint8_t *)buf.data(), buf.size(), false) );  
+  return json_iterator(this);
 }
 
 } // namespace ondemand

--- a/src/generic/ondemand/parser.h
+++ b/src/generic/ondemand/parser.h
@@ -28,10 +28,7 @@ private:
   size_t _capacity{0};
   size_t _max_depth{0};
   std::unique_ptr<uint8_t[]> string_buf{};
-  uint8_t *current_string_buf_loc{};
 
-  friend class raw_json_string;
-  friend class value;
   friend class json_iterator;
 };
 

--- a/src/generic/ondemand/parser.h
+++ b/src/generic/ondemand/parser.h
@@ -22,7 +22,8 @@ public:
   simdjson_really_inline parser &operator=(const parser &other) = delete;
 
   SIMDJSON_WARN_UNUSED error_code allocate(size_t capacity, size_t max_depth=DEFAULT_MAX_DEPTH) noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_result<document> parse(const padded_string &json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_result<document> iterate(const padded_string &json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_result<json_iterator> iterate_raw(const padded_string &json) noexcept;
 private:
   dom_parser_implementation dom_parser{};
   size_t _capacity{0};

--- a/src/generic/ondemand/parser.h
+++ b/src/generic/ondemand/parser.h
@@ -31,8 +31,8 @@ private:
   uint8_t *current_string_buf_loc{};
 
   friend class raw_json_string;
-  friend class document;
   friend class value;
+  friend class json_iterator;
 };
 
 } // namespace ondemand

--- a/src/generic/ondemand/raw_json_string-inl.h
+++ b/src/generic/ondemand/raw_json_string-inl.h
@@ -15,12 +15,8 @@ simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> ra
   return result;
 }
 
-simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> raw_json_string::unescape(parser &parser) const noexcept {
-  uint8_t *end = stage2::stringparsing::parse_string(buf, parser.current_string_buf_loc);
-  if (!end) { return STRING_ERROR; }
-  std::string_view result((const char *)parser.current_string_buf_loc, end-parser.current_string_buf_loc);
-  parser.current_string_buf_loc = end;
-  return result;
+simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> raw_json_string::unescape(json_iterator &iter) const noexcept {
+  return unescape(iter.current_string_buf_loc);
 }
 
 SIMDJSON_UNUSED simdjson_really_inline bool operator==(const raw_json_string &a, std::string_view b) noexcept {

--- a/src/generic/ondemand/raw_json_string.h
+++ b/src/generic/ondemand/raw_json_string.h
@@ -20,7 +20,7 @@ public:
   simdjson_really_inline raw_json_string &operator=(const raw_json_string &other) noexcept;
   simdjson_really_inline const char * raw() const noexcept;
   simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> unescape(uint8_t *&dst) const noexcept;
-  simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> unescape(parser &parser) const noexcept;
+  simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> unescape(json_iterator &iter) const noexcept;
 private:
   const uint8_t * buf;
   friend class object;

--- a/src/generic/ondemand/value-inl.h
+++ b/src/generic/ondemand/value-inl.h
@@ -63,7 +63,7 @@ simdjson_really_inline simdjson_result<std::string_view> value::get_string() noe
   error_code error;
   raw_json_string str;
   if ((error = get_raw_json_string().get(str))) { return error; }
-  return str.unescape(iter->parser->current_string_buf_loc);
+  return str.unescape(iter->current_string_buf_loc);
 }
 simdjson_really_inline simdjson_result<double> value::get_double() noexcept {
   log_value("double");

--- a/src/generic/ondemand/value.h
+++ b/src/generic/ondemand/value.h
@@ -59,7 +59,7 @@ protected:
    *
    * Use value::read() instead of this.
    */
-  simdjson_really_inline value(json_iterator *iter, const uint8_t *json) noexcept;
+  simdjson_really_inline value(json_iterator_ref &&iter, const uint8_t *json) noexcept;
 
   /**
    * Read a value.
@@ -68,12 +68,12 @@ protected:
    *
    * @param doc The document containing the value. Iterator must be at the value start position.
    */
-  static simdjson_really_inline value start(json_iterator *iter) noexcept;
+  static simdjson_really_inline value start(json_iterator_ref &&iter) noexcept;
 
   simdjson_really_inline void log_value(const char *type) const noexcept;
   simdjson_really_inline void log_error(const char *message) const noexcept;
 
-  json_iterator *iter{}; // For the string buffer (if we need it)
+  json_iterator_ref iter{}; // For the string buffer (if we need it)
   const uint8_t *json{}; // The JSON text of the value
 
   friend class document;

--- a/src/generic/ondemand/value.h
+++ b/src/generic/ondemand/value.h
@@ -27,31 +27,30 @@ public:
   // TODO assert if two values are ever alive at the same time, to ensure they get destroyed
   simdjson_really_inline ~value() noexcept;
   simdjson_really_inline void skip() noexcept;
-  simdjson_really_inline simdjson_result<array> get_array() noexcept;
-  simdjson_really_inline simdjson_result<object> get_object() noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_really_inline simdjson_result<array> get_array() && noexcept;
+  simdjson_really_inline simdjson_result<object> get_object() && noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() && noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
+  simdjson_really_inline bool is_null() & noexcept;
+  simdjson_really_inline bool is_null() && noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator array() noexcept(false);
-  simdjson_really_inline operator object() noexcept(false);
-  simdjson_really_inline operator uint64_t() noexcept(false);
-  simdjson_really_inline operator int64_t() noexcept(false);
-  simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() noexcept(false);
-  simdjson_really_inline operator raw_json_string() noexcept(false);
-  simdjson_really_inline operator bool() noexcept(false);
+  simdjson_really_inline operator array() && noexcept(false);
+  simdjson_really_inline operator object() && noexcept(false);
+  simdjson_really_inline operator uint64_t() && noexcept(false);
+  simdjson_really_inline operator int64_t() && noexcept(false);
+  simdjson_really_inline operator double() && noexcept(false);
+  simdjson_really_inline operator std::string_view() && noexcept(false);
+  simdjson_really_inline operator raw_json_string() && noexcept(false);
+  simdjson_really_inline operator bool() && noexcept(false);
 #endif
 
-  simdjson_really_inline simdjson_result<array::iterator> begin() noexcept;
-  simdjson_really_inline simdjson_result<array::iterator> end() noexcept;
-  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) noexcept;
-  simdjson_really_inline simdjson_result<value> operator[](const char *key) noexcept;
+  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) && noexcept;
+  simdjson_really_inline simdjson_result<value> operator[](const char *key) && noexcept;
 
 protected:
   /**
@@ -98,25 +97,26 @@ public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value &&value, error_code error) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() && noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() && noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
+  simdjson_really_inline bool is_null() & noexcept;
+  simdjson_really_inline bool is_null() && noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false);
-  simdjson_really_inline operator uint64_t() noexcept(false);
-  simdjson_really_inline operator int64_t() noexcept(false);
-  simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
-  simdjson_really_inline operator bool() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false);
+  simdjson_really_inline operator uint64_t() && noexcept(false);
+  simdjson_really_inline operator int64_t() && noexcept(false);
+  simdjson_really_inline operator double() && noexcept(false);
+  simdjson_really_inline operator std::string_view() && noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false);
+  simdjson_really_inline operator bool() && noexcept(false);
 #endif
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> begin() noexcept;

--- a/src/generic/ondemand/value.h
+++ b/src/generic/ondemand/value.h
@@ -59,7 +59,7 @@ protected:
    *
    * Use value::read() instead of this.
    */
-  simdjson_really_inline value(document *doc, const uint8_t *json) noexcept;
+  simdjson_really_inline value(json_iterator *iter, const uint8_t *json) noexcept;
 
   /**
    * Read a value.
@@ -68,12 +68,12 @@ protected:
    *
    * @param doc The document containing the value. Iterator must be at the value start position.
    */
-  static simdjson_really_inline value start(document *doc) noexcept;
+  static simdjson_really_inline value start(json_iterator *iter) noexcept;
 
   simdjson_really_inline void log_value(const char *type) const noexcept;
   simdjson_really_inline void log_error(const char *message) const noexcept;
 
-  document *doc{}; // For the string buffer (if we need it)
+  json_iterator *iter{}; // For the string buffer (if we need it)
   const uint8_t *json{}; // The JSON text of the value
 
   friend class document;


### PR DESCRIPTION
Posted to help awareness--I'll likely merge back to the branch soon. I'm happy with the performance.

In debug builds, this:
* Asserts if you try to destroy the top-level document / json_iterator while iteration is still in progress.
* Asserts if you use a parent object or array iterator while you are still iterating *child* values (i.e. you try to get a second field while you are still looking at the first one).
* Asserts if you try to reuse value or document objects (you already iterated that value, you can't do it again!).
  Since values can be checked multiple times (i.e. you can check if it's a string, and if it's not, try to parse as a number instead), there was a performance issue at first because the compiler was confused by the error case: if an error occurs, the parent can still use the value, even though in our examples we're throwing an exception if that happens. To keep it performant, I leaned on C++'s move semantics: if you call it on a temporary (like `uint64_t(tweet["favorite_count"])` it will release the iterator even when there is an error. This seems to make the compiler happy again.

This makes it a lot easier to tell if you're using the API in ways that would cause the iterator to get out of sync and give you invalid results. Since we're using destructors to ensure partially-iterated arrays and objects get finished before their parents look for the next value, this also helps ensure that the destructors run when they need to.

So, if you're seeing unexpected errors, compile with debug on and run your code: if it doesn't assert, it's pretty unlikely it has to do with the way you are *using* the API.

## Performance

This also improves performance of release builds, presumably because I simplified a number of things along the way, removing a few member variables.

The reason I was pushing so hard on performance is I felt this can be costless: we always know at compile time which object is allowed to do iteration, so it was a matter of telling the compiler about it in a way that it could understand at compile time.

It looks like we're paying a cost of around 2% for this. I think making it possible to be sure you're using the API correctly is worth that cost.

### Haswell clang10 (Skylake)

```
ondemand_tweets          170069 ns       170069 ns         4120 bytes=3.71329G/s docs=5.87997k/s tweets=587.997k/s
iter_tweets              164399 ns       164399 ns         4250 bytes=3.84135G/s docs=6.08275k/s tweets=608.275k/s
sax_tweets               168266 ns       168267 ns         4161 bytes=3.75305G/s docs=5.94293k/s tweets=594.293k/s
dom_tweets               277668 ns       277670 ns         2521 bytes=2.27434G/s docs=3.6014k/s tweets=360.14k/s
parse_tweets             260486 ns       260488 ns         2687 bytes=2.42435G/s docs=3.83895k/s
Creating a source file spanning 44921 KB 
dom_largerandom       119875037 ns    119876007 ns            5 bytes=383.72M/s docs=8.34195/s points=8.34195M/s
ondemand_largerandom   84857603 ns     84853750 ns            7 bytes=542.095M/s docs=11.785/s points=11.785M/s
iter_largerandom       76672222 ns     76672116 ns            8 bytes=599.941M/s docs=13.0426/s points=13.0426M/s
sax_largerandom        62633392 ns     62633001 ns           11 bytes=734.418M/s docs=15.966/s points=15.966M/s
```

For comparison, here are the numbers for #947 right now:

```
# From jkeiser/stream-parse
ondemand_tweets          164865 ns       164865 ns         4244 bytes=3.8305G/s docs=6.06557k/s tweets=606.557k/s
iter_tweets              163456 ns       163457 ns         4284 bytes=3.8635G/s docs=6.11783k/s tweets=611.783k/s
sax_tweets               167825 ns       167826 ns         4171 bytes=3.76291G/s docs=5.95855k/s tweets=595.855k/s
dom_tweets               275951 ns       275951 ns         2538 bytes=2.2885G/s docs=3.62383k/s tweets=362.383k/s
parse_tweets             259030 ns       259031 ns         2704 bytes=2.43799G/s docs=3.86054k/s
Creating a source file spanning 44921 KB 
dom_largerandom       119304651 ns    119305713 ns            5 bytes=385.554M/s docs=8.38183/s points=8.38183M/s
ondemand_largerandom   78179357 ns     78179573 ns            8 bytes=588.373M/s docs=12.7911/s points=12.7911M/s
iter_largerandom       77049479 ns     77049360 ns            8 bytes=597.004M/s docs=12.9787/s points=12.9787M/s
sax_largerandom        62382010 ns     62382038 ns           11 bytes=737.372M/s docs=16.0303/s points=16.0303M/s
```

### Haswell gcc10 (Skylake)

GCC is still behind clang:

```
ondemand_tweets          219962 ns       219962 ns         3182 bytes=2.87102G/s docs=4.54624k/s tweets=454.624k/s
iter_tweets              206015 ns       206015 ns         3396 bytes=3.06538G/s docs=4.85401k/s tweets=485.401k/s
sax_tweets               171884 ns       171884 ns         4071 bytes=3.67408G/s docs=5.81788k/s tweets=581.788k/s
dom_tweets               260789 ns       260788 ns         2685 bytes=2.42156G/s docs=3.83453k/s tweets=383.453k/s
parse_tweets             244040 ns       244040 ns         2868 bytes=2.58775G/s docs=4.09769k/s
Creating a source file spanning 44921 KB 
dom_largerandom       108266414 ns    108267184 ns            5 bytes=424.864M/s docs=9.23641/s points=9.23641M/s
ondemand_largerandom   80484031 ns     80483853 ns            8 bytes=571.528M/s docs=12.4249/s points=12.4249M/s
iter_largerandom       71843672 ns     71843402 ns            8 bytes=640.264M/s docs=13.9192/s points=13.9192M/s
sax_largerandom        56911550 ns     56911564 ns           12 bytes=808.25M/s docs=17.5711/s points=17.5711M/s
```