### PR TITLE
Simplify operator classification lookup on Intel

### DIFF
--- a/src/arm64/simd.h
+++ b/src/arm64/simd.h
@@ -462,16 +462,6 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       return vgetq_lane_u64(vreinterpretq_u64_u8(sum0), 0);
     }
 
-    simdjson_really_inline simd8x64<T> bit_or(const T m) const {
-      const simd8<T> mask = simd8<T>::splat(m);
-      return simd8x64<T>(
-        this->chunks[0] | mask,
-        this->chunks[1] | mask,
-        this->chunks[2] | mask,
-        this->chunks[3] | mask
-      );
-    }
-
     simdjson_really_inline uint64_t eq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -70,7 +70,11 @@ simdjson_really_inline json_character_block json_character_block::classify(const
     _mm256_shuffle_epi8(whitespace_table, in.chunks[0]),
     _mm256_shuffle_epi8(whitespace_table, in.chunks[1])
   });
-  const simd8x64<uint8_t> curlified = in.bit_or(0x20); // Turn [ and ] into { and }
+  // Turn [ and ] into { and }
+  const simd8x64<uint8_t> curlified{
+    in.chunks[0] | 0x20,
+    in.chunks[1] | 0x20
+  };
   const uint64_t op = curlified.eq({
     _mm256_shuffle_epi8(op_table, in.chunks[0]),
     _mm256_shuffle_epi8(op_table, in.chunks[1])

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -14,15 +14,19 @@ using namespace simd;
 struct json_character_block {
   static simdjson_really_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
   //  ASCII white-space ('\r','\n','\t',' ')
-  simdjson_really_inline uint64_t whitespace() const { return _whitespace; }
+  simdjson_really_inline uint64_t whitespace() const;
   // non-quote structural characters (comma, colon, braces, brackets)
-  simdjson_really_inline uint64_t op() const { return _op; }
+  simdjson_really_inline uint64_t op() const;
   // neither a structural character nor a white-space, so letters, numbers and quotes
-  simdjson_really_inline uint64_t scalar() { return ~(op() | whitespace()); }
+  simdjson_really_inline uint64_t scalar() const;
 
   uint64_t _whitespace; // ASCII white-space ('\r','\n','\t',' ')
   uint64_t _op; // structural characters (comma, colon, braces, brackets but not quotes)
 };
+
+simdjson_really_inline uint64_t json_character_block::whitespace() const { return _whitespace; }
+simdjson_really_inline uint64_t json_character_block::op() const { return _op; }
+simdjson_really_inline uint64_t json_character_block::scalar() const { return ~(op() | whitespace()); }
 
 // This identifies structural characters (comma, colon, braces, brackets),
 // and ASCII white-space ('\r','\n','\t',' ').
@@ -30,9 +34,34 @@ simdjson_really_inline json_character_block json_character_block::classify(const
   // These lookups rely on the fact that anything < 127 will match the lower 4 bits, which is why
   // we can't use the generic lookup_16.
   auto whitespace_table = simd8<uint8_t>::repeat_16(' ', 100, 100, 100, 17, 100, 113, 2, 100, '\t', '\n', 112, 100, '\r', 100, 100);
-  auto op_table = simd8<uint8_t>::repeat_16(',', '}', 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, ':', '{');
 
-  // We compute whitespace and op separately. If the code later only use one or the
+  // The 6 operators (:,[]{}) have these values:
+  //
+  // , 2C
+  // : 3A
+  // [ 5B
+  // { 7B
+  // ] 5D
+  // } 7D
+  //
+  // If you use | 0x20 to turn [ and ] into { and }, the lower 4 bits of each character is unique.
+  // We exploit this, using a simd 4-bit lookup to tell us which character match against, and then
+  // match it (against | 0x20).
+  //
+  // To prevent recognizing other characters, everything else gets compared with 0, which cannot
+  // match due to the | 0x20.
+  //
+  // NOTE: Due to the | 0x20, this ALSO treats <FF> and <SUB> (control characters 0C and 1A) like ,
+  // and :. This gets caught in stage 2, which checks the actual character to ensure the right
+  // operators are in the right places.
+  auto op_table = simd8<uint8_t>::repeat_16(
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+    0, 0, ':', '{', // : = 3A, [ = 5B, { = 7B
+    ',', '}', 0, 0  // , = 2C, ] = 5D, } = 7D
+  );
+
+  // We compute whitespace and op separately. If later code only uses one or the
   // other, given the fact that all functions are aggressively inlined, we can
   // hope that useless computations will be omitted. This is namely case when
   // minifying (we only need whitespace).
@@ -43,8 +72,8 @@ simdjson_really_inline json_character_block json_character_block::classify(const
   ).to_bitmask();
   
   uint64_t op = simd8x64<bool>(
-        (in.chunks[0] | 32) == simd8<uint8_t>(_mm256_shuffle_epi8(op_table, in.chunks[0]-',')),
-        (in.chunks[1] | 32) == simd8<uint8_t>(_mm256_shuffle_epi8(op_table, in.chunks[1]-','))
+        (in.chunks[0] | 0x20) == simd8<uint8_t>(_mm256_shuffle_epi8(op_table, in.chunks[0])),
+        (in.chunks[1] | 0x20) == simd8<uint8_t>(_mm256_shuffle_epi8(op_table, in.chunks[1]))
   ).to_bitmask();
   return { whitespace, op };
 }

--- a/src/haswell/simd.h
+++ b/src/haswell/simd.h
@@ -337,7 +337,7 @@ namespace simd {
       ).to_bitmask();
     }
 
-    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> other) const {
+    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
       return  simd8x64<bool>(
         this->chunks[0] == other.chunks[0],
         this->chunks[1] == other.chunks[1]

--- a/src/haswell/simd.h
+++ b/src/haswell/simd.h
@@ -337,6 +337,13 @@ namespace simd {
       ).to_bitmask();
     }
 
+    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> other) const {
+      return  simd8x64<bool>(
+        this->chunks[0] == other.chunks[0],
+        this->chunks[1] == other.chunks[1]
+      ).to_bitmask();
+    }
+
     simdjson_really_inline uint64_t lteq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -65,7 +65,13 @@ simdjson_really_inline json_character_block json_character_block::classify(const
     _mm_shuffle_epi8(whitespace_table, in.chunks[2]),
     _mm_shuffle_epi8(whitespace_table, in.chunks[3])
   });
-  const simd8x64<uint8_t> curlified = in.bit_or(0x20); // Turn [ and ] into { and }
+  // Turn [ and ] into { and }
+  const simd8x64<uint8_t> curlified{
+    in.chunks[0] | 0x20,
+    in.chunks[1] | 0x20,
+    in.chunks[2] | 0x20,
+    in.chunks[3] | 0x20
+  };
   const uint64_t op = curlified.eq({
     _mm_shuffle_epi8(op_table, in.chunks[0]),
     _mm_shuffle_epi8(op_table, in.chunks[1]),

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -26,7 +26,32 @@ simdjson_really_inline json_character_block json_character_block::classify(const
   // These lookups rely on the fact that anything < 127 will match the lower 4 bits, which is why
   // we can't use the generic lookup_16.
   auto whitespace_table = simd8<uint8_t>::repeat_16(' ', 100, 100, 100, 17, 100, 113, 2, 100, '\t', '\n', 112, 100, '\r', 100, 100);
-  auto op_table = simd8<uint8_t>::repeat_16(',', '}', 0, 0, 0xc0u, 0, 0, 0, 0, 0, 0, 0, 0, 0, ':', '{');
+
+  // The 6 operators (:,[]{}) have these values:
+  //
+  // , 2C
+  // : 3A
+  // [ 5B
+  // { 7B
+  // ] 5D
+  // } 7D
+  //
+  // If you use | 0x20 to turn [ and ] into { and }, the lower 4 bits of each character is unique.
+  // We exploit this, using a simd 4-bit lookup to tell us which character match against, and then
+  // match it (against | 0x20).
+  //
+  // To prevent recognizing other characters, everything else gets compared with 0, which cannot
+  // match due to the | 0x20.
+  //
+  // NOTE: Due to the | 0x20, this ALSO treats <FF> and <SUB> (control characters 0C and 1A) like ,
+  // and :. This gets caught in stage 2, which checks the actual character to ensure the right
+  // operators are in the right places.
+  const auto op_table = simd8<uint8_t>::repeat_16(
+    0, 0, 0, 0,
+    0, 0, 0, 0,
+    0, 0, ':', '{', // : = 3A, [ = 5B, { = 7B
+    ',', '}', 0, 0  // , = 2C, ] = 5D, } = 7D
+  );
 
   // We compute whitespace and op separately. If the code later only use one or the
   // other, given the fact that all functions are aggressively inlined, we can
@@ -42,10 +67,10 @@ simdjson_really_inline json_character_block json_character_block::classify(const
 
   // | 32 handles the fact that { } and [ ] are exactly 32 bytes apart
   uint64_t op = simd8x64<bool>(
-        (in.chunks[0] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[0]-',')),
-        (in.chunks[1] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[1]-',')),
-        (in.chunks[2] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[2]-',')),
-        (in.chunks[3] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[3]-','))
+        (in.chunks[0] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[0])),
+        (in.chunks[1] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[1])),
+        (in.chunks[2] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[2])),
+        (in.chunks[3] | 32) == simd8<uint8_t>(_mm_shuffle_epi8(op_table, in.chunks[3]))
   ).to_bitmask();
   return { whitespace, op };
 }

--- a/src/westmere/simd.h
+++ b/src/westmere/simd.h
@@ -288,23 +288,13 @@ namespace simd {
     }
 
     simdjson_really_inline uint64_t to_bitmask() const {
-      uint64_t r0 = uint32_t(this->chunks[0].to_bitmask());
-      uint64_t r1 =                       this->chunks[1].to_bitmask();
-      uint64_t r2 =                       this->chunks[2].to_bitmask();
-      uint64_t r3 =                       this->chunks[3].to_bitmask();
+      uint64_t r0 = uint32_t(this->chunks[0].to_bitmask() );
+      uint64_t r1 =          this->chunks[1].to_bitmask() ;
+      uint64_t r2 =          this->chunks[2].to_bitmask() ;
+      uint64_t r3 =          this->chunks[3].to_bitmask() ;
       return r0 | (r1 << 16) | (r2 << 32) | (r3 << 48);
     }
-
-    simdjson_really_inline simd8x64<T> bit_or(const T m) const {
-      const simd8<T> mask = simd8<T>::splat(m);
-      return simd8x64<T>(
-        this->chunks[0] | mask,
-        this->chunks[1] | mask,
-        this->chunks[2] | mask,
-        this->chunks[3] | mask
-      );
-    }
-
+    
     simdjson_really_inline uint64_t eq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(
@@ -315,7 +305,7 @@ namespace simd {
       ).to_bitmask();
     }
 
-    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> other) const {
+    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
       return  simd8x64<bool>(
         this->chunks[0] == other.chunks[0],
         this->chunks[1] == other.chunks[1],

--- a/src/westmere/simd.h
+++ b/src/westmere/simd.h
@@ -315,6 +315,15 @@ namespace simd {
       ).to_bitmask();
     }
 
+    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> other) const {
+      return  simd8x64<bool>(
+        this->chunks[0] == other.chunks[0],
+        this->chunks[1] == other.chunks[1],
+        this->chunks[2] == other.chunks[2],
+        this->chunks[3] == other.chunks[3]
+      ).to_bitmask();
+    }
+
     simdjson_really_inline uint64_t lteq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(


### PR DESCRIPTION
This removes one subtraction per SIMD block when identifying operators (`,:[]{}`), and demystifies the algorithm and lookup table a bit (as well as adding comments).

EDIT: I added a second change, which uses simd8x64 abstractions and consequently reorders things a bit, and that brought even more substantial speedups. I do not understand why this code is so deeply in the hot path ... I expected the string detection path to be the long pole. But it doesn't matter *why* they help or even that they do, as the abstractions make the code lighter and easier to read.

## Performance

Performance is better on gcc, probably down to the instruction count. clang fares worse, even though instruction count is down there too. I'm only showing stage 1 here, because that's all that's affected, and I saw some stage 2 jitter that was causing the results to look better than they actually are.

### Haswell gcc10 (Skylake)

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |
| numbers                          |   2345 |  37.4 |  36.6 |    2% | 142.8 | 140.8 |    1% |
| random                           |   7976 |  54.8 |  53.7 |    2% | 201.7 | 198.1 |    1% |
| canada                           |  35172 |  44.1 |  43.3 |    1% | 156.1 | 154.1 |    1% |
| gsoc-2018                        |  51997 |  35.7 |  35.1 |    1% |  99.6 |  97.6 |    2% |
| citm_catalog                     |  26987 |  33.3 |  32.8 |    1% | 129.2 | 127.2 |    1% |
| mesh.pretty                      |  24646 |  34.8 |  34.3 |    1% | 136.2 | 134.2 |    1% |
| instruments                      |   3442 |  36.9 |  36.4 |    1% | 141.7 | 139.7 |    1% |
| semanticscholar-corpus           | 134271 |  47.4 |  46.8 |    1% | 129.2 | 127.0 |    1% |
| twitter                          |   9867 |  41.8 |  41.3 |    1% | 145.1 | 142.5 |    1% |
| apache_builds                    |   1988 |  35.8 |  35.4 |    1% | 137.9 | 135.8 |    1% |
| twitterescaped                   |   8787 |  41.2 |  40.8 |    0% | 136.6 | 134.6 |    1% |
| github_events                    |   1017 |  33.5 |  33.2 |    0% | 128.3 | 126.3 |    1% |
| mesh                             |  11306 |  44.9 |  44.6 |    0% | 172.7 | 170.7 |    1% |
| marine_ik                        |  46616 |  52.7 |  52.3 |    0% | 179.4 | 177.4 |    1% |
| update-center                    |   8330 |  43.4 |  43.2 |    0% | 140.6 | 138.6 |    1% |

### Westmere gcc10 (Skylake)

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |
| instruments                      |   3442 |  61.1 |  59.2 |    3% | 238.6 | 231.6 |    2% |
| citm_catalog                     |  26987 |  55.6 |  54.0 |    2% | 224.0 | 217.0 |    3% |
| apache_builds                    |   1988 |  59.1 |  57.5 |    2% | 234.0 | 227.0 |    2% |
| gsoc-2018                        |  51997 |  56.6 |  55.2 |    2% | 190.2 | 183.2 |    3% |
| github_events                    |   1017 |  56.2 |  54.8 |    2% | 223.0 | 216.0 |    3% |
| mesh.pretty                      |  24646 |  57.8 |  56.5 |    2% | 232.2 | 225.2 |    3% |
| twitter                          |   9867 |  67.2 |  66.0 |    1% | 257.1 | 250.3 |    2% |
| random                           |   7976 |  90.0 |  89.4 |    0% | 349.4 | 343.1 |    1% |
| twitterescaped                   |   8787 |  62.7 |  62.3 |    0% | 232.7 | 225.6 |    3% |
| canada                           |  35172 |  67.9 |  67.5 |    0% | 255.9 | 248.9 |    2% |
| numbers                          |   2345 |  61.0 |  60.7 |    0% | 239.9 | 232.9 |    2% |
| semanticscholar-corpus           | 134271 |  69.6 |  69.3 |    0% | 229.4 | 222.4 |    3% |
| mesh                             |  11306 |  71.3 |  71.2 |    0% | 276.0 | 268.7 |    2% |
| update-center                    |   8330 |  65.6 |  65.6 |    0% | 237.8 | 230.8 |    2% |
| marine_ik                        |  46616 |  78.6 |  79.0 |    0% | 283.8 | 276.6 |    2% |

### Haswell clang10 (Skylake)

Fascinatingly, clang10 doesn't like this nearly so much. bisecting shows that the first commit (the one that cuts down on instructions) is responsible for the vast majority of this (but not all):

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |
| twitterescaped                   |   8787 |  42.2 |  40.9 |    2% | 128.5 | 123.5 |    3% |
| github_events                    |   1017 |  32.2 |  31.9 |    1% | 121.0 | 116.1 |    4% |
| twitter                          |   9867 |  41.6 |  41.7 |    0% | 136.0 | 131.6 |    3% |
| gsoc-2018                        |  51997 |  38.5 |  38.7 |    0% |  98.2 |  93.2 |    5% |
| semanticscholar-corpus           | 134271 |  48.1 |  48.5 |    0% | 122.8 | 118.0 |    3% |
| update-center                    |   8330 |  43.0 |  43.7 |   -1% | 131.0 | 126.2 |    3% |
| random                           |   7976 |  53.3 |  54.3 |   -1% | 184.1 | 181.1 |    1% |
| instruments                      |   3442 |  36.4 |  37.3 |   -2% | 131.7 | 126.8 |    3% |
| numbers                          |   2345 |  36.9 |  37.8 |   -2% | 132.6 | 127.7 |    3% |
| mesh                             |  11306 |  43.8 |  44.9 |   -2% | 159.1 | 153.7 |    3% |
| canada                           |  35172 |  43.0 |  44.1 |   -2% | 143.4 | 138.7 |    3% |
| marine_ik                        |  46616 |  51.3 |  52.8 |   -2% | 163.5 | 158.6 |    3% |
| citm_catalog                     |  26987 |  33.0 |  33.9 |   -2% | 121.6 | 116.6 |    4% |
| apache_builds                    |   1988 |  35.3 |  36.4 |   -3% | 128.6 | 123.7 |    3% |
| mesh.pretty                      |  24646 |  34.4 |  35.5 |   -3% | 127.2 | 122.3 |    3% |
