### PR TITLE
Depth Count In Stage 1

### DIFF
--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -12,14 +12,28 @@ using namespace simd;
 
 struct json_character_block {
   static simdjson_really_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
+  //  ASCII white-space ('\r','\n','\t',' ')
+  simdjson_really_inline uint64_t whitespace() const;
+  // non-quote structural characters (comma, colon, braces, brackets)
+  simdjson_really_inline uint64_t op() const;
+  // neither a structural character nor a white-space, so letters, numbers and quotes
+  simdjson_really_inline uint64_t scalar() const;
+  // open braces ([ and {)
+  simdjson_really_inline uint64_t open_brace() const;
+  // close braces (] and })
+  simdjson_really_inline uint64_t close_brace() const;
 
-  simdjson_really_inline uint64_t whitespace() const { return _whitespace; }
-  simdjson_really_inline uint64_t op() const { return _op; }
-  simdjson_really_inline uint64_t scalar() { return ~(op() | whitespace()); }
-
-  uint64_t _whitespace;
-  uint64_t _op;
+  uint64_t _whitespace;  // ASCII white-space ('\r','\n','\t',' ')
+  uint64_t _op;          // structural characters (comma, colon, braces, brackets but not quotes)
+  uint64_t _open_brace;  // [ and {
+  uint64_t _close_brace; // } and ]
 };
+
+simdjson_really_inline uint64_t json_character_block::whitespace() const { return _whitespace; }
+simdjson_really_inline uint64_t json_character_block::op() const { return _op; }
+simdjson_really_inline uint64_t json_character_block::scalar() const { return ~(op() | whitespace()); }
+simdjson_really_inline uint64_t json_character_block::open_brace() const { return _open_brace; }
+simdjson_really_inline uint64_t json_character_block::close_brace() const { return _close_brace; }
 
 simdjson_really_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
   // Functional programming causes trouble with Visual Studio.
@@ -72,7 +86,13 @@ simdjson_really_inline json_character_block json_character_block::classify(const
         v.chunks[3].any_bits_set(0x18)
   ).to_bitmask();
 
-  return { whitespace, op };
+  simd8x64<uint8_t> curlified{
+    v.chunks[0] | 0x20,
+    v.chunks[1] | 0x20,
+    v.chunks[2] | 0x20,
+    v.chunks[3] | 0x20
+  };
+  return { whitespace, op, curlified.eq('{'), curlified.eq('}') };
 }
 
 simdjson_really_inline bool is_ascii(const simd8x64<uint8_t>& input) {

--- a/src/generic/dom_parser_implementation.h
+++ b/src/generic/dom_parser_implementation.h
@@ -24,6 +24,8 @@ public:
   size_t len{0};
   /** Document passed to stage 2 */
   dom::document *doc{};
+  /** Final depth (total of open / close braces) from stage 1 */
+  int64_t stage1_depth{0};
 
   simdjson_really_inline dom_parser_implementation();
   dom_parser_implementation(const dom_parser_implementation &) = delete;

--- a/src/generic/stage1/json_scanner.h
+++ b/src/generic/stage1/json_scanner.h
@@ -28,6 +28,10 @@ public:
   simdjson_really_inline uint64_t structural_start() { return potential_structural_start() & ~_string.string_tail(); }
   /** All JSON whitespace (i.e. not in a string) */
   simdjson_really_inline uint64_t whitespace() { return non_quote_outside_string(_characters.whitespace()); }
+  simdjson_really_inline long long int depth() const {
+    return count_ones(_characters.open_brace()  & ~_string.string_head()) -
+           count_ones(_characters.close_brace() & ~_string.string_head());
+  }
 
   // Helpers
 

--- a/src/generic/stage1/json_string_scanner.h
+++ b/src/generic/stage1/json_string_scanner.h
@@ -19,6 +19,8 @@ struct json_string_block {
   simdjson_really_inline uint64_t non_quote_inside_string(uint64_t mask) const { return mask & _in_string; }
   // Return a mask of whether the given characters are inside a string (only works on non-quotes)
   simdjson_really_inline uint64_t non_quote_outside_string(uint64_t mask) const { return mask & ~_in_string; }
+  // Head of string (everything except the end quote)
+  simdjson_really_inline uint64_t string_head() const { return _in_string; }
   // Tail of string (everything except the start quote)
   simdjson_really_inline uint64_t string_tail() const { return _in_string ^ _quote; }
 

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -222,6 +222,7 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
     if (new_structural_indexes == 0 && parser.n_structural_indexes > 0) {
       return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
     }
+    parser.stage1_depth = 0;
     parser.n_structural_indexes = new_structural_indexes;
   }
   return checker.errors();

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -19,14 +19,22 @@ struct json_character_block {
   simdjson_really_inline uint64_t op() const;
   // neither a structural character nor a white-space, so letters, numbers and quotes
   simdjson_really_inline uint64_t scalar() const;
+  // open braces ([ and {)
+  simdjson_really_inline uint64_t open_brace() const;
+  // close braces (] and })
+  simdjson_really_inline uint64_t close_brace() const;
 
-  uint64_t _whitespace; // ASCII white-space ('\r','\n','\t',' ')
-  uint64_t _op; // structural characters (comma, colon, braces, brackets but not quotes)
+  uint64_t _whitespace;  // ASCII white-space ('\r','\n','\t',' ')
+  uint64_t _op;          // structural characters (comma, colon, braces, brackets but not quotes)
+  uint64_t _open_brace;  // [ and {
+  uint64_t _close_brace; // } and ]
 };
 
 simdjson_really_inline uint64_t json_character_block::whitespace() const { return _whitespace; }
 simdjson_really_inline uint64_t json_character_block::op() const { return _op; }
 simdjson_really_inline uint64_t json_character_block::scalar() const { return ~(op() | whitespace()); }
+simdjson_really_inline uint64_t json_character_block::open_brace() const { return _open_brace; }
+simdjson_really_inline uint64_t json_character_block::close_brace() const { return _close_brace; }
 
 // This identifies structural characters (comma, colon, braces, brackets),
 // and ASCII white-space ('\r','\n','\t',' ').
@@ -80,7 +88,7 @@ simdjson_really_inline json_character_block json_character_block::classify(const
     _mm256_shuffle_epi8(op_table, in.chunks[1])
   });
   
-  return { whitespace, op };
+  return { whitespace, op, curlified.eq('{'), curlified.eq('}') };
 }
 
 simdjson_really_inline bool is_ascii(const simd8x64<uint8_t>& input) {

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -13,14 +13,28 @@ using namespace simd;
 
 struct json_character_block {
   static simdjson_really_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
+  //  ASCII white-space ('\r','\n','\t',' ')
+  simdjson_really_inline uint64_t whitespace() const;
+  // non-quote structural characters (comma, colon, braces, brackets)
+  simdjson_really_inline uint64_t op() const;
+  // neither a structural character nor a white-space, so letters, numbers and quotes
+  simdjson_really_inline uint64_t scalar() const;
+  // open braces ([ and {)
+  simdjson_really_inline uint64_t open_brace() const;
+  // close braces (] and })
+  simdjson_really_inline uint64_t close_brace() const;
 
-  simdjson_really_inline uint64_t whitespace() const { return _whitespace; }
-  simdjson_really_inline uint64_t op() const { return _op; }
-  simdjson_really_inline uint64_t scalar() { return ~(op() | whitespace()); }
-
-  uint64_t _whitespace;
-  uint64_t _op;
+  uint64_t _whitespace;  // ASCII white-space ('\r','\n','\t',' ')
+  uint64_t _op;          // structural characters (comma, colon, braces, brackets but not quotes)
+  uint64_t _open_brace;  // [ and {
+  uint64_t _close_brace; // } and ]
 };
+
+simdjson_really_inline uint64_t json_character_block::whitespace() const { return _whitespace; }
+simdjson_really_inline uint64_t json_character_block::op() const { return _op; }
+simdjson_really_inline uint64_t json_character_block::scalar() const { return ~(op() | whitespace()); }
+simdjson_really_inline uint64_t json_character_block::open_brace() const { return _open_brace; }
+simdjson_really_inline uint64_t json_character_block::close_brace() const { return _close_brace; }
 
 simdjson_really_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
   // These lookups rely on the fact that anything < 127 will match the lower 4 bits, which is why
@@ -78,7 +92,7 @@ simdjson_really_inline json_character_block json_character_block::classify(const
     _mm_shuffle_epi8(op_table, in.chunks[2]),
     _mm_shuffle_epi8(op_table, in.chunks[3])
   });
-    return { whitespace, op };
+    return { whitespace, op, curlified.eq('{'), curlified.eq('}') };
 }
 
 simdjson_really_inline bool is_ascii(const simd8x64<uint8_t>& input) {


### PR DESCRIPTION
This is an implementation of depth count in stage 1: it tells you the terminating depth, specifically. This is one of the ways I'm thinking about making certain on-demand parsing stops (it can overrun if the final depth is greater than zero). It may also help us with actual streaming (knowing where the chunk is going to stop in advance).

It doesn't really help with performance for the existing code; and I'm unsure if it'll help with other code, either :) Posting here for posterity.

### Haswell gcc10 (Skylake)

| File                             | Blocks | master Cycles | PR Cycles | +Throughput | master Instr. | PR Instr. | -Instr. |
| ---                              |    --: |   --: |   --: |   --: |   --: |   --: |   --: |
| instruments                      |   3442 | 112.4 | 113.0 |    0% | 370.8 | 403.6 |   -8% |
| twitterescaped                   |   8787 | 190.3 | 191.3 |    0% | 488.1 | 518.9 |   -6% |
| random                           |   7976 | 148.9 | 149.8 |    0% | 484.3 | 523.4 |   -8% |
| update-center                    |   8330 | 118.3 | 119.8 |   -1% | 329.5 | 363.3 |  -10% |
| semanticscholar-corpus           | 134271 | 112.4 | 115.0 |   -2% | 278.2 | 309.3 |  -11% |
| marine_ik                        |  46616 | 288.2 | 297.8 |   -3% | 899.9 | 934.0 |   -3% |
| citm_catalog                     |  26987 |  85.3 |  88.2 |   -3% | 289.8 | 318.6 |   -9% |
| twitter                          |   9867 |  93.7 |  97.7 |   -4% | 284.0 | 314.8 |  -10% |
| apache_builds                    |   1988 |  89.5 |  93.4 |   -4% | 298.5 | 331.1 |  -10% |
| canada                           |  35172 | 273.6 | 286.2 |   -4% | 953.6 | 976.0 |   -2% |
| mesh.pretty                      |  24646 | 171.0 | 180.8 |   -5% | 575.8 | 603.6 |   -4% |
| mesh                             |  11306 | 294.3 | 313.0 |   -6% | 989.2 | 1020.1 |   -3% |
| github_events                    |   1017 |  81.1 |  86.4 |   -6% | 259.2 | 289.6 |  -11% |
| gsoc-2018                        |  51997 |  72.8 |  77.6 |   -6% | 162.7 | 189.9 |  -16% |
| numbers                          |   2345 | 244.8 | 270.8 |  -10% | 797.8 | 836.1 |   -4% |