### PR TITLE
Don't run off the end in on demand parsing

### DIFF
--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -141,7 +141,7 @@ simdjson_really_inline void read_tweets(ondemand::parser &parser, padded_string 
       if (!iter.has_next_field() || !iter.find_field_raw("screen_name")) { throw; }
       tweet.user.screen_name = iter.get_raw_json_string().value().unescape(iter);
 
-      iter.skip_container(); // Skip the rest of the user object
+      if (iter.skip_container()) { throw; } // Skip the rest of the user object
     }
 
     if (!iter.has_next_field() || !iter.find_field_raw("retweet_count")) { throw; }
@@ -152,7 +152,7 @@ simdjson_really_inline void read_tweets(ondemand::parser &parser, padded_string 
 
     tweets.push_back(tweet);
 
-    iter.skip_container(); // Skip the rest of the tweet object
+    if (iter.skip_container()) { throw; } // Skip the rest of the tweet object
 
   } while (iter.has_next_element());
 }

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -51,7 +51,7 @@ simdjson_really_inline array &array::operator=(array &&other) noexcept = default
 simdjson_really_inline array::~array() noexcept {
   if (iter.is_alive()) {
     logger::log_event(*iter, "unfinished", "array");
-    iter->skip_container();
+    SIMDJSON_UNUSED auto _err = iter->skip_container();
     iter.release();
   }
 }

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -111,14 +111,14 @@ public:
   /**
    * Skips a JSON value, whether it is a scalar, array or object.
    */
-  simdjson_really_inline void skip() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code skip() noexcept;
 
   /**
    * Skips to the end of a JSON object or array.
    * 
    * @return true if this was the end of an array, false if it was the end of an object.
    */
-  simdjson_really_inline bool skip_container() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline error_code skip_container() noexcept;
 
   /**
    * Tell whether the iterator is still at the start
@@ -126,7 +126,7 @@ public:
   simdjson_really_inline bool at_start() const noexcept;
 
   /**
-   * Tell whether the iterator has reached EOF
+   * Tell whether the iterator is at the EOF mark
    */
   simdjson_really_inline bool at_eof() const noexcept;
 

--- a/src/generic/ondemand/object-inl.h
+++ b/src/generic/ondemand/object-inl.h
@@ -56,7 +56,7 @@ simdjson_really_inline object &object::operator=(object &&other) noexcept = defa
 simdjson_really_inline object::~object() noexcept {
   if (iter.is_alive()) {
     logger::log_event(*iter, "unfinished", "object");
-    iter->skip_container();
+    SIMDJSON_UNUSED auto _err = iter->skip_container();
     iter.release();
   }
 }
@@ -85,7 +85,7 @@ simdjson_really_inline simdjson_result<value> object::operator[](const std::stri
       return value::start(iter.borrow());
     }
     logger::log_event(*iter, "no match", key, -2);
-    iter->skip(); // Skip the value entirely
+    SIMDJSON_TRY( iter->skip() ); // Skip the value entirely
     if ((error = iter->has_next_field().get(has_value) )) { return report_error(); }
   }
 

--- a/src/generic/ondemand/value-inl.h
+++ b/src/generic/ondemand/value-inl.h
@@ -21,7 +21,7 @@ simdjson_really_inline value::~value() noexcept {
   if (iter.is_alive()) {
     if (*json == '[' || *json == '{') {
       logger::log_start_value(*iter, "unused");
-      iter->skip_container();
+      SIMDJSON_UNUSED auto _err = iter->skip_container();
     } else {
       logger::log_value(*iter, "unused");
     }


### PR DESCRIPTION
Going to merge into #947 . The skip() and skip_container() methods currently run off the end into corruption if there are missing end braces. This fixes it, at the cost of around 7-8% throughput on the tweet benchmark (and bringing it back below SAX). Presumably it will be less on things that skip fewer entries.

Aside from stage 2 shenanigans, maybe unrolling the loop or experimenting with decreasing indexes instead of pointers might help?

### Haswell gcc10 (Skylake)

```
ondemand_tweets          178073 ns       178072 ns         3922 bytes=3.54639G/s docs=5.61569k/s tweets=561.569k/s
iter_tweets              170704 ns       170706 ns         4099 bytes=3.69944G/s docs=5.85804k/s tweets=585.804k/s
sax_tweets               162439 ns       162440 ns         4308 bytes=3.88767G/s docs=6.1561k/s tweets=615.61k/s
dom_tweets               270900 ns       270902 ns         2584 bytes=2.33116G/s docs=3.69138k/s tweets=369.138k/s
parse_tweets             253761 ns       253762 ns         2758 bytes=2.48861G/s docs=3.9407k/s
Creating a source file spanning 44921 KB 
dom_largerandom       113189994 ns    113190916 ns            5 bytes=406.382M/s docs=8.83463/s points=8.83463M/s
ondemand_largerandom   91234788 ns     91235540 ns            7 bytes=504.176M/s docs=10.9606/s points=10.9606M/s
iter_largerandom       76448373 ns     76448964 ns            8 bytes=601.693M/s docs=13.0806/s points=13.0806M/s
sax_largerandom        61895139 ns     61895539 ns           11 bytes=743.168M/s doc
```