### PR TITLE
This adds a frequency column 

### DIFF
--- a/benchmark/parse_records_benchmark.h
+++ b/benchmark/parse_records_benchmark.h
@@ -41,5 +41,6 @@ template<typename B, typename R> static void ParseRecordsBenchmark(benchmark::St
     state.counters["BranchMiss"]  = round(counts.branch_misses()    / double(state.iterations()));
     state.counters["CacheMiss"]   = round(counts.cache_misses()     / double(state.iterations()));
     state.counters["CacheRef"]    = round(counts.cache_references() / double(state.iterations()));
+    state.counters["Frequency"]    =  (counts.cycles() / counts.elapsed_sec()) / 1000000000.0;
   }
 }


### PR DESCRIPTION
This is useful, even compulsory I'd say, because if the frequency tanks, then other numbers are suspect. In my tests, this is not a problem, but you want to keep an eye on the frequency of the processor. If it is not flat, then you don't want to trust the numbers. Also, to interpret the speeds, it is really helpful to know about the frequency of the processor.

This is a PR for jkeiser/stream-parse (not for master).

```
Running ./benchmark/bench_sax
Run on (16 X 3193.88 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x8)
  L1 Instruction 32 KiB (x8)
  L2 Unified 512 KiB (x8)
  L3 Unified 16384 KiB (x8)
Load Average: 0.11, 0.09, 0.07
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations BranchMiss  CacheMiss   CacheRef Cycles/Byte  Frequency  Ins./Byte Ins./Cycle bytes_per_second items_per_second
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PartialTweets<OnDemand>     195490 ns       195487 ns         3586        789          0          0     1.04794    3.38529    3.44505    3.28744        3.0086G/s       511.542k/s
PartialTweets<Iter>         419893 ns       419904 ns         1664     1.981k          0          0      2.2487      3.382    6.70797    2.98305       1.40066G/s        238.15k/s
PartialTweets<Sax>          195301 ns       195295 ns         3575        593          0          0     1.04662     3.3843    3.36857    3.21851       3.01157G/s       512.047k/s
PartialTweets<Dom>          282020 ns       282027 ns         2481     1.589k          0          0     1.51177    3.38524    4.75518    3.14544       2.08542G/s       354.576k/s
Creating a source file spanning 44921 KB 
LargeRandom<Dom>          90468474 ns     90469152 ns            8   818.699k          0          0     6.65787    3.38514    21.8169    3.27686       484.893M/s       11.0535M/s
LargeRandom<OnDemand>     66044852 ns     66045341 ns           11   845.424k          0          0     4.86033    3.38505    15.1293    3.11282       664.208M/s       15.1411M/s
LargeRandom<Iter>         56502293 ns     56504432 ns           12   848.801k          0          0     4.15822    3.38518    12.3684    2.97443       776.361M/s       17.6977M/s
LargeRandom<Sax>          61007628 ns     61010001 ns           11   846.623k          0          0     4.48984    3.38522    13.8683    3.08883       719.027M/s       16.3908M/s
```