### PR TITLE
I think that this is better (fairer) code for the large random benchmark

### DIFF
--- a/benchmark/largerandom/ondemand.h
+++ b/benchmark/largerandom/ondemand.h
@@ -28,11 +28,10 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
   container.clear();
 
   auto doc = parser.iterate(json);
-  // TODO this sucks, you should be able to just say for ( ... : doc)
+  // TODO you should be able to just say for ( ... : doc)
   auto array = doc.get_array();
   for (ondemand::object point_object : array) {
-    auto point = point_object.begin();
-    container.emplace_back(my_point{(*point).value(), (*++point).value(), (*++point).value()});
+    container.emplace_back(my_point{point_object["x"], point_object["y"], point_object["z"]});
   }
 
   return true;


### PR DESCRIPTION
Another PR for jkeiser/stream-parse

The SAX change is a minor modification so that we do more validation. (It should be noted that the SAX code could eat garbage and be content.)

The on-demand change is, in my opinion, more legible code, and it also does more validation.

