### PR TITLE
Remove unnamed namespaces from ondemand

### DIFF
--- a/benchmark/kostya/iter.h
+++ b/benchmark/kostya/iter.h
@@ -6,7 +6,6 @@
 #include "kostya.h"
 
 namespace kostya {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -54,10 +53,8 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(Kostya, Iter);
 
-} // unnamed namespace
 
 namespace sum {
-namespace {
 
 class Iter {
 public:
@@ -95,7 +92,6 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(KostyaSum, Iter);
 
-} // unnamed namespace
 } // namespace sum
 } // namespace kostya
 

--- a/benchmark/kostya/ondemand.h
+++ b/benchmark/kostya/ondemand.h
@@ -6,7 +6,6 @@
 #include "kostya.h"
 
 namespace kostya {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -40,10 +39,8 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(Kostya, OnDemand);
 
-} // unnamed namespace
 
 namespace sum {
-namespace {
 
 class OnDemand {
 public:
@@ -75,7 +72,6 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(KostyaSum, OnDemand);
 
-} // unnamed namespace
 } // namespace sum
 } // namespace kostya
 

--- a/benchmark/largerandom/iter.h
+++ b/benchmark/largerandom/iter.h
@@ -6,7 +6,6 @@
 #include "largerandom.h"
 
 namespace largerandom {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -51,10 +50,8 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(LargeRandom, Iter);
 
-} // unnamed namespace
 
 namespace sum {
-namespace {
 
 class Iter {
 public:
@@ -91,7 +88,6 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(LargeRandomSum, Iter);
 
-} // unnamed namespace
 } // namespace sum
 } // namespace largerandom
 

--- a/benchmark/largerandom/ondemand.h
+++ b/benchmark/largerandom/ondemand.h
@@ -6,7 +6,6 @@
 #include "largerandom.h"
 
 namespace largerandom {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -37,10 +36,8 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(LargeRandom, OnDemand);
 
-} // unnamed namespace
 
 namespace sum {
-namespace {
 
 class OnDemand {
 public:
@@ -72,7 +69,6 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(LargeRandomSum, OnDemand);
 
-} // unnamed namespace
 } // namespace sum
 } // namespace largerandom
 

--- a/benchmark/largerandom/sax.h
+++ b/benchmark/largerandom/sax.h
@@ -6,7 +6,6 @@
 #include "largerandom.h"
 
 namespace largerandom {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -121,7 +120,6 @@ error_code Sax::Allocate(size_t new_capacity) {
 
 BENCHMARK_TEMPLATE(LargeRandom, Sax);
 
-}
 } // namespace largerandom
 
 #endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/partial_tweets/iter.h
+++ b/benchmark/partial_tweets/iter.h
@@ -6,7 +6,6 @@
 #include "partial_tweets.h"
 
 namespace partial_tweets {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -91,7 +90,6 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(PartialTweets, Iter);
 
-}
 } // namespace partial_tweets
 
 #endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/partial_tweets/ondemand.h
+++ b/benchmark/partial_tweets/ondemand.h
@@ -6,7 +6,6 @@
 #include "partial_tweets.h"
 
 namespace partial_tweets {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -56,7 +55,6 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
 
 BENCHMARK_TEMPLATE(PartialTweets, OnDemand);
 
-}
 } // namespace partial_tweets
 
 #endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/partial_tweets/sax.h
+++ b/benchmark/partial_tweets/sax.h
@@ -6,7 +6,6 @@
 #include "sax_tweet_reader_visitor.h"
 
 namespace partial_tweets {
-namespace {
 
 using namespace simdjson;
 using namespace SIMDJSON_IMPLEMENTATION;
@@ -67,7 +66,6 @@ error_code Sax::Allocate(size_t new_capacity) {
 
 BENCHMARK_TEMPLATE(PartialTweets, Sax);
 
-}
 } // namespace partial_tweets
 
 #endif // SIMDJSON_IMPLEMENTATION

--- a/src/arm64/bitmanipulation.h
+++ b/src/arm64/bitmanipulation.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_ARM64_BITMANIPULATION_H
 #define SIMDJSON_ARM64_BITMANIPULATION_H
 
+namespace SIMDJSON_IMPLEMENTATION {
 namespace {
-namespace arm64 {
 
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
@@ -55,7 +55,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint6
 #endif
 }
 
-} // namespace arm64
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_ARM64_BITMANIPULATION_H

--- a/src/arm64/bitmask.h
+++ b/src/arm64/bitmask.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_ARM64_BITMASK_H
 #define SIMDJSON_ARM64_BITMASK_H
 
+namespace SIMDJSON_IMPLEMENTATION {
 namespace {
-namespace arm64 {
 
 //
 // Perform a "cumulative bitwise xor," flipping bits each time a 1 is encountered.

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -5,8 +5,8 @@
 //
 // Stage 1
 //
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 using namespace simd;
 
@@ -98,8 +98,8 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
     return is_third_byte ^ is_fourth_byte;
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "generic/stage1/utf8_lookup4_algorithm.h"
 #include "generic/stage1/json_structural_indexer.h"
@@ -116,8 +116,8 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
 //
 // Implementation-specific overrides
 //
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
@@ -128,6 +128,7 @@ simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backs
 }
 
 } // namespace stage1
+} // unnamed namespace
 
 SIMDJSON_WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept {
   return arm64::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
@@ -158,6 +159,5 @@ SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "arm64/end_implementation.h"

--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -1,7 +1,6 @@
 #include "arm64/begin_implementation.h"
 #include "arm64/dom_parser_implementation.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation(
@@ -17,6 +16,5 @@ SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "arm64/end_implementation.h"

--- a/src/arm64/implementation.h
+++ b/src/arm64/implementation.h
@@ -4,7 +4,6 @@
 #include "simdjson.h"
 #include "isadetection.h"
 
-namespace {
 namespace arm64 {
 
 using namespace simdjson;
@@ -23,6 +22,5 @@ public:
 };
 
 } // namespace arm64
-} // unnamed namespace
 
 #endif // SIMDJSON_ARM64_IMPLEMENTATION_H

--- a/src/arm64/numberparsing.h
+++ b/src/arm64/numberparsing.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_ARM64_NUMBERPARSING_H
 #define SIMDJSON_ARM64_NUMBERPARSING_H
 
+namespace SIMDJSON_IMPLEMENTATION {
 namespace {
-namespace arm64 {
 
 // we don't have SSE, so let us use a scalar function
 // credit: https://johnnylee-sde.github.io/Fast-numeric-string-to-int/
@@ -14,8 +14,8 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
   return uint32_t((val & 0x0000FFFF0000FFFF) * 42949672960001 >> 32);
 }
 
-} // namespace arm64
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #define SWAR_NUMBER_PARSING
 

--- a/src/arm64/simd.h
+++ b/src/arm64/simd.h
@@ -7,8 +7,8 @@
 #include <type_traits>
 
 
+namespace SIMDJSON_IMPLEMENTATION {
 namespace {
-namespace arm64 {
 namespace simd {
 
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
@@ -484,7 +484,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
   }; // struct simd8x64<T>
 
 } // namespace simd
-} // namespace arm64
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_ARM64_SIMD_H

--- a/src/arm64/stringparsing.h
+++ b/src/arm64/stringparsing.h
@@ -5,8 +5,8 @@
 #include "arm64/simd.h"
 #include "arm64/bitmanipulation.h"
 
+namespace SIMDJSON_IMPLEMENTATION {
 namespace {
-namespace arm64 {
 
 using namespace simd;
 
@@ -43,8 +43,8 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
   };
 }
 
-} // namespace arm64
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "generic/stage2/stringparsing.h"
 

--- a/src/fallback/bitmanipulation.h
+++ b/src/fallback/bitmanipulation.h
@@ -4,8 +4,8 @@
 #include "simdjson.h"
 #include <limits>
 
+namespace SIMDJSON_IMPLEMENTATION {
 namespace {
-namespace fallback {
 
 #if defined(_MSC_VER) && !defined(_M_ARM64) && !defined(_M_X64)
 static inline unsigned char _BitScanForward64(unsigned long* ret, uint64_t x) {
@@ -39,7 +39,7 @@ simdjson_really_inline int leading_zeroes(uint64_t input_num) {
 #endif// _MSC_VER
 }
 
-} // namespace fallback
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_FALLBACK_BITMANIPULATION_H

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -7,8 +7,8 @@
 //
 #include "generic/stage1/find_next_document_index.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 class structural_scanner {
@@ -179,6 +179,7 @@ private:
 }; // structural_scanner
 
 } // namespace stage1
+} // unnamed namespace
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool partial) noexcept {
   this->buf = _buf;
@@ -308,7 +309,6 @@ SIMDJSON_WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t 
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 //
 // Stage 2
@@ -317,7 +317,6 @@ SIMDJSON_WARN_UNUSED bool implementation::validate_utf8(const char *buf, size_t 
 #include "fallback/numberparsing.h"
 #include "generic/stage2/tape_builder.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::stage2(dom::document &_doc) noexcept {
@@ -335,6 +334,5 @@ SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "fallback/end_implementation.h"

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -1,7 +1,6 @@
 #include "fallback/begin_implementation.h"
 #include "fallback/dom_parser_implementation.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation(
@@ -17,6 +16,5 @@ SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "fallback/end_implementation.h"

--- a/src/fallback/implementation.h
+++ b/src/fallback/implementation.h
@@ -4,7 +4,6 @@
 #include "simdjson.h"
 #include "isadetection.h"
 
-namespace {
 namespace fallback {
 
 using namespace simdjson;
@@ -27,6 +26,5 @@ public:
 };
 
 } // namespace fallback
-} // unnamed namespace
 
 #endif // SIMDJSON_FALLBACK_IMPLEMENTATION_H

--- a/src/fallback/numberparsing.h
+++ b/src/fallback/numberparsing.h
@@ -8,8 +8,8 @@ void found_unsigned_integer(uint64_t result, const uint8_t *buf);
 void found_float(double result, const uint8_t *buf);
 #endif
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const char *chars) {
   uint32_t result = 0;
   for (int i=0;i<8;i++) {
@@ -21,8 +21,8 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
   return parse_eight_digits_unrolled((const char *)chars);
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #define SWAR_NUMBER_PARSING
 #include "generic/stage2/numberparsing.h"

--- a/src/fallback/stringparsing.h
+++ b/src/fallback/stringparsing.h
@@ -3,8 +3,8 @@
 
 #include "simdjson.h"
 
+namespace SIMDJSON_IMPLEMENTATION {
 namespace {
-namespace fallback {
 
 // Holds backslashes and quotes locations.
 struct backslash_and_quote {
@@ -26,8 +26,8 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
   return { src[0] };
 }
 
-} // namespace fallback
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "generic/stage2/stringparsing.h"
 

--- a/src/generic/dom_parser_implementation.h
+++ b/src/generic/dom_parser_implementation.h
@@ -1,7 +1,6 @@
 #include "simdjson.h"
 #include "isadetection.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 // expectation: sizeof(open_container) = 64/8.
@@ -41,12 +40,10 @@ public:
 };
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "generic/stage1/allocate.h"
 #include "generic/stage2/allocate.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 inline dom_parser_implementation::dom_parser_implementation() noexcept = default;
@@ -69,4 +66,3 @@ SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::set_max_depth(size_t 
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace

--- a/src/generic/implementation_simdjson_result_base-inl.h
+++ b/src/generic/implementation_simdjson_result_base-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 //
@@ -75,4 +74,3 @@ simdjson_really_inline implementation_simdjson_result_base<T>::implementation_si
     : implementation_simdjson_result_base(T{}, UNINITIALIZED) {}
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace

--- a/src/generic/implementation_simdjson_result_base.h
+++ b/src/generic/implementation_simdjson_result_base.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 // This is a near copy of include/error.h's implementation_simdjson_result_base, except it doesn't use std::pair
@@ -119,4 +118,3 @@ struct implementation_simdjson_result_base {
 }; // struct implementation_simdjson_result_base
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace

--- a/src/generic/ondemand/array-inl.h
+++ b/src/generic/ondemand/array-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -73,7 +72,6 @@ simdjson_really_inline array_iterator array::end() & noexcept {
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 namespace simdjson {
 

--- a/src/generic/ondemand/array.h
+++ b/src/generic/ondemand/array.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -61,7 +60,6 @@ protected:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/array_iterator-inl.h
+++ b/src/generic/ondemand/array_iterator-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -23,7 +22,6 @@ simdjson_really_inline array_iterator &array_iterator::operator++() noexcept {
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 namespace simdjson {
 

--- a/src/generic/ondemand/array_iterator.h
+++ b/src/generic/ondemand/array_iterator.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -49,7 +48,6 @@ private:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 namespace simdjson {
 

--- a/src/generic/ondemand/document-inl.h
+++ b/src/generic/ondemand/document-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -94,7 +93,6 @@ simdjson_really_inline simdjson_result<value> document::operator[](const char *k
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/document.h
+++ b/src/generic/ondemand/document.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -83,7 +82,6 @@ protected:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/field-inl.h
+++ b/src/generic/ondemand/field-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -31,7 +30,6 @@ simdjson_really_inline value &field::value() noexcept {
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/field.h
+++ b/src/generic/ondemand/field.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -27,7 +26,6 @@ protected:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/json_iterator-inl.h
+++ b/src/generic/ondemand/json_iterator-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -324,7 +323,6 @@ simdjson_really_inline bool json_iterator_ref::is_active() const noexcept {
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/json_iterator.h
+++ b/src/generic/ondemand/json_iterator.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -184,7 +183,6 @@ private:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/logger-inl.h
+++ b/src/generic/ondemand/logger-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 namespace logger {
@@ -72,4 +71,3 @@ simdjson_really_inline void log_line(const json_iterator &iter, const char *titl
 } // namespace logger
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace

--- a/src/generic/ondemand/logger.h
+++ b/src/generic/ondemand/logger.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -19,4 +18,3 @@ static simdjson_really_inline void log_error(const json_iterator &iter, const ch
 } // namespace logger
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace

--- a/src/generic/ondemand/object-inl.h
+++ b/src/generic/ondemand/object-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -122,7 +121,6 @@ simdjson_really_inline object_iterator object::end() noexcept {
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/object.h
+++ b/src/generic/ondemand/object.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -64,7 +63,6 @@ protected:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/object_iterator-inl.h
+++ b/src/generic/ondemand/object_iterator-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -28,7 +27,6 @@ simdjson_really_inline object_iterator &object_iterator::operator++() noexcept {
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 namespace simdjson {
 

--- a/src/generic/ondemand/object_iterator.h
+++ b/src/generic/ondemand/object_iterator.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -43,7 +42,6 @@ private:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 namespace simdjson {
 

--- a/src/generic/ondemand/parser-inl.h
+++ b/src/generic/ondemand/parser-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -42,7 +41,6 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<json_iterator> parse
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/parser.h
+++ b/src/generic/ondemand/parser.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -36,7 +35,6 @@ private:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/raw_json_string-inl.h
+++ b/src/generic/ondemand/raw_json_string-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -35,7 +34,6 @@ SIMDJSON_UNUSED simdjson_really_inline bool operator!=(std::string_view a, const
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/raw_json_string.h
+++ b/src/generic/ondemand/raw_json_string.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -33,7 +32,6 @@ SIMDJSON_UNUSED simdjson_really_inline bool operator!=(std::string_view a, const
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/token_iterator-inl.h
+++ b/src/generic/ondemand/token_iterator-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -41,7 +40,6 @@ simdjson_really_inline bool token_iterator::operator<=(const token_iterator &oth
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/token_iterator.h
+++ b/src/generic/ondemand/token_iterator.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -74,7 +73,6 @@ protected:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/value-inl.h
+++ b/src/generic/ondemand/value-inl.h
@@ -1,4 +1,3 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -167,7 +166,6 @@ simdjson_really_inline void value::log_error(const char *message) const noexcept
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/ondemand/value.h
+++ b/src/generic/ondemand/value.h
@@ -1,6 +1,5 @@
 #include "simdjson/error.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -89,7 +88,6 @@ protected:
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
-} // namespace {
 
 namespace simdjson {
 

--- a/src/generic/stage1/allocate.h
+++ b/src/generic/stage1/allocate.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 namespace allocate {
 
@@ -17,5 +17,5 @@ simdjson_really_inline error_code set_capacity(internal::dom_parser_implementati
 
 } // namespace allocate
 } // namespace stage1
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/buf_block_reader.h
+++ b/src/generic/stage1/buf_block_reader.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 // Walks through a buffer in block-sized increments, loading the last part with spaces
 template<size_t STEP_SIZE>
@@ -85,5 +85,5 @@ simdjson_really_inline void buf_block_reader<STEP_SIZE>::advance() {
   idx += STEP_SIZE;
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/find_next_document_index.h
+++ b/src/generic/stage1/find_next_document_index.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 /**
   * This algorithm is used to quickly identify the last structural position that
@@ -67,5 +67,5 @@ simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementati
   return 0;
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/json_minifier.h
+++ b/src/generic/stage1/json_minifier.h
@@ -3,8 +3,8 @@
 // We assume the file in which it is included already includes
 // "simdjson/stage1.h" (this simplifies amalgation)
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 class json_minifier {
@@ -77,5 +77,5 @@ error_code json_minifier::minify(const uint8_t *buf, size_t len, uint8_t *dst, s
 }
 
 } // namespace stage1
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/json_scanner.h
+++ b/src/generic/stage1/json_scanner.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 /**
@@ -142,5 +142,5 @@ simdjson_really_inline error_code json_scanner::finish(bool streaming) {
 }
 
 } // namespace stage1
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/json_string_scanner.h
+++ b/src/generic/stage1/json_string_scanner.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 struct json_string_block {
@@ -139,5 +139,5 @@ simdjson_really_inline error_code json_string_scanner::finish(bool streaming) {
 }
 
 } // namespace stage1
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -9,8 +9,8 @@
 #include "generic/stage1/json_minifier.h"
 #include "generic/stage1/find_next_document_index.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 class bit_indexer {
@@ -225,5 +225,5 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
 }
 
 } // namespace stage1
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/utf8_fastvalidate_algorithm.h
+++ b/src/generic/stage1/utf8_fastvalidate_algorithm.h
@@ -180,5 +180,5 @@ struct utf8_checker {
   }
 }; // struct utf8_checker
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/utf8_lookup2_algorithm.h
+++ b/src/generic/stage1/utf8_lookup2_algorithm.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace utf8_validation {
 
 //

--- a/src/generic/stage1/utf8_lookup3_algorithm.h
+++ b/src/generic/stage1/utf8_lookup3_algorithm.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace utf8_validation {
 
 //

--- a/src/generic/stage1/utf8_lookup4_algorithm.h
+++ b/src/generic/stage1/utf8_lookup4_algorithm.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace utf8_validation {
 
 using namespace simd;
@@ -177,5 +177,5 @@ using namespace simd;
 
 using utf8_validation::utf8_checker;
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/utf8_lookup_algorithm.h
+++ b/src/generic/stage1/utf8_lookup_algorithm.h
@@ -299,5 +299,5 @@ struct utf8_checker {
 }; // struct utf8_checker
 
 } // namespace utf8_validation
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/utf8_range_algorithm.h
+++ b/src/generic/stage1/utf8_range_algorithm.h
@@ -182,5 +182,5 @@ struct utf8_checker {
   }
 }; // struct utf8_checker
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/utf8_validator.h
+++ b/src/generic/stage1/utf8_validator.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 /**
@@ -27,5 +27,5 @@ bool generic_validate_utf8(const char * input, size_t length) {
 }
 
 } // namespace stage1
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage1/utf8_zwegner_algorithm.h
+++ b/src/generic/stage1/utf8_zwegner_algorithm.h
@@ -361,5 +361,5 @@ struct utf8_checker {
   }
 }; // struct utf8_checker
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/allocate.h
+++ b/src/generic/stage2/allocate.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 namespace allocate {
 
@@ -18,5 +18,5 @@ simdjson_really_inline error_code set_max_depth(dom_parser_implementation &parse
 
 } // namespace allocate
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/atomparsing.h
+++ b/src/generic/stage2/atomparsing.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 namespace atomparsing {
 
@@ -60,5 +60,5 @@ simdjson_really_inline bool is_valid_null_atom(const uint8_t *src, size_t len) {
 
 } // namespace atomparsing
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -1,7 +1,7 @@
 #include "generic/stage2/logger.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 
 class json_iterator {
@@ -311,5 +311,5 @@ SIMDJSON_WARN_UNUSED simdjson_really_inline error_code json_iterator::visit_prim
 }
 
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/jsoncharutils.h
+++ b/src/generic/stage2/jsoncharutils.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 
 // return non-zero if not a structural or whitespace char
@@ -105,5 +105,5 @@ simdjson_really_inline value128 full_multiplication(uint64_t value1, uint64_t va
 }
 
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -1,7 +1,7 @@
 // This is for an internal-only stage 2 specific logger.
 // Set LOG_ENABLED = true to log what stage 2 is doing!
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace logger {
 
   static constexpr const char * DASHES = "----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
@@ -82,5 +82,5 @@ namespace logger {
   }
 
 } // namespace logger
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/numberparsing.h
+++ b/src/generic/stage2/numberparsing.h
@@ -1,8 +1,8 @@
 #include <cmath>
 #include <limits>
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 namespace numberparsing {
 
@@ -755,5 +755,5 @@ SIMDJSON_UNUSED simdjson_really_inline simdjson_result<double> parse_double(cons
 
 } // namespace numberparsing
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -1,8 +1,8 @@
 // This file contains the common code every implementation uses
 // It is intended to be included multiple times and compiled multiple times
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 namespace stringparsing {
 
@@ -129,5 +129,5 @@ SIMDJSON_UNUSED SIMDJSON_WARN_UNUSED simdjson_really_inline error_code parse_str
 
 } // namespace stringparsing
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 
 class structural_iterator {
@@ -48,5 +48,5 @@ public:
 };
 
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -2,8 +2,8 @@
 #include "generic/stage2/tape_writer.h"
 #include "generic/stage2/atomparsing.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 
 struct tape_builder {
@@ -279,5 +279,5 @@ simdjson_really_inline void tape_builder::on_end_string(uint8_t *dst) noexcept {
 }
 
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/generic/stage2/tape_writer.h
+++ b/src/generic/stage2/tape_writer.h
@@ -1,5 +1,5 @@
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage2 {
 
 struct tape_writer {
@@ -99,5 +99,5 @@ simdjson_really_inline void tape_writer::write(uint64_t &tape_loc, uint64_t val,
 }
 
 } // namespace stage2
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION

--- a/src/haswell/bitmanipulation.h
+++ b/src/haswell/bitmanipulation.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_HASWELL_BITMANIPULATION_H
 #define SIMDJSON_HASWELL_BITMANIPULATION_H
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
@@ -53,7 +53,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
 #endif
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_HASWELL_BITMANIPULATION_H

--- a/src/haswell/bitmask.h
+++ b/src/haswell/bitmask.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_HASWELL_BITMASK_H
 #define SIMDJSON_HASWELL_BITMASK_H
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 //
 // Perform a "cumulative bitwise xor," flipping bits each time a 1 is encountered.
@@ -17,7 +17,7 @@ simdjson_really_inline uint64_t prefix_xor(const uint64_t bitmask) {
   return _mm_cvtsi128_si64(result);
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_HASWELL_BITMASK_H

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -6,8 +6,8 @@
 // Stage 1
 //
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 using namespace simd;
 
@@ -102,8 +102,8 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
   return simd8<int8_t>(is_third_byte | is_fourth_byte) > int8_t(0);
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "generic/stage1/utf8_lookup4_algorithm.h"
 #include "generic/stage1/json_structural_indexer.h"
@@ -119,8 +119,8 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
 //
 // Implementation-specific overrides
 //
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
@@ -129,6 +129,7 @@ simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backs
 }
 
 } // namespace stage1
+} // unnamed namespace
 
 SIMDJSON_WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept {
   return haswell::stage1::json_minifier::minify<128>(buf, len, dst, dst_len);
@@ -159,7 +160,6 @@ SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "generic/ondemand.h"
 

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -1,7 +1,6 @@
 #include "haswell/begin_implementation.h"
 #include "haswell/dom_parser_implementation.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
 
 SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation(
@@ -17,7 +16,6 @@ SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "haswell/end_implementation.h"
 

--- a/src/haswell/implementation.h
+++ b/src/haswell/implementation.h
@@ -5,7 +5,6 @@
 #include "isadetection.h"
 
 // The constructor may be executed on any host, so we take care not to use SIMDJSON_TARGET_REGION
-namespace {
 namespace haswell {
 
 using namespace simdjson;
@@ -27,6 +26,5 @@ public:
 };
 
 } // namespace haswell
-} // unnamed namespace
 
 #endif // SIMDJSON_HASWELL_IMPLEMENTATION_H

--- a/src/haswell/numberparsing.h
+++ b/src/haswell/numberparsing.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_HASWELL_NUMBERPARSING_H
 #define SIMDJSON_HASWELL_NUMBERPARSING_H
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   // this actually computes *16* values so we are being wasteful.
@@ -22,8 +22,8 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
       t4); // only captures the sum of the first 8 digits, drop the rest
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #define SWAR_NUMBER_PARSING
 

--- a/src/haswell/simd.h
+++ b/src/haswell/simd.h
@@ -3,8 +3,8 @@
 
 #include "simdprune_tables.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace simd {
 
   // Forward-declared so they can be used by splat and friends.
@@ -355,7 +355,7 @@ namespace simd {
 
 } // namespace simd
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_HASWELL_SIMD_H

--- a/src/haswell/stringparsing.h
+++ b/src/haswell/stringparsing.h
@@ -5,8 +5,8 @@
 #include "haswell/simd.h"
 #include "haswell/bitmanipulation.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 using namespace simd;
 
@@ -38,8 +38,8 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
   };
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "generic/stage2/stringparsing.h"
 

--- a/src/westmere/bitmanipulation.h
+++ b/src/westmere/bitmanipulation.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_WESTMERE_BITMANIPULATION_H
 #define SIMDJSON_WESTMERE_BITMANIPULATION_H
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
@@ -62,7 +62,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
 #endif
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_WESTMERE_BITMANIPULATION_H

--- a/src/westmere/bitmask.h
+++ b/src/westmere/bitmask.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_WESTMERE_BITMASK_H
 #define SIMDJSON_WESTMERE_BITMASK_H
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 //
 // Perform a "cumulative bitwise xor," flipping bits each time a 1 is encountered.
@@ -17,7 +17,7 @@ simdjson_really_inline uint64_t prefix_xor(const uint64_t bitmask) {
   return _mm_cvtsi128_si64(result);
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_WESTMERE_BITMASK_H

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -6,8 +6,8 @@
 // Stage 1
 //
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 using namespace simd;
 
@@ -100,8 +100,8 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
   return simd8<int8_t>(is_third_byte | is_fourth_byte) > int8_t(0);
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "generic/stage1/utf8_lookup4_algorithm.h"
 #include "generic/stage1/json_structural_indexer.h"
@@ -118,8 +118,8 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
 // Implementation-specific overrides
 //
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace stage1 {
 
 simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
@@ -128,6 +128,7 @@ simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backs
 }
 
 } // namespace stage1
+} // unnamed namespace
 
 SIMDJSON_WARN_UNUSED error_code implementation::minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept {
   return westmere::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
@@ -158,6 +159,5 @@ SIMDJSON_WARN_UNUSED error_code dom_parser_implementation::parse(const uint8_t *
 }
 
 } // namespace SIMDJSON_IMPLEMENTATION
-} // unnamed namespace
 
 #include "westmere/end_implementation.h"

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -1,8 +1,8 @@
 #include "westmere/begin_implementation.h"
 #include "westmere/dom_parser_implementation.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation(
   size_t capacity,
@@ -16,7 +16,7 @@ SIMDJSON_WARN_UNUSED error_code implementation::create_dom_parser_implementation
   return SUCCESS;
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "westmere/end_implementation.h"

--- a/src/westmere/implementation.h
+++ b/src/westmere/implementation.h
@@ -6,8 +6,8 @@
 #include "isadetection.h"
 
 // The constructor may be executed on any host, so we take care not to use SIMDJSON_TARGET_REGION
-namespace {
 namespace westmere {
+namespace {
 
 using namespace simdjson;
 using namespace simdjson::dom;
@@ -24,7 +24,7 @@ public:
   SIMDJSON_WARN_UNUSED bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };
 
-} // namespace westmere
 } // unnamed namespace
+} // namespace westmere
 
 #endif // SIMDJSON_WESTMERE_IMPLEMENTATION_H

--- a/src/westmere/numberparsing.h
+++ b/src/westmere/numberparsing.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_WESTMERE_NUMBERPARSING_H
 #define SIMDJSON_WESTMERE_NUMBERPARSING_H
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   // this actually computes *16* values so we are being wasteful.
@@ -22,8 +22,8 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t
       t4); // only captures the sum of the first 8 digits, drop the rest
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #define SWAR_NUMBER_PARSING
 

--- a/src/westmere/simd.h
+++ b/src/westmere/simd.h
@@ -3,8 +3,8 @@
 
 #include "simdprune_tables.h"
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 namespace simd {
 
   template<typename Child>
@@ -326,7 +326,7 @@ namespace simd {
   }; // struct simd8x64<T>
 
 } // namespace simd
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #endif // SIMDJSON_WESTMERE_SIMD_INPUT_H

--- a/src/westmere/stringparsing.h
+++ b/src/westmere/stringparsing.h
@@ -1,8 +1,8 @@
 #ifndef SIMDJSON_WESTMERE_STRINGPARSING_H
 #define SIMDJSON_WESTMERE_STRINGPARSING_H
 
-namespace {
 namespace SIMDJSON_IMPLEMENTATION {
+namespace {
 
 using namespace simd;
 
@@ -36,8 +36,8 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
   };
 }
 
-} // namespace SIMDJSON_IMPLEMENTATION
 } // unnamed namespace
+} // namespace SIMDJSON_IMPLEMENTATION
 
 #include "generic/stage2/stringparsing.h"
 


### PR DESCRIPTION
This makes it so you can use ondemand without having to enclose your own classes in an anonymous namespace. To do this I had to change the main unnamed namespace in src/ from <unnamed namespace>::SIMDJSON_IMPLEMENTATION to SIMDJSON_IMPLEMENTATION::<unnamed namespace>. This does not appear to have changed instruction counts or performance of the parse benchmark.