### PR TITLE
Make ondemand easy to use when compiled for a specific system

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -7,10 +7,6 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
-#if SIMDJSON_IMPLEMENTATION_HASWELL
-#include "simdjson/haswell/begin.h"
-#endif // SIMDJSON_IMPLEMENTATION_HASWELL
-
 #include "partial_tweets/ondemand.h"
 #include "partial_tweets/iter.h"
 #include "partial_tweets/dom.h"
@@ -24,7 +20,3 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "kostya/dom.h"
 
 BENCHMARK_MAIN();
-
-#if SIMDJSON_IMPLEMENTATION_HASWELL
-#include "simdjson/haswell/end.h"
-#endif // SIMDJSON_IMPLEMENTATION_HASWELL

--- a/benchmark/bench_sax.cpp
+++ b/benchmark/bench_sax.cpp
@@ -8,16 +8,7 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
-
-#if SIMDJSON_IMPLEMENTATION_HASWELL
-#include "simdjson/haswell/begin.h"
-#endif // SIMDJSON_IMPLEMENTATION_HASWELL
-
 #include "partial_tweets/sax.h"
 #include "largerandom/sax.h"
 
 BENCHMARK_MAIN();
-
-#if SIMDJSON_IMPLEMENTATION_HASWELL
-#include "simdjson/haswell/end.h"
-#endif // SIMDJSON_IMPLEMENTATION_HASWELL

--- a/benchmark/kostya/iter.h
+++ b/benchmark/kostya/iter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 #if SIMDJSON_EXCEPTIONS
 
 #include "kostya.h"
@@ -8,7 +7,7 @@
 namespace kostya {
 
 using namespace simdjson;
-using namespace simdjson::SIMDJSON_IMPLEMENTATION;
+using namespace simdjson::builtin;
 
 class Iter {
 public:
@@ -21,12 +20,12 @@ private:
   ondemand::parser parser{};
   std::vector<my_point> container{};
 
-  simdjson_really_inline simdjson_result<double> first_double(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter, const char *key) {
+  simdjson_really_inline simdjson_result<double> first_double(ondemand::json_iterator &iter, const char *key) {
     if (!iter.start_object() || ondemand::raw_json_string(iter.field_key()) != key || iter.field_value()) { throw "Invalid field"; }
     return iter.get_double();
   }
 
-  simdjson_really_inline simdjson_result<double> next_double(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter, const char *key) {
+  simdjson_really_inline simdjson_result<double> next_double(ondemand::json_iterator &iter, const char *key) {
     if (!iter.has_next_field() || ondemand::raw_json_string(iter.field_key()) != key || iter.field_value()) { throw "Invalid field"; }
     return iter.get_double();
   }
@@ -95,4 +94,3 @@ BENCHMARK_TEMPLATE(KostyaSum, Iter);
 } // namespace kostya
 
 #endif // SIMDJSON_EXCEPTIONS
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/kostya/ondemand.h
+++ b/benchmark/kostya/ondemand.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 #if SIMDJSON_EXCEPTIONS
 
 #include "kostya.h"
@@ -8,7 +7,7 @@
 namespace kostya {
 
 using namespace simdjson;
-using namespace simdjson::SIMDJSON_IMPLEMENTATION;
+using namespace simdjson::builtin;
 
 class OnDemand {
 public:
@@ -75,4 +74,3 @@ BENCHMARK_TEMPLATE(KostyaSum, OnDemand);
 } // namespace kostya
 
 #endif // SIMDJSON_EXCEPTIONS
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/largerandom/iter.h
+++ b/benchmark/largerandom/iter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 #if SIMDJSON_EXCEPTIONS
 
 #include "largerandom.h"
@@ -8,7 +7,7 @@
 namespace largerandom {
 
 using namespace simdjson;
-using namespace simdjson::SIMDJSON_IMPLEMENTATION;
+using namespace simdjson::builtin;
 
 class Iter {
 public:
@@ -21,12 +20,12 @@ private:
   ondemand::parser parser{};
   std::vector<my_point> container{};
 
-  simdjson_really_inline double first_double(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) {
+  simdjson_really_inline double first_double(ondemand::json_iterator &iter) {
     if (iter.start_object().error() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
     return iter.get_double();
   }
 
-  simdjson_really_inline double next_double(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) {
+  simdjson_really_inline double next_double(ondemand::json_iterator &iter) {
     if (!iter.has_next_field() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
     return iter.get_double();
   }
@@ -91,4 +90,3 @@ BENCHMARK_TEMPLATE(LargeRandomSum, Iter);
 } // namespace largerandom
 
 #endif // SIMDJSON_EXCEPTIONS
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/largerandom/ondemand.h
+++ b/benchmark/largerandom/ondemand.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 #if SIMDJSON_EXCEPTIONS
 
 #include "largerandom.h"
@@ -8,7 +7,7 @@
 namespace largerandom {
 
 using namespace simdjson;
-using namespace simdjson::SIMDJSON_IMPLEMENTATION;
+using namespace simdjson::builtin;
 
 class OnDemand {
 public:
@@ -72,4 +71,3 @@ BENCHMARK_TEMPLATE(LargeRandomSum, OnDemand);
 } // namespace largerandom
 
 #endif // SIMDJSON_EXCEPTIONS
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/largerandom/sax.h
+++ b/benchmark/largerandom/sax.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 #if SIMDJSON_EXCEPTIONS
 
 #include "largerandom.h"
@@ -8,8 +7,8 @@
 namespace largerandom {
 
 using namespace simdjson;
-using namespace SIMDJSON_IMPLEMENTATION;
-using namespace SIMDJSON_IMPLEMENTATION::stage2;
+using namespace simdjson::builtin;
+using namespace simdjson::builtin::stage2;
 
 class Sax {
 public:
@@ -28,8 +27,8 @@ private:
 };
 
 using namespace simdjson;
-using namespace SIMDJSON_IMPLEMENTATION;
-using namespace SIMDJSON_IMPLEMENTATION::stage2;
+using namespace simdjson::builtin;
+using namespace simdjson::builtin::stage2;
 struct sax_point_reader_visitor {
 public:
   std::vector<my_point> &points;
@@ -123,4 +122,3 @@ BENCHMARK_TEMPLATE(LargeRandom, Sax);
 } // namespace largerandom
 
 #endif // SIMDJSON_EXCEPTIONS
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/partial_tweets/iter.h
+++ b/benchmark/partial_tweets/iter.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 #if SIMDJSON_EXCEPTIONS
 
 #include "partial_tweets.h"
@@ -8,7 +7,7 @@
 namespace partial_tweets {
 
 using namespace simdjson;
-using namespace simdjson::SIMDJSON_IMPLEMENTATION;
+using namespace simdjson::builtin;
 
 class Iter {
 public:
@@ -92,4 +91,3 @@ BENCHMARK_TEMPLATE(PartialTweets, Iter);
 } // namespace partial_tweets
 
 #endif // SIMDJSON_EXCEPTIONS
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/partial_tweets/ondemand.h
+++ b/benchmark/partial_tweets/ondemand.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 #if SIMDJSON_EXCEPTIONS
 
 #include "partial_tweets.h"
@@ -8,7 +7,7 @@
 namespace partial_tweets {
 
 using namespace simdjson;
-using namespace simdjson::SIMDJSON_IMPLEMENTATION;
+using namespace simdjson::builtin;
 
 class OnDemand {
 public:
@@ -57,4 +56,3 @@ BENCHMARK_TEMPLATE(PartialTweets, OnDemand);
 } // namespace partial_tweets
 
 #endif // SIMDJSON_EXCEPTIONS
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/partial_tweets/sax.h
+++ b/benchmark/partial_tweets/sax.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#ifdef SIMDJSON_IMPLEMENTATION
 
 #include "partial_tweets.h"
 #include "sax_tweet_reader_visitor.h"
@@ -8,8 +7,8 @@
 namespace partial_tweets {
 
 using namespace simdjson;
-using namespace SIMDJSON_IMPLEMENTATION;
-using namespace SIMDJSON_IMPLEMENTATION::stage2;
+using namespace simdjson::builtin;
+using namespace simdjson::builtin::stage2;
 
 class Sax {
 public:
@@ -68,4 +67,3 @@ BENCHMARK_TEMPLATE(PartialTweets, Sax);
 
 } // namespace partial_tweets
 
-#endif // SIMDJSON_IMPLEMENTATION

--- a/benchmark/partial_tweets/sax_tweet_reader_visitor.h
+++ b/benchmark/partial_tweets/sax_tweet_reader_visitor.h
@@ -7,8 +7,8 @@
 namespace partial_tweets {
 
 using namespace simdjson;
-using namespace SIMDJSON_IMPLEMENTATION;
-using namespace SIMDJSON_IMPLEMENTATION::stage2;
+using namespace simdjson::builtin;
+using namespace simdjson::builtin::stage2;
 
 struct sax_tweet_reader_visitor {
 public:

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -94,23 +94,42 @@ else()
   target_compile_options(simdjson-internal-flags INTERFACE -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
 endif()
 
+#
 # Optional flags
+#
+
+# Implementation selection
 option(SIMDJSON_IMPLEMENTATION_HASWELL "Include the haswell implementation" ON)
 if(NOT SIMDJSON_IMPLEMENTATION_HASWELL)
+  message(DEPRECATION "SIMDJSON_IMPLEMENTATION_HASWELL is deprecated. Use SIMDJSON_IMPLEMENTATION=haswell or SIMDJSON_IMPLEMENTATION=-haswell instead.")
   target_compile_definitions(simdjson-internal-flags INTERFACE SIMDJSON_IMPLEMENTATION_HASWELL=0)
 endif()
 option(SIMDJSON_IMPLEMENTATION_WESTMERE "Include the westmere implementation" ON)
 if(NOT SIMDJSON_IMPLEMENTATION_WESTMERE)
+  message(DEPRECATION "SIMDJSON_IMPLEMENTATION_WESTMERE is deprecated. SIMDJSON_IMPLEMENTATION=-westmere instead.")
   target_compile_definitions(simdjson-internal-flags INTERFACE SIMDJSON_IMPLEMENTATION_WESTMERE=0)
 endif()
 option(SIMDJSON_IMPLEMENTATION_ARM64 "Include the arm64 implementation" ON)
 if(NOT SIMDJSON_IMPLEMENTATION_ARM64)
+  message(DEPRECATION "SIMDJSON_IMPLEMENTATION_ARM64 is deprecated. Use SIMDJSON_IMPLEMENTATION=-arm64 instead.")
   target_compile_definitions(simdjson-internal-flags INTERFACE SIMDJSON_IMPLEMENTATION_ARM64=0)
 endif()
 option(SIMDJSON_IMPLEMENTATION_FALLBACK "Include the fallback implementation" ON)
 if(NOT SIMDJSON_IMPLEMENTATION_FALLBACK)
+  message(DEPRECATION "SIMDJSON_IMPLEMENTATION_FALLBACK is deprecated. Use SIMDJSON_IMPLEMENTATION=-fallback instead.")
   target_compile_definitions(simdjson-internal-flags INTERFACE SIMDJSON_IMPLEMENTATION_FALLBACK=0)
 endif()
+# e.g. SIMDJSON_IMPLEMENTATION="haswell westmere -fallback"
+set(SIMDJSON_IMPLEMENTATION "" CACHE STRING "Implementations to include/exclude: space separated list of architectures (haswell/westmere/arm64/fallback). Prepend with - to force an implementation off (e.g. -haswell). Defaults to compile-time detection.")
+foreach(implementation ${SIMDJSON_IMPLEMENTATION})
+  string(TOUPPER ${implementation} implementation_upper)
+  if(string(REGEX MATCH "^-(.*)" actual_implementation ${implementation_upper}))
+    target_compile_definitions(simdjson-internal-flags INTERFACE SIMDJSON_IMPLEMENTATION_${actual_implementation} 0)
+  else()
+    target_compile_definitions(simdjson-internal-flags INTERFACE SIMDJSON_IMPLEMENTATION_${implementation_upper} 1)
+  endif()
+endforeach(implementation)
+
 
 option(SIMDJSON_BASH "Allow usage of bash within CMake" ON)
 

--- a/include/simdjson.h
+++ b/include/simdjson.h
@@ -84,6 +84,10 @@ SIMDJSON_DISABLE_UNDESIRED_WARNINGS
 #include "simdjson/haswell.h"
 #include "simdjson/westmere.h"
 
+namespace simdjson {
+  namespace builtin = SIMDJSON_BUILTIN_IMPLEMENTATION;
+}
+
 SIMDJSON_POP_DISABLE_WARNINGS
 
 #endif // SIMDJSON_H

--- a/include/simdjson/arm64.h
+++ b/include/simdjson/arm64.h
@@ -8,6 +8,8 @@
 #include "simdjson/arm64/implementation.h"
 
 #include "simdjson/arm64/begin.h"
+
+// Declarations
 #include "simdjson/generic/dom_parser_implementation.h"
 #include "simdjson/arm64/intrinsics.h"
 #include "simdjson/arm64/bitmanipulation.h"
@@ -17,6 +19,12 @@
 #include "simdjson/generic/atomparsing.h"
 #include "simdjson/arm64/stringparsing.h"
 #include "simdjson/arm64/numberparsing.h"
+#include "simdjson/generic/implementation_simdjson_result_base.h"
+#include "simdjson/generic/ondemand.h"
+
+// Inline definitions
+#include "simdjson/generic/implementation_simdjson_result_base-inl.h"
+#include "simdjson/generic/ondemand-inl.h"
 #include "simdjson/arm64/end.h"
 
 #endif // SIMDJSON_IMPLEMENTATION_ARM64

--- a/include/simdjson/fallback.h
+++ b/include/simdjson/fallback.h
@@ -8,12 +8,21 @@
 #include "simdjson/fallback/implementation.h"
 
 #include "simdjson/fallback/begin.h"
+
+// Declarations
 #include "simdjson/generic/dom_parser_implementation.h"
 #include "simdjson/fallback/bitmanipulation.h"
 #include "simdjson/generic/jsoncharutils.h"
 #include "simdjson/generic/atomparsing.h"
 #include "simdjson/fallback/stringparsing.h"
 #include "simdjson/fallback/numberparsing.h"
+#include "simdjson/generic/implementation_simdjson_result_base.h"
+#include "simdjson/generic/ondemand.h"
+
+// Inline definitions
+#include "simdjson/generic/implementation_simdjson_result_base-inl.h"
+#include "simdjson/generic/ondemand-inl.h"
+
 #include "simdjson/fallback/end.h"
 
 #endif // SIMDJSON_IMPLEMENTATION_FALLBACK

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -70,18 +70,6 @@ use a 64-bit target such as x64 or 64-bit ARM.")
 #define STRINGIFY_IMPLEMENTATION_(a) #a
 #define STRINGIFY(a) STRINGIFY_IMPLEMENTATION_(a)
 
-#ifndef SIMDJSON_IMPLEMENTATION_FALLBACK
-#define SIMDJSON_IMPLEMENTATION_FALLBACK 1
-#endif
-
-#if SIMDJSON_IS_ARM64
-#ifndef SIMDJSON_IMPLEMENTATION_ARM64
-#define SIMDJSON_IMPLEMENTATION_ARM64 1
-#endif
-#define SIMDJSON_IMPLEMENTATION_HASWELL 0
-#define SIMDJSON_IMPLEMENTATION_WESTMERE 0
-#endif // SIMDJSON_IS_ARM64
-
 // Our fast kernels require 64-bit systems.
 //
 // On 32-bit x86, we lack 64-bit popcnt, lzcnt, blsr instructions. 
@@ -91,15 +79,92 @@ use a 64-bit target such as x64 or 64-bit ARM.")
 //
 // The simdjson users should still have the fallback kernel. It is 
 // slower, but it should run everywhere.
+
+//
+// Enable valid runtime implementations, and select SIMDJSON_BUILTIN_IMPLEMENTATION
+//
+
+//
+// ARM 64-bit (NEON / Other)
+//
+#if SIMDJSON_IS_ARM64
+// Default ARM64 to on: it could be selected at runtime.
+#ifndef SIMDJSON_IMPLEMENTATION_ARM64
+#define SIMDJSON_IMPLEMENTATION_ARM64 1
+#endif
+#if __ARM_NEON
+//
+// NEON
+//
+// We're compiled natively for NEON, so arm64 will *always* work (the program is going
+// to fail in other ways if it's not run on a machine supporting NEON).
+//
+// Set builtin to arm64, and leave fallback defaulted to off.
+// It can still be enabled with SIMDJSON_IMPLEMENTATION_XXX flags, though it's unclear why one
+// would do so).
+//
+#define SIMDJSON_BUILTIN_IMPLEMENTATION arm64
+#endif
+#endif // SIMDJSON_IS_ARM64
+
+//
+// Intel 64-bit (Haswell / Westmere / Other)
+//
 #if SIMDJSON_IS_X86_64
+
+// Default Haswell to on: it could be selected at runtime.
 #ifndef SIMDJSON_IMPLEMENTATION_HASWELL
 #define SIMDJSON_IMPLEMENTATION_HASWELL 1
 #endif
+
+#if __AVX2__ && __BMI__ && __PCLMUL__ && __LZCNT__ && SIMDJSON_IMPLEMENTATION_HASWELL
+//
+// Haswell
+//
+// We're compiled natively for Haswell, so Haswell will *always* work (more specifically, the
+// program is going to fail in other ways if it's not run on a machine supporting AVX2).
+//
+// Set builtin to haswell, and leave westmere and fallback defaulted to off.
+// They can still be enabled with SIMDJSON_IMPLEMENTATION_XXX flags, though it's unclear why one
+// would do so).
+//
+#define SIMDJSON_BUILTIN_IMPLEMENTATION haswell
+#else // Haswell
+
+// We're not compiled natively for Haswell. Default Westmere to on: it could be selected at runtime.
 #ifndef SIMDJSON_IMPLEMENTATION_WESTMERE
 #define SIMDJSON_IMPLEMENTATION_WESTMERE 1
 #endif
-#define SIMDJSON_IMPLEMENTATION_ARM64 0
+#if __SSE4_2__ && __PCLMUL__ && SIMDJSON_IMPLEMENTATION_WESTMERE
+//
+// Westmere
+//
+// We're compiled natively for Westmere, so Westmere will *always* work (the program is going
+// to fail in other ways if it's not run on a machine supporting SSE4.2).
+//
+// Set builtin to westmere, and leave fallback defaulted to off.
+// It can still be enabled with SIMDJSON_IMPLEMENTATION_XXX flags, though it's unclear why one
+// would do so).
+//
+#define SIMDJSON_BUILTIN_IMPLEMENTATION westmere
+#endif // Westmere
+#endif // Haswell
 #endif // SIMDJSON_IS_X86_64
+
+//
+// If no specific builtin architecture was discovered, set builtin to fallback and make sure it's
+// enabled.
+//
+#ifndef SIMDJSON_BUILTIN_IMPLEMENTATION
+#ifndef SIMDJSON_IMPLEMENTATION_FALLBACK
+#define SIMDJSON_IMPLEMENTATION_FALLBACK 1
+#endif
+#if SIMDJSON_IMPLEMENTATION_FALLBACK
+#define SIMDJSON_BUILTIN_IMPLEMENTATION fallback
+#else
+#error "fallback architecture is disabled, but is compiled with flags that allow it to run on machines that require fallback."
+#endif
+#endif // SIMDJSON_BUILTIN_IMPLEMENTATION
 
 // We are going to use runtime dispatch.
 #ifdef SIMDJSON_IS_X86_64

--- a/include/simdjson/simdjson.h
+++ b/include/simdjson/simdjson.h
@@ -7,4 +7,4 @@
 
 #include "simdjson/compiler_check.h"
 #include "simdjson/error.h"
-#endif // SIMDJSON_H
+#endif // SIMDJSON_SIMDJSON_H

--- a/include/simdjson/westmere.h
+++ b/include/simdjson/westmere.h
@@ -17,6 +17,8 @@
 // The rest need to be inside the region
 //
 #include "simdjson/westmere/begin.h"
+
+// Declarations
 #include "simdjson/generic/dom_parser_implementation.h"
 #include "simdjson/westmere/bitmanipulation.h"
 #include "simdjson/westmere/bitmask.h"
@@ -25,6 +27,13 @@
 #include "simdjson/generic/atomparsing.h"
 #include "simdjson/westmere/stringparsing.h"
 #include "simdjson/westmere/numberparsing.h"
+#include "simdjson/generic/implementation_simdjson_result_base.h"
+#include "simdjson/generic/ondemand.h"
+
+// Inline definitions
+#include "simdjson/generic/implementation_simdjson_result_base-inl.h"
+#include "simdjson/generic/ondemand-inl.h"
+
 #include "simdjson/westmere/end.h"
 
 #endif // SIMDJSON_IMPLEMENTATION_WESTMERE


### PR DESCRIPTION
This makes it possible to use ondemand on any system, and selects the fastest ondemand implementation for the compile flags you passed. Pass `-march=native` and no matter where you are, it'll use the best available (westmere, haswell, or arm64--or if none of them is available, fallback).

* Selects the minimum implementation based on variables like __ARM_NEON, __SSE4_2__, __AVX2__, __PCLMUL__, etc.
* Sets `SIMDJSON_BUILTIN_IMPLEMENTATION` to the minimum.
* Aliases `simdjson::builtin` to `simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION`
* Turns lesser implementations off by default, because the program will never work on anything with a lesser instruction set anyway. This has the effect that, if you are on a haswell or neon machine, only one implementation will be turned on.

SAX is almost as slow as DOM when you run the fallback implementation.

I left Windows as an exercise for the reader ... I think. It'll probably use fallback there, I imagine.

With this merged, we should be able to reduce the kostya benchmark to have only one weird edge (`-march=native`).