### PR TITLE
Removing the dependency on C++ stream in the core library

### DIFF
--- a/include/simdjson/dom/array.h
+++ b/include/simdjson/dom/array.h
@@ -5,7 +5,6 @@
 #include "simdjson/error.h"
 #include "simdjson/internal/tape_ref.h"
 #include "simdjson/minify.h"
-#include <ostream>
 
 namespace simdjson {
 namespace dom {

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -7,7 +7,6 @@
 #include "simdjson/dom/element.h"
 #include "simdjson/internal/tape_ref.h"
 #include "simdjson/internal/jsonformatutils.h"
-#include <ostream>
 #include <cstring>
 
 namespace simdjson {

--- a/include/simdjson/dom/document.h
+++ b/include/simdjson/dom/document.h
@@ -4,7 +4,6 @@
 #include "simdjson/common_defs.h"
 #include "simdjson/minify.h"
 #include <memory>
-#include <ostream>
 
 namespace simdjson {
 namespace dom {

--- a/include/simdjson/dom/element-inl.h
+++ b/include/simdjson/dom/element-inl.h
@@ -417,7 +417,7 @@ inline std::ostream& operator<<(std::ostream& out, element_type type) {
 } // namespace dom
 
 template<>
-inline std::ostream& minifier<dom::element>::print(std::ostream& out) {
+inline string_stream& minifier<dom::element>::print(string_stream& out) {
   using tape_type=internal::tape_type;
   size_t depth = 0;
   constexpr size_t MAX_DEPTH = 16;
@@ -543,12 +543,12 @@ inline std::ostream& minifier<dom::element>::print(std::ostream& out) {
 #if SIMDJSON_EXCEPTIONS
 
 template<>
-simdjson_really_inline std::ostream& minifier<simdjson_result<dom::element>>::print(std::ostream& out) {
+simdjson_really_inline string_stream& minifier<simdjson_result<dom::element>>::print(string_stream& out) {
   if (value.error()) { throw simdjson_error(value.error()); }
   return out << minify<dom::element>(value.first);
 }
 
-simdjson_really_inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::element> &value) noexcept(false) {
+simdjson_really_inline string_stream& operator<<(string_stream& out, const simdjson_result<dom::element> &value) noexcept(false) {
   return out << minify<simdjson_result<dom::element>>(value);
 }
 #endif

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -5,7 +5,6 @@
 #include "simdjson/error.h"
 #include "simdjson/internal/tape_ref.h"
 #include "simdjson/minify.h"
-#include <ostream>
 
 namespace simdjson {
 namespace dom {

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -246,7 +246,7 @@ inline std::ostream& operator<<(std::ostream& out, const key_value_pair &value) 
 } // namespace dom
 
 template<>
-inline std::ostream& minifier<dom::object>::print(std::ostream& out) {
+inline string_stream& minifier<dom::object>::print(string_stream& out) {
   out << '{';
   auto pair = value.begin();
   auto end = value.end();
@@ -260,19 +260,19 @@ inline std::ostream& minifier<dom::object>::print(std::ostream& out) {
 }
 
 template<>
-inline std::ostream& minifier<dom::key_value_pair>::print(std::ostream& out) {
+inline string_stream& minifier<dom::key_value_pair>::print(string_stream& out) {
   return out << '"' << internal::escape_json_string(value.key) << "\":" << value.value;
 }
 
 #if SIMDJSON_EXCEPTIONS
 
 template<>
-inline std::ostream& minifier<simdjson_result<dom::object>>::print(std::ostream& out) {
+inline string_stream& minifier<simdjson_result<dom::object>>::print(string_stream& out) {
   if (value.error()) { throw simdjson_error(value.error()); }
   return out << minify<dom::object>(value.first);
 }
 
-inline std::ostream& operator<<(std::ostream& out, const simdjson_result<dom::object> &value) noexcept(false) {
+inline string_stream& operator<<(string_stream& out, const simdjson_result<dom::object> &value) noexcept(false) {
   return out << minify<simdjson_result<dom::object>>(value);
 }
 #endif // SIMDJSON_EXCEPTIONS

--- a/include/simdjson/dom/object.h
+++ b/include/simdjson/dom/object.h
@@ -5,7 +5,6 @@
 #include "simdjson/error.h"
 #include "simdjson/internal/tape_ref.h"
 #include "simdjson/minify.h"
-#include <ostream>
 
 namespace simdjson {
 namespace dom {

--- a/include/simdjson/dom/parsedjson_iterator.h
+++ b/include/simdjson/dom/parsedjson_iterator.h
@@ -5,7 +5,6 @@
 
 #include <cstring>
 #include <string>
-#include <iostream>
 #include <iterator>
 #include <limits>
 #include <stdexcept>

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -10,7 +10,6 @@
 #include "simdjson/padded_string.h"
 #include "simdjson/portability.h"
 #include <memory>
-#include <ostream>
 #include <string>
 
 namespace simdjson {

--- a/include/simdjson/fast_stream.h
+++ b/include/simdjson/fast_stream.h
@@ -1,0 +1,33 @@
+/**
+ * Locale-independent stream implementation for simdjson, optimized
+ * for performance.
+ */
+#include <cstdint>
+
+struct string_stream {
+    template <size_t size> 
+    void print(const char (&array)[size]) {
+      for(size_t i = 0; i < size; ++i) { *this << array[i]; };
+    }
+
+    string_stream & operator<<(char ) {
+        return *this;
+    }
+
+    string_stream & operator<<(uint64_t ) {
+        return *this;
+    }
+
+    string_stream & operator<<(int64_t ) {
+        return *this;        
+    }
+
+    string_stream & operator<<(double ) {
+        return *this;
+    }
+
+
+    std::string str() {
+        return std::string("nothing");
+    }
+};

--- a/include/simdjson/minify.h
+++ b/include/simdjson/minify.h
@@ -3,9 +3,8 @@
 
 #include "simdjson/common_defs.h"
 #include "simdjson/padded_string.h"
+#include "simdjson/fast_stream.h"
 #include <string>
-#include <ostream>
-#include <sstream>
 
 namespace simdjson {
 
@@ -47,12 +46,12 @@ public:
   /**
    * Minify JSON to a string.
    */
-  inline operator std::string() const noexcept { std::stringstream s; s << *this; return s.str(); }
+  inline operator std::string() const noexcept { string_stream s; s << *this; return s.str(); }
 
   /**
    * Minify JSON to an output stream.
    */
-  inline std::ostream& print(std::ostream& out);
+  inline string_stream& print(string_stream& out);
 private:
   const T &value;
 };


### PR DESCRIPTION
This is not an actual implementation, but I want to start discussing implementation issues.

@jkeiser implemented the "dom element" => string by leveraging C++ streams. 

There are three problems with this approach...

1. It is slow. C++ streams are surprisingly slow.
2. It is locale-sensitive. 
3. It is lossy. Outputting a float to a stream does not at all guarantee that it can be later reparsed exactly.

I would rather not blow up John's work but we need move to something better. My current idea is to create our own string_stream that would be optimized for speed and that would be locale-independent. I am thinking that this would allow us to minimize changes to the code base.

I am opening this for discussion.


Note that I'd like to fix this for 0.6.
