### PR TITLE
Some minor documentation fixes.

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -279,9 +279,8 @@ In some cases, you may have valid JSON strings that you do not wish to parse but
   // It does not have to be null-terminated.
   const char * some_string = "[ 1, 2, 3, 4] ";
   size_t length = strlen(some_string);
-  // Create a buffer to receive the minified string. Make sure that there is enough room,
-  // including some padding (simdjson::SIMDJSON_PADDING).
-  std::unique_ptr<char[]> buffer{new(std::nothrow) char[length]};
+  // Create a buffer to receive the minified string. Make sure that there is enough room (length bytes).  
+  std::unique_ptr<char[]> buffer{new char[length]};
   size_t new_length{}; // It will receive the minified length.
   auto error = simdjson::minify(some_string, length, buffer.get(), new_length);
   // The buffer variable now has "[1,2,3,4]" and new_length has value 9.

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -253,7 +253,7 @@ for (dom::key_value_pair field : object) {
 Minifying JSON strings without parsing
 ----------------------
 
-In some cases, you may have valid JSON strings that you do not wish to parse but that you wish to minify. That is, you wish to remove all unnecessary spaces. We have a fast function for this purpose (`simdjson::minify(const char * input, size_t length, const char * output, size_t& new_length)`). This function does not validate your content, and it does not parse it.  It is much faster than parsing the string and re-serializing it in minified form (`simdjson::minify(parser.parse())`). Usage is relatively simple. You must pass an input pointer with a length parameter, as well as an output pointer and an output length parameter (by reference). The output length parameter is not read, but written to. The output pointer should point to a valid memory region that is slightly overallocated (by `simdjson::SIMDJSON_PADDING`) compared to the original string length. The input pointer and input length are read, but not written to.
+In some cases, you may have valid JSON strings that you do not wish to parse but that you wish to minify. That is, you wish to remove all unnecessary spaces. We have a fast function for this purpose (`simdjson::minify(const char * input, size_t length, const char * output, size_t& new_length)`). This function does not validate your content, and it does not parse it.  It is much faster than parsing the string and re-serializing it in minified form (`simdjson::minify(parser.parse())`). Usage is relatively simple. You must pass an input pointer with a length parameter, as well as an output pointer and an output length parameter (by reference). The output length parameter is not read, but written to. The output pointer should point to a valid memory region that is as large as the original string length. The input pointer and input length are read, but not written to.
 
 
 ```
@@ -261,9 +261,8 @@ In some cases, you may have valid JSON strings that you do not wish to parse but
   // It does not have to be null-terminated.
   const char * some_string = "[ 1, 2, 3, 4] ";
   size_t length = strlen(some_string);
-  // Create a buffer to receive the minified string. Make sure that there is enough room,
-  // including some padding (simdjson::SIMDJSON_PADDING).
-  std::unique_ptr<char[]> buffer{new(std::nothrow) char[length + simdjson::SIMDJSON_PADDING]};
+  // Create a buffer to receive the minified string. Make sure that there is enough room (length bytes).
+  std::unique_ptr<char[]> buffer{new char[length]};
   size_t new_length{}; // It will receive the minified length.
   auto error = simdjson::minify(some_string, length, buffer.get(), new_length);
   // The buffer variable now has "[1,2,3,4]" and new_length has value 9.

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -262,7 +262,7 @@ SIMDJSON_POP_DISABLE_WARNINGS
 void minify() {
   const char * some_string = "[ 1, 2, 3, 4] ";
   size_t length = strlen(some_string);
-  std::unique_ptr<char[]> buffer{new(std::nothrow) char[length]};
+  std::unique_ptr<char[]> buffer{new char[length]};
   size_t new_length{};
   auto error = simdjson::minify(some_string, length, buffer.get(), new_length);
   if(error != simdjson::SUCCESS) {


### PR DESCRIPTION
The non-parsing minify no longer requires padding but some of our documentation gives the wrong impression.