### PR TITLE
Allow direct document iteration in ondemand

### DIFF
--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -64,10 +64,26 @@ simdjson_really_inline array array::started(json_iterator_ref &&iter) noexcept {
   return array(std::forward<json_iterator_ref>(iter));
 }
 
-simdjson_really_inline array_iterator array::begin() & noexcept {
-  return iter;
+//
+// For array_iterator
+//
+simdjson_really_inline json_iterator &array::get_iterator() noexcept {
+  return *iter;
 }
-simdjson_really_inline array_iterator array::end() & noexcept {
+simdjson_really_inline json_iterator_ref array::borrow_iterator() noexcept {
+  return iter.borrow();
+}
+simdjson_really_inline bool array::is_iteration_finished() const noexcept {
+  return iter.is_alive();
+}
+simdjson_really_inline void array::iteration_finished() noexcept {
+  iter.release();
+}
+
+simdjson_really_inline array_iterator<array> array::begin() & noexcept {
+  return *this;
+}
+simdjson_really_inline array_iterator<array> array::end() & noexcept {
   return {};
 }
 
@@ -92,11 +108,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::begin() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::end() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::end() & noexcept {
   if (error()) { return error(); }
   return first.end();
 }

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -33,13 +33,13 @@ public:
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline array_iterator begin() & noexcept;
+  simdjson_really_inline array_iterator<array> begin() & noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline array_iterator end() & noexcept;
+  simdjson_really_inline array_iterator<array> end() & noexcept;
 
 protected:
   /**
@@ -69,6 +69,14 @@ protected:
    */
   simdjson_really_inline array(json_iterator_ref &&iter) noexcept;
 
+  //
+  // For array_iterator
+  //
+  simdjson_really_inline json_iterator &get_iterator() noexcept;
+  simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
+  simdjson_really_inline bool is_iteration_finished() const noexcept;
+  simdjson_really_inline void iteration_finished() noexcept;
+
   /**
    * Iterator marking current position.
    * 
@@ -79,6 +87,7 @@ protected:
   friend class value;
   friend struct simdjson_result<value>;
   friend struct simdjson_result<array>;
+  friend class array_iterator<array>;
 };
 
 } // namespace ondemand
@@ -97,8 +106,8 @@ public:
   simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> begin() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> end() & noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/array_iterator.h
+++ b/include/simdjson/generic/ondemand/array_iterator.h
@@ -16,12 +16,13 @@ class document;
  * - * must be called exactly once per element.
  * - ++ must be called exactly once in between each * (*, ++, *, ++, * ...)
  */
+template<typename T>
 class array_iterator {
 public:
   /** Create a new, invalid array iterator. */
   simdjson_really_inline array_iterator() noexcept = default;
-  simdjson_really_inline array_iterator(const array_iterator &a) noexcept = default;
-  simdjson_really_inline array_iterator &operator=(const array_iterator &a) noexcept = default;
+  simdjson_really_inline array_iterator(const array_iterator<T> &a) noexcept = default;
+  simdjson_really_inline array_iterator<T> &operator=(const array_iterator<T> &a) noexcept = default;
 
   //
   // Iterator interface
@@ -40,7 +41,7 @@ public:
    * 
    * @return true if there are no more elements in the JSON array.
    */
-  simdjson_really_inline bool operator==(const array_iterator &) noexcept;
+  simdjson_really_inline bool operator==(const array_iterator<T> &) noexcept;
   /**
    * Check if there are more elements in the JSON array.
    *
@@ -48,22 +49,22 @@ public:
    * 
    * @return true if there are more elements in the JSON array.
    */
-  simdjson_really_inline bool operator!=(const array_iterator &) noexcept;
+  simdjson_really_inline bool operator!=(const array_iterator<T> &) noexcept;
   /**
    * Move to the next element.
    * 
    * Part of the std::iterator interface.
    */
-  simdjson_really_inline array_iterator &operator++() noexcept;
+  simdjson_really_inline array_iterator<T> &operator++() noexcept;
 
 private:
-  json_iterator_ref *iter{};
+  T *iter{};
 
-  simdjson_really_inline array_iterator(json_iterator_ref &iter) noexcept;
+  simdjson_really_inline array_iterator(T &iter) noexcept;
 
   friend class array;
   friend class value;
-  friend struct simdjson_result<array_iterator>;
+  friend struct simdjson_result<array_iterator<T>>;
 };
 
 } // namespace ondemand
@@ -72,14 +73,14 @@ private:
 
 namespace simdjson {
 
-template<>
-struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> {
+template<typename T>
+struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array_iterator &&value) noexcept; ///< @private
+  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T> &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
 
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &&a) noexcept = default;
+  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   //
@@ -87,9 +88,9 @@ public:
   //
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) noexcept;
-  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &operator++() noexcept;
+  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) noexcept;
+  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &operator++() noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -92,6 +92,22 @@ simdjson_really_inline simdjson_result<value> document::operator[](const char *k
   return get_object()[key];
 }
 
+//
+// For array_iterator
+//
+simdjson_really_inline json_iterator &document::get_iterator() noexcept {
+  return iter;
+}
+simdjson_really_inline json_iterator_ref document::borrow_iterator() noexcept {
+  return iter.borrow();
+}
+simdjson_really_inline bool document::is_iteration_finished() const noexcept {
+  return json;
+}
+simdjson_really_inline void document::iteration_finished() noexcept {
+  json = nullptr;
+}
+
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -171,9 +171,19 @@ public:
   simdjson_really_inline operator bool() noexcept(false);
 #endif
 
-  // We don't have an array_iterator that can point at an owned json_iterator
-  // simdjson_really_inline simdjson_result<array::iterator> begin() & noexcept;
-  // simdjson_really_inline simdjson_result<array::iterator> end() & noexcept;
+  /**
+   * Begin array iteration.
+   *
+   * Part of the std::iterable interface.
+   */
+  simdjson_really_inline array_iterator<document> begin() & noexcept;
+  /**
+   * Sentinel representing the end of the array.
+   *
+   * Part of the std::iterable interface.
+   */
+  simdjson_really_inline array_iterator<document> end() & noexcept;
+
   /**
    * Look up a field by name on an object.
    *
@@ -209,10 +219,21 @@ protected:
   template<typename T>
   simdjson_result<T> consume_if_success(simdjson_result<T> &&result) noexcept;
 
+  simdjson_really_inline void assert_at_start() const noexcept;
+
+  //
+  // For array_iterator
+  //
+  simdjson_really_inline json_iterator &get_iterator() noexcept;
+  simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
+  simdjson_really_inline bool is_iteration_finished() const noexcept;
+  simdjson_really_inline void iteration_finished() noexcept;
+
+  //
+  // Fields
+  //
   json_iterator iter{}; ///< Current position in the document
   const uint8_t *json{}; ///< JSON for the value in the document (nullptr if value has been consumed)
-
-  simdjson_really_inline void assert_at_start() const noexcept;
 
   friend struct simdjson_result<document>;
   friend class value;
@@ -260,8 +281,8 @@ public:
   simdjson_really_inline operator bool() noexcept(false);
 #endif
 
-  // simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> begin() & noexcept;
-  // simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array::iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::document>> begin() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::document>> end() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
 };

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -138,15 +138,15 @@ simdjson_really_inline value::operator bool() && noexcept(false) {
 }
 #endif
 
-simdjson_really_inline simdjson_result<array_iterator> value::begin() & noexcept {
+simdjson_really_inline simdjson_result<array_iterator<value>> value::begin() & noexcept {
   if (*json != '[') {
     log_error("not an array");
     return INCORRECT_TYPE;
   }
   if (!iter->started_array()) { iter.release(); }
-  return array_iterator(iter);
+  return array_iterator(*this);
 }
-simdjson_really_inline simdjson_result<array_iterator> value::end() & noexcept {
+simdjson_really_inline simdjson_result<array_iterator<value>> value::end() & noexcept {
   return {};
 }
 simdjson_really_inline simdjson_result<value> value::operator[](std::string_view key) && noexcept {
@@ -163,6 +163,22 @@ simdjson_really_inline void value::log_value(const char *type) const noexcept {
 simdjson_really_inline void value::log_error(const char *message) const noexcept {
   char json_char[]{char(json[0]), '\0'};
   logger::log_error(*iter, message, json_char);
+}
+
+//
+// For array_iterator
+//
+simdjson_really_inline json_iterator &value::get_iterator() noexcept {
+  return *iter;
+}
+simdjson_really_inline json_iterator_ref value::borrow_iterator() noexcept {
+  return iter.borrow();
+}
+simdjson_really_inline bool value::is_iteration_finished() const noexcept {
+  return iter.is_alive();
+}
+simdjson_really_inline void value::iteration_finished() noexcept {
+  iter.release();
 }
 
 } // namespace ondemand
@@ -186,11 +202,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::begin() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::end() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::end() & noexcept {
   if (error()) { return error(); }
   return {};
 }

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -9,7 +9,6 @@ class document;
 class field;
 class object;
 class raw_json_string;
-class array_iterator;
 
 /**
  * An ephemeral JSON value returned during iteration.
@@ -180,13 +179,13 @@ public:
    * 
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator<value>> begin() & noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator<value>> end() & noexcept;
   /**
    * Look up a field by name on an object.
    *
@@ -233,11 +232,19 @@ protected:
   simdjson_really_inline void log_value(const char *type) const noexcept;
   simdjson_really_inline void log_error(const char *message) const noexcept;
 
+  //
+  // For array_iterator
+  //
+  simdjson_really_inline json_iterator &get_iterator() noexcept;
+  simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
+  simdjson_really_inline bool is_iteration_finished() const noexcept;
+  simdjson_really_inline void iteration_finished() noexcept;
+
   json_iterator_ref iter{};
   const uint8_t *json{}; // The JSON text of the value
 
   friend class document;
-  friend class array_iterator;
+  template<typename T> friend class array_iterator;
   friend class field;
   friend class object;
   friend struct simdjson_result<value>;
@@ -283,8 +290,8 @@ public:
   simdjson_really_inline operator bool() && noexcept(false);
 #endif
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> begin() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> end() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) && noexcept;
 };


### PR DESCRIPTION
This allows you to do `for (auto val : doc)` instead of `for (auto elem : doc.get_array())`. It's a small thing, but iterating over top-level arrays is common enough that I didn't want people to mis-learn how to use the API (you can say `for (auto elem : val)` anywhere else _except_ document).

The reason it was hard is that document *owns* the iterator, while value and array *reference* the iterator. The array_iterator marks the iteration as finished by releasing the iterator, but you can't do that with an owned iterator. This fixes the problem by having array_iterator<value>, array_iterator<array>, and array_iterator<document>, which call `finished_iterating()` on the value/array/document when it's finished. document just stores that state differently.

This is the only API design wart I know of, though there are still some bugs and safety issues I have plans to address.