### PR TITLE
Allow reuse of value to try multiple types

### DIFF
--- a/benchmark/kostya/iter.h
+++ b/benchmark/kostya/iter.h
@@ -22,12 +22,12 @@ private:
 
   simdjson_really_inline simdjson_result<double> first_double(ondemand::json_iterator &iter, const char *key) {
     if (!iter.start_object() || ondemand::raw_json_string(iter.field_key()) != key || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
   simdjson_really_inline simdjson_result<double> next_double(ondemand::json_iterator &iter, const char *key) {
     if (!iter.has_next_field() || ondemand::raw_json_string(iter.field_key()) != key || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
 };
@@ -76,11 +76,11 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
   if (!iter.start_array()) { return false; }
   do {
     if (!iter.start_object()   || !iter.find_field_raw("x")) { return false; }
-    sum.x += iter.get_double();
+    sum.x += iter.consume_double();
     if (!iter.has_next_field() || !iter.find_field_raw("y")) { return false; }
-    sum.y +=  iter.get_double();
+    sum.y +=  iter.consume_double();
     if (!iter.has_next_field() || !iter.find_field_raw("z")) { return false; }
-    sum.z +=  iter.get_double();
+    sum.z +=  iter.consume_double();
     if (iter.skip_container()) { return false; } // Skip the rest of the coordinates object
     count++;
   } while (iter.has_next_element());

--- a/benchmark/largerandom/iter.h
+++ b/benchmark/largerandom/iter.h
@@ -22,12 +22,12 @@ private:
 
   simdjson_really_inline double first_double(ondemand::json_iterator &iter) {
     if (iter.start_object().error() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
   simdjson_really_inline double next_double(ondemand::json_iterator &iter) {
     if (!iter.has_next_field() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
 };
@@ -72,11 +72,11 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
   if (!iter.start_array()) { return false; }
   do {
     if (!iter.start_object()   || iter.field_key().value() != "x" || iter.field_value()) { return false; }
-    sum.x += iter.get_double();
+    sum.x += iter.consume_double();
     if (!iter.has_next_field() || iter.field_key().value() != "y" || iter.field_value()) { return false; }
-    sum.y +=  iter.get_double();
+    sum.y +=  iter.consume_double();
     if (!iter.has_next_field() || iter.field_key().value() != "z" || iter.field_value()) { return false; }
-    sum.z +=  iter.get_double();
+    sum.z +=  iter.consume_double();
     if (*iter.advance() != '}') { return false; }
     count++;
   } while (iter.has_next_element());

--- a/benchmark/partial_tweets/iter.h
+++ b/benchmark/partial_tweets/iter.h
@@ -47,35 +47,35 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
     tweet tweet;
 
     if (!iter.start_object()   || !iter.find_field_raw("created_at")) { return false; }
-    tweet.created_at = iter.get_raw_json_string().value().unescape(iter);
+    tweet.created_at = iter.consume_raw_json_string().value().unescape(iter);
 
     if (!iter.has_next_field() || !iter.find_field_raw("id")) { return false; }
-    tweet.id = iter.get_uint64();
+    tweet.id = iter.consume_uint64();
 
     if (!iter.has_next_field() || !iter.find_field_raw("text")) { return false; }
-    tweet.text = iter.get_raw_json_string().value().unescape(iter);
+    tweet.text = iter.consume_raw_json_string().value().unescape(iter);
 
     if (!iter.has_next_field() || !iter.find_field_raw("in_reply_to_status_id")) { return false; }
     if (!iter.is_null()) {
-      tweet.in_reply_to_status_id = iter.get_uint64();
+      tweet.in_reply_to_status_id = iter.consume_uint64();
     }
 
     if (!iter.has_next_field() || !iter.find_field_raw("user")) { return false; }
     {
       if (!iter.start_object()   || !iter.find_field_raw("id")) { return false; }
-      tweet.user.id = iter.get_uint64();
+      tweet.user.id = iter.consume_uint64();
 
       if (!iter.has_next_field() || !iter.find_field_raw("screen_name")) { return false; }
-      tweet.user.screen_name = iter.get_raw_json_string().value().unescape(iter);
+      tweet.user.screen_name = iter.consume_raw_json_string().value().unescape(iter);
 
       if (iter.skip_container()) { return false; } // Skip the rest of the user object
     }
 
     if (!iter.has_next_field() || !iter.find_field_raw("retweet_count")) { return false; }
-    tweet.retweet_count = iter.get_uint64();
+    tweet.retweet_count = iter.consume_uint64();
 
     if (!iter.has_next_field() || !iter.find_field_raw("favorite_count")) { return false; }
-    tweet.favorite_count = iter.get_uint64();
+    tweet.favorite_count = iter.consume_uint64();
 
     tweets.push_back(tweet);
 

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -41,15 +41,15 @@ simdjson_really_inline simdjson_result<object> document::get_object() & noexcept
 }
 simdjson_really_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_uint64() );
+  return consume_if_success( iter.parse_uint64(json) );
 }
 simdjson_really_inline simdjson_result<int64_t> document::get_int64() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_int64() );
+  return consume_if_success( iter.parse_root_int64(json) );
 }
 simdjson_really_inline simdjson_result<double> document::get_double() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_double() );
+  return consume_if_success( iter.parse_root_double(json) );
 }
 simdjson_really_inline simdjson_result<std::string_view> document::get_string() & noexcept {
   return consume_if_success( as_value().get_string() );
@@ -59,11 +59,11 @@ simdjson_really_inline simdjson_result<raw_json_string> document::get_raw_json_s
 }
 simdjson_really_inline simdjson_result<bool> document::get_bool() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_bool() );
+  return consume_if_success( iter.parse_root_bool(json) );
 }
 simdjson_really_inline bool document::is_null() noexcept {
   assert_at_start();
-  if (iter.root_is_null()) { json = nullptr; return true; }
+  if (iter.root_is_null(json)) { json = nullptr; return true; }
   return false;
 }
 

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -33,6 +33,14 @@ public:
   /**
    * Check for an opening { and start an object iteration.
    *
+   * @param json A pointer to the potential {
+   * @returns Whether the object had any fields (returns false for empty).
+   * @error INCORRECT_TYPE if there is no opening {
+   */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> start_object(const uint8_t *json) noexcept;
+  /**
+   * Check for an opening { and start an object iteration.
+   *
    * @returns Whether the object had any fields (returns false for empty).
    * @error INCORRECT_TYPE if there is no opening {
    */
@@ -82,6 +90,14 @@ public:
   /**
    * Check for an opening [ and start an array iteration.
    *
+   * @param json A pointer to the potential [.
+   * @returns Whether the array had any elements (returns false for empty).
+   * @error INCORRECT_TYPE If there is no [.
+   */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> start_array(const uint8_t *json) noexcept;
+  /**
+   * Check for an opening [ and start an array iteration.
+   *
    * @returns Whether the array had any elements (returns false for empty).
    * @error INCORRECT_TYPE If there is no [.
    */
@@ -107,18 +123,31 @@ public:
    */
   SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> has_next_element() noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<std::string_view> parse_string(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<std::string_view> consume_string() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<raw_json_string> parse_raw_json_string(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<raw_json_string> consume_raw_json_string() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> parse_uint64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> consume_uint64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> parse_int64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> consume_int64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> parse_double(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> consume_double() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> consume_bool() noexcept;
+  simdjson_really_inline bool is_null(const uint8_t *json) noexcept;
   simdjson_really_inline bool is_null() noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> get_root_uint64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> get_root_int64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> get_root_double() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> get_root_bool() noexcept;
-  simdjson_really_inline bool root_is_null() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> parse_root_uint64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> consume_root_uint64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> parse_root_int64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> consume_root_int64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> consume_root_double() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> parse_root_bool(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> consume_root_bool() noexcept;
+  simdjson_really_inline bool root_is_null(const uint8_t *json) noexcept;
+  simdjson_really_inline bool root_is_null() & noexcept;
 
   /**
    * Skips a JSON value, whether it is a scalar, array or object.
@@ -185,7 +214,7 @@ protected:
 
   simdjson_really_inline json_iterator(ondemand::parser *parser) noexcept;
   template<int N>
-  SIMDJSON_WARN_UNUSED simdjson_really_inline bool advance_to_buffer(uint8_t (&buf)[N]) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline bool copy_to_buffer(const uint8_t *json, uint8_t (&buf)[N]) noexcept;
 
   simdjson_really_inline json_iterator_ref borrow() noexcept;
 

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -44,4 +44,17 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_js
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>(error) {}
 
+simdjson_really_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::raw() const noexcept {
+  if (error()) { return error(); }
+  return first.raw();
+}
+simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::unescape(uint8_t *&dst) const noexcept {
+  if (error()) { return error(); }
+  return first.unescape(dst);
+}
+simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept {
+  if (error()) { return error(); }
+  return first.unescape(iter);
+}
+
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -87,6 +87,10 @@ public:
   simdjson_really_inline simdjson_result() noexcept = default;
   simdjson_really_inline simdjson_result(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> &a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
+
+  simdjson_really_inline simdjson_result<const char *> raw() const noexcept;
+  simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> unescape(uint8_t *&dst) const noexcept;
+  simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -30,110 +30,74 @@ simdjson_really_inline value value::start(json_iterator_ref &&iter) noexcept {
   return { std::forward<json_iterator_ref>(iter), iter->advance() };
 }
 
-simdjson_really_inline simdjson_result<array> value::get_array() && noexcept {
-  if (*json != '[') {
-    log_error("not an array");
-    iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-    return INCORRECT_TYPE;
-  }
-  return array::started(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline void value::consume() noexcept {
+  iter.release();
 }
-simdjson_really_inline simdjson_result<object> value::get_object() && noexcept {
-  if (*json != '{') {
-    log_error("not an object");
-    iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-    return INCORRECT_TYPE;
-  }
-  return object::started(std::forward<json_iterator_ref>(iter));
+template<typename T>
+simdjson_really_inline simdjson_result<T> value::consume_if_success(simdjson_result<T> &&result) noexcept {
+  if (!result.error()) { consume(); }
+  return std::forward<simdjson_result<T>>(result);
 }
-simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() && noexcept {
-  log_value("string");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  if (*json != '"') { log_error("not a string"); return INCORRECT_TYPE; }
-  return raw_json_string{&json[1]};
+
+simdjson_really_inline simdjson_result<array> value::get_array() noexcept {
+  bool is_empty;
+  SIMDJSON_TRY( iter->start_array(json).get(is_empty) );
+  if (is_empty) { iter.release(); }
+  return array(std::move(iter));
 }
-simdjson_really_inline simdjson_result<std::string_view> value::get_string() && noexcept {
-  log_value("string");
-  if (*json != '"') {
-    log_error("not a string");
-    iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-    return INCORRECT_TYPE;
-  }
-  auto result = raw_json_string{&json[1]}.unescape(iter->current_string_buf_loc);
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  return result;
+simdjson_really_inline simdjson_result<object> value::get_object() noexcept {
+  bool is_empty;
+  SIMDJSON_TRY( iter->start_object(json).get(is_empty) );
+  if (is_empty) { iter.release(); }
+  return object(std::move(iter));
 }
-simdjson_really_inline simdjson_result<double> value::get_double() && noexcept {
-  log_value("double");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  double result;
-  error_code error;
-  if ((error = numberparsing::parse_double(json).get(result))) { log_error("not a double"); return error; }
-  return result;
+simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() noexcept {
+  return consume_if_success( iter->parse_raw_json_string(json) );
 }
-simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() && noexcept {
-  log_value("unsigned");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  uint64_t result;
-  error_code error;
-  if ((error = numberparsing::parse_unsigned(json).get(result))) { log_error("not a unsigned integer"); return error; }
-  return result;
+simdjson_really_inline simdjson_result<std::string_view> value::get_string() noexcept {
+  return consume_if_success( iter->parse_string(json) );
 }
-simdjson_really_inline simdjson_result<int64_t> value::get_int64() && noexcept {
-  log_value("integer");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  int64_t result;
-  error_code error;
-  if ((error = numberparsing::parse_integer(json).get(result))) { log_error("not an integer"); return error; }
-  return result;
+simdjson_really_inline simdjson_result<double> value::get_double() noexcept {
+  return consume_if_success( iter->parse_double(json) );
 }
-simdjson_really_inline simdjson_result<bool> value::get_bool() && noexcept {
-  log_value("bool");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  auto not_true = atomparsing::str4ncmp(json, "true");
-  auto not_false = atomparsing::str4ncmp(json, "fals") | (json[4] ^ 'e');
-  bool error = (not_true && not_false) || jsoncharutils::is_not_structural_or_whitespace(json[not_true ? 5 : 4]);
-  if (error) { log_error("not a boolean"); return INCORRECT_TYPE; }
-  return simdjson_result<bool>(!not_true, error ? INCORRECT_TYPE : SUCCESS);
+simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() noexcept {
+  return consume_if_success( iter->parse_uint64(json) );
 }
-simdjson_really_inline bool value::is_null() & noexcept {
-  log_value("null");
-  // Since it's a *reference*, we may want to check something other than is_null() if it isn't null,
-  // so we don't release the iterator unless it is actually null
-  if (atomparsing::str4ncmp(json, "null")) { return false; }
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  return true;
+simdjson_really_inline simdjson_result<int64_t> value::get_int64() noexcept {
+  return consume_if_success( iter->parse_int64(json) );
 }
-simdjson_really_inline bool value::is_null() && noexcept {
-  log_value("null");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  if (atomparsing::str4ncmp(json, "null")) { return false; }
+simdjson_really_inline simdjson_result<bool> value::get_bool() noexcept {
+  return consume_if_success( iter->parse_bool(json) );
+}
+simdjson_really_inline bool value::is_null() noexcept {
+  if (!iter->is_null(json)) { return false; }
+  consume();
   return true;
 }
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline value::operator array() && noexcept(false) {
+simdjson_really_inline value::operator array() noexcept(false) {
   return std::forward<value>(*this).get_array();
 }
-simdjson_really_inline value::operator object() && noexcept(false) {
+simdjson_really_inline value::operator object() noexcept(false) {
   return std::forward<value>(*this).get_object();
 }
-simdjson_really_inline value::operator uint64_t() && noexcept(false) {
+simdjson_really_inline value::operator uint64_t() noexcept(false) {
   return std::forward<value>(*this).get_uint64();
 }
-simdjson_really_inline value::operator int64_t() && noexcept(false) {
+simdjson_really_inline value::operator int64_t() noexcept(false) {
   return std::forward<value>(*this).get_int64();
 }
-simdjson_really_inline value::operator double() && noexcept(false) {
+simdjson_really_inline value::operator double() noexcept(false) {
   return std::forward<value>(*this).get_double();
 }
-simdjson_really_inline value::operator std::string_view() && noexcept(false) {
+simdjson_really_inline value::operator std::string_view() noexcept(false) {
   return std::forward<value>(*this).get_string();
 }
-simdjson_really_inline value::operator raw_json_string() && noexcept(false) {
+simdjson_really_inline value::operator raw_json_string() noexcept(false) {
   return std::forward<value>(*this).get_raw_json_string();
 }
-simdjson_really_inline value::operator bool() && noexcept(false) {
+simdjson_really_inline value::operator bool() noexcept(false) {
   return std::forward<value>(*this).get_bool();
 }
 #endif
@@ -219,77 +183,73 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first)[key];
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() && noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_array();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() && noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_object();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() && noexcept {
+simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_uint64();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() && noexcept {
+simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_int64();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() && noexcept {
+simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_double();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() && noexcept {
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() && noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() && noexcept {
+simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_bool();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() & noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() noexcept {
   if (error()) { return false; }
   return first.is_null();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() && noexcept {
-  if (error()) { return false; }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).is_null();
-}
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -38,35 +38,35 @@ public:
    * @returns An object that can be used to iterate the array.
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array> get_array() && noexcept;
+  simdjson_really_inline simdjson_result<array> get_array() noexcept;
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    */
-  simdjson_really_inline simdjson_result<object> get_object() && noexcept;
+  simdjson_really_inline simdjson_result<object> get_object() noexcept;
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
   /**
    * Cast this JSON value to a string.
    * 
@@ -78,7 +78,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
   /**
    * Cast this JSON value to a raw_json_string.
    * 
@@ -87,24 +87,20 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() && noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @returns INCORRECT_TYPE if the JSON value is not true or false.
    */
-  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
   /**
    * Checks if this JSON value is null.
    * 
    * @returns Whether the value is null.
    */
-  simdjson_really_inline bool is_null() & noexcept;
-  /**
-   * @overload bool is_null() & noexcept
-   */
-  simdjson_really_inline bool is_null() && noexcept;
+  simdjson_really_inline bool is_null() noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -113,35 +109,35 @@ public:
    * @returns An object that can be used to iterate the array.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an array.
    */
-  simdjson_really_inline operator array() && noexcept(false);
+  simdjson_really_inline operator array() noexcept(false);
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an object.
    */
-  simdjson_really_inline operator object() && noexcept(false);
+  simdjson_really_inline operator object() noexcept(false);
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline operator uint64_t() && noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline operator int64_t() && noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline operator double() && noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
   /**
    * Cast this JSON value to a string.
    * 
@@ -153,7 +149,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator std::string_view() && noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
   /**
    * Cast this JSON value to a raw_json_string.
    * 
@@ -162,14 +158,14 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator raw_json_string() && noexcept(false);
+  simdjson_really_inline operator raw_json_string() noexcept(false);
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not true or false.
    */
-  simdjson_really_inline operator bool() && noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
 #endif
 
   /**
@@ -239,6 +235,9 @@ protected:
   simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
   simdjson_really_inline bool is_iteration_finished() const noexcept;
   simdjson_really_inline void iteration_finished() noexcept;
+  simdjson_really_inline void consume() noexcept;
+  template<typename T>
+  simdjson_really_inline simdjson_result<T> consume_if_success(simdjson_result<T> &&result) noexcept;
 
   json_iterator_ref iter{};
   const uint8_t *json{}; // The JSON text of the value
@@ -268,26 +267,25 @@ public:
   simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() && noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() && noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
-  simdjson_really_inline bool is_null() & noexcept;
-  simdjson_really_inline bool is_null() && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false);
-  simdjson_really_inline operator uint64_t() && noexcept(false);
-  simdjson_really_inline operator int64_t() && noexcept(false);
-  simdjson_really_inline operator double() && noexcept(false);
-  simdjson_really_inline operator std::string_view() && noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false);
-  simdjson_really_inline operator bool() && noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
 #endif
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> begin() & noexcept;


### PR DESCRIPTION
This makes document and value more useful, allowing you to first try to parse a value as an array, and then as an object.

I believe it also fixes some issues that were leading to test failures (I'll check that separately, though ...)

## Performance

I absolutely cannot say *why*, but this version actually fulfills what I consider to be the true promise of ondemand: the reduction of branches. It brings the number of branches down from 3500 to 500, increasing speed to 6GB/s!!!! (It's still checking the results against the DOM, so as long as that check is still working, it may still be accurate.)

@lemire If you would be so kind, I'd love some confirmation / checks on this result. I'm having trouble believing it, as much as I want to. At the least, I would expect the branch predictor to suck at the string or number parsing loops. Could the branches really have been somewhere else?

### Haswell gcc10.2 (Skylake)

Compiled with `cmake SIMDJSON_IMPLEMENTATION=haswell CMAKE_CXX_FLAGS="-march=native" ..`

```c++
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PartialTweets<OnDemand>      110985 ns       110984 ns         6294              538           6.13556G               0         26.41k    380.178k             0.602009          9.71562k       3.69367G          1.38172M                    2.18794                      3.6344                  0     568.854   631.515k       5.29934G/s  0.0255799   26.5123k   381.003k        0.603317   9.01028k/s 3.43295G/s     1.38172M               2.18794                3.62653          0              0/s [best: throughput=  6.14 GB/s doc_throughput=  9715 docs/s instructions=     1381719 cycles=      380178 branch_miss=     538 cache_miss=       0 cache_ref=     26410 items=         0 avg_time=    103218 ns]
PartialTweets<Iter>          389673 ns       389671 ns         1794           3.046k           1.66902G               0        54.857k    1.39693M              2.21203          2.64289k       3.69193G          4.41354M                    6.98882                     3.15946           264.289k    3.22385k   631.515k       1.50933G/s   0.269788   54.9803k   1.40863M         2.23056   2.56627k/s 3.61493G/s     4.41354M               6.98882                3.13321        100       256.627k/s [best: throughput=  1.67 GB/s doc_throughput=  2642 docs/s instructions=     4413544 cycles=     1396930 branch_miss=    3046 cache_miss=       0 cache_ref=     54857 items=       100 avg_time=    381762 ns]
PartialTweets<Dom>           270718 ns       270718 ns         2584           3.618k           2.41985G               0        87.043k    963.578k              1.52582          3.83181k       3.69225G          2.91909M                    4.62236                     3.02943           383.181k    3.71913k   631.515k       2.17253G/s  0.0731424   87.1628k    969.03k         1.53445   3.69387k/s 3.57948G/s     2.91909M               4.62236                3.01238        100       369.387k/s [best: throughput=  2.42 GB/s doc_throughput=  3831 docs/s instructions=     2919092 cycles=      963578 branch_miss=    3618 cache_miss=       0 cache_ref=     87043 items=       100 avg_time=    262593 ns]
Creating a source file spanning 44921 KB 
LargeRandom<Dom>           87772101 ns     87771741 ns            8         908.793k           524.903M        11.0279M       15.2321M    323.242M               7.0272           11.4112        3.6886G          970.316M                    21.0944                     3.00182           11.4112M    908.714k   45.9988M       499.795M/s   11.0372M   15.2312M   323.728M         7.03774    11.3932/s 3.68829G/s     970.316M               21.0944                2.99732      1000k       11.3932M/s [best: throughput=  0.52 GB/s doc_throughput=    11 docs/s instructions=   970315577 cycles=   323242407 branch_miss=  908793 cache_miss=11027918 cache_ref=  15232088 items=   1000000 avg_time=  87758665 ns]
LargeRandomSum<Dom>        87310215 ns     87309740 ns            8         908.769k            527.24M        10.3713M       14.3767M    321.855M              6.99702           11.4621       3.68911G          974.316M                    21.1813                     3.02719           11.4621M    909.225k   45.9988M       502.439M/s   10.4238M   14.3788M   322.043M         7.00113    11.4535/s 3.68851G/s     974.316M               21.1813                3.02542      1000k       11.4535M/s [best: throughput=  0.53 GB/s doc_throughput=    11 docs/s instructions=   974315577 cycles=   321854511 branch_miss=  908769 cache_miss=10371311 cache_ref=  14376702 items=   1000000 avg_time=  87297241 ns]
LargeRandom<OnDemand>      13336425 ns     13336558 ns           52         283.171k           3.45602G        2.51136M       3.54749M    49.1038M               1.0675           75.1329       3.68931G          144.703M                     3.1458                     2.94688                  0    283.737k   45.9988M        3.2122G/s   2.52584M   3.54784M   49.1557M         1.06863    74.9819/s 3.68578G/s     144.703M                3.1458                2.94376          0              0/s [best: throughput=  3.46 GB/s doc_throughput=    75 docs/s instructions=   144702733 cycles=    49103777 branch_miss=  283171 cache_miss= 2511357 cache_ref=   3547489 items=         0 avg_time=  13325088 ns]
LargeRandomSum<OnDemand>   13329033 ns     13328388 ns           52         282.575k           3.45963G        2.50835M       3.54703M     49.052M              1.06638           75.2113       3.68927G          144.703M                     3.1458                     2.94999                  0    283.593k   45.9988M       3.21417G/s   2.52355M   3.54794M   49.1235M         1.06793    75.0278/s 3.68563G/s     144.703M                3.1458                2.94569          0              0/s [best: throughput=  3.46 GB/s doc_throughput=    75 docs/s instructions=   144702729 cycles=    49052009 branch_miss=  282575 cache_miss= 2508346 cache_ref=   3547030 items=         0 avg_time=  13317900 ns]
LargeRandom<Iter>          54251484 ns     54251078 ns           13         880.429k           850.609M        5.59487M       7.89165M    199.499M              4.33706            18.492       3.68914G          570.695M                    12.4067                     2.86063            18.492M    879.324k   45.9988M       808.608M/s   5.66611M   7.89564M   200.095M            4.35    18.4328/s 3.68831G/s     570.695M               12.4067                2.85212      1000k       18.4328M/s [best: throughput=  0.85 GB/s doc_throughput=    18 docs/s instructions=   570694598 cycles=   199499403 branch_miss=  880429 cache_miss= 5594870 cache_ref=   7891653 items=   1000000 avg_time=  54240015 ns]
LargeRandomSum<Iter>       55490086 ns     55489847 ns           13         883.247k           832.238M        5.13275M       7.05436M    203.882M              4.43234           18.0926       3.68876G          581.696M                    12.6459                      2.8531           18.0926M    881.331k   45.9988M       790.556M/s   5.08156M   7.04886M   204.656M         4.44916    18.0213/s 3.68817G/s     581.696M               12.6459                2.84231      1000k       18.0213M/s [best: throughput=  0.83 GB/s doc_throughput=    18 docs/s instructions=   581696111 cycles=   203882369 branch_miss=  883247 cache_miss= 5132749 cache_ref=   7054356 items=   1000000 avg_time=  55478018 ns]
Creating a source file spanning 134087 KB 
Kostya<Dom>                85336266 ns     85337119 ns            8         456.934k           1.61094G        15.7915M       22.1309M    314.421M              2.28995           11.7325       3.68896G          936.468M                    6.82035                     2.97838           6.15123M    453.718k   137.305M       1.49847G/s   15.8495M   22.1507M   314.739M         2.29226    11.7182/s 3.68819G/s     936.468M               6.82035                2.97538   524.288k       6.14373M/s [best: throughput=  1.61 GB/s doc_throughput=    11 docs/s instructions=   936467834 cycles=   314421352 branch_miss=  456934 cache_miss=15791535 cache_ref=  22130927 items=    524288 avg_time=  85323257 ns]
KostyaSum<Dom>             84917472 ns     84916847 ns            8          452.23k           1.62079G        15.5299M       21.7797M    312.525M              2.27614           11.8043       3.68916G          938.565M                    6.83562                     3.00316           6.18887M    455.497k   137.305M       1.50589G/s    15.579M   21.7169M   313.193M           2.281    11.7762/s 3.68823G/s     938.565M               6.83562                2.99677   524.288k       6.17413M/s [best: throughput=  1.62 GB/s doc_throughput=    11 docs/s instructions=   938564987 cycles=   312525386 branch_miss=  452230 cache_miss=15529878 cache_ref=  21779734 items=    524288 avg_time=  84903775 ns]
Kostya<OnDemand>           25374606 ns     25374850 ns           28         155.387k           5.41744G        4.93244M       6.78752M     93.502M              0.68098           39.4555       3.68917G          290.217M                    2.11367                     3.10386                  0    155.442k   137.305M       5.03945G/s   4.94441M   6.78768M   93.5632M        0.681426    39.4091/s 3.68724G/s     290.217M               2.11367                3.10183          0              0/s [best: throughput=  5.42 GB/s doc_throughput=    39 docs/s instructions=   290216998 cycles=    93501975 branch_miss=  155387 cache_miss= 4932442 cache_ref=   6787518 items=         0 avg_time=  25363465 ns]
KostyaSum<OnDemand>        25373695 ns     25373474 ns           28         155.303k           5.41688G        4.93959M       6.78811M    93.5123M             0.681055           39.4514        3.6892G          290.217M                    2.11367                     3.10352                  0      155.4k   137.305M       5.03972G/s   4.95093M   6.78829M   93.5588M        0.681394    39.4112/s 3.68727G/s     290.217M               2.11367                3.10197          0              0/s [best: throughput=  5.42 GB/s doc_throughput=    39 docs/s instructions=   290217001 cycles=    93512314 branch_miss=  155303 cache_miss= 4939587 cache_ref=   6788108 items=         0 avg_time=  25362328 ns]
Kostya<Iter>               59900132 ns     59899549 ns           12         457.862k            2.2957G        10.1502M       13.9903M    220.639M              1.60693           16.7197       3.68903G          642.015M                    4.67583                      2.9098           8.76596M    458.064k   137.305M       2.13483G/s   10.1909M   13.9473M   220.921M         1.60898    16.6946/s 3.68819G/s     642.015M               4.67583                2.90609   524.288k       8.75279M/s [best: throughput=  2.30 GB/s doc_throughput=    16 docs/s instructions=   642015217 cycles=   220638961 branch_miss=  457862 cache_miss=10150222 cache_ref=  13990264 items=    524288 avg_time=  59888148 ns]
KostyaSum<Iter>           117866389 ns    117867545 ns            6         458.421k           1.16793G        9.96235M       13.6368M    433.705M               3.1587           8.50609       3.68913G           1.3173G                    9.59395                     3.03731           4.45964M    458.104k   137.305M       1110.94M/s   9.98615M   13.6385M   434.782M         3.16654     8.4841/s 3.68873G/s      1.3173G               9.59395                3.02979   524.288k       4.44811M/s [best: throughput=  1.17 GB/s doc_throughput=     8 docs/s instructions=  1317297836 cycles=   433704863 branch_miss=  458421 cache_miss= 9962348 cache_ref=  13636832 items=    524288 avg_time= 117853309 ns]
```
