### PR TITLE
Allow value parse to be retried

### DIFF
--- a/benchmark/json_benchmark.h
+++ b/benchmark/json_benchmark.h
@@ -10,7 +10,7 @@ template<typename B, typename R> static void JsonBenchmark(benchmark::State &sta
   {
     R reference;
     if (!reference.Run(json)) { state.SkipWithError("reference tweet reading failed"); return; }
-    assert(bench.Result() == reference.Result());
+    if (bench.Result() != reference.Result()) { state.SkipWithError("results are not the same"); return; }
   }
 
   // Run the benchmark

--- a/benchmark/kostya/iter.h
+++ b/benchmark/kostya/iter.h
@@ -22,12 +22,12 @@ private:
 
   simdjson_really_inline simdjson_result<double> first_double(ondemand::json_iterator &iter, const char *key) {
     if (!iter.start_object() || ondemand::raw_json_string(iter.field_key()) != key || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
   simdjson_really_inline simdjson_result<double> next_double(ondemand::json_iterator &iter, const char *key) {
     if (!iter.has_next_field() || ondemand::raw_json_string(iter.field_key()) != key || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
 };
@@ -76,11 +76,11 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
   if (!iter.start_array()) { return false; }
   do {
     if (!iter.start_object()   || !iter.find_field_raw("x")) { return false; }
-    sum.x += iter.get_double();
+    sum.x += iter.consume_double();
     if (!iter.has_next_field() || !iter.find_field_raw("y")) { return false; }
-    sum.y +=  iter.get_double();
+    sum.y +=  iter.consume_double();
     if (!iter.has_next_field() || !iter.find_field_raw("z")) { return false; }
-    sum.z +=  iter.get_double();
+    sum.z +=  iter.consume_double();
     if (iter.skip_container()) { return false; } // Skip the rest of the coordinates object
     count++;
   } while (iter.has_next_element());

--- a/benchmark/largerandom/iter.h
+++ b/benchmark/largerandom/iter.h
@@ -22,12 +22,12 @@ private:
 
   simdjson_really_inline double first_double(ondemand::json_iterator &iter) {
     if (iter.start_object().error() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
   simdjson_really_inline double next_double(ondemand::json_iterator &iter) {
     if (!iter.has_next_field() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
-    return iter.get_double();
+    return iter.consume_double();
   }
 
 };
@@ -72,11 +72,11 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
   if (!iter.start_array()) { return false; }
   do {
     if (!iter.start_object()   || iter.field_key().value() != "x" || iter.field_value()) { return false; }
-    sum.x += iter.get_double();
+    sum.x += iter.consume_double();
     if (!iter.has_next_field() || iter.field_key().value() != "y" || iter.field_value()) { return false; }
-    sum.y +=  iter.get_double();
+    sum.y +=  iter.consume_double();
     if (!iter.has_next_field() || iter.field_key().value() != "z" || iter.field_value()) { return false; }
-    sum.z +=  iter.get_double();
+    sum.z +=  iter.consume_double();
     if (*iter.advance() != '}') { return false; }
     count++;
   } while (iter.has_next_element());

--- a/benchmark/partial_tweets/iter.h
+++ b/benchmark/partial_tweets/iter.h
@@ -47,13 +47,13 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
     tweet tweet;
 
     if (!iter.start_object()   || !iter.find_field_raw("created_at")) { return false; }
-    tweet.created_at = iter.consume_raw_json_string().value().unescape(iter);
+    tweet.created_at = iter.consume_string();
 
     if (!iter.has_next_field() || !iter.find_field_raw("id")) { return false; }
     tweet.id = iter.consume_uint64();
 
     if (!iter.has_next_field() || !iter.find_field_raw("text")) { return false; }
-    tweet.text = iter.consume_raw_json_string().value().unescape(iter);
+    tweet.text = iter.consume_string();
 
     if (!iter.has_next_field() || !iter.find_field_raw("in_reply_to_status_id")) { return false; }
     if (!iter.is_null()) {
@@ -66,7 +66,7 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
       tweet.user.id = iter.consume_uint64();
 
       if (!iter.has_next_field() || !iter.find_field_raw("screen_name")) { return false; }
-      tweet.user.screen_name = iter.consume_raw_json_string().value().unescape(iter);
+      tweet.user.screen_name = iter.consume_string();
 
       if (iter.skip_container()) { return false; } // Skip the rest of the user object
     }

--- a/benchmark/partial_tweets/iter.h
+++ b/benchmark/partial_tweets/iter.h
@@ -47,35 +47,35 @@ simdjson_really_inline bool Iter::Run(const padded_string &json) {
     tweet tweet;
 
     if (!iter.start_object()   || !iter.find_field_raw("created_at")) { return false; }
-    tweet.created_at = iter.get_raw_json_string().value().unescape(iter);
+    tweet.created_at = iter.consume_raw_json_string().value().unescape(iter);
 
     if (!iter.has_next_field() || !iter.find_field_raw("id")) { return false; }
-    tweet.id = iter.get_uint64();
+    tweet.id = iter.consume_uint64();
 
     if (!iter.has_next_field() || !iter.find_field_raw("text")) { return false; }
-    tweet.text = iter.get_raw_json_string().value().unescape(iter);
+    tweet.text = iter.consume_raw_json_string().value().unescape(iter);
 
     if (!iter.has_next_field() || !iter.find_field_raw("in_reply_to_status_id")) { return false; }
     if (!iter.is_null()) {
-      tweet.in_reply_to_status_id = iter.get_uint64();
+      tweet.in_reply_to_status_id = iter.consume_uint64();
     }
 
     if (!iter.has_next_field() || !iter.find_field_raw("user")) { return false; }
     {
       if (!iter.start_object()   || !iter.find_field_raw("id")) { return false; }
-      tweet.user.id = iter.get_uint64();
+      tweet.user.id = iter.consume_uint64();
 
       if (!iter.has_next_field() || !iter.find_field_raw("screen_name")) { return false; }
-      tweet.user.screen_name = iter.get_raw_json_string().value().unescape(iter);
+      tweet.user.screen_name = iter.consume_raw_json_string().value().unescape(iter);
 
       if (iter.skip_container()) { return false; } // Skip the rest of the user object
     }
 
     if (!iter.has_next_field() || !iter.find_field_raw("retweet_count")) { return false; }
-    tweet.retweet_count = iter.get_uint64();
+    tweet.retweet_count = iter.consume_uint64();
 
     if (!iter.has_next_field() || !iter.find_field_raw("favorite_count")) { return false; }
-    tweet.favorite_count = iter.get_uint64();
+    tweet.favorite_count = iter.consume_uint64();
 
     tweets.push_back(tweet);
 

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -15,7 +15,7 @@ simdjson_really_inline document::~document() noexcept {
 }
 
 simdjson_really_inline void document::assert_at_start() const noexcept {
-  SIMDJSON_ASSUME(json != nullptr);
+  SIMDJSON_ASSUME(json != nullptr && iter.is_alive());
 }
 simdjson_really_inline document document::start(json_iterator &&iter) noexcept {
   auto json = iter.advance();

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -41,15 +41,15 @@ simdjson_really_inline simdjson_result<object> document::get_object() & noexcept
 }
 simdjson_really_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_uint64() );
+  return consume_if_success( iter.parse_uint64(json) );
 }
 simdjson_really_inline simdjson_result<int64_t> document::get_int64() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_int64() );
+  return consume_if_success( iter.parse_root_int64(json) );
 }
 simdjson_really_inline simdjson_result<double> document::get_double() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_double() );
+  return consume_if_success( iter.parse_root_double(json) );
 }
 simdjson_really_inline simdjson_result<std::string_view> document::get_string() & noexcept {
   return consume_if_success( as_value().get_string() );
@@ -59,11 +59,11 @@ simdjson_really_inline simdjson_result<raw_json_string> document::get_raw_json_s
 }
 simdjson_really_inline simdjson_result<bool> document::get_bool() noexcept {
   assert_at_start();
-  return consume_if_success( iter.get_root_bool() );
+  return consume_if_success( iter.parse_root_bool(json) );
 }
 simdjson_really_inline bool document::is_null() noexcept {
   assert_at_start();
-  if (iter.root_is_null()) { json = nullptr; return true; }
+  if (iter.root_is_null(json)) { json = nullptr; return true; }
   return false;
 }
 

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -2,12 +2,13 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-#ifdef SIMDJSON_ONDEMAND_SAFETY_RAILS
 simdjson_really_inline json_iterator::json_iterator(json_iterator &&other) noexcept
   : token_iterator(std::forward<token_iterator>(other)),
     parser{other.parser},
-    current_string_buf_loc{other.current_string_buf_loc},
-    active_lease_depth{other.active_lease_depth}
+    current_string_buf_loc{other.current_string_buf_loc}
+#ifdef SIMDJSON_ONDEMAND_SAFETY_RAILS
+    , active_lease_depth{other.active_lease_depth}
+#endif
 {
   other.parser = nullptr;
 }
@@ -16,11 +17,12 @@ simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&o
   index = other.index;
   parser = other.parser;
   current_string_buf_loc = other.current_string_buf_loc;
+#ifdef SIMDJSON_ONDEMAND_SAFETY_RAILS
   active_lease_depth = other.active_lease_depth;
+#endif
   other.parser = nullptr;
   return *this;
 }
-#endif
 
 simdjson_really_inline json_iterator::json_iterator(ondemand::parser *_parser) noexcept
   : token_iterator(_parser->dom_parser.buf, _parser->dom_parser.structural_indexes.get()),

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -33,6 +33,14 @@ public:
   /**
    * Check for an opening { and start an object iteration.
    *
+   * @param json A pointer to the potential {
+   * @returns Whether the object had any fields (returns false for empty).
+   * @error INCORRECT_TYPE if there is no opening {
+   */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> start_object(const uint8_t *json) noexcept;
+  /**
+   * Check for an opening { and start an object iteration.
+   *
    * @returns Whether the object had any fields (returns false for empty).
    * @error INCORRECT_TYPE if there is no opening {
    */
@@ -82,6 +90,14 @@ public:
   /**
    * Check for an opening [ and start an array iteration.
    *
+   * @param json A pointer to the potential [.
+   * @returns Whether the array had any elements (returns false for empty).
+   * @error INCORRECT_TYPE If there is no [.
+   */
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> start_array(const uint8_t *json) noexcept;
+  /**
+   * Check for an opening [ and start an array iteration.
+   *
    * @returns Whether the array had any elements (returns false for empty).
    * @error INCORRECT_TYPE If there is no [.
    */
@@ -107,18 +123,31 @@ public:
    */
   SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> has_next_element() noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<std::string_view> parse_string(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<std::string_view> consume_string() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<raw_json_string> parse_raw_json_string(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<raw_json_string> consume_raw_json_string() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> parse_uint64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> consume_uint64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> parse_int64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> consume_int64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> parse_double(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> consume_double() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> consume_bool() noexcept;
+  simdjson_really_inline bool is_null(const uint8_t *json) noexcept;
   simdjson_really_inline bool is_null() noexcept;
 
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> get_root_uint64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> get_root_int64() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> get_root_double() noexcept;
-  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> get_root_bool() noexcept;
-  simdjson_really_inline bool root_is_null() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> parse_root_uint64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<uint64_t> consume_root_uint64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> parse_root_int64(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<int64_t> consume_root_int64() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<double> consume_root_double() noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> parse_root_bool(const uint8_t *json) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> consume_root_bool() noexcept;
+  simdjson_really_inline bool root_is_null(const uint8_t *json) noexcept;
+  simdjson_really_inline bool root_is_null() & noexcept;
 
   /**
    * Skips a JSON value, whether it is a scalar, array or object.
@@ -185,7 +214,7 @@ protected:
 
   simdjson_really_inline json_iterator(ondemand::parser *parser) noexcept;
   template<int N>
-  SIMDJSON_WARN_UNUSED simdjson_really_inline bool advance_to_buffer(uint8_t (&buf)[N]) noexcept;
+  SIMDJSON_WARN_UNUSED simdjson_really_inline bool copy_to_buffer(const uint8_t *json, uint8_t (&buf)[N]) noexcept;
 
   simdjson_really_inline json_iterator_ref borrow() noexcept;
 

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -145,7 +145,7 @@ public:
   SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> parse_root_bool(const uint8_t *json) noexcept;
   SIMDJSON_WARN_UNUSED simdjson_really_inline simdjson_result<bool> consume_root_bool() noexcept;
   simdjson_really_inline bool root_is_null(const uint8_t *json) noexcept;
-  simdjson_really_inline bool root_is_null() & noexcept;
+  simdjson_really_inline bool root_is_null() noexcept;
 
   /**
    * Skips a JSON value, whether it is a scalar, array or object.

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -18,13 +18,11 @@ class json_iterator_ref;
 class json_iterator : public token_iterator {
 public:
   simdjson_really_inline json_iterator() noexcept = default;
-#ifdef SIMDJSON_ONDEMAND_SAFETY_RAILS
   simdjson_really_inline json_iterator(json_iterator &&other) noexcept;
   simdjson_really_inline json_iterator &operator=(json_iterator &&other) noexcept;
+#ifdef SIMDJSON_ONDEMAND_SAFETY_RAILS
   simdjson_really_inline ~json_iterator() noexcept;
 #else
-  simdjson_really_inline json_iterator(json_iterator &&other) noexcept = default;
-  simdjson_really_inline json_iterator &operator=(json_iterator &&other) noexcept = default;
   simdjson_really_inline ~json_iterator() noexcept = default;
 #endif
   simdjson_really_inline json_iterator(const json_iterator &other) noexcept = delete;

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -44,4 +44,17 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_js
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>(error) {}
 
+simdjson_really_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::raw() const noexcept {
+  if (error()) { return error(); }
+  return first.raw();
+}
+simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::unescape(uint8_t *&dst) const noexcept {
+  if (error()) { return error(); }
+  return first.unescape(dst);
+}
+simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept {
+  if (error()) { return error(); }
+  return first.unescape(iter);
+}
+
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -87,6 +87,10 @@ public:
   simdjson_really_inline simdjson_result() noexcept = default;
   simdjson_really_inline simdjson_result(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> &a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
+
+  simdjson_really_inline simdjson_result<const char *> raw() const noexcept;
+  simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> unescape(uint8_t *&dst) const noexcept;
+  simdjson_really_inline SIMDJSON_WARN_UNUSED simdjson_result<std::string_view> unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -40,15 +40,15 @@ simdjson_really_inline simdjson_result<T> value::consume_if_success(simdjson_res
 }
 
 simdjson_really_inline simdjson_result<array> value::get_array() noexcept {
-  bool is_empty;
-  SIMDJSON_TRY( iter->start_array(json).get(is_empty) );
-  if (is_empty) { iter.release(); }
+  bool has_value;
+  SIMDJSON_TRY( iter->start_array(json).get(has_value) );
+  if (!has_value) { iter.release(); }
   return array(std::move(iter));
 }
 simdjson_really_inline simdjson_result<object> value::get_object() noexcept {
-  bool is_empty;
-  SIMDJSON_TRY( iter->start_object(json).get(is_empty) );
-  if (is_empty) { iter.release(); }
+  bool has_value;
+  SIMDJSON_TRY( iter->start_object(json).get(has_value) );
+  if (!has_value) { iter.release(); }
   return object(std::move(iter));
 }
 simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() noexcept {

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -30,110 +30,74 @@ simdjson_really_inline value value::start(json_iterator_ref &&iter) noexcept {
   return { std::forward<json_iterator_ref>(iter), iter->advance() };
 }
 
-simdjson_really_inline simdjson_result<array> value::get_array() && noexcept {
-  if (*json != '[') {
-    log_error("not an array");
-    iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-    return INCORRECT_TYPE;
-  }
-  return array::started(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline void value::consume() noexcept {
+  iter.release();
 }
-simdjson_really_inline simdjson_result<object> value::get_object() && noexcept {
-  if (*json != '{') {
-    log_error("not an object");
-    iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-    return INCORRECT_TYPE;
-  }
-  return object::started(std::forward<json_iterator_ref>(iter));
+template<typename T>
+simdjson_really_inline simdjson_result<T> value::consume_if_success(simdjson_result<T> &&result) noexcept {
+  if (!result.error()) { consume(); }
+  return std::forward<simdjson_result<T>>(result);
 }
-simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() && noexcept {
-  log_value("string");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  if (*json != '"') { log_error("not a string"); return INCORRECT_TYPE; }
-  return raw_json_string{&json[1]};
+
+simdjson_really_inline simdjson_result<array> value::get_array() noexcept {
+  bool is_empty;
+  SIMDJSON_TRY( iter->start_array(json).get(is_empty) );
+  if (is_empty) { iter.release(); }
+  return array(std::move(iter));
 }
-simdjson_really_inline simdjson_result<std::string_view> value::get_string() && noexcept {
-  log_value("string");
-  if (*json != '"') {
-    log_error("not a string");
-    iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-    return INCORRECT_TYPE;
-  }
-  auto result = raw_json_string{&json[1]}.unescape(iter->current_string_buf_loc);
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  return result;
+simdjson_really_inline simdjson_result<object> value::get_object() noexcept {
+  bool is_empty;
+  SIMDJSON_TRY( iter->start_object(json).get(is_empty) );
+  if (is_empty) { iter.release(); }
+  return object(std::move(iter));
 }
-simdjson_really_inline simdjson_result<double> value::get_double() && noexcept {
-  log_value("double");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  double result;
-  error_code error;
-  if ((error = numberparsing::parse_double(json).get(result))) { log_error("not a double"); return error; }
-  return result;
+simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() noexcept {
+  return consume_if_success( iter->parse_raw_json_string(json) );
 }
-simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() && noexcept {
-  log_value("unsigned");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  uint64_t result;
-  error_code error;
-  if ((error = numberparsing::parse_unsigned(json).get(result))) { log_error("not a unsigned integer"); return error; }
-  return result;
+simdjson_really_inline simdjson_result<std::string_view> value::get_string() noexcept {
+  return consume_if_success( iter->parse_string(json) );
 }
-simdjson_really_inline simdjson_result<int64_t> value::get_int64() && noexcept {
-  log_value("integer");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  int64_t result;
-  error_code error;
-  if ((error = numberparsing::parse_integer(json).get(result))) { log_error("not an integer"); return error; }
-  return result;
+simdjson_really_inline simdjson_result<double> value::get_double() noexcept {
+  return consume_if_success( iter->parse_double(json) );
 }
-simdjson_really_inline simdjson_result<bool> value::get_bool() && noexcept {
-  log_value("bool");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  auto not_true = atomparsing::str4ncmp(json, "true");
-  auto not_false = atomparsing::str4ncmp(json, "fals") | (json[4] ^ 'e');
-  bool error = (not_true && not_false) || jsoncharutils::is_not_structural_or_whitespace(json[not_true ? 5 : 4]);
-  if (error) { log_error("not a boolean"); return INCORRECT_TYPE; }
-  return simdjson_result<bool>(!not_true, error ? INCORRECT_TYPE : SUCCESS);
+simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() noexcept {
+  return consume_if_success( iter->parse_uint64(json) );
 }
-simdjson_really_inline bool value::is_null() & noexcept {
-  log_value("null");
-  // Since it's a *reference*, we may want to check something other than is_null() if it isn't null,
-  // so we don't release the iterator unless it is actually null
-  if (atomparsing::str4ncmp(json, "null")) { return false; }
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  return true;
+simdjson_really_inline simdjson_result<int64_t> value::get_int64() noexcept {
+  return consume_if_success( iter->parse_int64(json) );
 }
-simdjson_really_inline bool value::is_null() && noexcept {
-  log_value("null");
-  iter.release(); // Communicate that we have handled the value PERF TODO elided, right?
-  if (atomparsing::str4ncmp(json, "null")) { return false; }
+simdjson_really_inline simdjson_result<bool> value::get_bool() noexcept {
+  return consume_if_success( iter->parse_bool(json) );
+}
+simdjson_really_inline bool value::is_null() noexcept {
+  if (!iter->is_null(json)) { return false; }
+  consume();
   return true;
 }
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline value::operator array() && noexcept(false) {
+simdjson_really_inline value::operator array() noexcept(false) {
   return std::forward<value>(*this).get_array();
 }
-simdjson_really_inline value::operator object() && noexcept(false) {
+simdjson_really_inline value::operator object() noexcept(false) {
   return std::forward<value>(*this).get_object();
 }
-simdjson_really_inline value::operator uint64_t() && noexcept(false) {
+simdjson_really_inline value::operator uint64_t() noexcept(false) {
   return std::forward<value>(*this).get_uint64();
 }
-simdjson_really_inline value::operator int64_t() && noexcept(false) {
+simdjson_really_inline value::operator int64_t() noexcept(false) {
   return std::forward<value>(*this).get_int64();
 }
-simdjson_really_inline value::operator double() && noexcept(false) {
+simdjson_really_inline value::operator double() noexcept(false) {
   return std::forward<value>(*this).get_double();
 }
-simdjson_really_inline value::operator std::string_view() && noexcept(false) {
+simdjson_really_inline value::operator std::string_view() noexcept(false) {
   return std::forward<value>(*this).get_string();
 }
-simdjson_really_inline value::operator raw_json_string() && noexcept(false) {
+simdjson_really_inline value::operator raw_json_string() noexcept(false) {
   return std::forward<value>(*this).get_raw_json_string();
 }
-simdjson_really_inline value::operator bool() && noexcept(false) {
+simdjson_really_inline value::operator bool() noexcept(false) {
   return std::forward<value>(*this).get_bool();
 }
 #endif
@@ -219,77 +183,73 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first)[key];
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() && noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_array();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() && noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_object();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() && noexcept {
+simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_uint64();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() && noexcept {
+simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_int64();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() && noexcept {
+simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_double();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() && noexcept {
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() && noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() && noexcept {
+simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_bool();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() & noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() noexcept {
   if (error()) { return false; }
   return first.is_null();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() && noexcept {
-  if (error()) { return false; }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).is_null();
-}
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -38,35 +38,35 @@ public:
    * @returns An object that can be used to iterate the array.
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array> get_array() && noexcept;
+  simdjson_really_inline simdjson_result<array> get_array() noexcept;
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    */
-  simdjson_really_inline simdjson_result<object> get_object() && noexcept;
+  simdjson_really_inline simdjson_result<object> get_object() noexcept;
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
   /**
    * Cast this JSON value to a string.
    * 
@@ -78,7 +78,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
   /**
    * Cast this JSON value to a raw_json_string.
    * 
@@ -87,24 +87,20 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() && noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @returns INCORRECT_TYPE if the JSON value is not true or false.
    */
-  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
   /**
    * Checks if this JSON value is null.
    * 
    * @returns Whether the value is null.
    */
-  simdjson_really_inline bool is_null() & noexcept;
-  /**
-   * @overload bool is_null() & noexcept
-   */
-  simdjson_really_inline bool is_null() && noexcept;
+  simdjson_really_inline bool is_null() noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -113,35 +109,35 @@ public:
    * @returns An object that can be used to iterate the array.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an array.
    */
-  simdjson_really_inline operator array() && noexcept(false);
+  simdjson_really_inline operator array() noexcept(false);
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an object.
    */
-  simdjson_really_inline operator object() && noexcept(false);
+  simdjson_really_inline operator object() noexcept(false);
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline operator uint64_t() && noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline operator int64_t() && noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline operator double() && noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
   /**
    * Cast this JSON value to a string.
    * 
@@ -153,7 +149,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator std::string_view() && noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
   /**
    * Cast this JSON value to a raw_json_string.
    * 
@@ -162,14 +158,14 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator raw_json_string() && noexcept(false);
+  simdjson_really_inline operator raw_json_string() noexcept(false);
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not true or false.
    */
-  simdjson_really_inline operator bool() && noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
 #endif
 
   /**
@@ -239,6 +235,9 @@ protected:
   simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
   simdjson_really_inline bool is_iteration_finished() const noexcept;
   simdjson_really_inline void iteration_finished() noexcept;
+  simdjson_really_inline void consume() noexcept;
+  template<typename T>
+  simdjson_really_inline simdjson_result<T> consume_if_success(simdjson_result<T> &&result) noexcept;
 
   json_iterator_ref iter{};
   const uint8_t *json{}; // The JSON text of the value
@@ -268,26 +267,25 @@ public:
   simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() && noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() && noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
-  simdjson_really_inline bool is_null() & noexcept;
-  simdjson_really_inline bool is_null() && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false);
-  simdjson_really_inline operator uint64_t() && noexcept(false);
-  simdjson_really_inline operator int64_t() && noexcept(false);
-  simdjson_really_inline operator double() && noexcept(false);
-  simdjson_really_inline operator std::string_view() && noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false);
-  simdjson_really_inline operator bool() && noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
 #endif
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> begin() & noexcept;

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -39,6 +39,7 @@ public:
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
   simdjson_really_inline simdjson_result<array> get_array() noexcept;
+
   /**
    * Cast this JSON value to an object.
    *
@@ -46,27 +47,41 @@ public:
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    */
   simdjson_really_inline simdjson_result<object> get_object() noexcept;
+
+  // PERF NOTE: get_XXX() methods generally have both && and & variants because performance is demonstrably better on clang.
+  // Specifically, in typical cases where you use a temporary value (like doc["x"].get_double()) the && version is faster
+  // because the & version has to branch to check whether the parse failed or not before deciding whether the value was consumed.
+
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept */
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() & noexcept;
+
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept */
+  simdjson_really_inline simdjson_result<int64_t> get_int64() & noexcept;
+
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<double> get_double() && noexcept */
+  simdjson_really_inline simdjson_result<double> get_double() & noexcept;
+
   /**
    * Cast this JSON value to a string.
    * 
@@ -78,7 +93,10 @@ public:
    *          time it parses a document or when it is destroyed.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept */
+  simdjson_really_inline simdjson_result<std::string_view> get_string() & noexcept;
+
   /**
    * Cast this JSON value to a raw_json_string.
    * 
@@ -87,20 +105,28 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() && noexcept */
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() & noexcept;
+
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @returns INCORRECT_TYPE if the JSON value is not true or false.
    */
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<bool> get_bool() && noexcept */
+  simdjson_really_inline simdjson_result<bool> get_bool() & noexcept;
+
   /**
    * Checks if this JSON value is null.
    * 
    * @returns Whether the value is null.
    */
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_really_inline bool is_null() && noexcept;
+  /** @overload simdjson_really_inline bool is_null() && noexcept */
+  simdjson_really_inline bool is_null() & noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -123,21 +149,27 @@ public:
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator uint64_t() && noexcept(false);
+  /** @overload simdjson_really_inline operator uint64_t() && noexcept(false); */
+  simdjson_really_inline operator uint64_t() & noexcept(false);
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() && noexcept(false);
+  /** @overload simdjson_really_inline operator int64_t() && noexcept(false); */
+  simdjson_really_inline operator int64_t() & noexcept(false);
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator double() && noexcept(false);
+  /** @overload simdjson_really_inline operator double() && noexcept(false); */
+  simdjson_really_inline operator double() & noexcept(false);
   /**
    * Cast this JSON value to a string.
    * 
@@ -149,7 +181,9 @@ public:
    *          time it parses a document or when it is destroyed.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator std::string_view() && noexcept(false);
+  /** @overload simdjson_really_inline operator std::string_view() && noexcept(false); */
+  simdjson_really_inline operator std::string_view() & noexcept(false);
   /**
    * Cast this JSON value to a raw_json_string.
    * 
@@ -158,14 +192,18 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator raw_json_string() noexcept(false);
+  simdjson_really_inline operator raw_json_string() && noexcept(false);
+  /** @overload simdjson_really_inline operator raw_json_string() && noexcept(false); */
+  simdjson_really_inline operator raw_json_string() & noexcept(false);
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not true or false.
    */
-  simdjson_really_inline operator bool() noexcept(false);
+  simdjson_really_inline operator bool() && noexcept(false);
+  /** @overload simdjson_really_inline operator bool() && noexcept(false); */
+  simdjson_really_inline operator bool() & noexcept(false);
 #endif
 
   /**
@@ -235,7 +273,7 @@ protected:
   simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
   simdjson_really_inline bool is_iteration_finished() const noexcept;
   simdjson_really_inline void iteration_finished() noexcept;
-  simdjson_really_inline void consume() noexcept;
+  simdjson_really_inline const uint8_t *consume() noexcept;
   template<typename T>
   simdjson_really_inline simdjson_result<T> consume_if_success(simdjson_result<T> &&result) noexcept;
 
@@ -268,24 +306,45 @@ public:
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() noexcept;
+
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline bool is_null() noexcept;
+
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() & noexcept;
+
+  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() & noexcept;
+
+  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() & noexcept;
+
+  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() & noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() & noexcept;
+
+  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() & noexcept;
+
+  simdjson_really_inline bool is_null() && noexcept;
+  simdjson_really_inline bool is_null() & noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false);
   simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false);
-  simdjson_really_inline operator uint64_t() noexcept(false);
-  simdjson_really_inline operator int64_t() noexcept(false);
-  simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
-  simdjson_really_inline operator bool() noexcept(false);
+  simdjson_really_inline operator uint64_t() && noexcept(false);
+  simdjson_really_inline operator uint64_t() & noexcept(false);
+  simdjson_really_inline operator int64_t() && noexcept(false);
+  simdjson_really_inline operator int64_t() & noexcept(false);
+  simdjson_really_inline operator double() && noexcept(false);
+  simdjson_really_inline operator double() & noexcept(false);
+  simdjson_really_inline operator std::string_view() && noexcept(false);
+  simdjson_really_inline operator std::string_view() & noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() & noexcept(false);
+  simdjson_really_inline operator bool() && noexcept(false);
+  simdjson_really_inline operator bool() & noexcept(false);
 #endif
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> begin() & noexcept;


### PR DESCRIPTION
This allows you to try to parse a value multiple ways (for example, if `value.get_string()` fails, you can still try `value.get_double()`).

It also uses standard iterator code for parsing instead of special code in value, and fixes issues where we were advancing structural indexes multiple times when you parsed values at the root. (Or attempts to ... tests are still pending.)

## Performance

By my measure, this improves things on gcc by a small amount (2% or so for PartialTweets and Kostya, both of which have skipping), and reduces instruction count slightly as well. On clang, however, it makes things a bit *worse* by about 5%, significantly increasing branch misses. I'm not sure why yet. I'll think on this one.

### Haswell gcc10.2 (Skylake)

With this patch:

```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PartialTweets<OnDemand>      175706 ns       175707 ns         3979           1.561k           3.79042G               0        57.975k     615.24k             0.974229          6.00211k       3.69274G          2.11194M                    3.34425                     3.43271           600.211k    1.68753k   631.515k        3.3473G/s   0.017341   57.8757k   619.048k        0.980258    5.6913k/s 3.52319G/s     2.11194M               3.34425                 3.4116        100        569.13k/s [best: throughput=  3.79 GB/s doc_throughput=  6002 docs/s instructions=     2111941 cycles=      615240 branch_miss=    1561 cache_miss=       0 cache_ref=     57975 items=       100 avg_time=    167739 ns]
PartialTweets<Iter>          413260 ns       413189 ns         1690           3.018k           1.56446G               0        59.203k    1.49034M              2.35995          2.47732k       3.69205G          4.44231M                    7.03437                     2.98073           247.732k     3.1855k   631.515k       1.42343G/s  0.0171598   59.3027k   1.49523M         2.36769    2.4202k/s 3.61876G/s     4.44231M               7.03437                2.97098        100        242.02k/s [best: throughput=  1.56 GB/s doc_throughput=  2477 docs/s instructions=     4442308 cycles=     1490342 branch_miss=    3018 cache_miss=       0 cache_ref=     59203 items=       100 avg_time=    405266 ns]
LargeRandom<OnDemand>      59208577 ns     59196413 ns           12         867.944k           777.982M        5.62205M       8.02476M     218.12M              4.74186           16.9131       3.68908G          616.695M                    13.4068                     2.82732           16.9131M    867.787k   45.9988M       741.056M/s   5.66668M   8.02553M   218.321M         4.74624    16.8929/s 3.68808G/s     616.695M               13.4068                2.82471      1000k       16.8929M/s [best: throughput=  0.78 GB/s doc_throughput=    16 docs/s instructions=   616695084 cycles=   218119787 branch_miss=  867944 cache_miss= 5622048 cache_ref=   8024758 items=   1000000 avg_time=  59196416 ns]
LargeRandom<Iter>          53297188 ns     53287207 ns           13         870.255k            864.43M          5.628M       8.01742M    196.306M              4.26764           18.7924       3.68908G          570.695M                    12.4067                     2.90716           18.7924M    870.999k   45.9988M       823.234M/s   5.65342M   8.01889M    196.51M         4.27207    18.7662/s 3.68775G/s     570.695M               12.4067                2.90415      1000k       18.7662M/s [best: throughput=  0.86 GB/s doc_throughput=    18 docs/s instructions=   570694598 cycles=   196306411 branch_miss=  870255 cache_miss= 5628004 cache_ref=   8017425 items=   1000000 avg_time=  53285155 ns]
Kostya<OnDemand>           59404278 ns     59392435 ns           12         451.256k           2.31519G        9.95922M       13.9063M    218.733M              1.59304           16.8617        3.6882G          648.831M                    4.72547                     2.96632           8.84038M    451.521k   137.305M       2.15306G/s   10.0041M   13.9063M   218.971M         1.59477    16.8372/s 3.68684G/s     648.831M               4.72547                 2.9631   524.288k       8.82752M/s [best: throughput=  2.32 GB/s doc_throughput=    16 docs/s instructions=   648830818 cycles=   218732563 branch_miss=  451256 cache_miss= 9959225 cache_ref=  13906324 items=    524288 avg_time=  59392557 ns]
Kostya<Iter>               57719889 ns     57719511 ns           12         452.567k            2.3822G        9.99273M       13.8838M    212.574M              1.54818           17.3497       3.68808G          640.967M                     4.6682                     3.01527           9.09623M    452.514k   137.305M       2.21546G/s   10.0028M   13.8939M    212.85M          1.5502    17.3252/s 3.68766G/s     640.967M                4.6682                3.01136   524.288k       9.08338M/s [best: throughput=  2.38 GB/s doc_throughput=    17 docs/s instructions=   640966891 cycles=   212573506 branch_miss=  452567 cache_miss= 9992732 cache_ref=  13883818 items=    524288 avg_time=  57708281 ns]
```

Before this patch:

```
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PartialTweets<OnDemand>      180978 ns       180977 ns         3869           1.564k           3.70601G               0        58.491k    629.234k             0.996388          5.86844k       3.69262G          2.11195M                    3.34425                     3.35638           586.844k     1.7594k   631.515k       3.24983G/s   1.29232m   58.6616k   638.611k         1.01124   5.52557k/s 3.52869G/s     2.11195M               3.34425                 3.3071        100       552.557k/s [best: throughput=  3.71 GB/s doc_throughput=  5868 docs/s instructions=     2111947 cycles=      629234 branch_miss=    1564 cache_miss=       0 cache_ref=     58491 items=       100 avg_time=    173042 ns]
PartialTweets<Iter>          386232 ns       386152 ns         1815           3.108k           1.67989G               0        59.344k    1.38794M               2.1978           2.6601k       3.69206G          4.40453M                    6.97454                     3.17342            266.01k    3.27626k   631.515k       1.52309G/s   0.015427   59.3538k   1.39539M          2.2096   2.58965k/s 3.61358G/s     4.40453M               6.97454                3.15648        100       258.965k/s [best: throughput=  1.68 GB/s doc_throughput=  2660 docs/s instructions=     4404526 cycles=     1387942 branch_miss=    3108 cache_miss=       0 cache_ref=     59344 items=       100 avg_time=    378292 ns]
LargeRandom<OnDemand>      58630783 ns     58618830 ns           12         869.638k           785.824M        5.62459M       8.02289M    215.945M              4.69459           17.0836       3.68912G          614.695M                    13.3633                     2.84653           17.0836M    870.219k   45.9988M       748.358M/s   5.66826M    8.0247M   216.143M         4.69889    17.0594/s 3.68727G/s     614.695M               13.3633                2.84392      1000k       17.0594M/s [best: throughput=  0.79 GB/s doc_throughput=    17 docs/s instructions=   614695180 cycles=   215945356 branch_miss=  869638 cache_miss= 5624589 cache_ref=   8022886 items=   1000000 avg_time=  58618766 ns]
LargeRandom<Iter>          54140042 ns     54139736 ns           13         864.127k           850.741M        5.60486M       8.02276M    199.446M              4.33591           18.4949       3.68874G          571.695M                    12.4285                     2.86641           18.4949M    864.509k   45.9988M       810.271M/s   5.65229M   8.02376M   199.652M         4.34037    18.4707/s 3.68772G/s     571.695M               12.4285                2.86346      1000k       18.4707M/s [best: throughput=  0.85 GB/s doc_throughput=    18 docs/s instructions=   571694596 cycles=   199446414 branch_miss=  864127 cache_miss= 5604864 cache_ref=   8022761 items=   1000000 avg_time=  54128220 ns]
Kostya<OnDemand>           60838777 ns     60839545 ns           11         453.749k           2.26086G        10.0671M        14.032M    224.018M              1.63154            16.466       3.68867G          647.258M                    4.71402                     2.88931            8.6329M    454.131k   137.305M       2.10184G/s   10.0455M   14.0312M   224.343M          1.6339    16.4367/s 3.68746G/s     647.258M               4.71402                2.88513   524.288k       8.61755M/s [best: throughput=  2.26 GB/s doc_throughput=    16 docs/s instructions=   647257988 cycles=   224017971 branch_miss=  453749 cache_miss=10067083 cache_ref=  14031971 items=    524288 avg_time=  60826928 ns]
Kostya<Iter>               59252275 ns     59250146 ns           12          453.17k           2.32348G        10.0747M        14.024M    217.951M              1.58735            16.922       3.68816G          639.918M                    4.66056                     2.93607             8.872M    452.788k   137.305M       2.15823G/s   10.0237M   14.0261M   218.466M          1.5911    16.8776/s 3.68719G/s     639.918M               4.66056                2.92914   524.288k       8.84872M/s [best: throughput=  2.32 GB/s doc_throughput=    16 docs/s instructions=   639918058 cycles=   217950758 branch_miss=  453170 cache_miss=10074750 cache_ref=  14023984 items=    524288 avg_time=  59240277 ns]
```

## Haswell clang10 (Skylake)

With this patch:

```
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PartialTweets<OnDemand>     173875 ns       173876 ns         4093           1.404k           3.83827G               0        54.655k    607.533k             0.962025          6.07788k       3.69251G          1.93361M                    3.06186                     3.18272           607.788k       1.58k   631.515k       3.38255G/s  0.0163694   54.8714k   612.776k        0.970328   5.75123k/s 3.52422G/s     1.93361M               3.06186                3.15549        100       575.123k/s [best: throughput=  3.84 GB/s doc_throughput=  6077 docs/s instructions=     1933608 cycles=      607533 branch_miss=    1404 cache_miss=       0 cache_ref=     54655 items=       100 avg_time=    166032 ns]
PartialTweets<Iter>         179035 ns       179038 ns         3916           2.823k           3.75803G               0        54.568k    620.502k             0.982561          5.95082k        3.6925G          1.83669M                    2.90839                     2.96001           595.082k     3.1604k   631.515k       3.28503G/s  0.0735444   54.7074k   631.576k          1.0001   5.58542k/s 3.52761G/s     1.83669M               2.90839                2.90811        100       558.542k/s [best: throughput=  3.76 GB/s doc_throughput=  5950 docs/s instructions=     1836691 cycles=      620502 branch_miss=    2823 cache_miss=       0 cache_ref=     54568 items=       100 avg_time=    171125 ns]
Creating a source file spanning 44921 KB 
LargeRandom<OnDemand>     68934797 ns     68935741 ns           10         920.172k           667.883M         5.6818M       7.91918M    254.089M              5.52382           14.5196       3.68927G          678.851M                     14.758                      2.6717           14.5196M    920.914k   45.9988M       636.359M/s   5.72998M   7.92078M   254.267M          5.5277    14.5063/s 3.68847G/s     678.851M                14.758                2.66983      1000k       14.5063M/s [best: throughput=  0.67 GB/s doc_throughput=    14 docs/s instructions=   678850849 cycles=   254089075 branch_miss=  920172 cache_miss= 5681804 cache_ref=   7919178 items=   1000000 avg_time=  68922499 ns]
LargeRandom<Iter>         60783233 ns     60784064 ns           12         962.729k           758.008M         5.6942M       7.90349M    223.878M              4.86704           16.4789       3.68926G           581.85M                    12.6493                     2.59896           16.4789M    968.679k   45.9988M         721.7M/s   5.72905M   7.90575M   224.184M          4.8737    16.4517/s 3.68821G/s      581.85M               12.6493                2.59541      1000k       16.4517M/s [best: throughput=  0.76 GB/s doc_throughput=    16 docs/s instructions=   581850353 cycles=   223878024 branch_miss=  962729 cache_miss= 5694202 cache_ref=   7903490 items=   1000000 avg_time=  60770921 ns]
Creating a source file spanning 134087 KB 
Kostya<OnDemand>          61465597 ns     61466425 ns           11         455.813k           2.23602G        10.1644M       14.0161M    226.542M              1.64992           16.2851       3.68925G          649.466M                    4.73009                     2.86687           8.53806M     456.19k   137.305M       2.08041G/s   10.1823M   14.0158M   226.699M         1.65106     16.269/s 3.68817G/s     649.466M               4.73009                2.86488   524.288k       8.52966M/s [best: throughput=  2.24 GB/s doc_throughput=    16 docs/s instructions=   649465616 cycles=   226542030 branch_miss=  455813 cache_miss=10164365 cache_ref=  14016146 items=    524288 avg_time=  61452878 ns]
Kostya<Iter>              58592324 ns     58593125 ns           12          463.54k           2.34617G        10.1423M       13.9871M    215.897M              1.57239           17.0873       3.68909G            604.9M                    4.40552                      2.8018           8.95866M    465.007k   137.305M       2.18243G/s   10.1704M   13.9877M   216.112M         1.57396    17.0668/s 3.68835G/s       604.9M               4.40552                2.79901   524.288k       8.94794M/s [best: throughput=  2.35 GB/s doc_throughput=    17 docs/s instructions=   604900426 cycles=   215897094 branch_miss=  463540 cache_miss=10142262 cache_ref=  13987106 items=    524288 avg_time=  58579940 ns]
```

Before this patch:

```
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PartialTweets<OnDemand>     166021 ns       166020 ns         4290           1.749k           4.02336G               0        57.137k    579.582k             0.917764          6.37097k        3.6925G          1.92817M                    3.05324                     3.32682           637.097k    1.84778k   631.515k        3.5426G/s    4.4289m   57.1412k   583.506k        0.923978   6.02336k/s 3.51467G/s     1.92817M               3.05324                3.30445        100       602.336k/s [best: throughput=  4.02 GB/s doc_throughput=  6370 docs/s instructions=     1928167 cycles=      579582 branch_miss=    1749 cache_miss=       0 cache_ref=     57137 items=       100 avg_time=    158102 ns]
PartialTweets<Iter>         190679 ns       190648 ns         3671           2.492k           3.49891G               0        58.291k    666.493k              1.05539           5.5405k       3.69271G          1.89086M                    2.99416                     2.83702            554.05k    2.53456k   631.515k       3.08498G/s   1.90684m    58.303k   673.904k         1.06712   5.24527k/s 3.53481G/s     1.89086M               2.99416                2.80583        100       524.527k/s [best: throughput=  3.50 GB/s doc_throughput=  5540 docs/s instructions=     1890857 cycles=      666493 branch_miss=    2492 cache_miss=       0 cache_ref=     58291 items=       100 avg_time=    182628 ns]
Creating a source file spanning 44921 KB 
LargeRandom<OnDemand>     66565456 ns     66552340 ns           10         956.859k           691.788M        5.65646M       8.02952M     245.22M              5.33102           15.0393       3.68794G           637.85M                    13.8667                     2.60113           15.0393M    959.606k   45.9988M       659.148M/s   5.68265M   8.02896M   245.407M         5.33507    15.0258/s 3.68742G/s      637.85M               13.8667                2.59916      1000k       15.0258M/s [best: throughput=  0.69 GB/s doc_throughput=    15 docs/s instructions=   637850376 cycles=   245220390 branch_miss=  956859 cache_miss= 5656459 cache_ref=   8029525 items=   1000000 avg_time=  66553177 ns]
LargeRandom<Iter>         60269317 ns     60270140 ns           12         994.474k           763.878M        5.63885M       8.02648M    222.142M               4.8293           16.6065         3.689G           577.85M                    12.5623                     2.60127           16.6065M    995.255k   45.9988M       727.854M/s    5.6824M   8.02844M   222.272M         4.83213     16.592/s 3.68793G/s      577.85M               12.5623                2.59974      1000k        16.592M/s [best: throughput=  0.76 GB/s doc_throughput=    16 docs/s instructions=   577850356 cycles=   222142019 branch_miss=  994474 cache_miss= 5638853 cache_ref=   8026482 items=   1000000 avg_time=  60257265 ns]
Creating a source file spanning 134087 KB 
Kostya<OnDemand>          60503966 ns     60489902 ns           12         460.682k           2.27184G        9.95925M       14.0203M    222.961M              1.62384            16.546       3.68911G          632.688M                     4.6079                     2.83766           8.67485M    460.766k   137.305M       2.11399G/s   9.99879M   14.0045M   223.084M         1.62473    16.5317/s 3.68795G/s     632.688M                4.6079                 2.8361   524.288k       8.66736M/s [best: throughput=  2.27 GB/s doc_throughput=    16 docs/s instructions=   632687938 cycles=   222961329 branch_miss=  460682 cache_miss= 9959251 cache_ref=  14020269 items=    524288 avg_time=  60491726 ns]
Kostya<Iter>              56785866 ns     56784953 ns           12         459.651k           2.42018G        9.94725M         13.99M    209.297M              1.52432           17.6263       3.68912G          585.502M                    4.26424                     2.79747           9.24126M    459.567k   137.305M       2.25192G/s   9.98175M   13.9899M   209.409M         1.52514    17.6103/s 3.68776G/s     585.502M               4.26424                2.79597   524.288k       9.23287M/s [best: throughput=  2.42 GB/s doc_throughput=    17 docs/s instructions=   585501761 cycles=   209296553 branch_miss=  459651 cache_miss= 9947246 cache_ref=  13989980 items=    524288 avg_time=  56773169 ns]
```