### PR TITLE
add CI fuzzing on arm 64 bit

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -382,6 +382,26 @@ steps:
     - ctest $CTEST_FLAGS
 ---
 kind: pipeline
+name: arm64-fuzz
+platform: { os: linux, arch: arm64 }
+steps:
+- name: Build and run fuzzers shortly
+  image: ubuntu:20.04
+  environment:
+    CC: clang
+    CXX: clang++
+    DEBIAN_FRONTEND: noninteractive
+    ASAN_OPTIONS: detect_leaks=0
+  commands:
+    - apt-get update -qq
+    - apt-get install -q -y clang cmake git wget zip ninja-build
+    - wget --quiet https://dl.bintray.com/pauldreik/simdjson-fuzz-corpus/corpus/corpus.tar
+    - tar xf corpus.tar && rm corpus.tar
+    - fuzz/build_like_ossfuzz.sh
+    - mkdir -p common_out
+    - for fuzzer in build/fuzz/fuzz_* ; do echo $fuzzer;$fuzzer common_out out/* -max_total_time=40; done
+---
+kind: pipeline
 name: stylecheck
 platform: { os: linux, arch: amd64 }
 steps:

--- a/fuzz/fuzz_implementations.cpp
+++ b/fuzz/fuzz_implementations.cpp
@@ -84,7 +84,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     // let each implementation parse and store the result
     std::size_t nerrors=0;
-    for(auto& e: implementations) {
+    for(std::size_t i=0; i<Nimplementations; ++i) {
+        auto& e=implementations[i];
         simdjson::active_implementation=e.impl;
         e.error=e.parser.parse(Data,Size).get(e.element);
         if(e.error) {


### PR DESCRIPTION
This adds fuzzing on drone.io arm64

For some reason, leak detection had to be disabled. If it is enabled, the fuzzer falsely reports a crash at the end of fuzzing.

Closes: #1188 