### PR TITLE
Make it possible to check that an implementation is supported at runtime

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -382,6 +382,26 @@ steps:
     - ctest $CTEST_FLAGS
 ---
 kind: pipeline
+name: arm64-fuzz
+platform: { os: linux, arch: arm64 }
+steps:
+- name: Build and run fuzzers shortly
+  image: ubuntu:20.04
+  environment:
+    CC: clang
+    CXX: clang++
+    DEBIAN_FRONTEND: noninteractive
+    ASAN_OPTIONS: detect_leaks=0
+  commands:
+    - apt-get update -qq
+    - apt-get install -q -y clang cmake git wget zip ninja-build
+    - wget --quiet https://dl.bintray.com/pauldreik/simdjson-fuzz-corpus/corpus/corpus.tar
+    - tar xf corpus.tar && rm corpus.tar
+    - fuzz/build_like_ossfuzz.sh
+    - mkdir -p common_out
+    - for fuzzer in build/fuzz/fuzz_* ; do echo $fuzzer;$fuzzer common_out out/* -max_total_time=40; done
+---
+kind: pipeline
 name: stylecheck
 platform: { os: linux, arch: amd64 }
 steps:

--- a/benchmark/benchfeatures.cpp
+++ b/benchmark/benchfeatures.cpp
@@ -96,8 +96,14 @@ struct option_struct {
       case 'v':
         verbose = true;
         break;
-      case 'a':
-        simdjson::active_implementation = simdjson::available_implementations[optarg];
+      case 'a': {
+          auto impl = simdjson::available_implementations[optarg];
+          if(impl && impl->supported_by_runtime_system()) {
+            simdjson::active_implementation = impl; 
+          } else { 
+            std::cerr << "implementation " << optarg << " not found or not supported " << std::endl;
+          }
+        } 
         break;
       case 's':
         if (!strcmp(optarg, "stage1")) {

--- a/benchmark/minifiercompetition.cpp
+++ b/benchmark/minifiercompetition.cpp
@@ -125,9 +125,11 @@ int main(int argc, char *argv[]) {
   size_t outlength;
   uint8_t *cbuffer = (uint8_t *)buffer;
   for (auto imple : simdjson::available_implementations) {
-    BEST_TIME((std::string("simdjson->minify+")+imple->name()).c_str(), (imple->minify(cbuffer, p.size(), cbuffer, outlength) == simdjson::SUCCESS ? outlength : -1),
+    if(imple->supported_by_runtime_system()) {
+      BEST_TIME((std::string("simdjson->minify+")+imple->name()).c_str(), (imple->minify(cbuffer, p.size(), cbuffer, outlength) == simdjson::SUCCESS ? outlength : -1),
             outlength, memcpy(buffer, p.data(), p.size()), repeat, volume,
             !just_data);
+    }
   }
 
   printf("minisize = %zu, original size = %zu  (minified down to %.2f percent "

--- a/benchmark/parse.cpp
+++ b/benchmark/parse.cpp
@@ -67,7 +67,9 @@ void print_usage(ostream& out) {
   out << "-a IMPL      - Use the given parser implementation. By default, detects the most advanced" << endl;
   out << "               implementation supported on the host machine." << endl;
   for (auto impl : simdjson::available_implementations) {
-    out << "-a " << std::left << std::setw(9) << impl->name() << " - Use the " << impl->description() << " parser implementation." << endl;
+    if(impl->supported_by_runtime_system()) {
+      out << "-a " << std::left << std::setw(9) << impl->name() << " - Use the " << impl->description() << " parser implementation." << endl;
+    }
   }
 }
 
@@ -115,11 +117,13 @@ struct option_struct {
         break;
       case 'a': {
         const implementation *impl = simdjson::available_implementations[optarg];
-        if (!impl) {
+        if ((!impl) || (!impl->supported_by_runtime_system())) {
           std::string exit_message = string("Unsupported option value -a ") + optarg + ": expected -a  with one of ";
           for (auto imple : simdjson::available_implementations) {
-            exit_message += imple->name();
-            exit_message += " ";
+            if(imple->supported_by_runtime_system()) {
+              exit_message += imple->name();
+              exit_message += " ";
+            }
           }
           exit_usage(exit_message);
         }

--- a/doc/implementation-selection.md
+++ b/doc/implementation-selection.md
@@ -116,4 +116,4 @@ for (auto implementation : simdjson::available_implementations) {
 ```
 
 The call to `supported_by_runtime_system()` maybe relatively expensive. Do not call  `supported_by_runtime_system()` each
-time you parse a JSON input (for example).
+time you parse a JSON input (for example). It is meant to be called a handful of times at most in the life of a program.

--- a/doc/implementation-selection.md
+++ b/doc/implementation-selection.md
@@ -6,6 +6,7 @@ CPU Architecture-Specific Implementations
 * [Inspecting the Detected Implementation](#inspecting-the-detected-implementation)
 * [Querying Available Implementations](#querying-available-implementations)
 * [Manually Selecting the Implementation](#manually-selecting-the-implementation)
+* [Checking that an Implementation can Run on your System](#checking-that-an-implementation-can-run-on-your-system)
 
 Overview
 --------
@@ -70,6 +71,14 @@ And look them up by name:
 ```c++
 cout << simdjson::available_implementations["fallback"]->description() << endl;
 ```
+Though the fallback implementation should always be available, others might be missing. When 
+an implementation is not available, the bracket call `simdjson::available_implementations[name]`
+will return the null pointer.
+
+The available implementations have been compiled but may not necessarily be run safely on your system
+see [Checking that an Implementation can Run on your System](#checking-that-an-implementation-can-run-on-your-system).
+
+
 
 Manually Selecting the Implementation
 -------------------------------------
@@ -81,3 +90,30 @@ can select the CPU architecture yourself:
 // Use the fallback implementation, even though my machine is fast enough for anything
 simdjson::active_implementation = simdjson::available_implementations["fallback"];
 ```
+
+You are responsible for ensuring that the requirements of the selected implementation match your current system.
+Furthermore, you should check that the implementation is available before setting it to `simdjson::active_implementation`
+by comparing it with the null pointer.
+
+```c++
+auto my_implementation = simdjson::available_implementations["haswell"];
+if(! my_implementation) { exit(1); }
+if(! my_implementation->supported_by_runtime_system()) { exit(1); }
+simdjson::active_implementation = my_implementation;
+```
+
+Checking that an Implementation can Run on your System
+-------------------------------------
+
+You should call `supported_by_runtime_system()` to compare the processor's features with the need of the implementation.
+
+```c++
+for (auto implementation : simdjson::available_implementations) {
+  if(implementation->supported_by_runtime_system()) {
+    cout << implementation->name() << ": " << implementation->description() << endl;
+  }
+}
+```
+
+The call to `supported_by_runtime_system()` maybe relatively expensive. Do not call  `supported_by_runtime_system()` each
+time you parse a JSON input (for example).

--- a/fuzz/fuzz_implementations.cpp
+++ b/fuzz/fuzz_implementations.cpp
@@ -67,7 +67,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     // make this dynamic, so it works regardless of how it was compiled
     // or what hardware it runs on
     constexpr std::size_t Nimplementations_max=3;
-    const std::size_t Nimplementations=simdjson::available_implementations.size();
+    std::size_t Nimplementations = 0;
+    
+    for(auto impl : simdjson::available_implementations) {
+        if(impl->supported_by_runtime_system()) {
+              Nimplementations++;
+        }
+    }
     if(Nimplementations>Nimplementations_max) {
         //there is another backend added, please bump Nimplementations_max!
         std::abort();
@@ -78,7 +84,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     {
         std::size_t i=0;
         for(auto& e: simdjson::available_implementations) {
-            implementations[i++].impl=e;
+            if(e->supported_by_runtime_system()) {
+              implementations[i++].impl=e;
+            }
         }
     }
 

--- a/fuzz/fuzz_implementations.cpp
+++ b/fuzz/fuzz_implementations.cpp
@@ -84,7 +84,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     // let each implementation parse and store the result
     std::size_t nerrors=0;
-    for(auto& e: implementations) {
+    for(std::size_t i=0; i<Nimplementations; ++i) {
+        auto& e=implementations[i];
         simdjson::active_implementation=e.impl;
         e.error=e.parser.parse(Data,Size).get(e.element);
         if(e.error) {

--- a/fuzz/fuzz_utf8.cpp
+++ b/fuzz/fuzz_utf8.cpp
@@ -18,16 +18,20 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     };
 
 
-    auto first=simdjson::available_implementations.begin();
-    auto last=simdjson::available_implementations.end();
+    auto first = simdjson::available_implementations.begin();
+    auto last = simdjson::available_implementations.end();
 
-    //make sure there is an implementation
-    assert(first!=last);
 
-    const bool reference=utf8verify(*first);
+    auto it = first;
+    while((it != last) && (!(*it)->supported_by_runtime_system())) { it++; }
+    assert(it != last);
+
+
+    const bool reference=utf8verify(*it);
 
     bool failed=false;
-    for(auto it=first+1;it!=last; ++it) {
+    for(; it != last; ++it) {
+        if(!(*it)->supported_by_runtime_system()) { continue; }
         const bool current=utf8verify(*it);
         if(current!=reference) {
             failed=true;
@@ -36,7 +40,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 
     if(failed) {
         std::cerr<<std::boolalpha<<"Mismatch between implementations of validate_utf8() found:\n";
-        for(auto it=first;it!=last; ++it) {
+        for(it = first;it != last; ++it) {
+            if(!(*it)->supported_by_runtime_system()) { continue; }
             const bool current=utf8verify(*it);
             std::cerr<<(*it)->name()<<" returns "<<current<<std::endl;
         }

--- a/include/simdjson/implementation.h
+++ b/include/simdjson/implementation.h
@@ -190,6 +190,7 @@ public:
    *
    *     const implementation *impl = simdjson::available_implementations["westmere"];
    *     if (!impl) { exit(1); }
+   *     if (!imp->supported_by_runtime_system()) { exit(1); }
    *     simdjson::active_implementation = impl;
    *
    * @param name the implementation to find, e.g. "westmere", "haswell", "arm64"

--- a/include/simdjson/implementation.h
+++ b/include/simdjson/implementation.h
@@ -71,6 +71,16 @@ public:
    * @return the name of the implementation, e.g. "haswell", "westmere", "arm64"
    */
   virtual const std::string &description() const { return _description; }
+  
+  /**
+   * The instruction sets this implementation is compiled against
+   * and the current CPU match. This function may poll the current CPU/system
+   * and should therefore not be called too often if performance is a concern.
+   * 
+   *
+   * @return true if the implementation can be safely used on the current system (determined at runtime)
+   */
+  bool supported_by_runtime_system() const;
 
   /**
    * @private For internal implementation use

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -30,6 +30,13 @@ namespace simdjson { namespace internal { const fallback::implementation fallbac
 #endif // SIMDJSON_IMPLEMENTATION_FALLBACK
 
 namespace simdjson {
+
+bool implementation::supported_by_runtime_system() const {
+  uint32_t required_instruction_sets = this->required_instruction_sets();
+  uint32_t supported_instruction_sets = detect_supported_architectures();
+  return ((supported_instruction_sets & required_instruction_sets) == required_instruction_sets);
+}
+
 namespace internal {
 
 /**

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -1868,6 +1868,10 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Unsupported architecture value -a %s\n", optarg);
         return EXIT_FAILURE;
       }
+      if(!impl->supported_by_runtime_system()) {
+        fprintf(stderr, "The selected implementation does not match your current CPU: -a %s\n", optarg);
+        return EXIT_FAILURE;
+      }
       simdjson::active_implementation = impl;
       break;
     }

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -340,6 +340,10 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Unsupported architecture value -a %s\n", optarg);
         return EXIT_FAILURE;
       }
+      if(!impl->supported_by_runtime_system()) {
+        fprintf(stderr, "The selected implementation does not match your current CPU: -a %s\n", optarg);
+        return EXIT_FAILURE;
+      }
       simdjson::active_implementation = impl;
       break;
     }

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -202,6 +202,10 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Unsupported architecture value -a %s\n", optarg);
         return EXIT_FAILURE;
       }
+      if(!impl->supported_by_runtime_system()) {
+        fprintf(stderr, "The selected implementation does not match your current CPU: -a %s\n", optarg);
+        return EXIT_FAILURE;
+      }
       simdjson::active_implementation = impl;
       break;
     }

--- a/tests/jsoncheck.cpp
+++ b/tests/jsoncheck.cpp
@@ -119,6 +119,10 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Unsupported architecture value -a %s\n", optarg);
         return EXIT_FAILURE;
       }
+      if(!impl->supported_by_runtime_system()) {
+        fprintf(stderr, "The selected implementation does not match your current CPU: -a %s\n", optarg);
+        return EXIT_FAILURE;
+      }
       simdjson::active_implementation = impl;
       break;
     }

--- a/tests/minefieldcheck.cpp
+++ b/tests/minefieldcheck.cpp
@@ -117,6 +117,10 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "Unsupported architecture value -a %s\n", optarg);
         return EXIT_FAILURE;
       }
+      if(!impl->supported_by_runtime_system()) {
+        fprintf(stderr, "The selected implementation does not match your current CPU: -a %s\n", optarg);
+        return EXIT_FAILURE;
+      }
       simdjson::active_implementation = impl;
       break;
     }

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -201,8 +201,22 @@ void implementation_selection_2() {
   }
 }
 
+void implementation_selection_2_safe() {
+  for (auto implementation : simdjson::available_implementations) {
+    if(implementation->supported_by_runtime_system()) {
+      cout << implementation->name() << ": " << implementation->description() << endl;
+    }
+  }
+}
 void implementation_selection_3() {
   cout << simdjson::available_implementations["fallback"]->description() << endl;
+}
+
+void implementation_selection_safe() {
+  auto my_implementation = simdjson::available_implementations["haswell"];
+  if(! my_implementation) { exit(1); }
+  if(! my_implementation->supported_by_runtime_system()) { exit(1); }
+  simdjson::active_implementation = my_implementation;
 }
 
 void implementation_selection_4() {

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -9,7 +9,7 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include "cxxopts.hpp"
 SIMDJSON_POP_DISABLE_WARNINGS
 
-int main(int argc, char *argv[]) {
+int main(int argc, const char *argv[]) {
 #ifdef __cpp_exceptions
   try {
 #endif

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -9,7 +9,11 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include "cxxopts.hpp"
 SIMDJSON_POP_DISABLE_WARNINGS
 
+#if CXXOPTS__VERSION_MAJOR < 3 
+int main(int argc, char *argv[]) {
+#else
 int main(int argc, const char *argv[]) {
+#endif
 #ifdef __cpp_exceptions
   try {
 #endif

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -188,8 +188,11 @@ stat_t simdjson_compute_stats(const simdjson::padded_string &p) {
   recurse(doc, s, 0);
   return s;
 }
-
+#if CXXOPTS__VERSION_MAJOR < 3 
+int main(int argc, char *argv[]) {
+#else
 int main(int argc, const char *argv[]) {
+#endif
 #ifdef __cpp_exceptions
   try {
 #endif

--- a/tools/jsonstats.cpp
+++ b/tools/jsonstats.cpp
@@ -189,7 +189,7 @@ stat_t simdjson_compute_stats(const simdjson::padded_string &p) {
   return s;
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, const char *argv[]) {
 #ifdef __cpp_exceptions
   try {
 #endif

--- a/tools/minify.cpp
+++ b/tools/minify.cpp
@@ -20,7 +20,11 @@ void usage(std::string message) {
   std::cerr << options.help() << std::endl;
 }
 
+#if CXXOPTS__VERSION_MAJOR < 3 
+int main(int argc, char *argv[]) {
+#else
 int main(int argc, const char *argv[]) {
+#endif
 #ifdef __cpp_exceptions
   try {
 #endif

--- a/tools/minify.cpp
+++ b/tools/minify.cpp
@@ -20,7 +20,7 @@ void usage(std::string message) {
   std::cerr << options.help() << std::endl;
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, const char *argv[]) {
 #ifdef __cpp_exceptions
   try {
 #endif
@@ -28,7 +28,9 @@ int main(int argc, char *argv[]) {
   ss << "Parser implementation (by default, detects the most advanced implementation supported on the host machine)."  << std::endl;
   ss << "Available parser implementations:" << std::endl;
   for (auto impl : simdjson::available_implementations) {
-    ss << "-a " << std::left << std::setw(9) << impl->name() << " - Use the " << impl->description() << " parser implementation." << std::endl;
+    if(impl->supported_by_runtime_system()) {
+      ss << "-a " << std::left << std::setw(9) << impl->name() << " - Use the " << impl->description() << " parser implementation." << std::endl;
+    }
   }
   options.add_options()
     ("a,arch", ss.str(), cxxopts::value<std::string>())
@@ -52,6 +54,10 @@ int main(int argc, char *argv[]) {
     const simdjson::implementation *impl = simdjson::available_implementations[result["arch"].as<std::string>().c_str()];
     if(!impl) {
       usage("Unsupported implementation.");
+      return EXIT_FAILURE;
+    }
+    if(!impl->supported_by_runtime_system()) {
+      usage("The selected implementation does not match your current CPU.");
       return EXIT_FAILURE;
     }
     simdjson::active_implementation = impl;


### PR DESCRIPTION
The idea for this new method came via a discussion with @pauldreik

At compile-time, we generate several kernels. At runtime, they are all available. If you select the wrong one, you could crash your system. This function would tell you whether it is safe to call the kernel. This determination must be done at runtime.

This is highly specialized and not likely to be generally useful.

We should only merge this if it is actually useful to someone.

(This is the second and proper PR.)