### PR TITLE
Testing on minimalist alpine (linux) images

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,7 +1,7 @@
 name: Alpine Linux
-
-on: [push, pull_request]
-
+'on':
+  - push
+  - pull_request
 jobs:
   ubuntu-build:
     runs-on: ubuntu-latest
@@ -12,16 +12,16 @@ jobs:
           docker run -w /src -dit --name alpine -v $PWD:/src alpine:latest
           echo 'docker exec alpine "$@";' > ./alpine.sh
           chmod +x ./alpine.sh
-    - name: install packages
-      run: |
-        ./alpine.sh apk update
-        ./alpine.sh apk add build-base cmake g++ linux-headers git bash
-    - name: cmake
-      run: |
-        ./alpine.sh cmake -B build_for_alpine
-    - name: build
-      run: |
-        ./alpine.sh cmake --build build_for_alpine
-    - name: test
-      run: |
-        ./alpine.sh bash -c "cd build_for_alpine && ctest"
+      - name: install packages
+        run: |
+          ./alpine.sh apk update
+          ./alpine.sh apk add build-base cmake g++ linux-headers git bash
+      - name: cmake
+        run: |
+          ./alpine.sh cmake -B build_for_alpine
+      - name: build
+        run: |
+          ./alpine.sh cmake --build build_for_alpine
+      - name: test
+        run: |
+          ./alpine.sh bash -c "cd build_for_alpine && ctest"

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,0 +1,27 @@
+name: Alpine Linux
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: start docker
+        run: |
+          docker run -w /src -dit --name alpine -v $PWD:/src alpine:latest
+          echo 'docker exec alpine "$@";' > ./alpine.sh
+          chmod +x ./alpine.sh
+    - name: install packages
+      run: |
+        ./alpine.sh apk update
+        ./alpine.sh apk add build-base cmake g++ linux-headers git bash
+    - name: cmake
+      run: |
+        ./alpine.sh cmake -B build_for_alpine
+    - name: build
+      run: |
+        ./alpine.sh cmake --build build_for_alpine
+    - name: test
+      run: |
+        ./alpine.sh bash -c "cd build_for_alpine && ctest"

--- a/benchmark/linux/linux-perf-events.h
+++ b/benchmark/linux/linux-perf-events.h
@@ -1,8 +1,16 @@
 // https://github.com/WojciechMula/toys/blob/master/000helpers/linux-perf-events.h
 #pragma once
 #ifdef __linux__
-
+#ifdef __has_include
+#if __has_include(<asm/unistd.h>)
 #include <asm/unistd.h>       // for __NR_perf_event_open
+#else
+#warning "Header asm/unistd.h cannot be found though it is a linux system. Are linux headers missing?"
+#endif
+#else // no __has_include
+// Please insure that linux headers have been installed.
+#include <asm/unistd.h>       // for __NR_perf_event_open
+#endif 
 #include <linux/perf_event.h> // for perf event constants
 #include <sys/ioctl.h>        // for ioctl
 #include <unistd.h>           // for syscall


### PR DESCRIPTION
The idea here is that if we can build and run tests on alpine, we should be pretty much set on all Linux systems given how minimalist alpine is. These tests revealed a hidden dependency on the linux headers which I had assumed were present on all systems.