### PR TITLE
fix broken fuzzer action job

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -100,7 +100,7 @@ jobs:
 
     - name: Package the corpus into an artifact
       run: |
-        for fuzzer in $allfuzzers; do      
+        for fuzzer in $defaultimplfuzzers $implfuzzers; do      
           tar rf corpus.tar out/$fuzzer
         done
 


### PR DESCRIPTION
forgot a place during refactoring, did not show up until run on the master branch