### PR TITLE
This would allow users to find out what builtin is.

### DIFF
--- a/benchmark/kostya/ondemand.h
+++ b/benchmark/kostya/ondemand.h
@@ -11,10 +11,7 @@ using namespace simdjson::builtin;
 
 class OnDemand {
 public:
-  OnDemand() { std::cout << "On Demand implementation: " << builtin_implementation.name() << std::endl; } 
-
   simdjson_really_inline bool Run(const padded_string &json);
-
   simdjson_really_inline const std::vector<my_point> &Result() { return container; }
   simdjson_really_inline size_t ItemCount() { return container.size(); }
 
@@ -45,7 +42,6 @@ namespace sum {
 class OnDemand {
 public:
   simdjson_really_inline bool Run(const padded_string &json);
-
   simdjson_really_inline my_point &Result() { return sum; }
   simdjson_really_inline size_t ItemCount() { return count; }
 

--- a/benchmark/kostya/ondemand.h
+++ b/benchmark/kostya/ondemand.h
@@ -11,6 +11,8 @@ using namespace simdjson::builtin;
 
 class OnDemand {
 public:
+  OnDemand() { std::cout << "On Demand implementation: " << builtin_implementation.name() << std::endl; } 
+
   simdjson_really_inline bool Run(const padded_string &json);
 
   simdjson_really_inline const std::vector<my_point> &Result() { return container; }

--- a/benchmark/largerandom/ondemand.h
+++ b/benchmark/largerandom/ondemand.h
@@ -11,6 +11,7 @@ using namespace simdjson::builtin;
 
 class OnDemand {
 public:
+  OnDemand() { std::cout << "On Demand implementation: " << builtin_implementation.name() << std::endl; } 
   simdjson_really_inline bool Run(const padded_string &json);
 
   simdjson_really_inline const std::vector<my_point> &Result() { return container; }

--- a/benchmark/largerandom/ondemand.h
+++ b/benchmark/largerandom/ondemand.h
@@ -11,9 +11,7 @@ using namespace simdjson::builtin;
 
 class OnDemand {
 public:
-  OnDemand() { std::cout << "On Demand implementation: " << builtin_implementation.name() << std::endl; } 
   simdjson_really_inline bool Run(const padded_string &json);
-
   simdjson_really_inline const std::vector<my_point> &Result() { return container; }
   simdjson_really_inline size_t ItemCount() { return container.size(); }
 
@@ -41,7 +39,6 @@ namespace sum {
 class OnDemand {
 public:
   simdjson_really_inline bool Run(const padded_string &json);
-
   simdjson_really_inline my_point &Result() { return sum; }
   simdjson_really_inline size_t ItemCount() { return count; }
 

--- a/benchmark/partial_tweets/ondemand.h
+++ b/benchmark/partial_tweets/ondemand.h
@@ -11,6 +11,7 @@ using namespace simdjson::builtin;
 
 class OnDemand {
 public:
+  OnDemand() { std::cout << "On Demand implementation: " << builtin_implementation.name() << std::endl; } 
   simdjson_really_inline bool Run(const padded_string &json);
 
   simdjson_really_inline const std::vector<tweet> &Result() { return tweets; }

--- a/benchmark/partial_tweets/ondemand.h
+++ b/benchmark/partial_tweets/ondemand.h
@@ -9,11 +9,16 @@ namespace partial_tweets {
 using namespace simdjson;
 using namespace simdjson::builtin;
 
+
 class OnDemand {
 public:
-  OnDemand() { std::cout << "On Demand implementation: " << builtin_implementation.name() << std::endl; } 
+  OnDemand() { 
+    if(!displayed_implementation) {
+      std::cout << "On Demand implementation: " << builtin_implementation()->name() << std::endl; 
+      displayed_implementation = true;
+    }
+  } 
   simdjson_really_inline bool Run(const padded_string &json);
-
   simdjson_really_inline const std::vector<tweet> &Result() { return tweets; }
   simdjson_really_inline size_t ItemCount() { return tweets.size(); }
 
@@ -31,6 +36,7 @@ private:
     ondemand::object u = std::move(user);
     return { u["id"], u["screen_name"] };
   }
+  static inline bool displayed_implementation = false;
 };
 
 simdjson_really_inline bool OnDemand::Run(const padded_string &json) {

--- a/doc/ondemand.md
+++ b/doc/ondemand.md
@@ -498,3 +498,11 @@ Good applications for the On Demand API might be:
 * You have a closed system on predetermined hardware. Both the generation and the consumption of JSON data is within your system. Your team controls both the software that produces the JSON and the software the parses it, your team knows and control the hardware. Thus you can fully test your system.
 * You are working with stable JSON APIs which have a consistent layout and JSON dialect.
 
+## Checking Your CPU Selection
+
+Given that the On Demand API does not offer runtime dispatching, your code is compiled against a specific CPU target. You should
+verify that the code is compiled against the target you expect: `haswell` (AVX2 x64 processors), `westmere` (SSE4 x64 processors), `arm64` (64-bit ARM), `fallback` (others).
+
+```C++
+  std::cout << simdjson::builtin_implementation.name() << std::endl;
+```

--- a/doc/ondemand.md
+++ b/doc/ondemand.md
@@ -501,8 +501,9 @@ Good applications for the On Demand API might be:
 ## Checking Your CPU Selection
 
 Given that the On Demand API does not offer runtime dispatching, your code is compiled against a specific CPU target. You should
-verify that the code is compiled against the target you expect: `haswell` (AVX2 x64 processors), `westmere` (SSE4 x64 processors), `arm64` (64-bit ARM), `fallback` (others).
+verify that the code is compiled against the target you expect: `haswell` (AVX2 x64 processors), `westmere` (SSE4 x64 processors), `arm64` (64-bit ARM), `fallback` (others). Under x64 processors, many programmers will want to target `haswell` whereas under ARM,
+most programmers will want to target `arm64`. The `fallback` is probably only good for testing purposes, not for deployment.
 
 ```C++
-  std::cout << simdjson::builtin_implementation.name() << std::endl;
+  std::cout << simdjson::builtin_implementation()->name() << std::endl;
 ```

--- a/doc/ondemand.md
+++ b/doc/ondemand.md
@@ -507,3 +507,12 @@ most programmers will want to target `arm64`. The `fallback` is probably only go
 ```C++
   std::cout << simdjson::builtin_implementation()->name() << std::endl;
 ```
+
+If you are using CMake for your C++ project, then you can pass compilation flags to your compiler during the first configuration
+by using the `CXXFLAGS`  configuration variable:
+```
+CXXFLAGS=-march=haswell cmake -B build_haswell
+cmake --build build_haswell
+```
+
+You may also use the  `CMAKE_CXX_FLAGS` variable.

--- a/include/simdjson/builtin.h
+++ b/include/simdjson/builtin.h
@@ -30,9 +30,9 @@ namespace simdjson {
    */
   namespace builtin = SIMDJSON_BUILTIN_IMPLEMENTATION;
   /**
-   * It is handy to be able to check what builtin was used.
+   * It is handy to be able to check what builtin was used: builtin_implementation.name().
    */
-  constexpr const char * builtin_name = STRINGIFY(SIMDJSON_BUILTIN_IMPLEMENTATION);
+  const builtin::implementation builtin_implementation{};
 } // namespace simdjson
 
 #endif // SIMDJSON_BUILTIN_H

--- a/include/simdjson/builtin.h
+++ b/include/simdjson/builtin.h
@@ -30,9 +30,12 @@ namespace simdjson {
    */
   namespace builtin = SIMDJSON_BUILTIN_IMPLEMENTATION;
   /**
-   * It is handy to be able to check what builtin was used: builtin_implementation.name().
+   * Function which returns a pointer to an implementation matching the "builtin" implementation.
+   * The builtin implementation is the best statically linked simdjson implementation that can be used by the compiling
+   * program. If you compile with g++ -march=haswell, this will return the haswell implementation.
+   * It is handy to be able to check what builtin was used: builtin_implementation()->name().
    */
-  const builtin::implementation builtin_implementation{};
+  const implementation * builtin_implementation();
 } // namespace simdjson
 
 #endif // SIMDJSON_BUILTIN_H

--- a/include/simdjson/builtin.h
+++ b/include/simdjson/builtin.h
@@ -29,6 +29,10 @@ namespace simdjson {
    * code that uses it) will use westmere.
    */
   namespace builtin = SIMDJSON_BUILTIN_IMPLEMENTATION;
+  /**
+   * It is handy to be able to check what builtin was used.
+   */
+  constexpr const char * builtin_name = STRINGIFY(SIMDJSON_BUILTIN_IMPLEMENTATION);
 } // namespace simdjson
 
 #endif // SIMDJSON_BUILTIN_H

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -147,5 +147,10 @@ simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) noexcept {
   return active_implementation->validate_utf8(buf, len);
 }
 
+const implementation * builtin_implementation() {
+  static const implementation * builtin_impl = available_implementations[STRINGIFY(SIMDJSON_BUILTIN_IMPLEMENTATION)];
+  return builtin_impl;
+}
+
 
 } // namespace simdjson

--- a/tests/ondemand/ondemand_basictests.cpp
+++ b/tests/ondemand/ondemand_basictests.cpp
@@ -1241,7 +1241,7 @@ int main(int argc, char *argv[]) {
   }
   // We want to know what we are testing.
   std::cout << "Running tests against this implementation: " << simdjson::active_implementation->name();
-  std::cout << "(" << simdjson::active_implementation->description() << ")" << std::endl;
+  std::cout << "builtin_implementation -- " << builtin_implementation.name() << std::endl;
   std::cout << "------------------------------------------------------------" << std::endl;
 
   std::cout << "Running basic tests." << std::endl;

--- a/tests/ondemand/ondemand_basictests.cpp
+++ b/tests/ondemand/ondemand_basictests.cpp
@@ -1242,8 +1242,9 @@ int main(int argc, char *argv[]) {
   // We want to know what we are testing.
   // Next line would be the runtime dispatched implementation but that's not necessarily what gets tested.
   // std::cout << "Running tests against this implementation: " << simdjson::active_implementation->name();
+  // Rather, we want to display builtin_implementation()->name().
   // In practice, by default, we often end up testing against fallback.
-  std::cout << "builtin_implementation -- " << builtin_implementation.name() << std::endl;
+  std::cout << "builtin_implementation -- " << builtin_implementation()->name() << std::endl;
   std::cout << "------------------------------------------------------------" << std::endl;
 
   std::cout << "Running basic tests." << std::endl;

--- a/tests/ondemand/ondemand_basictests.cpp
+++ b/tests/ondemand/ondemand_basictests.cpp
@@ -1240,7 +1240,9 @@ int main(int argc, char *argv[]) {
     printf("unsupported CPU\n");
   }
   // We want to know what we are testing.
-  std::cout << "Running tests against this implementation: " << simdjson::active_implementation->name();
+  // Next line would be the runtime dispatched implementation but that's not necessarily what gets tested.
+  // std::cout << "Running tests against this implementation: " << simdjson::active_implementation->name();
+  // In practice, by default, we often end up testing against fallback.
   std::cout << "builtin_implementation -- " << builtin_implementation.name() << std::endl;
   std::cout << "------------------------------------------------------------" << std::endl;
 


### PR DESCRIPTION
Currently, if you write an On Demand piece of code, you have no convenient way to tell which implementation is actually being used. So you could have someone, on a powerful Intel processor, compiling On Demand in fallback mode and getting terrible performance, and we would have no quick way to identify the problem.


It would be nice if we could ask the user for which implementation they are using, and to be able to point them to documentation as to how they can print it out, if only for debugging purposes.

For discussion.
