### PR TITLE
fix some warnings in the sax benchmark

### DIFF
--- a/benchmark/largerandom/sax.h
+++ b/benchmark/largerandom/sax.h
@@ -26,17 +26,14 @@ private:
   std::vector<my_point> container{};
 };
 
-using namespace simdjson;
-using namespace simdjson::builtin;
-using namespace simdjson::builtin::stage2;
 struct sax_point_reader_visitor {
 public:
   std::vector<my_point> &points;
   enum {GOT_X=0, GOT_Y=1, GOT_Z=2, GOT_SOMETHING_ELSE=4};
   size_t idx{GOT_SOMETHING_ELSE};
-  double buffer[3];
+  double buffer[3]={};
 
-  sax_point_reader_visitor(std::vector<my_point> &_points) : points(_points) {}
+  explicit sax_point_reader_visitor(std::vector<my_point> &_points) : points(_points) {}
 
   simdjson_really_inline error_code visit_object_start(json_iterator &) {
     idx = 0;
@@ -96,7 +93,7 @@ error_code Sax::RunNoExcept(const padded_string &json) noexcept {
   }
 
   // Run stage 1 first.
-  SIMDJSON_TRY( dom_parser.stage1((uint8_t *)json.data(), json.size(), false) );
+  SIMDJSON_TRY( dom_parser.stage1(json.u8data(), json.size(), false) );
 
   // Then walk the document, parsing the tweets as we go
   json_iterator iter(dom_parser, 0);

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -85,6 +85,7 @@ struct padded_string final {
    * The string data.
    **/
   const char *data() const noexcept;
+  const uint8_t *u8data() const noexcept { return static_cast<const uint8_t*>(static_cast<const void*>(data_ptr));}
 
   /**
    * The string data.


### PR DESCRIPTION
For some reason, warnings started popping up in CI seemingly unrelated to what I was working on.

This fixes a "potentially use of uninitialized value" warning, as well as a cstyle cast to non-const.
