### PR TITLE
Adding a new benchmark for ondemand: distinct user id

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -7,16 +7,20 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
-#include "partial_tweets/ondemand.h"
-#include "partial_tweets/iter.h"
-#include "partial_tweets/dom.h"
+//#include "partial_tweets/ondemand.h"
+//#include "partial_tweets/iter.h"
+//#include "partial_tweets/dom.h"
 
-#include "largerandom/ondemand.h"
-#include "largerandom/iter.h"
-#include "largerandom/dom.h"
+//#include "largerandom/ondemand.h"
+//#include "largerandom/iter.h"
+//#include "largerandom/dom.h"
 
-#include "kostya/ondemand.h"
-#include "kostya/iter.h"
-#include "kostya/dom.h"
+//#include "kostya/ondemand.h"
+//#include "kostya/iter.h"
+//#include "kostya/dom.h"
+
+#include "distinctuserid/ondemand.h"
+#include "distinctuserid/dom.h"
+
 
 BENCHMARK_MAIN();

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -7,17 +7,17 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
-//#include "partial_tweets/ondemand.h"
-//#include "partial_tweets/iter.h"
-//#include "partial_tweets/dom.h"
+#include "partial_tweets/ondemand.h"
+#include "partial_tweets/iter.h"
+#include "partial_tweets/dom.h"
 
-//#include "largerandom/ondemand.h"
-//#include "largerandom/iter.h"
-//#include "largerandom/dom.h"
+#include "largerandom/ondemand.h"
+#include "largerandom/iter.h"
+#include "largerandom/dom.h"
 
-//#include "kostya/ondemand.h"
-//#include "kostya/iter.h"
-//#include "kostya/dom.h"
+#include "kostya/ondemand.h"
+#include "kostya/iter.h"
+#include "kostya/dom.h"
 
 #include "distinctuserid/ondemand.h"
 #include "distinctuserid/dom.h"

--- a/benchmark/distinctuserid/distinctuserid.h
+++ b/benchmark/distinctuserid/distinctuserid.h
@@ -1,0 +1,52 @@
+
+#pragma once
+#include <vector>
+#include <cstdint>
+#include "event_counter.h"
+#include "json_benchmark.h"
+
+
+bool equals(const char *s1, const char *s2) { return strcmp(s1, s2) == 0; }
+
+void remove_duplicates(std::vector<int64_t> &v) {
+  std::sort(v.begin(), v.end());
+  auto last = std::unique(v.begin(), v.end());
+  v.erase(last, v.end());
+}
+
+//
+// Interface
+//
+
+namespace distinct_user_id {
+template<typename T> static void DistinctUserID(benchmark::State &state);
+} // namespace 
+
+//
+// Implementation
+//
+
+#include "dom.h"
+
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+
+template<typename T> static void DistinctUserID(benchmark::State &state) {
+  //
+  // Load the JSON file
+  //
+  constexpr const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+  error_code error;
+  padded_string json;
+  if ((error = padded_string::load(TWITTER_JSON).get(json))) {
+    std::cerr << error << std::endl;
+    state.SkipWithError("error loading");
+    return;
+  }
+
+  JsonBenchmark<T, Dom>(state, json);
+}
+
+} // namespace distinct_user_id

--- a/benchmark/distinctuserid/dom.h
+++ b/benchmark/distinctuserid/dom.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "distinctuserid.h"
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+
+
+simdjson_really_inline void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::element element);
+void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::array array) {
+  for (auto child : array) {
+    simdjson_recurse(v, child);
+  }
+}
+void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::object object) {
+  for (auto [key, value] : object) {
+    if((key.size() == 4) && (memcmp(key.data(), "user", 4) == 0)) {
+      // we are in an object under the key "user"
+      simdjson::error_code error;
+      simdjson::dom::object child_object;
+      simdjson::dom::object child_array;
+      if (not (error = value.get(child_object))) {
+        for (auto [child_key, child_value] : child_object) {
+          if((child_key.size() == 2) && (memcmp(child_key.data(), "id", 2) == 0)) {
+            int64_t x;
+            if (not (error = child_value.get(x))) {
+              v.push_back(x);
+            }
+          }
+          simdjson_recurse(v, child_value);
+        }
+      } else if (not (error = value.get(child_array))) {
+        simdjson_recurse(v, child_array);
+      }
+      // end of: we are in an object under the key "user"
+    } else {
+      simdjson_recurse(v, value);
+    }
+  }
+}
+simdjson_really_inline void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::element element) {
+  simdjson_unused simdjson::error_code error;
+  simdjson::dom::array array;
+  simdjson::dom::object object;
+  if (not (error = element.get(array))) {
+    simdjson_recurse(v, array);
+  } else if (not (error = element.get(object))) {
+    simdjson_recurse(v, object);
+  }
+}
+
+
+
+
+
+class Dom {
+public:
+  simdjson_really_inline bool Run(const padded_string &json);
+  simdjson_really_inline const std::vector<int64_t> &Result() { return ids; }
+  simdjson_really_inline size_t ItemCount() { return ids.size(); }
+
+private:
+  dom::parser parser{};
+  std::vector<int64_t> ids{};
+
+};
+void print_vec(const std::vector<int64_t> &v) {
+  for (auto i : v) {
+    std::cout << i << " ";
+  }
+  std::cout << std::endl;
+}
+
+simdjson_really_inline bool Dom::Run(const padded_string &json) {
+  ids.clear();
+  dom::element doc = parser.parse(json);
+  simdjson_recurse(ids, doc);
+  remove_duplicates(ids);
+  return true;
+}
+
+BENCHMARK_TEMPLATE(DistinctUserID, Dom);
+
+} // namespace distinct_user_id
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/distinctuserid/ondemand.h
+++ b/benchmark/distinctuserid/ondemand.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "distinctuserid.h"
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+using namespace simdjson::builtin;
+
+
+class OnDemand {
+public:
+  OnDemand() { 
+    if(!displayed_implementation) {
+      std::cout << "On Demand implementation: " << builtin_implementation()->name() << std::endl; 
+      displayed_implementation = true;
+    }
+  } 
+  simdjson_really_inline bool Run(const padded_string &json);
+  simdjson_really_inline const std::vector<int64_t> &Result() { return ids; }
+  simdjson_really_inline size_t ItemCount() { return ids.size(); }
+
+private:
+  ondemand::parser parser{};
+  std::vector<int64_t> ids{};
+
+  static inline bool displayed_implementation = false;
+};
+
+simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
+  ids.clear();
+  // Walk the document, parsing as we go
+  auto doc = parser.iterate(json);
+  for (ondemand::object tweet : doc["statuses"]) {
+      // We believe that all statuses have a matching
+      // user, and we are willing to throw when they do not:
+      //
+      // You might think that you do not need the braces, but
+      // you do, otherwise you will get the wrong answer. That is
+      // because you can only have one active object or array 
+      // at a time. 
+      {
+        ondemand::object user = tweet["user"];
+        int64_t id = user["id"]; 
+        ids.push_back(id);
+      }
+      // Not all tweets have a "retweeted_status", but when they do 
+      // we want to go and find the user within.
+      auto retweet = tweet["retweeted_status"];
+      if(!retweet.error()) {
+          ondemand::object retweet_content = retweet.value();
+          ondemand::object reuser = retweet_content["user"];
+          int64_t rid = reuser["id"]; 
+          ids.push_back(rid);
+      }
+  }
+  remove_duplicates(ids);
+  return true;
+}
+
+BENCHMARK_TEMPLATE(DistinctUserID, OnDemand);
+
+} // namespace distinct_user_id
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/distinctuserid/ondemand.h
+++ b/benchmark/distinctuserid/ondemand.h
@@ -50,7 +50,7 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
       // we want to go and find the user within.
       auto retweet = tweet["retweeted_status"];
       if(!retweet.error()) {
-          ondemand::object retweet_content = retweet.value();
+          ondemand::object retweet_content = retweet;
           ondemand::object reuser = retweet_content["user"];
           int64_t rid = reuser["id"]; 
           ids.push_back(rid);

--- a/tests/ondemand/ondemand_basictests.cpp
+++ b/tests/ondemand/ondemand_basictests.cpp
@@ -872,6 +872,7 @@ namespace twitter_tests {
     }));
     TEST_SUCCEED();
   }
+#if SIMDJSON_EXCEPTIONS
   bool twitter_example() {
     TEST_START();
     padded_string json;
@@ -881,19 +882,6 @@ namespace twitter_tests {
     for (ondemand::object tweet : doc["statuses"]) {
       uint64_t         id            = tweet["id"];
       std::string_view text          = tweet["text"];
-      /**
-       *  Here we are constrained by the API.
-       * Doing 
-       *  std::string_view screen_name = tweet["user"]["screen_name"];
-       * fails to compile with the error
-       * "error: invalid conversion from 'char' to 'const char*'"
-       * 
-       * Doing 
-       * std::string_view screen_name = tweet["user"].get_object()["screen_name"];
-       * fails at runtime with 
-       * "terminate called after throwing an instance of 'simdjson::simdjson_error'
-       *   what():  The JSON field referenced does not exist in this object."
-       */
       std::string_view screen_name;
       {
         ondemand::object user        = tweet["user"];
@@ -909,6 +897,7 @@ namespace twitter_tests {
     }
     TEST_SUCCEED();
   }
+#endif
 
   bool twitter_default_profile() {
     TEST_START();


### PR DESCRIPTION
This benchmark extracts all user ids for a file. The On Demand approach is roughly twice as fast. So we get 4.6GB/s  (On Demand) vs 2.3GB/s for the DOM approach. So definitively worth it if you can have it.

@pauldreik : this is partially to answer your proposal that the release notes include some numbers.

Some extra documentation is needed. To be discussed.

```
cmake -DCMAKE_CXX_FLAGS="-march=haswell" -B newbuild
cmake --build  newbuild --target bench_ondemand
./newbuild/benchmark/bench_ondemand     

-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
DistinctUserID<Dom>          292407 ns       291718 ns         2405 best_bytes_per_sec=2.28583G best_docs_per_sec=3.6196k best_items_per_sec=416.253k bytes=631.515k bytes_per_second=2.01614G/s docs_per_sec=3.42797k/s items=115 items_per_second=394.217k/s [best: throughput=  2.29 GB/s doc_throughput=  3619 docs/s items=       115 avg_time=    292196 ns]
On Demand implementation: haswell
DistinctUserID<OnDemand>     144774 ns       144476 ns         4812 best_bytes_per_sec=4.60677G best_docs_per_sec=7.2948k best_items_per_sec=838.902k bytes=631.515k bytes_per_second=4.07088G/s docs_per_sec=6.92156k/s items=115 items_per_second=795.979k/s [best: throughput=  4.61 GB/s doc_throughput=  7294 docs/s items=       115 avg_time=    144617 ns]
```