### PR TITLE
tweaking documentation again

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -7,16 +7,20 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
-#include "partial_tweets/ondemand.h"
-#include "partial_tweets/iter.h"
-#include "partial_tweets/dom.h"
+//#include "partial_tweets/ondemand.h"
+//#include "partial_tweets/iter.h"
+//#include "partial_tweets/dom.h"
 
-#include "largerandom/ondemand.h"
-#include "largerandom/iter.h"
-#include "largerandom/dom.h"
+//#include "largerandom/ondemand.h"
+//#include "largerandom/iter.h"
+//#include "largerandom/dom.h"
 
-#include "kostya/ondemand.h"
-#include "kostya/iter.h"
-#include "kostya/dom.h"
+//#include "kostya/ondemand.h"
+//#include "kostya/iter.h"
+//#include "kostya/dom.h"
+
+#include "distinctuserid/ondemand.h"
+#include "distinctuserid/dom.h"
+
 
 BENCHMARK_MAIN();

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -7,17 +7,17 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 SIMDJSON_POP_DISABLE_WARNINGS
 
-//#include "partial_tweets/ondemand.h"
-//#include "partial_tweets/iter.h"
-//#include "partial_tweets/dom.h"
+#include "partial_tweets/ondemand.h"
+#include "partial_tweets/iter.h"
+#include "partial_tweets/dom.h"
 
-//#include "largerandom/ondemand.h"
-//#include "largerandom/iter.h"
-//#include "largerandom/dom.h"
+#include "largerandom/ondemand.h"
+#include "largerandom/iter.h"
+#include "largerandom/dom.h"
 
-//#include "kostya/ondemand.h"
-//#include "kostya/iter.h"
-//#include "kostya/dom.h"
+#include "kostya/ondemand.h"
+#include "kostya/iter.h"
+#include "kostya/dom.h"
 
 #include "distinctuserid/ondemand.h"
 #include "distinctuserid/dom.h"

--- a/benchmark/distinctuserid/distinctuserid.h
+++ b/benchmark/distinctuserid/distinctuserid.h
@@ -1,0 +1,52 @@
+
+#pragma once
+#include <vector>
+#include <cstdint>
+#include "event_counter.h"
+#include "json_benchmark.h"
+
+
+bool equals(const char *s1, const char *s2) { return strcmp(s1, s2) == 0; }
+
+void remove_duplicates(std::vector<int64_t> &v) {
+  std::sort(v.begin(), v.end());
+  auto last = std::unique(v.begin(), v.end());
+  v.erase(last, v.end());
+}
+
+//
+// Interface
+//
+
+namespace distinct_user_id {
+template<typename T> static void DistinctUserID(benchmark::State &state);
+} // namespace 
+
+//
+// Implementation
+//
+
+#include "dom.h"
+
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+
+template<typename T> static void DistinctUserID(benchmark::State &state) {
+  //
+  // Load the JSON file
+  //
+  constexpr const char *TWITTER_JSON = SIMDJSON_BENCHMARK_DATA_DIR "twitter.json";
+  error_code error;
+  padded_string json;
+  if ((error = padded_string::load(TWITTER_JSON).get(json))) {
+    std::cerr << error << std::endl;
+    state.SkipWithError("error loading");
+    return;
+  }
+
+  JsonBenchmark<T, Dom>(state, json);
+}
+
+} // namespace distinct_user_id

--- a/benchmark/distinctuserid/dom.h
+++ b/benchmark/distinctuserid/dom.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "distinctuserid.h"
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+
+
+simdjson_really_inline void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::element element);
+void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::array array) {
+  for (auto child : array) {
+    simdjson_recurse(v, child);
+  }
+}
+void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::object object) {
+  for (auto [key, value] : object) {
+    if((key.size() == 4) && (memcmp(key.data(), "user", 4) == 0)) {
+      // we are in an object under the key "user"
+      simdjson::error_code error;
+      simdjson::dom::object child_object;
+      simdjson::dom::object child_array;
+      if (not (error = value.get(child_object))) {
+        for (auto [child_key, child_value] : child_object) {
+          if((child_key.size() == 2) && (memcmp(child_key.data(), "id", 2) == 0)) {
+            int64_t x;
+            if (not (error = child_value.get(x))) {
+              v.push_back(x);
+            }
+          }
+          simdjson_recurse(v, child_value);
+        }
+      } else if (not (error = value.get(child_array))) {
+        simdjson_recurse(v, child_array);
+      }
+      // end of: we are in an object under the key "user"
+    } else {
+      simdjson_recurse(v, value);
+    }
+  }
+}
+simdjson_really_inline void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::element element) {
+  simdjson_unused simdjson::error_code error;
+  simdjson::dom::array array;
+  simdjson::dom::object object;
+  if (not (error = element.get(array))) {
+    simdjson_recurse(v, array);
+  } else if (not (error = element.get(object))) {
+    simdjson_recurse(v, object);
+  }
+}
+
+
+
+
+
+class Dom {
+public:
+  simdjson_really_inline bool Run(const padded_string &json);
+  simdjson_really_inline const std::vector<int64_t> &Result() { return ids; }
+  simdjson_really_inline size_t ItemCount() { return ids.size(); }
+
+private:
+  dom::parser parser{};
+  std::vector<int64_t> ids{};
+
+};
+void print_vec(const std::vector<int64_t> &v) {
+  for (auto i : v) {
+    std::cout << i << " ";
+  }
+  std::cout << std::endl;
+}
+
+simdjson_really_inline bool Dom::Run(const padded_string &json) {
+  ids.clear();
+  dom::element doc = parser.parse(json);
+  simdjson_recurse(ids, doc);
+  remove_duplicates(ids);
+  return true;
+}
+
+BENCHMARK_TEMPLATE(DistinctUserID, Dom);
+
+} // namespace distinct_user_id
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/distinctuserid/ondemand.h
+++ b/benchmark/distinctuserid/ondemand.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "distinctuserid.h"
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+using namespace simdjson::builtin;
+
+
+class OnDemand {
+public:
+  OnDemand() { 
+    if(!displayed_implementation) {
+      std::cout << "On Demand implementation: " << builtin_implementation()->name() << std::endl; 
+      displayed_implementation = true;
+    }
+  } 
+  simdjson_really_inline bool Run(const padded_string &json);
+  simdjson_really_inline const std::vector<int64_t> &Result() { return ids; }
+  simdjson_really_inline size_t ItemCount() { return ids.size(); }
+
+private:
+  ondemand::parser parser{};
+  std::vector<int64_t> ids{};
+
+  static inline bool displayed_implementation = false;
+};
+
+simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
+  ids.clear();
+  // Walk the document, parsing as we go
+  auto doc = parser.iterate(json);
+  for (ondemand::object tweet : doc["statuses"]) {
+      // We believe that all statuses have a matching
+      // user, and we are willing to throw when they do not:
+      //
+      // You might think that you do not need the braces, but
+      // you do, otherwise you will get the wrong answer. That is
+      // because you can only have one active object or array 
+      // at a time. 
+      {
+        ondemand::object user = tweet["user"];
+        int64_t id = user["id"]; 
+        ids.push_back(id);
+      }
+      // Not all tweets have a "retweeted_status", but when they do 
+      // we want to go and find the user within.
+      auto retweet = tweet["retweeted_status"];
+      if(!retweet.error()) {
+          ondemand::object retweet_content = retweet.value();
+          ondemand::object reuser = retweet_content["user"];
+          int64_t rid = reuser["id"]; 
+          ids.push_back(rid);
+      }
+  }
+  remove_duplicates(ids);
+  return true;
+}
+
+BENCHMARK_TEMPLATE(DistinctUserID, OnDemand);
+
+} // namespace distinct_user_id
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -129,7 +129,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 * **Extracting Values (with exceptions):** You can cast a JSON element to a native type: `double(element)` or
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
   dom::object and dom::array. An exception is thrown if the cast is not possible.
-* **Extracting Values (without expceptions):** You can use a variant usage of `get()` with error codes to avoid exceptions. You first declare the variable of the appropriate type (`double`, `uint64_t`, `int64_t`, `bool`,
+* **Extracting Values (without exceptions):** You can use a variant usage of `get()` with error codes to avoid exceptions. You first declare the variable of the appropriate type (`double`, `uint64_t`, `int64_t`, `bool`,
   `dom::object` and `dom::array`) and pass it by reference to `get()` which gives you back an error code: e.g.,
   ```c++
   simdjson::error_code error;
@@ -152,11 +152,11 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 * **Array and Object size** Given an array or an object, you can get its size (number of elements or keys)
   with the `size()` method.
 * **Checking an Element Type:** You can check an element's type with `element.type()`. It
-  returns an `element_type`.
+  returns an `element_type` with values such as `simdjson::dom::element_type::ARRAY`, `simdjson::dom::element_type::OBJECT`, `simdjson::dom::element_type::INT64`,  `simdjson::dom::element_type::UINT64`,`simdjson::dom::element_type::DOUBLE`, `simdjson::dom::element_type::BOOL` or, `simdjson::dom::element_type::NULL_VALUE`.
 * **Output to streams and strings:** Given a document or an element (or node) out of a JSON document, you can output a minified string version using the C++ stream idiom (`out << element`). You can also request the construction of a minified string version (`simdjson::minify(element)`).
 
 
-Here are some examples of all of the above:
+The following code illustrates all of the above:
 
 ```c++
 auto cars_json = R"( [

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -110,7 +110,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 * **Extracting Values (with exceptions):** You can cast a JSON element to a native type: `double(element)` or
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
   dom::object and dom::array. An exception is thrown if the cast is not possible.
-* **Extracting Values (without expceptions):** You can use a variant usage of `get()` with error codes to avoid exceptions. You first declare the variable of the appropriate type (`double`, `uint64_t`, `int64_t`, `bool`,
+* **Extracting Values (without exceptions):** You can use a variant usage of `get()` with error codes to avoid exceptions. You first declare the variable of the appropriate type (`double`, `uint64_t`, `int64_t`, `bool`,
   `dom::object` and `dom::array`) and pass it by reference to `get()` which gives you back an error code: e.g.,
   ```
   simdjson::error_code error;
@@ -133,11 +133,11 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
 * **Array and Object size** Given an array or an object, you can get its size (number of elements or keys)
   with the `size()` method.
 * **Checking an Element Type:** You can check an element's type with `element.type()`. It
-  returns an `element_type`.
+  returns an `element_type` with values such as `simdjson::dom::element_type::ARRAY`, `simdjson::dom::element_type::OBJECT`, `simdjson::dom::element_type::INT64`,  `simdjson::dom::element_type::UINT64`,`simdjson::dom::element_type::DOUBLE`, `simdjson::dom::element_type::BOOL` or, `simdjson::dom::element_type::NULL_VALUE`.
 * **Output to Streams and Strings:** Given a document or an element (or node) out of a JSON document, you can output a minified string version using the C++ stream idiom (`out << element`). You can also request the construction of a minified string version (`simdjson::minify(element)`).
 
 
-Here are some examples of all of the above:
+The following code illustrates all of the above:
 
 ```
 auto cars_json = R"( [


### PR DESCRIPTION
This corrects a type and tries to make it clearer how one can use the `type()` function. This is partly to address the issue of some users finding it difficult to find out whether the element is an object or not.