### PR TITLE
Adds yyjson to our internal benchmarks.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 [submodule "dependencies/boost.json"]
 	path = dependencies/boost.json
 	url = https://github.com/CPPAlliance/json.git
+[submodule "dependencies/yyjson"]
+	path = dependencies/yyjson
+	url = https://github.com/ibireme/yyjson.git

--- a/benchmark/parsingcompetition.cpp
+++ b/benchmark/parsingcompetition.cpp
@@ -13,6 +13,7 @@
 #include "benchmark.h"
 
 SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
+#include "yyjson.h"
 
 // #define RAPIDJSON_SSE2 // bad for performance
 // #define RAPIDJSON_SSE42 // bad for performance
@@ -189,6 +190,17 @@ bool bench(const char *filename, bool verbose, bool just_data,
     };
 
     BEST_TIME("Boost.json", execute(sv), false, , repeat, volume, !just_data);
+  }
+  {
+    
+    auto execute = [&p]() -> bool {
+      yyjson_doc *doc = yyjson_read(p.data(), p.size(), 0);
+      bool is_ok = doc != nullptr;
+      yyjson_doc_free(doc);
+      return is_ok;
+    };
+    
+    BEST_TIME("yyjson", execute(), true, , repeat, volume, !just_data);
   }
 #ifndef ALLPARSER
   if (!just_data)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -72,8 +72,12 @@ if ((Git_FOUND) AND SIMDJSON_GIT AND (SIMDJSON_IS_UNDER_GIT))
     target_compile_definitions(boostjson PUBLIC BOOST_JSON_STANDALONE)
     target_include_directories(boostjson PUBLIC boost.json/include)
 
+    initialize_submodule(yyjson)
+    add_library(yyjson yyjson/src/yyjson.c)
+    target_include_directories(yyjson PUBLIC yyjson/src)
+
     add_library(competition-core INTERFACE)
-    target_link_libraries(competition-core INTERFACE competition-json competition-rapidjson competition-sajson competition-cJSON competition-jsmn boostjson)
+    target_link_libraries(competition-core INTERFACE competition-json competition-rapidjson competition-sajson competition-cJSON competition-jsmn boostjson yyjson)
 
     add_library(competition-all INTERFACE)
     target_link_libraries(competition-all INTERFACE competition-core competition-jsoncppdist competition-json11 competition-fastjson competition-gason competition-ujson4c)


### PR DESCRIPTION
I think yyjson is the fastest C library I have ever seen.

```
$ cmake -B buildnewbench
$ cmake --build buildnewbench --target parsingcompetition
```

AMD Rome, GCC 9...

gsoc-2018.json:
```
getline                                 	:   0.706 cycles/byte 	  1.754 instructions/byte 	  4.809 GB/s 	1445.154 documents/s
simdjson (dynamic mem)                  	:   1.003 cycles/byte 	  2.548 instructions/byte 	  3.377 GB/s 	1014.902 documents/s
simdjson                                	:   1.001 cycles/byte 	  2.547 instructions/byte 	  3.385 GB/s 	1017.167 documents/s
RapidJSON                               	:  11.740 cycles/byte 	 45.576 instructions/byte 	  0.273 GB/s 	 82.185 documents/s
RapidJSON (accurate number parsing)     	:   8.622 cycles/byte 	 23.561 instructions/byte 	  0.365 GB/s 	109.544 documents/s
RapidJSON (insitu)                      	:   5.481 cycles/byte 	 19.510 instructions/byte 	  0.604 GB/s 	181.567 documents/s
RapidJSON (insitu, accurate number parsing)	:   5.469 cycles/byte 	 19.510 instructions/byte 	  0.606 GB/s 	182.214 documents/s
Boost.json                              	:   5.411 cycles/byte 	 12.914 instructions/byte 	  0.626 GB/s 	188.136 documents/s
yyjson                                  	:   1.791 cycles/byte 	  3.862 instructions/byte 	  1.893 GB/s 	568.797 documents/s
sajson (dynamic mem)                    	:   2.926 cycles/byte 	 11.109 instructions/byte 	  1.158 GB/s 	347.905 documents/s
sajson                                  	:   3.307 cycles/byte 	 10.768 instructions/byte 	  1.025 GB/s 	307.918 documents/s
nlohmann-json                           	:  25.613 cycles/byte 	 76.237 instructions/byte 	  0.132 GB/s 	 39.743 documents/s
memcpy                                  	:   0.071 cycles/byte 	  0.102 instructions/byte 	 47.993 GB/s 	14421.690 documents/s
```

twitter.json:

```
$ ./buildnewbench/benchmark/parsingcompetition ./jsonexamples/twitter.json
getline                                 	:   2.281 cycles/byte 	  5.612 instructions/byte 	  1.488 GB/s 	2356.295 documents/s
simdjson (dynamic mem)                  	:   1.409 cycles/byte 	  4.471 instructions/byte 	  2.409 GB/s 	3814.886 documents/s
simdjson                                	:   1.406 cycles/byte 	  4.467 instructions/byte 	  2.414 GB/s 	3823.215 documents/s
RapidJSON                               	:  10.616 cycles/byte 	 33.109 instructions/byte 	  0.299 GB/s 	474.202 documents/s
RapidJSON (accurate number parsing)     	:   8.155 cycles/byte 	 21.240 instructions/byte 	  0.383 GB/s 	606.221 documents/s
RapidJSON (insitu)                      	:   6.070 cycles/byte 	 17.605 instructions/byte 	  0.524 GB/s 	829.200 documents/s
RapidJSON (insitu, accurate number parsing)	:   5.905 cycles/byte 	 17.876 instructions/byte 	  0.536 GB/s 	848.017 documents/s
Boost.json                              	:   6.929 cycles/byte 	 17.577 instructions/byte 	  0.489 GB/s 	773.740 documents/s
yyjson                                  	:   1.910 cycles/byte 	  4.573 instructions/byte 	  1.777 GB/s 	2814.238 documents/s
sajson (dynamic mem)                    	:   3.943 cycles/byte 	 12.814 instructions/byte 	  0.861 GB/s 	1363.113 documents/s
sajson                                  	:   3.744 cycles/byte 	 11.732 instructions/byte 	  0.907 GB/s 	1435.447 documents/s
nlohmann-json                           	:  36.138 cycles/byte 	 85.978 instructions/byte 	  0.093 GB/s 	147.871 documents/s
memcpy                                  	:   0.085 cycles/byte 	  0.102 instructions/byte 	 40.173 GB/s 	63613.232 documents/s
```

canada.json:
```
$ ./buildnewbench/benchmark/parsingcompetition ./jsonexamples/canada.json
getline                                 	:   0.120 cycles/byte 	  0.205 instructions/byte 	 28.205 GB/s 	12529.915 documents/s
simdjson (dynamic mem)                  	:   4.464 cycles/byte 	 15.171 instructions/byte 	  0.759 GB/s 	337.163 documents/s
simdjson                                	:   4.468 cycles/byte 	 15.170 instructions/byte 	  0.758 GB/s 	336.844 documents/s
RapidJSON                               	:   6.595 cycles/byte 	 23.348 instructions/byte 	  0.460 GB/s 	204.410 documents/s
RapidJSON (accurate number parsing)     	:  14.330 cycles/byte 	 49.761 instructions/byte 	  0.225 GB/s 	 99.973 documents/s
RapidJSON (insitu)                      	:   7.574 cycles/byte 	 24.113 instructions/byte 	  0.408 GB/s 	181.093 documents/s
RapidJSON (insitu, accurate number parsing)	:  15.784 cycles/byte 	 49.868 instructions/byte 	  0.205 GB/s 	 91.126 documents/s
Boost.json                              	:   5.318 cycles/byte 	 18.838 instructions/byte 	  0.637 GB/s 	282.980 documents/s
yyjson                                  	:   6.602 cycles/byte 	 16.255 instructions/byte 	  0.513 GB/s 	228.038 documents/s
sajson (dynamic mem)                    	:   6.374 cycles/byte 	 25.964 instructions/byte 	  0.532 GB/s 	236.148 documents/s
sajson                                  	:   5.492 cycles/byte 	 23.086 instructions/byte 	  0.617 GB/s 	274.155 documents/s
nlohmann-json                           	:  70.382 cycles/byte 	180.013 instructions/byte 	  0.048 GB/s 	 21.384 documents/s
memcpy                                  	:   0.071 cycles/byte 	  0.102 instructions/byte 	 48.060 GB/s 	21350.186 documents/s
```