### PR TITLE
Disable exceptions when compiling with MSVC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,6 +18,10 @@ environment:
       platform: Win32
       CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_ENABLE_THREADS=ON # This should be the default. Testing anyway.
       CTEST_ARGS: -E "checkperf|ondemand_basictests"
+    - job_name: VS2019 (Win32, No Exceptions)
+      platform: Win32
+      CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_ENABLE_THREADS=ON -DSIMDJSON_EXCEPTIONS=OFF
+      CTEST_ARGS: -E "checkperf|ondemand_basictests"
     - job_name: VS2015
       image: Visual Studio 2015
       CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_ENABLE_THREADS=OFF

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -184,6 +184,16 @@ option(SIMDJSON_EXCEPTIONS "Enable simdjson's exception-throwing interface" ON)
 if(NOT SIMDJSON_EXCEPTIONS)
   message(STATUS "simdjson exception interface turned off. Code that does not check error codes will not compile.")
   target_compile_definitions(simdjson-flags INTERFACE SIMDJSON_EXCEPTIONS=0)
+  if(MSVC)
+    # CMake currently /EHsc as a default flag in CMAKE_CXX_FLAGS on MSVC. Replacing this with a more general abstraction is a WIP (see https://gitlab.kitware.com/cmake/cmake/-/issues/20610)
+    # /EHs enables standard C++ stack unwinding when catching exceptions (non-structured exception handling)
+    # /EHc used in conjection with /EHs indicates that extern "C" functions never throw (terminate-on-throw)
+    # Here, we disable both with the - argument negation operator
+    string(REPLACE "/EHsc" "/EHs-c-" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+
+    # Because we cannot change the flag above on an invidual target (yet), the definition below must similarly be added globally
+    add_definitions(-D_HAS_EXCEPTIONS=0)
+  endif()
 endif()
 
 option(SIMDJSON_ENABLE_THREADS "Link with thread support" ON)

--- a/fuzz/fuzz_element.cpp
+++ b/fuzz/fuzz_element.cpp
@@ -58,7 +58,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     simdjson_unused auto v = elem fun;                                                         \
     break;                                                                     \
   }
+#if SIMDJSON_EXCEPTIONS
   try {
+#endif
 
     switch (action) {
       CASE(0, type);
@@ -122,9 +124,11 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
 #undef CASE
 #undef CASE2
 
+#if SIMDJSON_EXCEPTIONS
   } catch (std::exception &) {
     // do nothing
   }
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Projects that link simdjson from MSVC with exceptions off will
include simdjson headers which transitively include STL headers.
The MSVC STL stipulates that _HAS_EXCEPTIONS=0 be defined or code
requiring exceptions will be enabled. This change adds a new job
to the appveyor build matrix to verify the build and tests with
exceptions disabled, and disables exceptions at the compiler level
when SIMDJSON_EXCEPTIONS is specified to OFF.