### PR TITLE
Remove old CMake version from CI (Rely on CMake 3.17)

### DIFF
--- a/.github/workflows/ubuntu18-checkperf.yml
+++ b/.github/workflows/ubuntu18-checkperf.yml
@@ -7,10 +7,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.0
-        with:
-          cmake-version: '3.9.x'
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -7,10 +7,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.0
-        with:
-          cmake-version: '3.9.x'
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu20-checkperf.yml
+++ b/.github/workflows/ubuntu20-checkperf.yml
@@ -7,10 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.0
-        with:
-          cmake-version: '3.9.x'
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -7,10 +7,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.0
-        with:
-          cmake-version: '3.9.x'
       - name: Use cmake
         run: |
           mkdir build &&


### PR DESCRIPTION
Github already provides CMake 3.17 in the Ubuntu images for workflows.

Please refer to the following specifications:
* https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu1804-README.md#tools
* https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#tools

This will enable #1258 to run more workflows, as it requires at least CMake 3.14 because of `FetchContent`.