### PR TITLE
fuzz with the intended clang version

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -19,6 +19,7 @@ jobs:
       implementations: haswell westmere fallback
       UBSAN_OPTIONS: halt_on_error=1
       MAXLEN: -max_len=4000
+      CLANGVER: 11
 
     steps:
     - name: Install packages necessary for building
@@ -27,7 +28,7 @@ jobs:
         sudo apt-get install --quiet ninja-build valgrind zip unzip
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 10
+        sudo ./llvm.sh $CLANGVER
 
     - uses: actions/checkout@v1
 

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -20,6 +20,8 @@ jobs:
       UBSAN_OPTIONS: halt_on_error=1
       MAXLEN: -max_len=4000
       CLANGVER: 11
+      # which optimization level to use for the sanitizer build (see build_fuzzer.variants.sh)
+      OPTLEVEL: -O3
 
     steps:
     - name: Install packages necessary for building
@@ -72,7 +74,7 @@ jobs:
           others=$(find out -type d -not -name $fuzzer -not -name out -not -name cmin)
           for implementation in $implementations; do
             export SIMDJSON_FORCE_IMPLEMENTATION=$implementation
-            build-sanitizers/fuzz/fuzz_$fuzzer out/$fuzzer $others seedcorpus -max_total_time=20 $MAXLEN
+            build-sanitizers$OPTLEVEL/fuzz/fuzz_$fuzzer out/$fuzzer $others seedcorpus -max_total_time=20 $MAXLEN
           done
           echo now have $(ls out/$fuzzer |wc -l) files in corpus        
         done
@@ -83,7 +85,7 @@ jobs:
         for fuzzer in $implfuzzers; do
           # get input from everyone else (corpus cross pollination)
           others=$(find out -type d -not -name $fuzzer -not -name out -not -name cmin)
-          build-sanitizers/fuzz/fuzz_$fuzzer out/$fuzzer $others seedcorpus -max_total_time=20 $MAXLEN
+          build-sanitizers$OPTLEVEL/fuzz/fuzz_$fuzzer out/$fuzzer $others seedcorpus -max_total_time=20 $MAXLEN
           echo now have $(ls out/$fuzzer |wc -l) files in corpus
         done
 

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -30,7 +30,7 @@ jobs:
         sudo apt-get install --quiet ninja-build valgrind zip unzip
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh $CLANGVER
+        sudo ./llvm.sh $CLANGVERSION
 
     - uses: actions/checkout@v1
 
@@ -54,7 +54,7 @@ jobs:
         clang++ --version
 
     - name: Build all the variants
-      run: fuzz/build_fuzzer_variants.sh
+      run: CLANGSUFFIX=-$CLANGVERSION fuzz/build_fuzzer_variants.sh
 
     - name: Explore fast (release build, default implementation)
       run: |

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -19,7 +19,7 @@ jobs:
       implementations: haswell westmere fallback
       UBSAN_OPTIONS: halt_on_error=1
       MAXLEN: -max_len=4000
-      CLANGVER: 11
+      CLANGVERSION: 11
       # which optimization level to use for the sanitizer build (see build_fuzzer.variants.sh)
       OPTLEVEL: -O3
 

--- a/fuzz/build_fuzzer_variants.sh
+++ b/fuzz/build_fuzzer_variants.sh
@@ -5,7 +5,7 @@
 # - different build options
 # - reproduce build, for running through valgrind
 #
-# Set environment variable CLANGVERSION to select clang version (example: "-11")
+# Set environment variable CLANGSUFFIX to select clang version (example: "-11")
 
 # fail on error
 set -e
@@ -15,16 +15,16 @@ unset CXX CC CFLAGS CXXFLAGS LDFLAGS
 me=$(basename $0)
 
 
-if [ -z $CLANGVERSION ] ; then
+if [ -z $CLANGSUFFIX ] ; then
     # the default clang version is set low enough to be found on current Debian stable (Buster)
-    CLANGVERSION=-8
+    CLANGSUFFIX=-8
 fi
 
 # detect unset variables
 set -u
 
 # common options
-COMMON="-GNinja -DCMAKE_CXX_COMPILER=clang++$CLANGVERSION -DCMAKE_C_COMPILER=clang$CLANGVERSION -DSIMDJSON_BUILD_STATIC=Off -DENABLE_FUZZING=On -DSIMDJSON_COMPETITION=OFF -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DSIMDJSON_GIT=Off"
+COMMON="-GNinja -DCMAKE_CXX_COMPILER=clang++$CLANGSUFFIX -DCMAKE_C_COMPILER=clang$CLANGSUFFIX -DSIMDJSON_BUILD_STATIC=Off -DENABLE_FUZZING=On -DSIMDJSON_COMPETITION=OFF -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DSIMDJSON_GIT=Off"
 
 # A replay build, as plain as it gets. For use with valgrind/gdb.
 variant=replay

--- a/fuzz/build_fuzzer_variants.sh
+++ b/fuzz/build_fuzzer_variants.sh
@@ -4,17 +4,27 @@
 # - different sanitizers
 # - different build options
 # - reproduce build, for running through valgrind
+#
+# Set environment variable CLANGVERSION to select clang version (example: "-11")
 
 # fail on error
-set -eu
+set -e
 
 unset CXX CC CFLAGS CXXFLAGS LDFLAGS
 
 me=$(basename $0)
 
+
+if [ -z $CLANGVERSION ] ; then
+    # the default clang version is set low enough to be found on current Debian stable (Buster)
+    CLANGVERSION=-8
+fi
+
+# detect unset variables
+set -u
+
 # common options
-CLANGVER=-9
-COMMON="-GNinja -DCMAKE_CXX_COMPILER=clang++$CLANGVER -DCMAKE_C_COMPILER=clang$CLANGVER -DSIMDJSON_BUILD_STATIC=Off -DENABLE_FUZZING=On -DSIMDJSON_COMPETITION=OFF -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DSIMDJSON_GIT=Off"
+COMMON="-GNinja -DCMAKE_CXX_COMPILER=clang++$CLANGVERSION -DCMAKE_C_COMPILER=clang$CLANGVERSION -DSIMDJSON_BUILD_STATIC=Off -DENABLE_FUZZING=On -DSIMDJSON_COMPETITION=OFF -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DSIMDJSON_GIT=Off"
 
 # A replay build, as plain as it gets. For use with valgrind/gdb.
 variant=replay

--- a/fuzz/quick_check.sh
+++ b/fuzz/quick_check.sh
@@ -27,7 +27,10 @@ if [ ! -d out ] ; then
   tar xf corpus.tar && rm corpus.tar
 fi
 
-builddir=build-sanitizers-O3
+# By default, use the debug friendly variant since this script is intended
+# for developers reproducing bugs/validating fixes locally.
+builddir=build-sanitizers-O0
+#...but feel free to use this one instead, if you want to build coverage fast.
 #builddir=build-fast
 
 if [ ! -d $builddir ] ; then

--- a/fuzz/quick_check.sh
+++ b/fuzz/quick_check.sh
@@ -27,7 +27,8 @@ if [ ! -d out ] ; then
   tar xf corpus.tar && rm corpus.tar
 fi
 
-builddir=build-sanitizers
+builddir=build-sanitizers-O3
+#builddir=build-fast
 
 if [ ! -d $builddir ] ; then
   fuzz/build_fuzzer_variants.sh


### PR DESCRIPTION
This builds the CI fuzzers with the intended clang version. It also allows users to set the clang version locally,
in case they need to.

It also switches the CI fuzzers to use an optimized sanitizer build, to do something oss-fuzz doesn't and get more done in the short time the CI fuzzer runs.