### PR TITLE
detect trailing whitespace in CI

### DIFF
--- a/.github/workflows/fix-trailing-whitespace.yml
+++ b/.github/workflows/fix-trailing-whitespace.yml
@@ -1,0 +1,33 @@
+name: Detect trailing whitespace
+
+on: [pull_request]
+
+jobs:
+  whitespace:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Remove whitespace and check the diff
+        run: |
+          set -eu
+          scripts/remove_trailing_whitespace.sh
+          git diff >whitespace.patch
+          if [ $(wc -c <whitespace.patch) -ne 0 ] ; then
+             echo " !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! "
+             echo "You have trailing whitespace, please download the artifact"
+             echo "and apply with git apply <whitespace.patch or"
+             echo "run scripts/remove_trailing_whitespace.sh locally."
+             echo " !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! "
+             exit 1
+          else
+             echo "no trailing whitespace found, good!"
+          fi
+      - name: Archive whitespace patch
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: whitespace-patch
+          path: |
+            whitespace.patch
+          if-no-files-found: ignore
+

--- a/scripts/remove_trailing_whitespace.sh
+++ b/scripts/remove_trailing_whitespace.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# removes trailing whitespace from source files and other
+
+set -eu
+
+# go to the git root dir
+cd "$(git rev-parse --show-toplevel)"
+
+#make a list of all files (null separated, to handle whitespace)
+git ls-tree -r HEAD --name-only -z >all_files.null.txt
+
+for suffix in cpp cmake h hpp js md py rb sh ; do
+   echo "removing trailing whitespace from files with suffix $suffix"
+   cat all_files.null.txt | grep -z '\.'$suffix'$' |xargs -n1 --null sed -i 's/[ \t]*$//'
+done
+rm all_files.null.txt
+echo "done!"
+


### PR DESCRIPTION
This adds a script for removing trailing whitespace from files.

It also adds a CI job which detects if the script needs to run, and provides instructions how to do so.

Note that the job currently fails - because a lot of files do have trailing whitespace. I did not want to touch a lot of files in this PR, so I won't fix it. That could be for another PR which only does that (runs the removal script and commits the results).