### PR TITLE
fix non ascii sources

### DIFF
--- a/include/simdjson/internal/numberparsing_tables.h
+++ b/include/simdjson/internal/numberparsing_tables.h
@@ -6,11 +6,11 @@
 namespace simdjson {
 namespace internal {
 /**
- * The smallest non-zero float (binary64) is 2^−1074.
+ * The smallest non-zero float (binary64) is 2^-1074.
  * We take as input numbers of the form w x 10^q where w < 2^64.
  * We have that w * 10^-343  <  2^(64-344) 5^-343 < 2^-1076.
  * However, we have that 
- * (2^64-1) * 10^-342 =  (2^64-1) * 2^-342 * 5^-342 > 2^−1074.
+ * (2^64-1) * 10^-342 =  (2^64-1) * 2^-342 * 5^-342 > 2^-1074.
  * Thus it is possible for a number of the form w * 10^-342 where 
  * w is a 64-bit value to be a non-zero floating-point number.
  *********

--- a/scripts/detect_nonascii_sourcefiles.py
+++ b/scripts/detect_nonascii_sourcefiles.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python3
+
+import sys
+
+def verifyContent(f,filename):
+  linenumber=-999
+  line=''
+  try:
+    for linenumber, line in enumerate(f):
+      try:
+        ascii=line.encode('ascii')
+      except UnicodeEncodeError as e:
+        #print(f"a: found problem {e} at line {linenumber+1} in {filename}:")
+        print(f"Found problem at line {linenumber+1} in {filename}:")
+        print(line.rstrip()) 
+        for col, char in enumerate(line.encode('utf-8')):
+          if char>=127:
+             offender=char
+             offendingcol=col
+             break
+        print(" "*offendingcol + "^")
+        print(f"Column {offendingcol+1} contains 0x{offender:02X}")
+        sys.exit(1)
+
+  except UnicodeDecodeError as e:
+    print(f"Could not open {filename} as utf-8, it can't be ascii.")
+    sys.exit(1)
+
+
+    
+for filename in sys.argv[1:]:
+  with open(filename,encoding='utf-8') as f:
+    #print(f"file {filename} was possible to open as utf-8")
+    verifyContent(f,filename)
+  print("all files were found to be ascii.")
+

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on sön  1 nov 2020 07:02:00 CET. Do not edit! */
+/* auto-generated on Sun Nov  1 11:09:32 CET 2020. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on sön  1 nov 2020 07:02:00 CET. Do not edit! */
+/* auto-generated on Sun Nov  1 11:09:32 CET 2020. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -8610,11 +8610,11 @@ extern SIMDJSON_DLLIMPORTEXPORT const uint32_t digit_to_val32[886];
 namespace simdjson {
 namespace internal {
 /**
- * The smallest non-zero float (binary64) is 2^−1074.
+ * The smallest non-zero float (binary64) is 2^-1074.
  * We take as input numbers of the form w x 10^q where w < 2^64.
  * We have that w * 10^-343  <  2^(64-344) 5^-343 < 2^-1076.
  * However, we have that 
- * (2^64-1) * 10^-342 =  (2^64-1) * 2^-342 * 5^-342 > 2^−1074.
+ * (2^64-1) * 10^-342 =  (2^64-1) * 2^-342 * 5^-342 > 2^-1074.
  * Thus it is possible for a number of the form w * 10^-342 where 
  * w is a 64-bit value to be a non-zero floating-point number.
  *********


### PR DESCRIPTION
There are two problems
* amalgamate being locale sensitive (will be fixed in #1269)
* source files with non-utf8 (numberparsing_tables.h), would have been detected earlier if #1269 had been in place

this fixes master to build again.