### PR TITLE
Additional define to silence the 32-bit portability warning.

### DIFF
--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -61,11 +61,13 @@
 #endif // defined(__x86_64__) || defined(_M_AMD64)
 
 #ifdef SIMDJSON_IS_32BITS
+#ifndef SIMDJSON_NO_PORTABILITY_WARNING
 #pragma message("The simdjson library is designed \
 for 64-bit processors and it seems that you are not \
 compiling for a known 64-bit platform. All fast kernels \
 will be disabled and performance may be poor. Please \
 use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
+#endif // SIMDJSON_NO_PORTABILITY_WARNING
 #endif // SIMDJSON_IS_32BITS
 
 // this is almost standard?


### PR DESCRIPTION
Under compilers like MSVC the `#pragma message` about portability will be issued for each translation unit; regardless of whether or not `SIMDJSON_PORTABILITY_H` has already been defined. As such a new define `SIMDJSON_NO_PORTABILITY_WARNING`, can be defined prior to the inclusion of `<simdjson.h>` to silence it.