### PR TITLE
Improve CI workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,19 @@ executors:
 
 # Reusable test commands (and initializer for clang 6)
 commands:
+  dependency_restore:
+    steps:
+      - restore_cache:
+          keys:
+            - {{ checksum "dependencies/CMakeLists.txt" }}
+
+  dependency_cache:
+    steps:
+      - save_cache:
+          key: {{ checksum "dependencies/CMakeLists.txt" }}
+          paths:
+            - dependencies/.cache
+
   install_cmake:
     steps:
       - run: apt-get update -qq
@@ -74,7 +87,9 @@ commands:
   cmake_build_cache:
     steps:
       - cmake_prep
+      - dependency_restore
       - run: cmake $CMAKE_FLAGS -DCMAKE_INSTALL_PREFIX:PATH=destination -B build . 
+      - dependency_cache # dependencies are produced in the configure step
 
   cmake_build:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,12 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - {{ checksum "dependencies/CMakeLists.txt" }}
+            - cmake-cache-{{ checksum "dependencies/CMakeLists.txt" }}
 
   dependency_cache:
     steps:
       - save_cache:
-          key: {{ checksum "dependencies/CMakeLists.txt" }}
+          key: cmake-cache-{{ checksum "dependencies/CMakeLists.txt" }}
           paths:
             - dependencies/.cache
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -10,7 +10,7 @@ task:
   dep_cache:
     folder: $HOME/.dep_cache
     reupload_on_changes: false
-    fingerprint_script: cmake -E sha512sum dependencies/CMakeLists.txt
+    fingerprint_script: cat dependencies/CMakeLists.txt
   setup_script:
     - pkg update -f
     - pkg install bash

--- a/.github/workflows/mingw-ci.yml
+++ b/.github/workflows/mingw-ci.yml
@@ -26,6 +26,12 @@ jobs:
           path: |
             C:\ProgramData\scoop
           key: scoop32 # static key: should be good forever
+
+      - uses: actions/cache@v2
+        with:
+          path: dependencies/.cache
+          key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
+
       - name: Setup Windows # This should almost never run if the cache works.
         if: steps.cache.outputs.cache-hit != 'true'
         shell: powershell

--- a/.github/workflows/mingw64-ci.yml
+++ b/.github/workflows/mingw64-ci.yml
@@ -26,6 +26,12 @@ jobs:
           path: |
             C:\ProgramData\scoop
           key: scoop64 # static key: should be good forever
+
+      - uses: actions/cache@v2
+        with:
+          path: dependencies/.cache
+          key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
+
       - name: Setup Windows # This should almost never run if the cache works.
         if: steps.cache.outputs.cache-hit != 'true'
         shell: powershell


### PR DESCRIPTION
Follow up for #1282

This fixes an erroneous assumption about the presence of `cmake` at the fingerprint step in Cirrus CI and adds caching to Circle CI and the MinGW workflows in Github.

Regarding Drone CI, I think [this blogpost](https://laszlo.cloud/the-ultimate-droneci-caching-guide) is worth reading.  
It seems volume (filesystem) caching does not work properly on `cloud.drone.io`, which leaves only S3 buckets as a caching mechanism.