### PR TITLE
enable boost json

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -183,6 +183,27 @@ steps:
     - ASAN_OPTIONS="detect_leaks=0" ctest $CTEST_FLAGS -LE "acceptance|per_implementation" # Everything we haven't run yet, run now.
 ---
 kind: pipeline
+name: cpp20-clang11-libcpp
+platform: { os: linux, arch: amd64 }
+steps:
+- name: Build and Test
+  image: conanio/clang11
+  user: root
+  environment:
+    CC: clang-11
+    CXX: clang++-11
+    CMAKE_FLAGS:
+    BUILD_FLAGS: -- -j
+    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CXXFLAGS: -std=c++20 -stdlib=libc++
+  commands:
+    - mkdir build
+    - cd build
+    - cmake $CMAKE_FLAGS ..
+    - cmake --build . $BUILD_FLAGS
+    - ctest $CTEST_FLAGS
+---
+kind: pipeline
 name: arm64-gcc8
 platform: { os: linux, arch: arm64 }
 steps:

--- a/.drone.yml
+++ b/.drone.yml
@@ -187,13 +187,13 @@ name: cpp20-clang11-libcpp
 platform: { os: linux, arch: amd64 }
 steps:
 - name: Build and Test
-  image: conanio/clang11
+  image: pauldreik/llvm-11
   user: root
   environment:
     CC: clang-11
     CXX: clang++-11
-    CMAKE_FLAGS:
-    BUILD_FLAGS: -- -j
+    CMAKE_FLAGS: -GNinja
+    BUILD_FLAGS:
     CTEST_FLAGS: -j4 --output-on-failure -E checkperf
     CXXFLAGS: -std=c++20 -stdlib=libc++
   commands:

--- a/benchmark/parsingcompetition.cpp
+++ b/benchmark/parsingcompetition.cpp
@@ -27,8 +27,10 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
+#ifdef HAS_BOOST_JSON
 #include <boost/json/parser.hpp>
 #include <boost/json/monotonic_resource.hpp>
+#endif
 
 #ifdef ALLPARSER
 
@@ -177,6 +179,7 @@ bool bench(const char *filename, bool verbose, bool just_data,
             std::memcpy(buffer, p.data(), p.size()) &&
                 (buffer[p.size()] = '\0'),
             repeat, volume, !just_data);
+#ifdef HAS_BOOST_JSON
   {
     const boost::json::string_view sv(p.data(), p.size());
     boost::json::parser p;
@@ -192,6 +195,7 @@ bool bench(const char *filename, bool verbose, bool just_data,
 
     BEST_TIME("Boost.json", execute(sv), false, , repeat, volume, !just_data);
   }
+#endif
   {
 
     auto execute = [&p]() -> bool {

--- a/benchmark/parsingcompetition.cpp
+++ b/benchmark/parsingcompetition.cpp
@@ -27,16 +27,8 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-#if defined(__clang__)
-// Under some clang/libc++ configurations, boost json fails
-// to build.
-#define DISABLE_BOOST_JSON
-#endif
-
-#ifndef DISABLE_BOOST_JSON
 #include <boost/json/parser.hpp>
 #include <boost/json/monotonic_resource.hpp>
-#endif
 
 #ifdef ALLPARSER
 
@@ -185,7 +177,6 @@ bool bench(const char *filename, bool verbose, bool just_data,
             std::memcpy(buffer, p.data(), p.size()) &&
                 (buffer[p.size()] = '\0'),
             repeat, volume, !just_data);
-#ifndef DISABLE_BOOST_JSON
   {
     const boost::json::string_view sv(p.data(), p.size());
     boost::json::parser p;
@@ -201,7 +192,6 @@ bool bench(const char *filename, bool verbose, bool just_data,
 
     BEST_TIME("Boost.json", execute(sv), false, , repeat, volume, !just_data);
   }
-#endif
   {
 
     auto execute = [&p]() -> bool {

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -14,11 +14,16 @@ endif()
 # This prevents variables declared with set() from unnecessarily escaping and
 # should not be called more than once
 function(competition_scope_)
+  # boost json in standalone mode requires C++17 string_view
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_compiles("#include <string_view>\n#if __cpp_lib_string_view < 201606\n#error no string view support\n#endif\nint main(){}" USE_BOOST_JSON)
+  if(USE_BOOST_JSON)
   import_dependency(boostjson boostorg/json ee8d72d8502b409b5561200299cad30ccdb91415)
   add_library(boostjson STATIC "${boostjson_SOURCE_DIR}/src/src.cpp")
   target_compile_definitions(boostjson PUBLIC BOOST_JSON_STANDALONE)
   target_include_directories(boostjson SYSTEM PUBLIC
           "${boostjson_SOURCE_DIR}/include")
+  endif()
 
   import_dependency(cjson DaveGamble/cJSON c69134d)
   add_library(cjson STATIC "${cjson_SOURCE_DIR}/cJSON.c")
@@ -83,7 +88,11 @@ function(competition_scope_)
   target_include_directories(yyjson SYSTEM PUBLIC "${yyjson_SOURCE_DIR}/src")
 
   add_library(competition-core INTERFACE)
-  target_link_libraries(competition-core INTERFACE boostjson nlohmann_json rapidjson sajson cjson jsmn yyjson)
+  target_link_libraries(competition-core INTERFACE nlohmann_json rapidjson sajson cjson jsmn yyjson)
+  if(USE_BOOST_JSON)
+     target_compile_definitions(boostjson INTERFACE HAS_BOOST_JSON)
+     target_link_libraries(competition-core INTERFACE boostjson)
+  endif()
 
   add_library(competition-all INTERFACE)
   target_link_libraries(competition-all INTERFACE competition-core jsoncpp json11 fastjson gason ujson4c)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -15,13 +15,13 @@ endif()
 # should not be called more than once
 function(competition_scope_)
   # Boost JSON is not compatible with some clang/libc++ configurations.
-  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    import_dependency(boostjson CPPAlliance/json a0983f7)
+  #if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    import_dependency(boostjson boostorg/json ee8d72d8502b409b5561200299cad30ccdb91415)
     add_library(boostjson STATIC "${boostjson_SOURCE_DIR}/src/src.cpp")
     target_compile_definitions(boostjson PUBLIC BOOST_JSON_STANDALONE)
     target_include_directories(boostjson SYSTEM PUBLIC
             "${boostjson_SOURCE_DIR}/include")
-  endif()
+  #endif()
 
   import_dependency(cjson DaveGamble/cJSON c69134d)
   add_library(cjson STATIC "${cjson_SOURCE_DIR}/cJSON.c")

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -83,10 +83,7 @@ function(competition_scope_)
   target_include_directories(yyjson SYSTEM PUBLIC "${yyjson_SOURCE_DIR}/src")
 
   add_library(competition-core INTERFACE)
-  target_link_libraries(competition-core INTERFACE nlohmann_json rapidjson sajson cjson jsmn yyjson)
-  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    target_link_libraries(competition-core INTERFACE boostjson)
-  endif()
+  target_link_libraries(competition-core INTERFACE boostjson nlohmann_json rapidjson sajson cjson jsmn yyjson)
 
   add_library(competition-all INTERFACE)
   target_link_libraries(competition-all INTERFACE competition-core jsoncpp json11 fastjson gason ujson4c)

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -14,14 +14,11 @@ endif()
 # This prevents variables declared with set() from unnecessarily escaping and
 # should not be called more than once
 function(competition_scope_)
-  # Boost JSON is not compatible with some clang/libc++ configurations.
-  #if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    import_dependency(boostjson boostorg/json ee8d72d8502b409b5561200299cad30ccdb91415)
-    add_library(boostjson STATIC "${boostjson_SOURCE_DIR}/src/src.cpp")
-    target_compile_definitions(boostjson PUBLIC BOOST_JSON_STANDALONE)
-    target_include_directories(boostjson SYSTEM PUBLIC
-            "${boostjson_SOURCE_DIR}/include")
-  #endif()
+  import_dependency(boostjson boostorg/json ee8d72d8502b409b5561200299cad30ccdb91415)
+  add_library(boostjson STATIC "${boostjson_SOURCE_DIR}/src/src.cpp")
+  target_compile_definitions(boostjson PUBLIC BOOST_JSON_STANDALONE)
+  target_include_directories(boostjson SYSTEM PUBLIC
+          "${boostjson_SOURCE_DIR}/include")
 
   import_dependency(cjson DaveGamble/cJSON c69134d)
   add_library(cjson STATIC "${cjson_SOURCE_DIR}/cJSON.c")


### PR DESCRIPTION
This will get boost json building again. The reason it did not work before was because it requires a working string_view in standalone mode (without the rest of boost).

Therefore, I added a check to see if string_view was available. I also added a c++20 CI job. 

I had to switch docker container to get the proper libc++. I made a docker image, which I am happy to contribute (with whatever license is appropriate, since I wrote it myself) to the project (perhaps put in the new simdjson/docker-images repo?): https://github.com/pauldreik/docker-images 

Seems like simdjson does not explicitly test different C++ versions in CI?