### PR TITLE
Disable Github CI in feature branches

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -1,7 +1,13 @@
 name: Alpine Linux
-'on':
-  - push
-  - pull_request
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
 jobs:
   ubuntu-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/fix-trailing-whitespace.yml
+++ b/.github/workflows/fix-trailing-whitespace.yml
@@ -1,6 +1,9 @@
 name: Detect trailing whitespace
 
-on: [pull_request]
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   whitespace:

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
   schedule:
     - cron: 23 */8 * * *
 

--- a/.github/workflows/mingw-ci.yml
+++ b/.github/workflows/mingw-ci.yml
@@ -1,6 +1,12 @@
 name: MinGW32-CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 # Important: scoop will either install 32-bit GCC or 64-bit GCC, not both.
 

--- a/.github/workflows/mingw64-ci.yml
+++ b/.github/workflows/mingw64-ci.yml
@@ -1,6 +1,12 @@
 name: MinGW64-CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 # Important: scoop will either install 32-bit GCC or 64-bit GCC, not both.
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,6 +1,12 @@
 name: MSYS2-CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   windows-mingw:

--- a/.github/workflows/ubuntu18-checkperf.yml
+++ b/.github/workflows/ubuntu18-checkperf.yml
@@ -1,6 +1,12 @@
 name: Performance check on Ubuntu 18.04 CI (GCC 7)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ubuntu-build:

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -1,6 +1,12 @@
 name: Ubuntu 18.04 CI (GCC 7)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ubuntu-build:

--- a/.github/workflows/ubuntu20-checkperf.yml
+++ b/.github/workflows/ubuntu20-checkperf.yml
@@ -1,6 +1,12 @@
 name: Performance check on Ubuntu 20.04 CI (GCC 9)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ubuntu-build:

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -1,6 +1,12 @@
 name: Ubuntu 20.04 CI (GCC 9)
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ubuntu-build:

--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -1,6 +1,12 @@
 name: VS16-CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ci:

--- a/.github/workflows/vs16-clang-ci.yml
+++ b/.github/workflows/vs16-clang-ci.yml
@@ -1,6 +1,12 @@
 name: VS16-CLANG-CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ci:

--- a/.github/workflows/vs16-ninja-ci.yml
+++ b/.github/workflows/vs16-ninja-ci.yml
@@ -1,6 +1,12 @@
 name: VS16-Ninja-CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   ci:


### PR DESCRIPTION
Forks that would like to contribute via PRs from feature branches needlessly run CI on those branches on top of the ones run for PRs.  
This is a waste of resources.