### PR TITLE
Prototype test for issue 1299: using parse_many, find the location of the end of the last document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 language: cpp
+
 dist: bionic
+
 arch:
   - ppc64le
+
 cache:
   directories:
     - $HOME/.dep_cache
+
 env:
   global:
     - simdjson_DEPENDENCY_CACHE_DIR=$HOME/.dep_cache
+
 matrix:
   include:
     - os: linux
@@ -156,13 +161,11 @@ before_install:
   - eval "${COMPILER}"
 
 install:
-  - if [[ "${TRAVIS_CPU_ARCH}" == "ppc64le" ]]; then
-      sudo apt-get install libuv1 rhash libstdc++6;
-      wget https://anaconda.org/conda-forge/cmake/3.17.0/download/linux-ppc64le/cmake-3.17.0-hfb1cb51_0.tar.bz2;
-      mkdir $HOME/cmake;
-      tar -xjf cmake-3.17.0-hfb1cb51_0.tar.bz2 -C $HOME/cmake;
-      export PATH=$HOME/cmake/bin:$PATH;
-    fi
+  - wget -q -O - "https://raw.githubusercontent.com/simdjson/debian-ppa/master/key.gpg" | sudo apt-key add -
+  - sudo apt-add-repository "deb https://raw.githubusercontent.com/simdjson/debian-ppa/master simdjson main"
+  - sudo apt-get -qq update
+  - sudo apt-get purge cmake cmake-data
+  - sudo apt-get -t simdjson -y install cmake
   - export CMAKE_CXX_FLAGS="-maltivec -mcpu=power9 -mtune=power9"
   - export CMAKE_C_FLAGS="${CMAKE_CXX_FLAGS}"
   - export CMAKE_FLAGS="-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS} -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS} -DSIMDJSON_IMPLEMENTATION=ppc64;fallback";

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -13,6 +13,8 @@ Contents
 - [Support](#support)
 - [API](#api)
 - [Use cases](#use-cases)
+- [Tracking your position](#tracking-your-position)
+- [Incomplete streams](#incomplete-streams)
 
 Motivation
 -----------
@@ -158,3 +160,58 @@ From [jsonlines.org](http://jsonlines.org/examples/):
     ```
     JSON Lines' biggest strength is in handling lots of similar nested data structures. One .jsonl file is easier to
     work with than a directory full of XML files.
+
+
+Tracking your position
+-----------
+
+Some users would like to know where the document they parsed is in the input array of bytes.
+It is possible to do so by accessing directly the iterator and calling its `current_index()`
+method which reports the location (in bytes) of the current document in the input stream.
+
+Let us illustrate the idea with code:
+
+
+```C++
+    auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} [1,2,3]  )"_padded;
+    simdjson::dom::parser parser;
+    simdjson::dom::document_stream stream;
+    ASSERT_SUCCESS( parser.parse_many(json).get(stream) );
+    auto i = stream.begin();
+    for(; i != stream.end(); ++i) {
+        auto doc = *i;
+        if(!doc.error()) {
+          std::cout << "got full document at " << i.current_index() << std::endl;
+        }
+    }
+    size_t index = i.current_index();
+    if(index != 38) {
+      std::cerr << "Expected to stop after the three full documents " << std::endl;
+      std::cerr << "index = " << index << std::endl;
+      return false;
+    }
+```
+
+This code will print:
+```
+got full document at 0
+got full document at 9
+got full document at 29
+```
+
+The last call to `i.current_index()` return the byte index 38, which is just beyond 
+the last document.
+
+Incomplete streams
+-----------
+
+Some users may need to work with truncated streams while tracking their location in the stream.
+The same code, with the `current_index()` will work. However, the last block (by default 1MB)
+terminates with an unclosed string, then no JSON document within this last block will validate.
+In particular, it means that if your input string is `[1,2,3]  {"1":1,"2":3,"4":4} [1,2` then 
+no JSON document will be successfully parsed. The error `simdjson::UNCLOSED_STRING` will be
+given (even with the first JSON document). It is then your responsability to terminate the input
+maybe by appending the missing data at the end of the truncated string, or by copying the truncated
+data before the continuing input.
+
+

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -199,7 +199,7 @@ got full document at 9
 got full document at 29
 ```
 
-The last call to `i.current_index()` return the byte index 38, which is just beyond 
+The last call to `i.current_index()` return the byte index 38, which is just beyond
 the last document.
 
 Incomplete streams
@@ -208,7 +208,7 @@ Incomplete streams
 Some users may need to work with truncated streams while tracking their location in the stream.
 The same code, with the `current_index()` will work. However, the last block (by default 1MB)
 terminates with an unclosed string, then no JSON document within this last block will validate.
-In particular, it means that if your input string is `[1,2,3]  {"1":1,"2":3,"4":4} [1,2` then 
+In particular, it means that if your input string is `[1,2,3]  {"1":1,"2":3,"4":4} [1,2` then
 no JSON document will be successfully parsed. The error `simdjson::UNCLOSED_STRING` will be
 given (even with the first JSON document). It is then your responsability to terminate the input
 maybe by appending the missing data at the end of the truncated string, or by copying the truncated

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -131,7 +131,7 @@ namespace document_stream_tests {
     }
     return count == 1;
   }
-#endif 
+#endif
   bool simple_example() {
     std::cout << "Running " << __func__ << std::endl;
     // The last JSON document is

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -131,7 +131,7 @@ namespace document_stream_tests {
     }
     return count == 1;
   }
-#endif
+#endif 
   bool simple_example() {
     std::cout << "Running " << __func__ << std::endl;
     // The last JSON document is

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -299,7 +299,7 @@ namespace document_stream_tests {
     }
     return count == 1;
   }
-#endif 
+#endif
   bool simple_example() {
     std::cout << "Running " << __func__ << std::endl;
     // The last JSON document is

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -132,7 +132,71 @@ namespace document_stream_tests {
     return count == 1;
   }
 #endif
+  bool truncated_window() {
+    std::cout << "Running " << __func__ << std::endl;
+    // The last JSON document is
+    // intentionally truncated.
+    auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} [1,2  )"_padded;
+    simdjson::dom::parser parser;
+    size_t count = 0;
+    simdjson::dom::document_stream stream;
+    // We use a window of json.size() though any large value would do.
+    ASSERT_SUCCESS( parser.parse_many(json, json.size()).get(stream) );
+    auto i = stream.begin();
+    for(; i != stream.end(); ++i) {
+        auto doc = *i;
+        if(!doc.error()) {
+          std::cout << "got full document at " << i.current_index() << std::endl;
+          count++;
+        }
+    }
+    if(count != 2) {
+      std::cerr << "Expected to get two full documents " << std::endl;
+      return false;
+    }
+    size_t index = i.current_index();
+    if(index != 29) {
+      std::cerr << "Expected to stop after the two full documents " << std::endl;
+      std::cerr << "index = " << index << std::endl;
+      return false;
+    }
+    return true;
+  }
 
+  bool truncated_window_unclosed_string() {
+    std::cout << "Running " << __func__ << std::endl;
+    // The last JSON document is intentionally truncated. In this instance, we use
+    // a truncated string which will create trouble since stage 1 will recognize the
+    // JSON as invalid and refuse to even start parsing.
+    auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} "intentionally unclosed string  )"_padded;
+    simdjson::dom::parser parser;
+    size_t count = 0;
+    simdjson::dom::document_stream stream;
+    // We use a window of json.size() though any large value would do.
+    ASSERT_SUCCESS( parser.parse_many(json,json.size()).get(stream) );
+    // Rest is ineffective because stage 1 fails.
+    auto i = stream.begin();
+    for(; i != stream.end(); ++i) {
+        auto doc = *i;
+        if(!doc.error()) {
+          std::cout << "got full document at " << i.current_index() << std::endl;
+          count++;
+        }
+    }
+    if(count != 2) {
+      std::cerr << "Expected to get two full documents " << std::endl;
+      std::cerr << "got " << count << std::endl;
+
+      return false;
+    }
+    size_t index = i.current_index();
+    if(index != 29) {
+      std::cerr << "Expected to stop after the two full documents " << std::endl;
+      std::cerr << "index = " << index << std::endl;
+      return false;
+    }
+    return true;
+  }
   bool small_window() {
     std::cout << "Running " << __func__ << std::endl;
     auto json = R"({"error":[],"result":{"token":"xxx"}}{"error":[],"result":{"token":"xxx"}})"_padded;
@@ -310,7 +374,9 @@ namespace document_stream_tests {
   }
 
   bool run() {
-    return test_current_index()  &&
+    return truncated_window() &&
+           truncated_window_unclosed_string() &&
+           test_current_index()  &&
            single_document() &&
 #if SIMDJSON_EXCEPTIONS
            single_document_exceptions() &&


### PR DESCRIPTION
Suppose you have a stream of JSON documents, but the last JSON document has been truncated. You'd want to parse all JSON documents up to that point and then know where you are (in bytes) within the stream.

It turns out that our API already allows you to do it...

```C++
    simdjson::dom::parser parser;
    simdjson::dom::document_stream stream;
    auto error = parser.parse_many(json, json.size()).get(stream);
     if(error) { return; }
    auto i = stream.begin();
    for(; i != stream.end(); ++i) {
        auto doc = *i;
        if(!doc.error()) {
          std::cout << "got full document at " << i.current_index() << std::endl;
        }
    }
    size_t index = i.current_index();// start of the truncated document
```

And this will always work *except* if your JSON stream ends with a truncated string. Then it does not work anymore because stage 1 will flag the whole thing as being broken. It will return with simdjson::UNCLOSED_STRING and then you need to go and find the rest of the document to continue parsing.


Fixes https://github.com/simdjson/simdjson/issues/1299