### PR TITLE
don't memcpy after failed alloc

### DIFF
--- a/include/simdjson/padded_string-inl.h
+++ b/include/simdjson/padded_string-inl.h
@@ -65,6 +65,11 @@ inline padded_string::padded_string(const std::string & str_ ) noexcept
 // note: do pass std::string_view arguments by value
 inline padded_string::padded_string(std::string_view sv_) noexcept
     : viable_size(sv_.size()), data_ptr(internal::allocate_padded_buffer(sv_.size())) {
+  if(simdjson_unlikely(!data_ptr)) {
+    //allocation failed or zero size
+    viable_size=0;
+    return;
+  }
   if (sv_.size()) {
     std::memcpy(data_ptr, sv_.data(), sv_.size());
   }


### PR DESCRIPTION
If the allocator fails and returns nullptr, the memcpy should not happen.

See ossfuzz https://oss-fuzz.com/testcase-detail/6612227272212480

I don't know what the error strategy for padded_string is, I guess it should be kept noexcept so we can't throw here. Setting the size to zero and data to nullptr seems reasonable, but that looks exactly like a default constructed empty padded_string. Should those be kept separate? As of now, if the allocation fails, the padded string will be empty, and the program will proceed as if the input was empty which may be surprising.

One way to keep the failed alloc case apart from the zero size case would be to let the zero size point to a static buffer. That would make it always be padded, even in case of zero size. A member function could be added to query the padded_string object if it's empty, or failed. That function would check for zero size and then disambiguate on the dataptr being null or pointing to the static buffer.