### PR TITLE
Mark comparison operators as const

### DIFF
--- a/include/simdjson/generic/ondemand/array_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/array_iterator-inl.h
@@ -19,11 +19,11 @@ simdjson_really_inline simdjson_result<value> array_iterator<T>::operator*() noe
   return value::start(iter->borrow_iterator());
 }
 template<typename T>
-simdjson_really_inline bool array_iterator<T>::operator==(const array_iterator<T> &other) noexcept {
+simdjson_really_inline bool array_iterator<T>::operator==(const array_iterator<T> &other) const noexcept {
   return !(*this != other);
 }
 template<typename T>
-simdjson_really_inline bool array_iterator<T>::operator!=(const array_iterator<T> &) noexcept {
+simdjson_really_inline bool array_iterator<T>::operator!=(const array_iterator<T> &) const noexcept {
   return iter->is_iterator_alive();
 }
 template<typename T>
@@ -62,12 +62,12 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
   return *this->first;
 }
 template<typename T>
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &other) noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &other) const noexcept {
   if (this->error()) { return true; }
   return this->first == other.first;
 }
 template<typename T>
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &other) noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &other) const noexcept {
   if (this->error()) { return false; }
   return this->first != other.first;
 }

--- a/include/simdjson/generic/ondemand/array_iterator.h
+++ b/include/simdjson/generic/ondemand/array_iterator.h
@@ -41,7 +41,7 @@ public:
    *
    * @return true if there are no more elements in the JSON array.
    */
-  simdjson_really_inline bool operator==(const array_iterator<T> &) noexcept;
+  simdjson_really_inline bool operator==(const array_iterator<T> &) const noexcept;
   /**
    * Check if there are more elements in the JSON array.
    *
@@ -49,7 +49,7 @@ public:
    *
    * @return true if there are more elements in the JSON array.
    */
-  simdjson_really_inline bool operator!=(const array_iterator<T> &) noexcept;
+  simdjson_really_inline bool operator!=(const array_iterator<T> &) const noexcept;
   /**
    * Move to the next element.
    *
@@ -91,8 +91,8 @@ public:
   //
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) noexcept;
-  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) noexcept;
+  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) const noexcept;
+  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) const noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &operator++() noexcept;
 };
 

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -17,10 +17,10 @@ simdjson_really_inline simdjson_result<field> object_iterator::operator*() noexc
   if (result.error()) { iter->release(); }
   return result;
 }
-simdjson_really_inline bool object_iterator::operator==(const object_iterator &other) noexcept {
+simdjson_really_inline bool object_iterator::operator==(const object_iterator &other) const noexcept {
   return !(*this != other);
 }
-simdjson_really_inline bool object_iterator::operator!=(const object_iterator &) noexcept {
+simdjson_really_inline bool object_iterator::operator!=(const object_iterator &) const noexcept {
   return iter->is_alive();
 }
 simdjson_really_inline object_iterator &object_iterator::operator++() noexcept {
@@ -55,12 +55,12 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>
   return *first;
 }
 // Assumes it's being compared with the end. true if depth < iter->depth.
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
   if (error()) { return true; }
   return first == other.first;
 }
 // Assumes it's being compared with the end. true if depth >= iter->depth.
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
   if (error()) { return false; }
   return first != other.first;
 }

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -26,9 +26,9 @@ public:
   // MUST ONLY BE CALLED ONCE PER ITERATION.
   simdjson_really_inline simdjson_result<field> operator*() noexcept;
   // Assumes it's being compared with the end. true if depth < iter->depth.
-  simdjson_really_inline bool operator==(const object_iterator &) noexcept;
+  simdjson_really_inline bool operator==(const object_iterator &) const noexcept;
   // Assumes it's being compared with the end. true if depth >= iter->depth.
-  simdjson_really_inline bool operator!=(const object_iterator &) noexcept;
+  simdjson_really_inline bool operator!=(const object_iterator &) const noexcept;
   // Checks for ']' and ','
   simdjson_really_inline object_iterator &operator++() noexcept;
 private:
@@ -61,9 +61,9 @@ public:
   // Reads key and value, yielding them to the user.
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
   // Assumes it's being compared with the end. true if depth < iter->depth.
-  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) noexcept;
+  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) const noexcept;
   // Assumes it's being compared with the end. true if depth >= iter->depth.
-  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) noexcept;
+  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) const noexcept;
   // Checks for ']' and ','
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &operator++() noexcept;
 };


### PR DESCRIPTION
This fix is required for successful compilation with C++20. Without this fix clang is complaining about range-based for loops:

```
/home/mmatrosov/dev/simdjson/tests/ondemand/ondemand_basictests.cpp:35:37: error: use of overloaded operator '!=' is ambiguous (with operand types 'simdjson::simdjson_result<simdjson::fallback::ondemand::array_iterator<simdjson::fallback::ondemand::value> >' and 'simdjson::simdjson_result<simdjson::fallback::ondemand::array_iterator<simdjson::fallback::ondemand::value> >')
    for (ondemand::object my_object : doc["mykey"]) {
                                    ^
/home/mmatrosov/dev/simdjson/include/simdjson/generic/ondemand/array_iterator.h:95:31: note: candidate function
  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) noexcept;
                              ^
/home/mmatrosov/dev/simdjson/include/simdjson/generic/ondemand/array_iterator.h:94:31: note: candidate function
  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) noexcept;
                              ^
/home/mmatrosov/dev/simdjson/include/simdjson/generic/ondemand/array_iterator.h:94:31: note: candidate function (with reversed parameter order)
/home/mmatrosov/dev/simdjson/tests/ondemand/ondemand_basictests.cpp:35:39: note: in implicit call to 'operator!=' for iterator of type 'simdjson::simdjson_result<fallback::ondemand::value>'
    for (ondemand::object my_object : doc["mykey"]) {
                                      ^~~
```
You can see this error when compiling `ondemand_basictests.cpp` with `-std=c++20`. 

Sadly, this is a required but not a sufficient change for full C++20 compatibility. Errors like the following still remain:

```
/home/mmatrosov/dev/simdjson/include/simdjson/haswell/simd.h:268:115: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'simd8<uint8_t>' (aka 'simd8<unsigned char>') and 'const simd8<uint8_t>' (aka 'const simd8<unsigned char>')) to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
    simdjson_really_inline simd8<bool> operator<=(const simd8<uint8_t> other) const { return other.max_val(*this) == other; }
                                                                                             ~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~
/home/mmatrosov/dev/simdjson/include/simdjson/haswell/simd.h:48:33: note: ambiguity is between a regular call to this operator and a call with the argument order reversed
    simdjson_really_inline Mask operator==(const simd8<T> other) const { return _mm256_cmpeq_epi8(*this, other); }
                                ^
```
I don't know of an easy way to fix this error too. See this related discussion: https://github.com/boostorg/date_time/issues/132

However, this fix allows users of ondemand mode to use range-based for loops under C++20, which is very important IMO.