### PR TITLE
[WIP] ndjson thread sanitizer

### DIFF
--- a/fuzz/build_fuzzer_variants.sh
+++ b/fuzz/build_fuzzer_variants.sh
@@ -95,7 +95,23 @@ variant=sanitizers-O3
 	ninja all_fuzzers
 	cd ..
     fi
+variant=threadsanitizer-O1
 
+    if [ ! -d build-$variant ] ; then
+
+	mkdir build-$variant
+	cd build-$variant
+	cmake .. \
+	      $COMMON \
+	      -DCMAKE_CXX_FLAGS="-O1 -fsanitize=fuzzer-no-link,thread -fno-sanitize-recover=undefined $CXX_CLAGS_COMMON" \
+	      -DCMAKE_C_FLAGS="-O1 -fsanitize=fuzzer-no-link,thread -fno-sanitize-recover=undefined" \
+	      -DCMAKE_BUILD_TYPE=Debug \
+	      -DSIMDJSON_FUZZ_LINKMAIN=Off \
+	      -DSIMDJSON_FUZZ_LDFLAGS="-fsanitize=fuzzer"
+
+	ninja all_fuzzers
+	cd ..
+    fi
 variant=sanitizers-O0
 
     if [ ! -d build-$variant ] ; then

--- a/fuzz/quick_check.sh
+++ b/fuzz/quick_check.sh
@@ -32,6 +32,8 @@ fi
 builddir=build-sanitizers-O0
 #...but feel free to use this one instead, if you want to build coverage fast.
 #builddir=build-fast
+#...or this one, to find data races
+#builddir=build-threadsanitizer-O1
 
 if [ ! -d $builddir ] ; then
   fuzz/build_fuzzer_variants.sh


### PR DESCRIPTION
When run, gives stuff like this.

Build with:

fuzz/build_fuzzer_variants.sh

run with:

build-threadsanitizer-O1/fuzz/fuzz_ndjson 

And get something like this:

```
INFO: Seed: 3844882090
INFO: Loaded 2 modules   (4268 inline 8-bit counters): 3757 [0x7f7bdf0b5cc8, 0x7f7bdf0b6b75), 511 [0x533ea8, 0x5340a7), 
INFO: Loaded 2 PC tables (4268 PCs): 3757 [0x7f7bdf0b6b78,0x7f7bdf0c5648), 511 [0x5340a8,0x536098), 
INFO:     3832 files found in out/ndjson/
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 3832 min: 1b max: 4089b total: 780813b rss: 103Mb
==================
WARNING: ThreadSanitizer: data race (pid=22655)
  Write of size 1 at 0x000000533ff2 by main thread:
    #0 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_mutex.h:196 (fuzz_ndjson+0x4ea2fd)
    #1 simdjson::dom::stage1_worker::run(simdjson::dom::document_stream*, simdjson::dom::parser*, unsigned long) /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:57:32 (fuzz_ndjson+0x4eca93)
    #2 simdjson::dom::document_stream::start_stage1_thread() /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:262:11 (fuzz_ndjson+0x4e8a8a)
    #3 simdjson::dom::document_stream::start() /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:178:5 (fuzz_ndjson+0x4e8325)
    #4 simdjson::dom::document_stream::begin() /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:108:3 (fuzz_ndjson+0x4e171e)
    #5 LLVMFuzzerTestOneInput /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../fuzz/fuzz_ndjson.cpp:23 (fuzz_ndjson+0x4e171e)
    #6 fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) <null> (fuzz_ndjson+0x43475a)

  Previous write of size 1 at 0x000000533ff2 by thread T2:
    #0 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/std_mutex.h:196 (fuzz_ndjson+0x4ea2fd)
    #1 simdjson::dom::stage1_worker::start_thread()::'lambda'()::operator()() const /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:28:38 (fuzz_ndjson+0x4eb797)
    #2 void std::__invoke_impl<void, simdjson::dom::stage1_worker::start_thread()::'lambda'()>(std::__invoke_other, simdjson::dom::stage1_worker::start_thread()::'lambda'()&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/invoke.h:60:14 (fuzz_ndjson+0x4eb670)
    #3 std::__invoke_result<simdjson::dom::stage1_worker::start_thread()::'lambda'()>::type std::__invoke<simdjson::dom::stage1_worker::start_thread()::'lambda'()>(simdjson::dom::stage1_worker::start_thread()::'lambda'()&&) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/bits/invoke.h:95:14 (fuzz_ndjson+0x4eb510)
    #4 decltype(std::__invoke(_S_declval<0ul>())) std::thread::_Invoker<std::tuple<simdjson::dom::stage1_worker::start_thread()::'lambda'()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:244:13 (fuzz_ndjson+0x4eb478)
    #5 std::thread::_Invoker<std::tuple<simdjson::dom::stage1_worker::start_thread()::'lambda'()> >::operator()() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:253:11 (fuzz_ndjson+0x4eb3d8)
    #6 std::thread::_State_impl<std::thread::_Invoker<std::tuple<simdjson::dom::stage1_worker::start_thread()::'lambda'()> > >::_M_run() /usr/bin/../lib/gcc/x86_64-linux-gnu/8/../../../../include/c++/8/thread:196:13 (fuzz_ndjson+0x4eb0bf)
    #7 <null> <null> (libstdc++.so.6+0xbbb2e)

  Location is global '__TMC_END__' at 0x000000533ea8 (fuzz_ndjson+0x000000533ff2)

  Thread T2 (tid=22659, running) created by main thread at:
    #0 pthread_create <null> (fuzz_ndjson+0x455f05)
    #1 std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) <null> (libstdc++.so.6+0xbbdb4)
    #2 simdjson::dom::stage1_worker::start_thread() /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:26:12 (fuzz_ndjson+0x4e895d)
    #3 simdjson::dom::document_stream::start() /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:177:13 (fuzz_ndjson+0x4e831d)
    #4 simdjson::dom::document_stream::begin() /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../include/simdjson/dom/document_stream-inl.h:108:3 (fuzz_ndjson+0x4e171e)
    #5 LLVMFuzzerTestOneInput /home/paul/code/delaktig/simdjson/build-threadsanitizer-O1/../fuzz/fuzz_ndjson.cpp:23 (fuzz_ndjson+0x4e171e)
    #6 fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) <null> (fuzz_ndjson+0x43475a)
```