### PR TITLE
Hunting for data races in document_stream

### DIFF
--- a/.github/workflows/ubuntu18-threadsani.yml
+++ b/.github/workflows/ubuntu18-threadsani.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 18.04 CI (GCC 7)
+name: Ubuntu 18.04 CI (GCC 7) with Thread Sanitizer
 
 on:
   push:

--- a/.github/workflows/ubuntu18-threadsani.yml
+++ b/.github/workflows/ubuntu18-threadsani.yml
@@ -1,0 +1,27 @@
+name: Ubuntu 18.04 CI (GCC 7)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: dependencies/.cache
+          key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
+      - name: Use cmake
+        run: |
+          mkdir build &&
+          cd build &&
+          cmake  -DSIMDJSON_SANITIZE_THREADS=ON ..  &&
+          cmake --build . --target document_stream_tests --target parse_many_test  &&
+          ctest --output-on-failure  -R parse_many_test  &&
+          ctest --output-on-failure  -R document_stream_tests

--- a/.github/workflows/ubuntu20-threadsani.yml
+++ b/.github/workflows/ubuntu20-threadsani.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 20.04 CI (GCC 9)
+name: Ubuntu 20.04 CI (GCC 9) with Thread Sanitizer
 
 on:
   push:
@@ -24,4 +24,4 @@ jobs:
           cmake  -DSIMDJSON_SANITIZE_THREADS=ON ..  &&
           cmake --build . --target document_stream_tests --target parse_many_test  &&
           ctest --output-on-failure  -R parse_many_test  &&
-          ctest --output-on-failure  -R document_stream_tests 
+          ctest --output-on-failure  -R document_stream_tests

--- a/.github/workflows/ubuntu20-threadsani.yml
+++ b/.github/workflows/ubuntu20-threadsani.yml
@@ -1,0 +1,27 @@
+name: Ubuntu 20.04 CI (GCC 9)
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ubuntu-build:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: dependencies/.cache
+          key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
+      - name: Use cmake
+        run: |
+          mkdir build &&
+          cd build &&
+          cmake  -DSIMDJSON_SANITIZE_THREADS=ON ..  &&
+          cmake --build . --target document_stream_tests --target parse_many_test  &&
+          ctest --output-on-failure  -R parse_many_test  &&
+          ctest --output-on-failure  -R document_stream_tests 

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -27,6 +27,15 @@ if(SIMDJSON_SANITIZE)
   endif()
 endif()
 
+if(SIMDJSON_SANITIZE_THREADS)
+  target_compile_options(simdjson-flags INTERFACE -fsanitize=thread -fsanitize=undefined -fno-sanitize-recover=all)
+  target_link_libraries(simdjson-flags INTERFACE -fsanitize=thread -fsanitize=undefined -fno-sanitize-recover=all)
+
+  # Ubuntu bug for GCC 5.0+ (safe for all versions)
+  if (CMAKE_COMPILER_IS_GNUCC)
+    target_link_libraries(simdjson-flags INTERFACE -fuse-ld=gold)
+  endif()
+endif()
 
 if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type selected, default to Release")

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -24,7 +24,7 @@ inline void stage1_worker::start_thread() {
     return; // This should never happen but we never want to create more than one thread.
   }
   thread = std::thread([this]{
-      while(can_work) {
+      while(true) {
         std::unique_lock<std::mutex> thread_lock(locking_mutex);
         cond_var.wait(thread_lock, [this]{return has_work || !can_work;});
         if(!can_work) {


### PR DESCRIPTION
I believe I found a potential data race in our document_stream. I believe that it is never of any consequence because, in the worst case, we will do a bit more work than we should. However, the thread sanitizer cannot know this.

I have added tests where we run document_stream_test and parse_many_test with thread sanitizers. With this change, they run clean.

Credit to @pauldreik  for reporting potential data race.
