### PR TITLE
Permit partial iteration in On Demand

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -8,15 +8,15 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 SIMDJSON_POP_DISABLE_WARNINGS
 
 #include "partial_tweets/ondemand.h"
-#include "partial_tweets/iter.h"
+// #include "partial_tweets/iter.h"
 #include "partial_tweets/dom.h"
 
 #include "largerandom/ondemand.h"
-#include "largerandom/iter.h"
+// #include "largerandom/iter.h"
 #include "largerandom/dom.h"
 
 #include "kostya/ondemand.h"
-#include "kostya/iter.h"
+// #include "kostya/iter.h"
 #include "kostya/dom.h"
 
 #include "distinctuserid/ondemand.h"

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -22,5 +22,8 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "distinctuserid/ondemand.h"
 #include "distinctuserid/dom.h"
 
+#include "find_tweet/ondemand.h"
+#include "find_tweet/dom.h"
+
 
 BENCHMARK_MAIN();

--- a/benchmark/distinctuserid/dom.h
+++ b/benchmark/distinctuserid/dom.h
@@ -8,54 +8,6 @@ namespace distinct_user_id {
 
 using namespace simdjson;
 
-
-simdjson_really_inline void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::element element);
-void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::array array) {
-  for (auto child : array) {
-    simdjson_recurse(v, child);
-  }
-}
-void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::object object) {
-  for (auto [key, value] : object) {
-    if((key.size() == 4) && (memcmp(key.data(), "user", 4) == 0)) {
-      // we are in an object under the key "user"
-      simdjson::error_code error;
-      simdjson::dom::object child_object;
-      simdjson::dom::object child_array;
-      if (not (error = value.get(child_object))) {
-        for (auto [child_key, child_value] : child_object) {
-          if((child_key.size() == 2) && (memcmp(child_key.data(), "id", 2) == 0)) {
-            int64_t x;
-            if (not (error = child_value.get(x))) {
-              v.push_back(x);
-            }
-          }
-          simdjson_recurse(v, child_value);
-        }
-      } else if (not (error = value.get(child_array))) {
-        simdjson_recurse(v, child_array);
-      }
-      // end of: we are in an object under the key "user"
-    } else {
-      simdjson_recurse(v, value);
-    }
-  }
-}
-simdjson_really_inline void simdjson_recurse(std::vector<int64_t> & v, simdjson::dom::element element) {
-  simdjson_unused simdjson::error_code error;
-  simdjson::dom::array array;
-  simdjson::dom::object object;
-  if (not (error = element.get(array))) {
-    simdjson_recurse(v, array);
-  } else if (not (error = element.get(object))) {
-    simdjson_recurse(v, object);
-  }
-}
-
-
-
-
-
 class Dom {
 public:
   simdjson_really_inline bool Run(const padded_string &json);
@@ -65,19 +17,23 @@ public:
 private:
   dom::parser parser{};
   std::vector<int64_t> ids{};
-
 };
-void print_vec(const std::vector<int64_t> &v) {
-  for (auto i : v) {
-    std::cout << i << " ";
-  }
-  std::cout << std::endl;
-}
 
 simdjson_really_inline bool Dom::Run(const padded_string &json) {
   ids.clear();
-  dom::element doc = parser.parse(json);
-  simdjson_recurse(ids, doc);
+  // Walk the document, parsing as we go
+  auto doc = parser.parse(json);
+  for (dom::object tweet : doc["statuses"]) {
+      // We believe that all statuses have a matching
+      // user, and we are willing to throw when they do not.
+      ids.push_back(tweet["user"]["id"]);
+      // Not all tweets have a "retweeted_status", but when they do
+      // we want to go and find the user within.
+      auto retweet = tweet["retweeted_status"];
+      if(retweet.error() != NO_SUCH_FIELD) {
+          ids.push_back(retweet["user"]["id"]);
+      }
+  }
   remove_duplicates(ids);
   return true;
 }

--- a/benchmark/distinctuserid/ondemand.h
+++ b/benchmark/distinctuserid/ondemand.h
@@ -35,25 +35,13 @@ simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
   auto doc = parser.iterate(json);
   for (ondemand::object tweet : doc["statuses"]) {
       // We believe that all statuses have a matching
-      // user, and we are willing to throw when they do not:
-      //
-      // You might think that you do not need the braces, but
-      // you do, otherwise you will get the wrong answer. That is
-      // because you can only have one active object or array
-      // at a time.
-      {
-        ondemand::object user = tweet["user"];
-        int64_t id = user["id"];
-        ids.push_back(id);
-      }
+      // user, and we are willing to throw when they do not.
+      ids.push_back(tweet["user"]["id"]);
       // Not all tweets have a "retweeted_status", but when they do
       // we want to go and find the user within.
       auto retweet = tweet["retweeted_status"];
       if(!retweet.error()) {
-          ondemand::object retweet_content = retweet;
-          ondemand::object reuser = retweet_content["user"];
-          int64_t rid = reuser["id"];
-          ids.push_back(rid);
+          ids.push_back(retweet["user"]["id"]);
       }
   }
   remove_duplicates(ids);

--- a/benchmark/find_tweet/dom.h
+++ b/benchmark/find_tweet/dom.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "find_tweet.h"
+
+namespace find_tweet {
+
+using namespace simdjson;
+
+class Dom {
+public:
+  simdjson_really_inline bool Run(const padded_string &json);
+  simdjson_really_inline std::string_view Result() { return text; }
+  simdjson_really_inline size_t ItemCount() { return 1; }
+
+private:
+  dom::parser parser{};
+  std::string_view text{};
+};
+
+simdjson_really_inline bool Dom::Run(const padded_string &json) {
+  text = "";
+  auto doc = parser.parse(json);
+  for (dom::object tweet : doc["statuses"]) {
+      if (uint64_t(tweet["id"]) == TWEET_ID) {
+        text = tweet["text"];
+        return true;
+      }
+  }
+  return false;
+}
+
+BENCHMARK_TEMPLATE(FindTweet, Dom);
+
+} // namespace find_tweet
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/find_tweet/find_tweet.h
+++ b/benchmark/find_tweet/find_tweet.h
@@ -10,16 +10,9 @@
 // Interface
 //
 
-namespace distinct_user_id {
-template<typename T> static void DistinctUserID(benchmark::State &state);
-
-bool equals(const char *s1, const char *s2) { return strcmp(s1, s2) == 0; }
-
-void remove_duplicates(std::vector<int64_t> &v) {
-  std::sort(v.begin(), v.end());
-  auto last = std::unique(v.begin(), v.end());
-  v.erase(last, v.end());
-}
+namespace find_tweet {
+template<typename T> static void FindTweet(benchmark::State &state);
+const uint64_t TWEET_ID = 505874901689851900;
 } // namespace
 
 //
@@ -29,11 +22,11 @@ void remove_duplicates(std::vector<int64_t> &v) {
 #include "dom.h"
 
 
-namespace distinct_user_id {
+namespace find_tweet {
 
 using namespace simdjson;
 
-template<typename T> static void DistinctUserID(benchmark::State &state) {
+template<typename T> static void FindTweet(benchmark::State &state) {
   //
   // Load the JSON file
   //
@@ -49,4 +42,4 @@ template<typename T> static void DistinctUserID(benchmark::State &state) {
   JsonBenchmark<T, Dom>(state, json);
 }
 
-} // namespace distinct_user_id
+} // namespace find_tweet

--- a/benchmark/find_tweet/ondemand.h
+++ b/benchmark/find_tweet/ondemand.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "find_tweet.h"
+
+namespace find_tweet {
+
+using namespace simdjson;
+using namespace simdjson::builtin;
+
+
+class OnDemand {
+public:
+  OnDemand() {
+    if(!displayed_implementation) {
+      std::cout << "On Demand implementation: " << builtin_implementation()->name() << std::endl;
+      displayed_implementation = true;
+    }
+  }
+  simdjson_really_inline bool Run(const padded_string &json);
+  simdjson_really_inline std::string_view Result() { return text; }
+  simdjson_really_inline size_t ItemCount() { return 1; }
+
+private:
+  ondemand::parser parser{};
+  std::string_view text{};
+
+  static inline bool displayed_implementation = false;
+};
+
+simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
+  text = "";
+  // Walk the document, parsing as we go
+  auto doc = parser.iterate(json);
+  for (ondemand::object tweet : doc["statuses"]) {
+      if (uint64_t(tweet["id"]) == TWEET_ID) {
+        text = tweet["text"];
+        return true;
+      }
+  }
+  return false;
+}
+
+BENCHMARK_TEMPLATE(FindTweet, OnDemand);
+
+} // namespace find_tweet
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/partial_tweets/ondemand.h
+++ b/benchmark/partial_tweets/ondemand.h
@@ -26,16 +26,15 @@ private:
   ondemand::parser parser{};
   std::vector<tweet> tweets{};
 
-  simdjson_really_inline uint64_t nullable_int(ondemand::value && value) {
+  simdjson_really_inline uint64_t nullable_int(ondemand::value value) {
     if (value.is_null()) { return 0; }
-    return std::move(value);
+    return value;
   }
 
-  simdjson_really_inline twitter_user read_user(ondemand::object && user) {
-    // Move user into a local object so it gets destroyed (and moves the iterator)
-    ondemand::object u = std::move(user);
-    return { u["id"], u["screen_name"] };
+  simdjson_really_inline twitter_user read_user(ondemand::object user) {
+    return { user["id"], user["screen_name"] };
   }
+
   static inline bool displayed_implementation = false;
 };
 

--- a/include/simdjson/generic/ondemand-inl.h
+++ b/include/simdjson/generic/ondemand-inl.h
@@ -2,6 +2,7 @@
 #include "simdjson/generic/ondemand/raw_json_string-inl.h"
 #include "simdjson/generic/ondemand/token_iterator-inl.h"
 #include "simdjson/generic/ondemand/json_iterator-inl.h"
+#include "simdjson/generic/ondemand/value_iterator-inl.h"
 #include "simdjson/generic/ondemand/array_iterator-inl.h"
 #include "simdjson/generic/ondemand/object_iterator-inl.h"
 #include "simdjson/generic/ondemand/array-inl.h"

--- a/include/simdjson/generic/ondemand.h
+++ b/include/simdjson/generic/ondemand.h
@@ -6,6 +6,7 @@ namespace SIMDJSON_IMPLEMENTATION {
  * Designed for maximum speed and a lower memory profile.
  */
 namespace ondemand {
+    using depth_t = int32_t;
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
@@ -14,6 +15,7 @@ namespace ondemand {
 #include "simdjson/generic/ondemand/raw_json_string.h"
 #include "simdjson/generic/ondemand/token_iterator.h"
 #include "simdjson/generic/ondemand/json_iterator.h"
+#include "simdjson/generic/ondemand/value_iterator.h"
 #include "simdjson/generic/ondemand/array_iterator.h"
 #include "simdjson/generic/ondemand/object_iterator.h"
 #include "simdjson/generic/ondemand/array.h"

--- a/include/simdjson/generic/ondemand.h
+++ b/include/simdjson/generic/ondemand.h
@@ -6,6 +6,7 @@ namespace SIMDJSON_IMPLEMENTATION {
  * Designed for maximum speed and a lower memory profile.
  */
 namespace ondemand {
+    /** Represents the depth of a JSON value (number of nested arrays/objects). */
     using depth_t = int32_t;
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -40,57 +40,30 @@ namespace ondemand {
 //   error == SUCCESS.
 //
 
-simdjson_really_inline array::array(json_iterator_ref &&_iter) noexcept
-  : iter{std::forward<json_iterator_ref>(_iter)}
+simdjson_really_inline array::array(const value_iterator &_iter) noexcept
+  : iter{_iter}
 {
 }
 
-simdjson_really_inline simdjson_result<array> array::start(json_iterator_ref &&iter) noexcept {
-  bool has_value;
-  SIMDJSON_TRY( iter->start_array().get(has_value) );
-  if (has_value) { iter.started_container(); } else { iter.abandon(); }
-  return array(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline simdjson_result<array> array::start(value_iterator &iter) noexcept {
+  simdjson_unused bool has_value;
+  SIMDJSON_TRY( iter.start_array().get(has_value) );
+  return array(iter);
 }
-simdjson_really_inline simdjson_result<array> array::start(const uint8_t *json, json_iterator_ref &&iter) noexcept {
-  bool has_value;
-  SIMDJSON_TRY( iter->start_array(json).get(has_value) );
-  if (has_value) { iter.started_container(); } else { iter.abandon(); }
-  return array(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline simdjson_result<array> array::try_start(value_iterator &iter) noexcept {
+  simdjson_unused bool has_value;
+  SIMDJSON_TRY( iter.try_start_array().get(has_value) );
+  return array(iter);
 }
-simdjson_really_inline array array::started(json_iterator_ref &&iter) noexcept {
-  if (iter->started_array()) { iter.started_container(); } else { iter.abandon(); }
-  return array(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline array array::started(value_iterator &iter) noexcept {
+  simdjson_unused bool has_value = iter.started_array();
+  return array(iter);
 }
 
-//
-// For array_iterator
-//
-simdjson_really_inline json_iterator &array::get_iterator() noexcept {
-  return *iter;
+simdjson_really_inline array_iterator array::begin() noexcept {
+  return iter;
 }
-simdjson_really_inline json_iterator_ref array::borrow_iterator_child() noexcept {
-  return iter.borrow();
-}
-simdjson_really_inline bool array::is_iterator_alive() const noexcept {
-  return iter.is_alive();
-}
-simdjson_really_inline void array::start_iterator() noexcept {
-  iter.started_container();
-}
-simdjson_really_inline void array::finish_iterator() noexcept {
-  iter.finished_container();
-}
-simdjson_really_inline void array::abandon_iterator() noexcept {
-  iter.abandon();
-}
-simdjson_warn_unused simdjson_really_inline error_code array::finish_iterator_child() noexcept {
-  return iter.finish_child();
-}
-
-simdjson_really_inline array_iterator<array> array::begin() & noexcept {
-  return *this;
-}
-simdjson_really_inline array_iterator<array> array::end() & noexcept {
+simdjson_really_inline array_iterator array::end() noexcept {
   return {};
 }
 
@@ -115,11 +88,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::begin() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::begin() noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::end() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::end() noexcept {
   if (error()) { return error(); }
   return first.end();
 }

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -24,11 +24,6 @@ public:
   array &operator=(const array &) = delete;
 
   /**
-   * Finishes iterating the array if it is not already fully iterated.
-   */
-  simdjson_really_inline ~array() noexcept;
-
-  /**
    * Begin array iteration.
    *
    * Part of the std::iterable interface.
@@ -50,6 +45,7 @@ protected:
    * @error INCORRECT_TYPE if the iterator is not at [.
    */
   static simdjson_really_inline simdjson_result<array> start(json_iterator_ref &&iter) noexcept;
+  static simdjson_really_inline simdjson_result<array> start(const uint8_t *json, json_iterator_ref &&iter) noexcept;
   /**
    * Begin array iteration.
    *
@@ -73,9 +69,12 @@ protected:
   // For array_iterator
   //
   simdjson_really_inline json_iterator &get_iterator() noexcept;
-  simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
+  simdjson_really_inline json_iterator_ref borrow_iterator_child() noexcept;
   simdjson_really_inline bool is_iterator_alive() const noexcept;
-  simdjson_really_inline void iteration_finished() noexcept;
+  simdjson_really_inline void start_iterator() noexcept;
+  simdjson_really_inline void finish_iterator() noexcept;
+  simdjson_really_inline void abandon_iterator() noexcept;
+  simdjson_warn_unused simdjson_really_inline error_code finish_iterator_child() noexcept;
 
   /**
    * Iterator marking current position.

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -28,13 +28,13 @@ public:
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline array_iterator<array> begin() & noexcept;
+  simdjson_really_inline array_iterator begin() noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline array_iterator<array> end() & noexcept;
+  simdjson_really_inline array_iterator end() noexcept;
 
 protected:
   /**
@@ -44,8 +44,15 @@ protected:
    *        resulting array.
    * @error INCORRECT_TYPE if the iterator is not at [.
    */
-  static simdjson_really_inline simdjson_result<array> start(json_iterator_ref &&iter) noexcept;
-  static simdjson_really_inline simdjson_result<array> start(const uint8_t *json, json_iterator_ref &&iter) noexcept;
+  static simdjson_really_inline simdjson_result<array> start(value_iterator &iter) noexcept;
+  /**
+   * Begin array iteration.
+   *
+   * @param iter The iterator. Must be where the initial [ is expected. Will be *moved* into the
+   *        resulting array.
+   * @error INCORRECT_TYPE if the iterator is not at [.
+   */
+  static simdjson_really_inline simdjson_result<array> try_start(value_iterator &iter) noexcept;
   /**
    * Begin array iteration.
    *
@@ -54,7 +61,7 @@ protected:
    *
    * @param iter The iterator. Must be after the initial [. Will be *moved* into the resulting array.
    */
-  static simdjson_really_inline array started(json_iterator_ref &&iter) noexcept;
+  static simdjson_really_inline array started(value_iterator &iter) noexcept;
 
   /**
    * Create an array at the given Internal array creation. Call array::start() or array::started() instead of this.
@@ -63,30 +70,19 @@ protected:
    *        == true, or past the [] with is_alive() == false if the array is empty. Will be *moved*
    *        into the resulting array.
    */
-  simdjson_really_inline array(json_iterator_ref &&iter) noexcept;
-
-  //
-  // For array_iterator
-  //
-  simdjson_really_inline json_iterator &get_iterator() noexcept;
-  simdjson_really_inline json_iterator_ref borrow_iterator_child() noexcept;
-  simdjson_really_inline bool is_iterator_alive() const noexcept;
-  simdjson_really_inline void start_iterator() noexcept;
-  simdjson_really_inline void finish_iterator() noexcept;
-  simdjson_really_inline void abandon_iterator() noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code finish_iterator_child() noexcept;
+  simdjson_really_inline array(const value_iterator &iter) noexcept;
 
   /**
    * Iterator marking current position.
    *
    * iter.is_alive() == false indicates iteration is complete.
    */
-  json_iterator_ref iter{};
+  value_iterator iter{};
 
   friend class value;
   friend struct simdjson_result<value>;
   friend struct simdjson_result<array>;
-  friend class array_iterator<array>;
+  friend class array_iterator;
 };
 
 } // namespace ondemand
@@ -105,8 +101,8 @@ public:
   simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::array>> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -18,10 +18,6 @@ public:
    * Exists so you can declare a variable and later assign to it before use.
    */
   simdjson_really_inline array() noexcept = default;
-  simdjson_really_inline array(array &&other) noexcept = default;
-  simdjson_really_inline array &operator=(array &&other) noexcept = default;
-  array(const array &) = delete;
-  array &operator=(const array &) = delete;
 
   /**
    * Begin array iteration.
@@ -96,10 +92,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> : public SIMDJS
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;

--- a/include/simdjson/generic/ondemand/array_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/array_iterator-inl.h
@@ -2,43 +2,27 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-template<typename T>
-simdjson_really_inline array_iterator<T>::array_iterator(T &_iter) noexcept : iter{&_iter} {}
+simdjson_really_inline array_iterator::array_iterator(const value_iterator &_iter) noexcept
+  : iter{_iter}
+{}
 
-template<typename T>
-simdjson_really_inline simdjson_result<array_iterator<T>> array_iterator<T>::start(T &iter, const uint8_t *json) noexcept {
-  bool has_value;
-  SIMDJSON_TRY( iter.get_iterator().start_array(json).get(has_value) );
-  if (has_value) { iter.start_iterator(); } else { iter.abandon_iterator(); }
-  return array_iterator<T>(iter);
+simdjson_really_inline simdjson_result<value> array_iterator::operator*() noexcept {
+  if (iter.error()) { iter.abandon(); return iter.error(); }
+  return value(iter.child());
 }
-template<typename T>
-simdjson_really_inline simdjson_result<value> array_iterator<T>::operator*() noexcept {
-  error_code error = iter->get_iterator().error();
-  if (error) { iter->abandon_iterator(); return error; }
-  return value::start(iter->borrow_iterator_child());
-}
-template<typename T>
-simdjson_really_inline bool array_iterator<T>::operator==(const array_iterator<T> &other) const noexcept {
+simdjson_really_inline bool array_iterator::operator==(const array_iterator &other) const noexcept {
   return !(*this != other);
 }
-template<typename T>
-simdjson_really_inline bool array_iterator<T>::operator!=(const array_iterator<T> &) const noexcept {
-  return iter->is_iterator_alive();
+simdjson_really_inline bool array_iterator::operator!=(const array_iterator &) const noexcept {
+  return iter.is_open();
 }
-template<typename T>
-simdjson_really_inline array_iterator<T> &array_iterator<T>::operator++() noexcept {
-  // TODO this is a safety rail ... users should exit loops as soon as they receive an error.
-  // Nonetheless, let's see if performance is OK with this if statement--the compiler may give it to us for free.
-  if (!iter->is_iterator_alive()) { return *this; } // Iterator will be released if there is an error
-
-  auto error = iter->finish_iterator_child();
-  if (error) { return *this; }
-
-  bool has_value;
-  error = iter->get_iterator().has_next_element().get(has_value);
-  if (error) { return *this; }
-  if (!has_value) { iter->finish_iterator(); }
+simdjson_really_inline array_iterator &array_iterator::operator++() noexcept {
+  error_code error;
+  // PERF NOTE this is a safety rail ... users should exit loops as soon as they receive an error, so we'll never get here.
+  // However, it does not seem to make a perf difference, so we add it out of an abundance of caution.
+  if ((error = iter.error()) ) { return *this; }
+  if ((error = iter.finish_child() )) { return *this; }
+  if ((error = iter.has_next_element().error() )) { return *this; }
   return *this;
 }
 
@@ -48,36 +32,30 @@ simdjson_really_inline array_iterator<T> &array_iterator<T>::operator++() noexce
 
 namespace simdjson {
 
-template<typename T>
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::simdjson_result(
-  SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T> &&value
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::simdjson_result(
+  SIMDJSON_IMPLEMENTATION::ondemand::array_iterator &&value
 ) noexcept
-  : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>(value))
+  : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>(value))
 {
 }
-template<typename T>
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::simdjson_result(error_code error) noexcept
-  : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>({}, error)
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::simdjson_result(error_code error) noexcept
+  : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>({}, error)
 {
 }
 
-template<typename T>
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator*() noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator*() noexcept {
   if (this->error()) { this->second = SUCCESS; return this->error(); }
   return *this->first;
 }
-template<typename T>
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &other) const noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
   if (this->error()) { return true; }
   return this->first == other.first;
 }
-template<typename T>
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &other) const noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
   if (this->error()) { return false; }
   return this->first != other.first;
 }
-template<typename T>
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>>::operator++() noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator++() noexcept {
   if (this->error()) { return *this; }
   ++(this->first);
   return *this;

--- a/include/simdjson/generic/ondemand/array_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/array_iterator-inl.h
@@ -21,7 +21,7 @@ simdjson_really_inline array_iterator &array_iterator::operator++() noexcept {
   // PERF NOTE this is a safety rail ... users should exit loops as soon as they receive an error, so we'll never get here.
   // However, it does not seem to make a perf difference, so we add it out of an abundance of caution.
   if ((error = iter.error()) ) { return *this; }
-  if ((error = iter.finish_child() )) { return *this; }
+  if ((error = iter.skip_child() )) { return *this; }
   if ((error = iter.has_next_element().error() )) { return *this; }
   return *this;
 }

--- a/include/simdjson/generic/ondemand/array_iterator.h
+++ b/include/simdjson/generic/ondemand/array_iterator.h
@@ -16,13 +16,10 @@ class document;
  * - * must be called exactly once per element.
  * - ++ must be called exactly once in between each * (*, ++, *, ++, * ...)
  */
-template<typename T>
 class array_iterator {
 public:
   /** Create a new, invalid array iterator. */
   simdjson_really_inline array_iterator() noexcept = default;
-  simdjson_really_inline array_iterator(const array_iterator<T> &a) noexcept = default;
-  simdjson_really_inline array_iterator<T> &operator=(const array_iterator<T> &a) noexcept = default;
 
   //
   // Iterator interface
@@ -41,7 +38,7 @@ public:
    *
    * @return true if there are no more elements in the JSON array.
    */
-  simdjson_really_inline bool operator==(const array_iterator<T> &) const noexcept;
+  simdjson_really_inline bool operator==(const array_iterator &) const noexcept;
   /**
    * Check if there are more elements in the JSON array.
    *
@@ -49,25 +46,22 @@ public:
    *
    * @return true if there are more elements in the JSON array.
    */
-  simdjson_really_inline bool operator!=(const array_iterator<T> &) const noexcept;
+  simdjson_really_inline bool operator!=(const array_iterator &) const noexcept;
   /**
    * Move to the next element.
    *
    * Part of the std::iterator interface.
    */
-  simdjson_really_inline array_iterator<T> &operator++() noexcept;
+  simdjson_really_inline array_iterator &operator++() noexcept;
 
 private:
-  T *iter{};
+  value_iterator iter{};
 
-  simdjson_really_inline array_iterator(T &iter) noexcept;
+  simdjson_really_inline array_iterator(const value_iterator &iter) noexcept;
 
-  static simdjson_really_inline simdjson_result<array_iterator<T>> start(T &iter, const uint8_t *json) noexcept;
-
-  friend T;
   friend class array;
   friend class value;
-  friend struct simdjson_result<array_iterator<T>>;
+  friend struct simdjson_result<array_iterator>;
 };
 
 } // namespace ondemand
@@ -76,14 +70,14 @@ private:
 
 namespace simdjson {
 
-template<typename T>
-struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> {
+template<>
+struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T> &&value) noexcept; ///< @private
+  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array_iterator &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
 
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &&a) noexcept = default;
+  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   //
@@ -91,9 +85,9 @@ public:
   //
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) const noexcept;
-  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &) const noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<T>> &operator++() noexcept;
+  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) const noexcept;
+  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) const noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &operator++() noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/array_iterator.h
+++ b/include/simdjson/generic/ondemand/array_iterator.h
@@ -75,10 +75,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> : publ
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array_iterator &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   //
   // Iterator interface

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -9,7 +9,7 @@ simdjson_really_inline document::document(ondemand::json_iterator &&_iter) noexc
 }
 
 simdjson_really_inline void document::assert_at_start() const noexcept {
-  SIMDJSON_ASSUME(iter.at_start());
+  iter.assert_at_start();
 }
 simdjson_really_inline document document::start(json_iterator &&iter) noexcept {
   return document(std::forward<json_iterator>(iter));

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -2,69 +2,58 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline document::document(ondemand::json_iterator &&_iter, const uint8_t *_json) noexcept
-  : iter{std::forward<json_iterator>(_iter)},
-    json{_json}
+simdjson_really_inline document::document(ondemand::json_iterator &&_iter) noexcept
+  : iter{std::forward<json_iterator>(_iter)}
 {
   logger::log_start_value(iter, "document");
-  SIMDJSON_ASSUME(json);
 }
 
 simdjson_really_inline void document::assert_at_start() const noexcept {
-  SIMDJSON_ASSUME(json);
+  SIMDJSON_ASSUME(iter.at_start());
 }
 simdjson_really_inline document document::start(json_iterator &&iter) noexcept {
-  SIMDJSON_ASSUME(iter.container_depth == DOCUMENT_DEPTH);
-  auto json = iter.advance();
-  return document(std::forward<json_iterator>(iter), json);
+  return document(std::forward<json_iterator>(iter));
 }
 
 simdjson_really_inline value document::as_value() noexcept {
-  assert_at_start();
-  SIMDJSON_ASSUME(iter.container_depth == DOCUMENT_DEPTH);
-  return { json_iterator_ref(&iter, DOCUMENT_DEPTH + 1), json };
+  return as_value_iterator();
 }
-
-template<typename T>
-simdjson_result<T> document::consume_if_success(simdjson_result<T> &&result) noexcept {
-  if (!result.error()) { json = nullptr; }
-  return std::forward<simdjson_result<T>>(result);
+simdjson_really_inline value_iterator document::as_value_iterator() noexcept {
+  assert_at_start();
+  return value_iterator(&iter, 1);
 }
 
 simdjson_really_inline simdjson_result<array> document::get_array() & noexcept {
-  assert_at_start();
-  return consume_if_success( as_value().get_array() );
+  return as_value().get_array();
 }
 simdjson_really_inline simdjson_result<object> document::get_object() & noexcept {
-  assert_at_start();
-  return consume_if_success( as_value().get_object() );
+  return as_value().get_object();
 }
 simdjson_really_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
   assert_at_start();
-  return consume_if_success( iter.parse_root_uint64(json) );
+  return as_value_iterator().require_root_uint64();
 }
 simdjson_really_inline simdjson_result<int64_t> document::get_int64() noexcept {
   assert_at_start();
-  return consume_if_success( iter.parse_root_int64(json) );
+  return as_value_iterator().require_root_int64();
 }
 simdjson_really_inline simdjson_result<double> document::get_double() noexcept {
   assert_at_start();
-  return consume_if_success( iter.parse_root_double(json) );
+  return as_value_iterator().require_root_double();
 }
 simdjson_really_inline simdjson_result<std::string_view> document::get_string() & noexcept {
-  return consume_if_success( as_value().get_string() );
+  return as_value().get_string();
 }
 simdjson_really_inline simdjson_result<raw_json_string> document::get_raw_json_string() & noexcept {
-  return consume_if_success( as_value().get_raw_json_string() );
+  return as_value().get_raw_json_string();
 }
 simdjson_really_inline simdjson_result<bool> document::get_bool() noexcept {
   assert_at_start();
-  return consume_if_success( iter.parse_root_bool(json) );
+  return as_value_iterator().require_root_bool();
 }
 simdjson_really_inline bool document::is_null() noexcept {
   assert_at_start();
-  if (iter.root_is_null(json)) { json = nullptr; return true; }
-  return false;
+  return as_value_iterator().is_root_null();
 }
 
 template<> simdjson_really_inline simdjson_result<array> document::get() & noexcept { return get_array(); }
@@ -99,10 +88,10 @@ simdjson_really_inline document::operator raw_json_string() & noexcept(false) { 
 simdjson_really_inline document::operator bool() noexcept(false) { return get_bool(); }
 #endif
 
-simdjson_really_inline simdjson_result<array_iterator<document>> document::begin() & noexcept {
-  return consume_if_success( array_iterator<document>::start(*this, json) );
+simdjson_really_inline simdjson_result<array_iterator> document::begin() & noexcept {
+  return get_array().begin();
 }
-simdjson_really_inline simdjson_result<array_iterator<document>> document::end() & noexcept {
+simdjson_really_inline simdjson_result<array_iterator> document::end() & noexcept {
   return {};
 }
 simdjson_really_inline simdjson_result<value> document::operator[](std::string_view key) & noexcept {
@@ -110,33 +99,6 @@ simdjson_really_inline simdjson_result<value> document::operator[](std::string_v
 }
 simdjson_really_inline simdjson_result<value> document::operator[](const char *key) & noexcept {
   return get_object()[key];
-}
-
-//
-// For array_iterator
-//
-simdjson_really_inline json_iterator &document::get_iterator() noexcept {
-  return iter;
-}
-simdjson_really_inline json_iterator_ref document::borrow_iterator_child() noexcept {
-  SIMDJSON_ASSUME(iter.container_depth == DOCUMENT_DEPTH + 1);
-  return json_iterator_ref(&iter, DOCUMENT_DEPTH);
-}
-simdjson_really_inline bool document::is_iterator_alive() const noexcept {
-  return iter.container_depth != DOCUMENT_DEPTH;
-}
-simdjson_really_inline void document::start_iterator() noexcept {
-  SIMDJSON_ASSUME(iter.container_depth == DOCUMENT_DEPTH + 1);
-}
-simdjson_really_inline void document::finish_iterator() noexcept {
-  SIMDJSON_ASSUME(iter.container_depth == DOCUMENT_DEPTH);
-}
-simdjson_really_inline void document::abandon_iterator() noexcept {
-  iter.container_depth = DOCUMENT_DEPTH;
-}
-simdjson_warn_unused simdjson_really_inline error_code document::finish_iterator_child() noexcept {
-  SIMDJSON_ASSUME(iter.container_depth > DOCUMENT_DEPTH);
-  return iter.finish_child(DOCUMENT_DEPTH + 1);
 }
 
 } // namespace ondemand
@@ -162,11 +124,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::docume
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::document>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::begin() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::document>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::end() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::end() & noexcept {
   return {};
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator[](std::string_view key) & noexcept {

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -31,10 +31,6 @@ public:
   simdjson_really_inline document() noexcept = default;
   simdjson_really_inline document(const document &other) = delete;
   simdjson_really_inline document &operator=(const document &other) = delete;
-  /**
-   * Finishes logging (if logging is enabled).
-   */
-  simdjson_really_inline ~document() noexcept;
 
   /**
    * Cast this JSON value to an array.
@@ -251,15 +247,19 @@ protected:
   // For array_iterator
   //
   simdjson_really_inline json_iterator &get_iterator() noexcept;
-  simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
+  simdjson_really_inline json_iterator_ref borrow_iterator_child() noexcept;
   simdjson_really_inline bool is_iterator_alive() const noexcept;
-  simdjson_really_inline void iteration_finished() noexcept;
+  simdjson_really_inline void start_iterator() noexcept;
+  simdjson_really_inline void finish_iterator() noexcept;
+  simdjson_really_inline void abandon_iterator() noexcept;
+  simdjson_warn_unused simdjson_really_inline error_code finish_iterator_child() noexcept;
 
   //
   // Fields
   //
   json_iterator iter{}; ///< Current position in the document
   const uint8_t *json{}; ///< JSON for the value in the document (nullptr if value has been consumed)
+  static constexpr uint32_t DOCUMENT_DEPTH = 0; ///< document depth is always 0
 
   friend struct simdjson_result<document>;
   friend class array_iterator<document>;

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -208,14 +208,14 @@ public:
 
   /**
    * Look up a field by name on an object.
-   * 
+   *
    * Important notes:
-   * 
+   *
    * * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    *   e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
    * * **Once Only:** You may only look up a single field on a document. To look up multiple fields,
    *   use `.get_object()` or cast to `object`.
-   * 
+   *
    * @param key The key to look up.
    * @returns The value of the field, NO_SUCH_FIELD if the field is not in the object, or
    *          INCORRECT_TYPE if the JSON value is not an array.

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -208,23 +208,20 @@ public:
 
   /**
    * Look up a field by name on an object.
-   *
-   * This method may only be called once on a given value. If you want to look up multiple fields,
-   * you must first get the object using value.get_object() or object(value).
-   *
+   * 
+   * Important notes:
+   * 
+   * * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
+   *   e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
+   * * **Once Only:** You may only look up a single field on a document. To look up multiple fields,
+   *   use `.get_object()` or cast to `object`.
+   * 
    * @param key The key to look up.
-   * @returns INCORRECT_TYPE If the JSON value is not an array.
+   * @returns The value of the field, NO_SUCH_FIELD if the field is not in the object, or
+   *          INCORRECT_TYPE if the JSON value is not an array.
    */
   simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
-  /**
-   * Look up a field by name on an object.
-   *
-   * This method may only be called once on a given value. If you want to look up multiple fields,
-   * you must first get the object using value.get_object() or object(value).
-   *
-   * @param key The key to look up.
-   * @returns INCORRECT_TYPE If the JSON value is not an array.
-   */
+  /** @overload simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept; */
   simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
 
 protected:

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -9,7 +9,7 @@ class array;
 class object;
 class value;
 class raw_json_string;
-template<typename T> class array_iterator;
+class array_iterator;
 
 /**
  * A JSON document iteration.
@@ -198,13 +198,13 @@ public:
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator<document>> begin() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator<document>> end() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
 
   /**
    * Look up a field by name on an object.
@@ -228,41 +228,23 @@ public:
   simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
 
 protected:
-  simdjson_really_inline document(ondemand::json_iterator &&iter, const uint8_t *json) noexcept;
+  simdjson_really_inline document(ondemand::json_iterator &&iter) noexcept;
   simdjson_really_inline const uint8_t *text(uint32_t idx) const noexcept;
 
   simdjson_really_inline value as_value() noexcept;
+  simdjson_really_inline value_iterator as_value_iterator() noexcept;
   static simdjson_really_inline document start(ondemand::json_iterator &&iter) noexcept;
-  /**
-   * Set json to null if the result is successful.
-   *
-   * Convenience function for value-getters.
-   */
-  template<typename T>
-  simdjson_result<T> consume_if_success(simdjson_result<T> &&result) noexcept;
 
   simdjson_really_inline void assert_at_start() const noexcept;
-
-  //
-  // For array_iterator
-  //
-  simdjson_really_inline json_iterator &get_iterator() noexcept;
-  simdjson_really_inline json_iterator_ref borrow_iterator_child() noexcept;
-  simdjson_really_inline bool is_iterator_alive() const noexcept;
-  simdjson_really_inline void start_iterator() noexcept;
-  simdjson_really_inline void finish_iterator() noexcept;
-  simdjson_really_inline void abandon_iterator() noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code finish_iterator_child() noexcept;
 
   //
   // Fields
   //
   json_iterator iter{}; ///< Current position in the document
-  const uint8_t *json{}; ///< JSON for the value in the document (nullptr if value has been consumed)
-  static constexpr uint32_t DOCUMENT_DEPTH = 0; ///< document depth is always 0
+  static constexpr depth_t DOCUMENT_DEPTH = 0; ///< document depth is always 0
 
   friend struct simdjson_result<document>;
-  friend class array_iterator<document>;
+  friend class array_iterator;
   friend class value;
   friend class ondemand::parser;
   friend class object;
@@ -314,8 +296,8 @@ public:
   simdjson_really_inline operator bool() noexcept(false);
 #endif
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::document>> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::document>> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
 };

--- a/include/simdjson/generic/ondemand/field-inl.h
+++ b/include/simdjson/generic/ondemand/field-inl.h
@@ -10,20 +10,20 @@ simdjson_really_inline field::field(raw_json_string key, ondemand::value &&value
 {
 }
 
-simdjson_really_inline simdjson_result<field> field::start(json_iterator_ref &parent_iter) noexcept {
+simdjson_really_inline simdjson_result<field> field::start(value_iterator &parent_iter) noexcept {
   raw_json_string key;
-  SIMDJSON_TRY( parent_iter->field_key().get(key) );
-  SIMDJSON_TRY( parent_iter->field_value() );
-  return field::start(parent_iter.borrow(), key);
+  SIMDJSON_TRY( parent_iter.field_key().get(key) );
+  SIMDJSON_TRY( parent_iter.field_value() );
+  return field::start(parent_iter, key);
 }
 
-simdjson_really_inline simdjson_result<field> field::start(json_iterator_ref &&iter, raw_json_string key) noexcept {
-    return field(key, value::start(std::forward<json_iterator_ref>(iter)));
+simdjson_really_inline simdjson_result<field> field::start(const value_iterator &parent_iter, raw_json_string key) noexcept {
+    return field(key, parent_iter.child());
 }
 
 simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> field::unescaped_key() noexcept {
   SIMDJSON_ASSUME(first.buf != nullptr); // We would like to call .alive() by Visual Studio won't let us.
-  simdjson_result<std::string_view> answer = first.unescape(second.get_iterator());
+  simdjson_result<std::string_view> answer = first.unescape(second.iter.string_buf_loc());
   first.consume();
   return answer;
 }

--- a/include/simdjson/generic/ondemand/field.h
+++ b/include/simdjson/generic/ondemand/field.h
@@ -50,8 +50,8 @@ public:
 
 protected:
   simdjson_really_inline field(raw_json_string key, ondemand::value &&value) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(json_iterator_ref &iter) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(json_iterator_ref &&iter, raw_json_string key) noexcept;
+  static simdjson_really_inline simdjson_result<field> start(value_iterator &parent_iter) noexcept;
+  static simdjson_really_inline simdjson_result<field> start(const value_iterator &parent_iter, raw_json_string key) noexcept;
   friend struct simdjson_result<field>;
   friend class object_iterator;
 };

--- a/include/simdjson/generic/ondemand/field.h
+++ b/include/simdjson/generic/ondemand/field.h
@@ -20,11 +20,6 @@ public:
    */
   simdjson_really_inline field() noexcept;
 
-  simdjson_really_inline field(field &&other) noexcept = default;
-  simdjson_really_inline field &operator=(field &&other) noexcept = default;
-  simdjson_really_inline field(const field &other) noexcept = delete;
-  simdjson_really_inline field &operator=(const field &other) noexcept = delete;
-
   /**
    * Get the key as a string_view (for higher speed, consider raw_key).
    * We deliberately use a more cumbersome name (unescaped_key) to force users
@@ -67,10 +62,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> : public SIMDJS
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::field &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   simdjson_really_inline simdjson_result<std::string_view> unescaped_key() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> key() noexcept;

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -3,273 +3,51 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
 simdjson_really_inline json_iterator::json_iterator(json_iterator &&other) noexcept
-  : token_iterator(std::forward<token_iterator>(other)),
+  : token(std::forward<token_iterator>(other.token)),
     parser{other.parser},
-    current_string_buf_loc{other.current_string_buf_loc},
-    container_depth{other.container_depth}
+    _string_buf_loc{other._string_buf_loc},
+    _depth{other._depth}
 {
   other.parser = nullptr;
 }
 simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&other) noexcept {
-  buf = other.buf;
-  index = other.index;
+  token = other.token;
   parser = other.parser;
-  current_string_buf_loc = other.current_string_buf_loc;
-  container_depth = other.container_depth;
+  _string_buf_loc = other._string_buf_loc;
+  _depth = other._depth;
   other.parser = nullptr;
   return *this;
 }
 
 simdjson_really_inline json_iterator::json_iterator(ondemand::parser *_parser) noexcept
-  : token_iterator(_parser->dom_parser.buf, _parser->dom_parser.structural_indexes.get()),
+  : token(_parser->dom_parser.buf, _parser->dom_parser.structural_indexes.get()),
     parser{_parser},
-    current_string_buf_loc{parser->string_buf.get()},
-    container_depth{0}
+    _string_buf_loc{parser->string_buf.get()},
+    _depth{1}
 {
   // Release the string buf so it can be reused by the next document
   logger::log_headers();
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> json_iterator::start_object(const uint8_t *json) noexcept {
-  if (*json != '{') { logger::log_error(*this, "Not an object"); return INCORRECT_TYPE; }
-  return started_object();
-}
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> json_iterator::start_object() noexcept {
-  return start_object(advance());
-}
+simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child(depth_t parent_depth) noexcept {
+  SIMDJSON_ASSUME(depth() == parent_depth+1);
 
-simdjson_warn_unused simdjson_really_inline bool json_iterator::started_object() noexcept {
-  if (*peek() == '}') {
-    logger::log_value(*this, "empty object");
-    advance();
-    return false;
-  }
-  container_depth++;
-  logger::log_start_value(*this, "object");
-  return true;
-}
-
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> json_iterator::has_next_field() noexcept {
   switch (*advance()) {
-    case '}':
-      logger::log_end_value(*this, "object");
-      container_depth--;
-      return false;
-    case ',':
-      return true;
-    default:
-      return report_error(TAPE_ERROR, "Missing comma between object fields");
-  }
-}
-
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> json_iterator::find_field_raw(const char *key) noexcept {
-  bool has_next;
-  do {
-    raw_json_string actual_key;
-    SIMDJSON_TRY( consume_raw_json_string().get(actual_key) );
-    if (*advance() != ':') { return report_error(TAPE_ERROR, "Missing colon in object field"); }
-    if (actual_key == key) {
-      logger::log_event(*this, "match", key);
-      return true;
-    }
-    logger::log_event(*this, "non-match", key);
-    SIMDJSON_TRY( skip() ); // Skip the value so we can look at the next key
-
-    SIMDJSON_TRY( has_next_field().get(has_next) );
-  } while (has_next);
-  logger::log_event(*this, "no matches", key);
-  return false;
-}
-
-simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> json_iterator::field_key() noexcept {
-  const uint8_t *key = advance();
-  if (*(key++) != '"') { return report_error(TAPE_ERROR, "Object key is not a string"); }
-  return raw_json_string(key);
-}
-
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::field_value() noexcept {
-  if (*advance() != ':') { return report_error(TAPE_ERROR, "Missing colon in object field"); }
-  return SUCCESS;
-}
-
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> json_iterator::start_array(const uint8_t *json) noexcept {
-  if (*json != '[') { logger::log_error(*this, "Not an array"); return INCORRECT_TYPE; }
-  return started_array();
-}
-
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> json_iterator::start_array() noexcept {
-  return start_array(advance());
-}
-
-simdjson_warn_unused simdjson_really_inline bool json_iterator::started_array() noexcept {
-  if (*peek() == ']') {
-    logger::log_value(*this, "empty array");
-    advance();
-    return false;
-  }
-  logger::log_start_value(*this, "array");
-  container_depth++;
-  return true;
-}
-
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> json_iterator::has_next_element() noexcept {
-  switch (*advance()) {
-    case ']':
-      logger::log_end_value(*this, "array");
-      container_depth--;
-      return false;
-    case ',':
-      return true;
-    default:
-      return report_error(TAPE_ERROR, "Missing comma between array elements");
-  }
-}
-
-simdjson_warn_unused simdjson_result<std::string_view> json_iterator::parse_string(const uint8_t *json) noexcept {
-  return parse_raw_json_string(json).unescape(current_string_buf_loc);
-}
-simdjson_warn_unused simdjson_result<std::string_view> json_iterator::consume_string() noexcept {
-  return parse_string(advance());
-}
-simdjson_warn_unused simdjson_result<raw_json_string> json_iterator::parse_raw_json_string(const uint8_t *json) noexcept {
-  logger::log_value(*this, "string", "");
-  if (*json != '"') { logger::log_error(*this, "Not a string"); return INCORRECT_TYPE; }
-  return raw_json_string(json+1);
-}
-simdjson_warn_unused simdjson_result<raw_json_string> json_iterator::consume_raw_json_string() noexcept {
-  return parse_raw_json_string(advance());
-}
-simdjson_warn_unused simdjson_result<uint64_t> json_iterator::parse_uint64(const uint8_t *json) noexcept {
-  logger::log_value(*this, "uint64", "");
-  return numberparsing::parse_unsigned(json);
-}
-simdjson_warn_unused simdjson_result<uint64_t> json_iterator::consume_uint64() noexcept {
-  return parse_uint64(advance());
-}
-simdjson_warn_unused simdjson_result<int64_t> json_iterator::parse_int64(const uint8_t *json) noexcept {
-  logger::log_value(*this, "int64", "");
-  return numberparsing::parse_integer(json);
-}
-simdjson_warn_unused simdjson_result<int64_t> json_iterator::consume_int64() noexcept {
-  return parse_int64(advance());
-}
-simdjson_warn_unused simdjson_result<double> json_iterator::parse_double(const uint8_t *json) noexcept {
-  logger::log_value(*this, "double", "");
-  return numberparsing::parse_double(json);
-}
-simdjson_warn_unused simdjson_result<double> json_iterator::consume_double() noexcept {
-  return parse_double(advance());
-}
-simdjson_warn_unused simdjson_result<bool> json_iterator::parse_bool(const uint8_t *json) noexcept {
-  logger::log_value(*this, "bool", "");
-  auto not_true = atomparsing::str4ncmp(json, "true");
-  auto not_false = atomparsing::str4ncmp(json, "fals") | (json[4] ^ 'e');
-  bool error = (not_true && not_false) || jsoncharutils::is_not_structural_or_whitespace(json[not_true ? 5 : 4]);
-  if (error) { logger::log_error(*this, "Not a boolean"); return INCORRECT_TYPE; }
-  return simdjson_result<bool>(!not_true);
-}
-simdjson_warn_unused simdjson_result<bool> json_iterator::consume_bool() noexcept {
-  return parse_bool(advance());
-}
-simdjson_really_inline bool json_iterator::is_null(const uint8_t *json) noexcept {
-  if (!atomparsing::str4ncmp(json, "null")) {
-    logger::log_value(*this, "null", "");
-    return true;
-  }
-  return false;
-}
-simdjson_really_inline bool json_iterator::is_null() noexcept {
-  if (is_null(peek())) {
-    advance();
-    return true;
-  }
-  return false;
-}
-
-template<int N>
-simdjson_warn_unused simdjson_really_inline bool json_iterator::copy_to_buffer(const uint8_t *json, uint8_t (&tmpbuf)[N]) noexcept {
-  // Truncate whitespace to fit the buffer.
-  auto len = peek_length(-1);
-  if (len > N-1) {
-    if (jsoncharutils::is_not_structural_or_whitespace(json[N])) { return false; }
-    len = N-1;
-  }
-
-  // Copy to the buffer.
-  std::memcpy(tmpbuf, json, len);
-  tmpbuf[len] = ' ';
-  return true;
-}
-
-constexpr const uint32_t MAX_INT_LENGTH = 1024;
-
-simdjson_warn_unused simdjson_result<uint64_t> json_iterator::parse_root_uint64(const uint8_t *json) noexcept {
-  uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
-  if (!copy_to_buffer(json, tmpbuf)) { logger::log_error(*this, "Root number more than 20 characters"); return NUMBER_ERROR; }
-  logger::log_value(*this, "uint64", "");
-  auto result = numberparsing::parse_unsigned(tmpbuf);
-  if (result.error()) { logger::log_error(*this, "Error parsing unsigned integer"); return result.error(); }
-  return result;
-}
-simdjson_warn_unused simdjson_result<uint64_t> json_iterator::consume_root_uint64() noexcept {
-  return parse_root_uint64(advance());
-}
-simdjson_warn_unused simdjson_result<int64_t> json_iterator::parse_root_int64(const uint8_t *json) noexcept {
-  uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
-  if (!copy_to_buffer(json, tmpbuf)) { logger::log_error(*this, "Root number more than 20 characters"); return NUMBER_ERROR; }
-  logger::log_value(*this, "int64", "");
-  auto result = numberparsing::parse_integer(tmpbuf);
-  if (result.error()) { report_error(result.error(), "Error parsing integer"); }
-  return result;
-}
-simdjson_warn_unused simdjson_result<int64_t> json_iterator::consume_root_int64() noexcept {
-  return parse_root_int64(advance());
-}
-simdjson_warn_unused simdjson_result<double> json_iterator::parse_root_double(const uint8_t *json) noexcept {
-  // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest number: -0.<fraction>e-308.
-  uint8_t tmpbuf[1074+8+1];
-  if (!copy_to_buffer(json, tmpbuf)) { logger::log_error(*this, "Root number more than 1082 characters"); return NUMBER_ERROR; }
-  logger::log_value(*this, "double", "");
-  auto result = numberparsing::parse_double(tmpbuf);
-  if (result.error()) { report_error(result.error(), "Error parsing double"); }
-  return result;
-}
-simdjson_warn_unused simdjson_result<double> json_iterator::consume_root_double() noexcept {
-  return parse_root_double(advance());
-}
-simdjson_warn_unused simdjson_result<bool> json_iterator::parse_root_bool(const uint8_t *json) noexcept {
-  uint8_t tmpbuf[5+1];
-  if (!copy_to_buffer(json, tmpbuf)) { logger::log_error(*this, "Not a boolean"); return INCORRECT_TYPE; }
-  return parse_bool(tmpbuf);
-}
-simdjson_warn_unused simdjson_result<bool> json_iterator::consume_root_bool() noexcept {
-  return parse_root_bool(advance());
-}
-simdjson_really_inline bool json_iterator::root_is_null(const uint8_t *json) noexcept {
-  uint8_t tmpbuf[4+1];
-  if (!copy_to_buffer(json, tmpbuf)) { return false; }
-  return is_null(tmpbuf);
-}
-
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip() noexcept {
-  switch (*advance()) {
-    // PERF TODO does it skip the depth check when we don't decrement depth?
     case '[': case '{':
-      container_depth++;
       logger::log_start_value(*this, "skip");
-      return skip_container();
+      return finish_child(parent_depth);
     default:
-      logger::log_value(*this, "skip", "");
+      logger::log_value(*this, "skip");
+      ascend_to(parent_depth);
       return SUCCESS;
   }
 }
 
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::finish_child(uint32_t depth) noexcept {
-  uint32_t relative_depth = container_depth - depth;
-  if (relative_depth == 0) { return SUCCESS; }
-  // The loop breaks only when depth-- happens.
+simdjson_warn_unused simdjson_really_inline error_code json_iterator::finish_child(depth_t parent_depth) noexcept {
+  if (depth() <= parent_depth) { return SUCCESS; }
+  // The loop breaks only when depth()-- happens.
   auto end = &parser->dom_parser.structural_indexes[parser->dom_parser.n_structural_indexes];
-  while (index <= end) {
+  while (token.index <= end) {
     uint8_t ch = *advance();
     switch (ch) {
       // TODO consider whether matching braces is a requirement: if non-matching braces indicates
@@ -278,13 +56,13 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::finish_chi
       // looking at the right values."
       case ']': case '}':
         logger::log_end_value(*this, "skip");
-        relative_depth--;
-        if (relative_depth == 0) { container_depth = depth; return SUCCESS; }
+        _depth--;
+        if (depth() <= parent_depth) { return SUCCESS; }
         break;
-      // PERF TODO does it skip the depth check when we don't decrement depth?
+      // PERF TODO does it skip the depth() check when we don't decrement depth()?
       case '[': case '{':
         logger::log_start_value(*this, "skip");
-        relative_depth++;
+        _depth++;
         break;
       default:
         logger::log_value(*this, "skip", "");
@@ -295,110 +73,93 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::finish_chi
   return report_error(TAPE_ERROR, "not enough close braces");
 }
 
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_container() noexcept {
-  return finish_child(container_depth-1);
-}
-
 simdjson_really_inline bool json_iterator::at_start() const noexcept {
-  return index == parser->dom_parser.structural_indexes.get();
+  return token.index == parser->dom_parser.structural_indexes.get();
 }
 
 simdjson_really_inline bool json_iterator::at_eof() const noexcept {
-  return index == &parser->dom_parser.structural_indexes[parser->dom_parser.n_structural_indexes];
+  return token.index == &parser->dom_parser.structural_indexes[parser->dom_parser.n_structural_indexes];
 }
 
 simdjson_really_inline bool json_iterator::is_alive() const noexcept {
   return parser;
 }
 
-simdjson_really_inline error_code json_iterator::report_error(error_code error, const char *message) noexcept {
-  SIMDJSON_ASSUME(error != SUCCESS && error != UNINITIALIZED && error != INCORRECT_TYPE && error != NO_SUCH_FIELD);
+simdjson_really_inline void json_iterator::abandon() noexcept {
+  parser = nullptr;
+  _depth = 0;
+}
+
+simdjson_really_inline const uint8_t *json_iterator::advance() noexcept {
+  return token.advance();
+}
+
+simdjson_really_inline const uint8_t *json_iterator::peek(int32_t delta) const noexcept {
+  return token.peek(delta);
+}
+
+simdjson_really_inline uint32_t json_iterator::peek_length(int32_t delta) const noexcept {
+  return token.peek_length(delta);
+}
+
+simdjson_really_inline void json_iterator::ascend_to(depth_t parent_depth) noexcept {
+  SIMDJSON_ASSUME(depth() == parent_depth + 1);
+  _depth = parent_depth;
+}
+
+simdjson_really_inline void json_iterator::descend_to(depth_t child_depth) noexcept {
+  SIMDJSON_ASSUME(depth() == child_depth - 1);
+  _depth = child_depth;
+}
+
+simdjson_really_inline depth_t json_iterator::depth() const noexcept {
+  return _depth;
+}
+
+simdjson_really_inline uint8_t *&json_iterator::string_buf_loc() noexcept {
+  return _string_buf_loc;
+}
+
+simdjson_really_inline error_code json_iterator::report_error(error_code _error, const char *message) noexcept {
+  SIMDJSON_ASSUME(_error != SUCCESS && _error != UNINITIALIZED && _error != INCORRECT_TYPE && _error != NO_SUCH_FIELD);
   logger::log_error(*this, message);
-  _error = error;
+  error = _error;
   return error;
 }
-simdjson_really_inline error_code json_iterator::error() const noexcept {
+
+simdjson_really_inline error_code json_iterator::optional_error(error_code _error, const char *message) noexcept {
+  SIMDJSON_ASSUME(_error == INCORRECT_TYPE || _error == NO_SUCH_FIELD);
+  logger::log_error(*this, message);
   return _error;
 }
 
-//
-// json_iterator_ref
-//
-simdjson_really_inline json_iterator_ref::json_iterator_ref(json_iterator_ref &&other) noexcept
-  : iter{other.iter},
-    depth{other.depth}
-{
-  other.iter = nullptr;
-}
-simdjson_really_inline json_iterator_ref &json_iterator_ref::operator=(json_iterator_ref &&other) noexcept {
-  assert_is_not_active();
-  iter = other.iter;
-  depth = other.depth;
-  other.iter = nullptr;
-  return *this;
+template<int N>
+simdjson_warn_unused simdjson_really_inline bool json_iterator::copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept {
+  // Truncate whitespace to fit the buffer.
+  if (max_len > N-1) {
+    if (jsoncharutils::is_not_structural_or_whitespace(json[N])) { return false; }
+    max_len = N-1;
+  }
+
+  // Copy to the buffer.
+  std::memcpy(tmpbuf, json, max_len);
+  tmpbuf[max_len] = ' ';
+  return true;
 }
 
-simdjson_really_inline json_iterator_ref::json_iterator_ref(
-  json_iterator *_iter,
-  uint32_t _depth
-) noexcept : iter{_iter}, depth{_depth}
-{
-  assert_is_active();
+template<int N>
+simdjson_warn_unused simdjson_really_inline bool json_iterator::peek_to_buffer(uint8_t (&tmpbuf)[N]) noexcept {
+  auto max_len = token.peek_length();
+  auto json = token.peek();
+  return copy_to_buffer(json, max_len, tmpbuf);
 }
 
-simdjson_really_inline json_iterator_ref json_iterator_ref::borrow() noexcept {
-  assert_is_active();
-  return json_iterator_ref(iter, depth + 1);
+template<int N>
+simdjson_warn_unused simdjson_really_inline bool json_iterator::advance_to_buffer(uint8_t (&tmpbuf)[N]) noexcept {
+  auto max_len = peek_length();
+  auto json = advance();
+  return copy_to_buffer(json, max_len, tmpbuf);
 }
-simdjson_really_inline void json_iterator_ref::started_container() noexcept {
-  assert_is_active();
-  SIMDJSON_ASSUME(iter->container_depth == depth);
-}
-simdjson_really_inline void json_iterator_ref::finished_container() noexcept {
-  assert_is_active();
-  SIMDJSON_ASSUME(iter->container_depth == depth - 1);
-  iter = nullptr;
-}
-simdjson_really_inline void json_iterator_ref::abandon() noexcept {
-  assert_is_active();
-  iter = nullptr;
-}
-
-simdjson_really_inline json_iterator *json_iterator_ref::operator->() noexcept {
-  assert_is_active();
-  return iter;
-}
-simdjson_really_inline json_iterator &json_iterator_ref::operator*() noexcept {
-  assert_is_active();
-  return *iter;
-}
-simdjson_really_inline const json_iterator &json_iterator_ref::operator*() const noexcept {
-  assert_is_active();
-  return *iter;
-}
-
-simdjson_warn_unused simdjson_really_inline error_code json_iterator_ref::finish_child() noexcept {
-  assert_is_active();
-  return iter->finish_child(depth);
-}
-
-simdjson_really_inline bool json_iterator_ref::is_alive() const noexcept {
-  return iter != nullptr;
-}
-simdjson_really_inline bool json_iterator_ref::is_active() const noexcept {
-  return is_alive() && depth == iter->container_depth;
-}
-simdjson_really_inline void json_iterator_ref::assert_is_active() const noexcept {
-  // We don't call const functions because VC++ is worried they might have side effects in __assume
-  // TODO fix depth check
-  SIMDJSON_ASSUME(iter != nullptr); // && depth == iter->container_depth);
-}
-simdjson_really_inline void json_iterator_ref::assert_is_not_active() const noexcept {
-  // We don't call const functions because VC++ is worried they might have side effects in __assume
-  SIMDJSON_ASSUME(!(iter != nullptr)); // && depth == iter->container_depth));
-}
-
-
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
@@ -410,10 +171,5 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_i
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>(value)) {}
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>(error) {}
-
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref &&value) noexcept
-    : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref>::simdjson_result(error_code error) noexcept
-    : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref>(error) {}
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -91,7 +91,15 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
 }
 
 simdjson_really_inline bool json_iterator::at_start() const noexcept {
-  return token.index == parser->dom_parser.structural_indexes.get();
+  return token.index == &parser->dom_parser.structural_indexes[0];
+}
+
+simdjson_really_inline void json_iterator::assert_at_start() const noexcept {
+  SIMDJSON_ASSUME( _depth == 1 );
+  // Visual Studio Clang treats unique_ptr.get() as "side effecting."
+#ifndef SIMDJSON_CLANG_VISUAL_STUDIO
+  SIMDJSON_ASSUME( token.index == parser->dom_parser.structural_indexes.get() );
+#endif
 }
 
 simdjson_really_inline bool json_iterator::at_eof() const noexcept {
@@ -120,12 +128,12 @@ simdjson_really_inline uint32_t json_iterator::peek_length(int32_t delta) const 
 }
 
 simdjson_really_inline void json_iterator::ascend_to(depth_t parent_depth) noexcept {
-  SIMDJSON_ASSUME(depth() == parent_depth + 1);
+  SIMDJSON_ASSUME(_depth == parent_depth + 1);
   _depth = parent_depth;
 }
 
 simdjson_really_inline void json_iterator::descend_to(depth_t child_depth) noexcept {
-  SIMDJSON_ASSUME(depth() == child_depth - 1);
+  SIMDJSON_ASSUME(_depth == child_depth - 1);
   _depth = child_depth;
 }
 

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -63,6 +63,11 @@ public:
   simdjson_really_inline bool at_start() const noexcept;
 
   /**
+   * Assert if the iterator is not at the start
+   */
+  simdjson_really_inline void assert_at_start() const noexcept;
+
+  /**
    * Tell whether the iterator is at the EOF mark
    */
   simdjson_really_inline bool at_eof() const noexcept;

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -37,7 +37,7 @@ protected:
   error_code error{SUCCESS};
   /**
    * Depth of the current token in the JSON.
-   * 
+   *
    * - 0 = finished with document
    * - 1 = document root value (could be [ or {, not yet known)
    * - 2 = , or } inside root array/object
@@ -56,11 +56,6 @@ public:
    * Skips a JSON value, whether it is a scalar, array or object.
    */
   simdjson_warn_unused simdjson_really_inline error_code skip_child(depth_t parent_depth) noexcept;
-
-  /**
-   * Finishes iteration of a child in an object or array.
-   */
-  simdjson_warn_unused simdjson_really_inline error_code finish_child(depth_t parent_depth) noexcept;
 
   /**
    * Tell whether the iterator is still at the start
@@ -113,18 +108,18 @@ public:
 
   /**
    * Ascend one level.
-   * 
+   *
    * Validates that the depth - 1 == parent_depth.
-   * 
+   *
    * @param parent_depth the expected parent depth.
    */
   simdjson_really_inline void ascend_to(depth_t parent_depth) noexcept;
 
   /**
    * Descend one level.
-   * 
+   *
    * Validates that the new depth == child_depth.
-   * 
+   *
    * @param child_depth the expected child depth.
    */
   simdjson_really_inline void descend_to(depth_t parent_depth) noexcept;

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -8,14 +8,43 @@ class array;
 class value;
 class raw_json_string;
 class parser;
-class json_iterator_ref;
 
 /**
- * Iterates through JSON, with structure-sensitive algorithms.
+ * Iterates through JSON tokens, keeping track of depth and string buffer.
  *
  * @private This is not intended for external use.
  */
-class json_iterator : public token_iterator {
+class json_iterator {
+protected:
+  token_iterator token{};
+  ondemand::parser *parser{};
+  /**
+   * Next free location in the string buffer.
+   *
+   * Used by raw_json_string::unescape() to have a place to unescape strings to.
+   */
+  uint8_t *_string_buf_loc{};
+  /**
+   * JSON error, if there is one.
+   *
+   * INCORRECT_TYPE and NO_SUCH_FIELD are *not* stored here, ever.
+   *
+   * PERF NOTE: we *hope* this will be elided into control flow, as it is only used (a) in the first
+   * iteration of the loop, or (b) for the final iteration after a missing comma is found in ++. If
+   * this is not elided, we should make sure it's at least not using up a register. Failing that,
+   * we should store it in document so there's only one of them.
+   */
+  error_code error{SUCCESS};
+  /**
+   * Depth of the current token in the JSON.
+   * 
+   * - 0 = finished with document
+   * - 1 = document root value (could be [ or {, not yet known)
+   * - 2 = , or } inside root array/object
+   * - 3 = key or value inside root array/object.
+   */
+  depth_t _depth{};
+
 public:
   simdjson_really_inline json_iterator() noexcept = default;
   simdjson_really_inline json_iterator(json_iterator &&other) noexcept;
@@ -24,140 +53,14 @@ public:
   simdjson_really_inline json_iterator &operator=(const json_iterator &other) noexcept = delete;
 
   /**
-   * Check for an opening { and start an object iteration.
-   *
-   * @param json A pointer to the potential {
-   * @returns Whether the object had any fields (returns false for empty).
-   * @error INCORRECT_TYPE if there is no opening {
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_object(const uint8_t *json) noexcept;
-  /**
-   * Check for an opening { and start an object iteration.
-   *
-   * @returns Whether the object had any fields (returns false for empty).
-   * @error INCORRECT_TYPE if there is no opening {
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_object() noexcept;
-
-  /**
-   * Start an object iteration after the user has already checked and moved past the {.
-   *
-   * Does not move the iterator.
-   *
-   * @returns Whether the object had any fields (returns false for empty).
-   */
-  simdjson_warn_unused simdjson_really_inline bool started_object() noexcept;
-
-  /**
-   * Moves to the next field in an object.
-   *
-   * Looks for , and }. If } is found, the object is finished and the iterator advances past it.
-   * Otherwise, it advances to the next value.
-   *
-   * @return whether there is another field in the object.
-   * @error TAPE_ERROR If there is a comma missing between fields.
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> has_next_field() noexcept;
-
-  /**
-   * Get the current field's key.
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> field_key() noexcept;
-
-  /**
-   * Pass the : in the field and move to its value.
-   */
-  simdjson_warn_unused simdjson_really_inline error_code field_value() noexcept;
-
-  /**
-   * Find the next field with the given key.
-   *
-   * Assumes you have called next_field() or otherwise matched the previous value.
-   *
-   * Key is *raw JSON,* meaning it will be matched against the verbatim JSON without attempting to
-   * unescape it. This works well for typical ASCII and UTF-8 keys (almost all of them), but may
-   * fail to match some keys with escapes (\u, \n, etc.).
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> find_field_raw(const char *key) noexcept;
-
-  /**
-   * Check for an opening [ and start an array iteration.
-   *
-   * @param json A pointer to the potential [.
-   * @returns Whether the array had any elements (returns false for empty).
-   * @error INCORRECT_TYPE If there is no [.
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_array(const uint8_t *json) noexcept;
-  /**
-   * Check for an opening [ and start an array iteration.
-   *
-   * @returns Whether the array had any elements (returns false for empty).
-   * @error INCORRECT_TYPE If there is no [.
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_array() noexcept;
-
-  /**
-   * Start an array iteration after the user has already checked and moved past the [.
-   *
-   * Does not move the iterator.
-   *
-   * @returns Whether the array had any elements (returns false for empty).
-   */
-  simdjson_warn_unused simdjson_really_inline bool started_array() noexcept;
-
-  /**
-   * Moves to the next element in an array.
-   *
-   * Looks for , and ]. If ] is found, the array is finished and the iterator advances past it.
-   * Otherwise, it advances to the next value.
-   *
-   * @return Whether there is another element in the array.
-   * @error TAPE_ERROR If there is a comma missing between elements.
-   */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> has_next_element() noexcept;
-
-  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> parse_string(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> consume_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> parse_raw_json_string(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> consume_raw_json_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> parse_uint64(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> consume_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> parse_int64(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> consume_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> parse_double(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> consume_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> consume_bool() noexcept;
-  simdjson_really_inline bool is_null(const uint8_t *json) noexcept;
-  simdjson_really_inline bool is_null() noexcept;
-
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> parse_root_uint64(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> consume_root_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> parse_root_int64(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> consume_root_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> consume_root_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> parse_root_bool(const uint8_t *json) noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> consume_root_bool() noexcept;
-  simdjson_really_inline bool root_is_null(const uint8_t *json) noexcept;
-  simdjson_really_inline bool root_is_null() noexcept;
-
-  /**
    * Skips a JSON value, whether it is a scalar, array or object.
    */
-  simdjson_warn_unused simdjson_really_inline error_code skip() noexcept;
+  simdjson_warn_unused simdjson_really_inline error_code skip_child(depth_t parent_depth) noexcept;
 
   /**
    * Finishes iteration of a child in an object or array.
    */
-  simdjson_warn_unused simdjson_really_inline error_code finish_child(uint32_t depth) noexcept;
-
-  /**
-   * Skips to the end of a JSON object or array.
-   *
-   * @return true if this was the end of an array, false if it was the end of an object.
-   */
-  simdjson_warn_unused simdjson_really_inline error_code skip_container() noexcept;
+  simdjson_warn_unused simdjson_really_inline error_code finish_child(depth_t parent_depth) noexcept;
 
   /**
    * Tell whether the iterator is still at the start
@@ -175,6 +78,68 @@ public:
   simdjson_really_inline bool is_alive() const noexcept;
 
   /**
+   * Abandon this iterator, setting depth to 0 (as if the document is finished).
+   */
+  simdjson_really_inline void abandon() noexcept;
+
+  /**
+   * Advance the current token.
+   */
+  simdjson_really_inline const uint8_t *advance() noexcept;
+
+  /**
+   * Whether we are at the start of an object.
+   */
+
+  /**
+   * Get the JSON text for a given token (relative).
+   *
+   * This is not null-terminated; it is a view into the JSON.
+   *
+   * @param delta The relative position of the token to retrieve. e.g. 0 = next token, -1 = prev token.
+   *
+   * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
+   * it isn't used ...
+   */
+  simdjson_really_inline const uint8_t *peek(int32_t delta=0) const noexcept;
+  /**
+   * Get the maximum length of the JSON text for a given token.
+   *
+   * The length will include any whitespace at the end of the token.
+   *
+   * @param delta The relative position of the token to retrieve. e.g. 0 = next token, -1 = prev token.
+   */
+  simdjson_really_inline uint32_t peek_length(int32_t delta=0) const noexcept;
+
+  /**
+   * Ascend one level.
+   * 
+   * Validates that the depth - 1 == parent_depth.
+   * 
+   * @param parent_depth the expected parent depth.
+   */
+  simdjson_really_inline void ascend_to(depth_t parent_depth) noexcept;
+
+  /**
+   * Descend one level.
+   * 
+   * Validates that the new depth == child_depth.
+   * 
+   * @param child_depth the expected child depth.
+   */
+  simdjson_really_inline void descend_to(depth_t parent_depth) noexcept;
+
+  /**
+   * Get current depth.
+   */
+  simdjson_really_inline depth_t depth() const noexcept;
+
+  /**
+   * Get current (writeable) location in the string buffer.
+   */
+  simdjson_really_inline uint8_t *&string_buf_loc() noexcept;
+
+  /**
    * Report an error, preventing further iteration.
    *
    * @param error The error to report. Must not be SUCCESS, UNINITIALIZED, INCORRECT_TYPE, or NO_SUCH_FIELD.
@@ -183,34 +148,18 @@ public:
   simdjson_really_inline error_code report_error(error_code error, const char *message) noexcept;
 
   /**
-   * Get the error (if any).
+   * Log error, but don't stop iteration.
+   * @param error The error to report. Must be INCORRECT_TYPE, or NO_SUCH_FIELD.
+   * @param message An error message to report with the error.
    */
-  simdjson_really_inline error_code error() const noexcept;
+  simdjson_really_inline error_code optional_error(error_code error, const char *message) noexcept;
+
+  template<int N> simdjson_warn_unused simdjson_really_inline bool copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept;
+  template<int N> simdjson_warn_unused simdjson_really_inline bool peek_to_buffer(uint8_t (&tmpbuf)[N]) noexcept;
+  template<int N> simdjson_warn_unused simdjson_really_inline bool advance_to_buffer(uint8_t (&tmpbuf)[N]) noexcept;
 
 protected:
-  ondemand::parser *parser{};
-  /**
-   * Next free location in the string buffer.
-   *
-   * Used by raw_json_string::unescape() to have a place to unescape strings to.
-   */
-  uint8_t *current_string_buf_loc{};
-  /**
-   * JSON error, if there is one.
-   *
-   * INCORRECT_TYPE and NO_SUCH_FIELD are *not* stored here, ever.
-   *
-   * PERF NOTE: we *hope* this will be elided into control flow, as it is only used (a) in the first
-   * iteration of the loop, or (b) for the final iteration after a missing comma is found in ++. If
-   * this is not elided, we should make sure it's at least not using up a register. Failing that,
-   * we should store it in document so there's only one of them.
-   */
-  error_code _error{};
-  uint32_t container_depth{};
-
   simdjson_really_inline json_iterator(ondemand::parser *parser) noexcept;
-  template<int N>
-  simdjson_warn_unused simdjson_really_inline bool copy_to_buffer(const uint8_t *json, uint8_t (&buf)[N]) noexcept;
 
   friend class document;
   friend class object;
@@ -218,51 +167,9 @@ protected:
   friend class value;
   friend class raw_json_string;
   friend class parser;
-  friend class json_iterator_ref;
+  friend class value_iterator;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
 }; // json_iterator
-
-class json_iterator_ref {
-public:
-  simdjson_really_inline json_iterator_ref() noexcept = default;
-  simdjson_really_inline json_iterator_ref(json_iterator_ref &&other) noexcept;
-  simdjson_really_inline json_iterator_ref &operator=(json_iterator_ref &&other) noexcept;
-
-  simdjson_really_inline json_iterator_ref(const json_iterator_ref &other) noexcept = delete;
-  simdjson_really_inline json_iterator_ref &operator=(const json_iterator_ref &other) noexcept = delete;
-
-  /** Borrow this iterator, incrementing depth */
-  simdjson_really_inline json_iterator_ref borrow() noexcept;
-  /** Identify this iterator as a container, incrementing container_depth */
-  simdjson_really_inline void started_container() noexcept;
-  /** Denote the container as having finished iterating, decrementing container_depth */
-  simdjson_really_inline void finished_container() noexcept;
-  /** Release this iterator without modifying depth */
-  simdjson_really_inline void abandon() noexcept;
-
-  simdjson_really_inline json_iterator *operator->() noexcept;
-  simdjson_really_inline json_iterator &operator*() noexcept;
-  simdjson_really_inline const json_iterator &operator*() const noexcept;
-
-  simdjson_really_inline bool is_alive() const noexcept;
-  simdjson_really_inline bool is_active() const noexcept;
-
-  simdjson_really_inline void assert_is_active() const noexcept;
-  simdjson_really_inline void assert_is_not_active() const noexcept;
-
-  /**
-   * Finishes iteration of a child in an object or array.
-   */
-  simdjson_warn_unused simdjson_really_inline error_code finish_child() noexcept;
-
-private:
-  json_iterator *iter{};
-  uint32_t depth{};
-  simdjson_really_inline json_iterator_ref(json_iterator *iter, uint32_t depth) noexcept;
-
-  friend class json_iterator;
-  friend class document;
-}; // class json_iterator_ref
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
@@ -278,17 +185,6 @@ public:
 
   simdjson_really_inline simdjson_result() noexcept = default;
   simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
-};
-
-template<>
-struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref> {
-public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
-  simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator_ref> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 };
 

--- a/include/simdjson/generic/ondemand/logger-inl.h
+++ b/include/simdjson/generic/ondemand/logger-inl.h
@@ -36,6 +36,22 @@ simdjson_really_inline void log_error(const json_iterator &iter, const char *err
   log_line(iter, "ERROR: ", error, detail, delta, depth_delta);
 }
 
+simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
+  log_event(iter.json_iter(), type, detail, delta, depth_delta);
+}
+simdjson_really_inline void log_value(const value_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
+  log_value(iter.json_iter(), type, detail, delta, depth_delta);
+}
+simdjson_really_inline void log_start_value(const value_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
+  log_start_value(iter.json_iter(), type, delta, depth_delta);
+}
+simdjson_really_inline void log_end_value(const value_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
+  log_end_value(iter.json_iter(), type, delta, depth_delta);
+}
+simdjson_really_inline void log_error(const value_iterator &iter, const char *error, const char *detail, int delta, int depth_delta) noexcept {
+  log_error(iter.json_iter(), error, detail, delta, depth_delta);
+}
+
 simdjson_really_inline void log_headers() noexcept {
   log_depth = 0;
   if (LOG_ENABLED) {
@@ -70,7 +86,7 @@ simdjson_really_inline void log_line(const json_iterator &iter, const char *titl
       }
       printf(" ");
     }
-    printf("| %5u ", iter.peek_index(delta+1));
+    printf("| %5u ", iter.token.peek_index(delta+1));
     printf("| %.*s ", int(detail.size()), detail.data());
     printf("|\n");
     fflush(stdout);

--- a/include/simdjson/generic/ondemand/logger-inl.h
+++ b/include/simdjson/generic/ondemand/logger-inl.h
@@ -56,8 +56,21 @@ simdjson_really_inline void log_headers() noexcept {
   log_depth = 0;
   if (LOG_ENABLED) {
     printf("\n");
-    printf("| %-*s | %-*s | %-*s | %-*s | Detail |\n", LOG_EVENT_LEN, "Event", LOG_BUFFER_LEN, "Buffer", LOG_SMALL_BUFFER_LEN, "Next", 5, "Next#");
-    printf("|%.*s|%.*s|%.*s|%.*s|--------|\n", LOG_EVENT_LEN+2, DASHES, LOG_BUFFER_LEN+2, DASHES, LOG_SMALL_BUFFER_LEN+2, DASHES, 5+2, DASHES);
+    printf("| %-*s ", LOG_EVENT_LEN,        "Event");
+    printf("| %-*s ", LOG_BUFFER_LEN,       "Buffer");
+    printf("| %-*s ", LOG_SMALL_BUFFER_LEN, "Next");
+    // printf("| %-*s ", 5,                    "Next#");
+    printf("| %-*s ", 5,                    "Depth");
+    printf("| Detail ");
+    printf("|\n");
+
+    printf("|%.*s", LOG_EVENT_LEN+2, DASHES);
+    printf("|%.*s", LOG_BUFFER_LEN+2, DASHES);
+    printf("|%.*s", LOG_SMALL_BUFFER_LEN+2, DASHES);
+    // printf("|%.*s", 5+2, DASHES);
+    printf("|%.*s", 5+2, DASHES);
+    printf("|--------");
+    printf("|\n");
     fflush(stdout);
   }
 }
@@ -86,7 +99,8 @@ simdjson_really_inline void log_line(const json_iterator &iter, const char *titl
       }
       printf(" ");
     }
-    printf("| %5u ", iter.token.peek_index(delta+1));
+    // printf("| %5u ", iter.token.peek_index(delta+1));
+    printf("| %5u ", iter.depth());
     printf("| %.*s ", int(detail.size()), detail.data());
     printf("|\n");
     fflush(stdout);

--- a/include/simdjson/generic/ondemand/logger.h
+++ b/include/simdjson/generic/ondemand/logger.h
@@ -3,6 +3,7 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
 class json_iterator;
+class value_iterator;
 
 namespace logger {
 
@@ -19,6 +20,12 @@ static simdjson_really_inline void log_value(const json_iterator &iter, const ch
 static simdjson_really_inline void log_start_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_end_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_error(const json_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
+
+static simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_value(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_start_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_end_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_error(const value_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
 
 } // namespace logger
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/logger.h
+++ b/include/simdjson/generic/ondemand/logger.h
@@ -15,13 +15,13 @@ namespace logger {
 
 static simdjson_really_inline void log_headers() noexcept;
 static simdjson_really_inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
-static simdjson_really_inline void log_event(const json_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_event(const json_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_value(const json_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_start_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_end_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_error(const json_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
 
-static simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_value(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_start_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_end_value(const value_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -78,7 +78,7 @@ simdjson_really_inline object::object(const value_iterator &_iter) noexcept
 }
 
 simdjson_really_inline object_iterator object::begin() noexcept {
-  SIMDJSON_ASSUME( iter.at_start || !iter.iter.is_open() );
+  SIMDJSON_ASSUME( iter.at_start || iter.iter._json_iter->_depth < iter.iter._depth );
   return iter;
 }
 simdjson_really_inline object_iterator object::end() noexcept {

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -5,31 +5,31 @@ namespace ondemand {
 //
 // ### Live States
 //
-// While iterating or looking up values, depth >= iter->depth. at_start may vary. Error is
+// While iterating or looking up values, depth >= iter.depth. at_start may vary. Error is
 // always SUCCESS:
 //
 // - Start: This is the state when the object is first found and the iterator is just past the {.
 //   In this state, at_start == true.
 // - Next: After we hand a scalar value to the user, or an array/object which they then fully
 //   iterate over, the iterator is at the , or } before the next value. In this state,
-//   depth == iter->depth, at_start == false, and error == SUCCESS.
+//   depth == iter.depth, at_start == false, and error == SUCCESS.
 // - Unfinished Business: When we hand an array/object to the user which they do not fully
 //   iterate over, we need to finish that iteration by skipping child values until we reach the
-//   Next state. In this state, depth > iter->depth, at_start == false, and error == SUCCESS.
+//   Next state. In this state, depth > iter.depth, at_start == false, and error == SUCCESS.
 //
 // ## Error States
 //
-// In error states, we will yield exactly one more value before stopping. iter->depth == depth
+// In error states, we will yield exactly one more value before stopping. iter.depth == depth
 // and at_start is always false. We decrement after yielding the error, moving to the Finished
 // state.
 //
 // - Chained Error: When the object iterator is part of an error chain--for example, in
 //   `for (auto tweet : doc["tweets"])`, where the tweet field may be missing or not be an
 //   object--we yield that error in the loop, exactly once. In this state, error != SUCCESS and
-//   iter->depth == depth, and at_start == false. We decrement depth when we yield the error.
+//   iter.depth == depth, and at_start == false. We decrement depth when we yield the error.
 // - Missing Comma Error: When the iterator ++ method discovers there is no comma between fields,
 //   we flag that as an error and treat it exactly the same as a Chained Error. In this state,
-//   error == TAPE_ERROR, iter->depth == depth, and at_start == false.
+//   error == TAPE_ERROR, iter.depth == depth, and at_start == false.
 //
 // Errors that occur while reading a field to give to the user (such as when the key is not a
 // string or the field is missing a colon) are yielded immediately. Depth is then decremented,
@@ -37,86 +37,48 @@ namespace ondemand {
 //
 // ## Terminal State
 //
-// The terminal state has iter->depth < depth. at_start is always false.
+// The terminal state has iter.depth < depth. at_start is always false.
 //
 // - Finished: When we have reached a }, we are finished. We signal this by decrementing depth.
-//   In this state, iter->depth < depth, at_start == false, and error == SUCCESS.
+//   In this state, iter.depth < depth, at_start == false, and error == SUCCESS.
 //
 
-simdjson_really_inline object::object(json_iterator_ref &&_iter) noexcept
-  : iter{std::forward<json_iterator_ref>(_iter)},
-    at_start{iter.is_alive()}
-{
-}
-
-
-simdjson_really_inline error_code object::find_field(const std::string_view key) noexcept {
-  if (!iter.is_alive()) { return NO_SUCH_FIELD; }
-
-  // Unless this is the first field, we need to advance past the , and check for }
-  error_code error;
-  bool has_value;
-  if (at_start) {
-    at_start = false;
-    has_value = true;
-  } else {
-    if ((error = iter.finish_child() )) { iter.abandon(); return error; }
-    if ((error = iter->has_next_field().get(has_value) )) { iter.abandon(); return error; }
-  }
-  while (has_value) {
-    // Get the key
-    raw_json_string actual_key;
-    if ((error = iter->field_key().get(actual_key) )) { iter.abandon(); return error; };
-    if ((error = iter->field_value() )) { iter.abandon(); return error; }
-
-    // Check if it matches
-    if (actual_key == key) {
-      logger::log_event(*iter, "match", key, -2);
-      return SUCCESS;
-    }
-    logger::log_event(*iter, "no match", key, -2);
-    SIMDJSON_TRY( iter->skip() ); // Skip the value entirely
-    if ((error = iter->has_next_field().get(has_value) )) { iter.abandon(); return error; }
-  }
-
-  // If the loop ended, we're out of fields to look at.
-  iter.finished_container();
-  return NO_SUCH_FIELD;
+simdjson_warn_unused simdjson_really_inline error_code object::find_field_raw(const std::string_view key) noexcept {
+  return iter.find_field_raw(key);
 }
 
 simdjson_really_inline simdjson_result<value> object::operator[](const std::string_view key) & noexcept {
-  SIMDJSON_TRY( find_field(key) );
-  return value::start(iter.borrow());
+  SIMDJSON_TRY( find_field_raw(key) );
+  return value(iter.iter.child());
 }
 
 simdjson_really_inline simdjson_result<value> object::operator[](const std::string_view key) && noexcept {
-  SIMDJSON_TRY( find_field(key) );
-  return value::start(iter.borrow());
+  SIMDJSON_TRY( find_field_raw(key) );
+  return value(iter.iter.child());
 }
 
-simdjson_really_inline simdjson_result<object> object::start(json_iterator_ref &&iter) noexcept {
-  bool has_value;
-  SIMDJSON_TRY( iter->start_object().get(has_value) );
-  if (has_value) { iter.started_container(); } else { iter.abandon(); }
-  return object(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline simdjson_result<object> object::start(value_iterator &iter) noexcept {
+  simdjson_unused bool has_value;
+  SIMDJSON_TRY( iter.start_object().get(has_value) );
+  return object(iter);
 }
-simdjson_really_inline simdjson_result<object> object::start(const uint8_t *json, json_iterator_ref &&iter) noexcept {
-  bool has_value;
-  SIMDJSON_TRY( iter->start_object(json).get(has_value) );
-  if (has_value) { iter.started_container(); } else { iter.abandon(); }
-  return object(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline simdjson_result<object> object::try_start(value_iterator &iter) noexcept {
+  simdjson_unused bool has_value;
+  SIMDJSON_TRY( iter.try_start_object().get(has_value) );
+  return object(iter);
 }
-simdjson_really_inline object object::started(json_iterator_ref &&iter) noexcept {
-  if (iter->started_object()) { iter.started_container(); } else { iter.abandon(); }
-  return object(std::forward<json_iterator_ref>(iter));
+simdjson_really_inline object object::started(value_iterator &iter) noexcept {
+  simdjson_unused bool has_value = iter.started_object();
+  return iter;
 }
+
+simdjson_really_inline object::object(const value_iterator &_iter) noexcept
+  : iter{_iter}
+{
+}
+
 simdjson_really_inline object_iterator object::begin() noexcept {
-  if (at_start) {
-    iter.assert_is_active();
-  } else {
-    iter.assert_is_not_active();
-  }
-  at_start = false;
+  SIMDJSON_ASSUME( iter.at_start || !iter.iter.is_open() );
   return iter;
 }
 simdjson_really_inline object_iterator object::end() noexcept {

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -21,8 +21,6 @@ public:
   object(const object &) = delete;
   object &operator=(const object &) = delete;
 
-  simdjson_really_inline ~object() noexcept;
-
   simdjson_really_inline object_iterator begin() noexcept;
   simdjson_really_inline object_iterator end() noexcept;
   simdjson_really_inline simdjson_result<value> operator[](const std::string_view key) & noexcept;
@@ -36,6 +34,7 @@ protected:
    * @param error If this is not SUCCESS, creates an error chained object.
    */
   static simdjson_really_inline simdjson_result<object> start(json_iterator_ref &&iter) noexcept;
+  static simdjson_really_inline simdjson_result<object> start(const uint8_t *json, json_iterator_ref &&iter) noexcept;
   static simdjson_really_inline object started(json_iterator_ref &&iter) noexcept;
 
   /**

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -26,15 +26,15 @@ public:
 
   /**
    * Look up a field by name on an object.
-   * 
+   *
    * Important notes:
-   * 
+   *
    * * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    *   e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
    * * **Order Sensitive:** Each field lookup will only move forward in the object. In particular,
    *   the following code reads z, then y, then x, and thus will not retrieve x or y if fed the
    *   JSON `{ "x": 1, "y": 2, "z": 3 }`:
-   * 
+   *
    *   ```c++
    *   simdjson::builtin::ondemand::parser parser;
    *   auto obj = parser.parse(R"( { "x": 1, "y": 2, "z": 3 } )"_padded);
@@ -42,7 +42,7 @@ public:
    *   double y = obj["y"];
    *   double x = obj["x"];
    *   ```
-   * 
+   *
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -16,11 +16,6 @@ public:
    */
   simdjson_really_inline object() noexcept = default;
 
-  simdjson_really_inline object(object &&other) noexcept = default;
-  simdjson_really_inline object &operator=(object &&other) noexcept = default;
-  object(const object &) = delete;
-  object &operator=(const object &) = delete;
-
   simdjson_really_inline object_iterator begin() noexcept;
   simdjson_really_inline object_iterator end() noexcept;
 
@@ -76,10 +71,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> : public SIMDJ
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> begin() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> end() noexcept;

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -33,9 +33,9 @@ protected:
    * @param doc The document containing the object. The iterator must be just after the opening `{`.
    * @param error If this is not SUCCESS, creates an error chained object.
    */
-  static simdjson_really_inline simdjson_result<object> start(json_iterator_ref &&iter) noexcept;
-  static simdjson_really_inline simdjson_result<object> start(const uint8_t *json, json_iterator_ref &&iter) noexcept;
-  static simdjson_really_inline object started(json_iterator_ref &&iter) noexcept;
+  static simdjson_really_inline simdjson_result<object> start(value_iterator &iter) noexcept;
+  static simdjson_really_inline simdjson_result<object> try_start(value_iterator &iter) noexcept;
+  static simdjson_really_inline object started(value_iterator &iter) noexcept;
 
   /**
    * Internal object creation. Call object::begin(doc) instead of this.
@@ -43,24 +43,11 @@ protected:
    * @param doc The document containing the object. doc->depth must already be incremented to
    *            reflect the object's depth. The iterator must be just after the opening `{`.
    */
-  simdjson_really_inline object(json_iterator_ref &&_iter) noexcept;
+  simdjson_really_inline object(const value_iterator &_iter) noexcept;
 
-  simdjson_really_inline error_code find_field(const std::string_view key) noexcept;
+  simdjson_warn_unused simdjson_really_inline error_code find_field_raw(const std::string_view key) noexcept;
 
-  /**
-   * Document containing the primary iterator.
-   *
-   * PERF NOTE: expected to be elided in favor of the parent document: this is set when the object
-   * is first used, and never changes afterwards.
-   */
-  json_iterator_ref iter{};
-  /**
-   * Whether we are at the start.
-   *
-   * PERF NOTE: this should be elided into inline control flow: it is only used for the first []
-   * or * call, and SSA optimizers commonly do first-iteration loop optimization.
-   */
-  bool at_start{};
+  object_iterator iter{};
 
   friend class value;
   friend class document;

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -6,36 +6,111 @@ namespace ondemand {
 // object_iterator
 //
 
-simdjson_really_inline object_iterator::object_iterator(json_iterator_ref &_iter) noexcept : iter{&_iter} {}
+simdjson_really_inline object_iterator::object_iterator(const value_iterator &_iter) noexcept
+  : iter{_iter},
+    at_start{true}
+{}
 
 simdjson_really_inline simdjson_result<field> object_iterator::operator*() noexcept {
-  error_code error = (*iter)->error();
-  if (error) { iter->abandon(); return error; }
-  auto result = field::start(*iter);
+  error_code error = iter.error();
+  if (error) { iter.abandon(); return error; }
+  auto result = field::start(iter);
   // TODO this is a safety rail ... users should exit loops as soon as they receive an error.
   // Nonetheless, let's see if performance is OK with this if statement--the compiler may give it to us for free.
-  if (result.error()) { iter->abandon(); }
+  if (result.error()) { iter.abandon(); }
   return result;
 }
 simdjson_really_inline bool object_iterator::operator==(const object_iterator &other) const noexcept {
   return !(*this != other);
 }
 simdjson_really_inline bool object_iterator::operator!=(const object_iterator &) const noexcept {
-  return iter->is_alive();
+  return iter.is_open();
 }
 simdjson_really_inline object_iterator &object_iterator::operator++() noexcept {
   // TODO this is a safety rail ... users should exit loops as soon as they receive an error.
   // Nonetheless, let's see if performance is OK with this if statement--the compiler may give it to us for free.
-  if (!iter->is_alive()) { return *this; } // Iterator will be released if there is an error
+  if (!iter.is_open()) { return *this; } // Iterator will be released if there is an error
 
-  auto error = iter->finish_child();
-  if (error) { return *this; }
+  simdjson_unused error_code error;
+  if ((error = iter.finish_child() )) { return *this; }
 
-  bool has_value;
-  error = (*iter)->has_next_field().get(has_value);
-  if (error) { return *this; }
-  if (!has_value) { iter->finished_container(); }
+  simdjson_unused bool has_value;
+  if ((error = iter.has_next_field().get(has_value) )) { return *this; };
   return *this;
+}
+
+//
+// ### Live States
+//
+// While iterating or looking up values, depth >= iter.depth. at_start may vary. Error is
+// always SUCCESS:
+//
+// - Start: This is the state when the object is first found and the iterator is just past the {.
+//   In this state, at_start == true.
+// - Next: After we hand a scalar value to the user, or an array/object which they then fully
+//   iterate over, the iterator is at the , or } before the next value. In this state,
+//   depth == iter.depth, at_start == false, and error == SUCCESS.
+// - Unfinished Business: When we hand an array/object to the user which they do not fully
+//   iterate over, we need to finish that iteration by skipping child values until we reach the
+//   Next state. In this state, depth > iter.depth, at_start == false, and error == SUCCESS.
+//
+// ## Error States
+//
+// In error states, we will yield exactly one more value before stopping. iter.depth == depth
+// and at_start is always false. We decrement after yielding the error, moving to the Finished
+// state.
+//
+// - Chained Error: When the object iterator is part of an error chain--for example, in
+//   `for (auto tweet : doc["tweets"])`, where the tweet field may be missing or not be an
+//   object--we yield that error in the loop, exactly once. In this state, error != SUCCESS and
+//   iter.depth == depth, and at_start == false. We decrement depth when we yield the error.
+// - Missing Comma Error: When the iterator ++ method discovers there is no comma between fields,
+//   we flag that as an error and treat it exactly the same as a Chained Error. In this state,
+//   error == TAPE_ERROR, iter.depth == depth, and at_start == false.
+//
+// Errors that occur while reading a field to give to the user (such as when the key is not a
+// string or the field is missing a colon) are yielded immediately. Depth is then decremented,
+// moving to the Finished state without transitioning through an Error state at all.
+//
+// ## Terminal State
+//
+// The terminal state has iter.depth < depth. at_start is always false.
+//
+// - Finished: When we have reached a }, we are finished. We signal this by decrementing depth.
+//   In this state, iter.depth < depth, at_start == false, and error == SUCCESS.
+//
+
+simdjson_warn_unused simdjson_really_inline error_code object_iterator::find_field_raw(const std::string_view key) noexcept {
+  if (!iter.is_open()) { return NO_SUCH_FIELD; }
+
+  // Unless this is the first field, we need to advance past the , and check for }
+  error_code error;
+  bool has_value;
+  if (at_start) {
+    at_start = false;
+    has_value = true;
+  } else {
+    if ((error = iter.finish_child() )) { iter.abandon(); return error; }
+    if ((error = iter.has_next_field().get(has_value) )) { iter.abandon(); return error; }
+  }
+  while (has_value) {
+    // Get the key
+    raw_json_string actual_key;
+    if ((error = iter.field_key().get(actual_key) )) { iter.abandon(); return error; };
+    if ((error = iter.field_value() )) { iter.abandon(); return error; }
+
+    // Check if it matches
+    if (actual_key == key) {
+      logger::log_event(iter, "match", key, -2);
+      return SUCCESS;
+    }
+    logger::log_event(iter, "no match", key, -2);
+    SIMDJSON_TRY( iter.skip_child() ); // Skip the value entirely
+    if ((error = iter.has_next_field().get(has_value) )) { iter.abandon(); return error; }
+  }
+
+  // If the loop ended, we're out of fields to look at.
+  return NO_SUCH_FIELD;
 }
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -32,7 +32,7 @@ simdjson_really_inline object_iterator &object_iterator::operator++() noexcept {
   if (!iter.is_open()) { return *this; } // Iterator will be released if there is an error
 
   simdjson_unused error_code error;
-  if ((error = iter.finish_child() )) { return *this; }
+  if ((error = iter.skip_child() )) { return *this; }
 
   simdjson_unused bool has_value;
   if ((error = iter.has_next_field().get(has_value) )) { return *this; };
@@ -90,7 +90,7 @@ simdjson_warn_unused simdjson_really_inline error_code object_iterator::find_fie
     at_start = false;
     has_value = true;
   } else {
-    if ((error = iter.finish_child() )) { iter.abandon(); return error; }
+    if ((error = iter.skip_child() )) { iter.abandon(); return error; }
     if ((error = iter.has_next_field().get(has_value) )) { iter.abandon(); return error; }
   }
   while (has_value) {

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -31,9 +31,31 @@ public:
   simdjson_really_inline bool operator!=(const object_iterator &) const noexcept;
   // Checks for ']' and ','
   simdjson_really_inline object_iterator &operator++() noexcept;
+
+  /**
+   * Find the field with the given key. May be used in place of ++.
+   */
+  simdjson_warn_unused simdjson_really_inline error_code find_field_raw(const std::string_view key) noexcept;
+
 private:
-  json_iterator_ref *iter{};
-  simdjson_really_inline object_iterator(json_iterator_ref &iter) noexcept;
+  /**
+   * The underlying JSON iterator.
+   *
+   * PERF NOTE: expected to be elided in favor of the parent document: this is set when the object
+   * is first used, and never changes afterwards.
+   */
+  value_iterator iter{};
+  /**
+   * Whether we are at the start.
+   *
+   * PERF NOTE: this should be elided into inline control flow: it is only used for the first []
+   * or * call, and SSA optimizers commonly do first-iteration loop optimization.
+   * 
+   * SAFETY: this is not safe; the object_iterator can be copied freely, so the state CAN be lost.
+   */
+  bool at_start{};
+  
+  simdjson_really_inline object_iterator(const value_iterator &iter) noexcept;
   friend struct simdjson_result<object_iterator>;
   friend class object;
 };

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -50,11 +50,11 @@ private:
    *
    * PERF NOTE: this should be elided into inline control flow: it is only used for the first []
    * or * call, and SSA optimizers commonly do first-iteration loop optimization.
-   * 
+   *
    * SAFETY: this is not safe; the object_iterator can be copied freely, so the state CAN be lost.
    */
   bool at_start{};
-  
+
   simdjson_really_inline object_iterator(const value_iterator &iter) noexcept;
   friend struct simdjson_result<object_iterator>;
   friend class object;

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -15,9 +15,6 @@ public:
    */
   simdjson_really_inline object_iterator() noexcept = default;
 
-  simdjson_really_inline object_iterator(const object_iterator &o) noexcept = default;
-  simdjson_really_inline object_iterator &operator=(const object_iterator &o) noexcept = default;
-
   //
   // Iterator interface
   //
@@ -71,10 +68,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> : pub
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object_iterator &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   //
   // Iterator interface

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -14,7 +14,7 @@ simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> ra
 }
 
 simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> raw_json_string::unescape(json_iterator &iter) const noexcept {
-  return unescape(iter.current_string_buf_loc);
+  return unescape(iter.string_buf_loc());
 }
 
 simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, std::string_view b) noexcept {

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -32,9 +32,6 @@ public:
    */
   simdjson_really_inline raw_json_string() noexcept = default;
 
-  simdjson_really_inline raw_json_string(const raw_json_string &other) noexcept = default;
-  simdjson_really_inline raw_json_string &operator=(const raw_json_string &other) noexcept = default;
-
   /**
    * Create a new invalid raw_json_string pointed at the given location in the JSON.
    *

--- a/include/simdjson/generic/ondemand/token_iterator.h
+++ b/include/simdjson/generic/ondemand/token_iterator.h
@@ -16,11 +16,10 @@ public:
    * Exists so you can declare a variable and later assign to it before use.
    */
   simdjson_really_inline token_iterator() noexcept = default;
-
   simdjson_really_inline token_iterator(token_iterator &&other) noexcept = default;
   simdjson_really_inline token_iterator &operator=(token_iterator &&other) noexcept = default;
-  simdjson_really_inline token_iterator(const token_iterator &other) noexcept = delete;
-  simdjson_really_inline token_iterator &operator=(const token_iterator &other) noexcept = delete;
+  simdjson_really_inline token_iterator(const token_iterator &other) noexcept = default;
+  simdjson_really_inline token_iterator &operator=(const token_iterator &other) noexcept = default;
 
   /**
    * Get the JSON text for a given token (relative).
@@ -76,6 +75,9 @@ protected:
 
   const uint8_t *buf{};
   const uint32_t *index{};
+
+  friend class json_iterator;
+  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
 };
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -145,14 +145,18 @@ simdjson_really_inline simdjson_result<array_iterator> value::end() & noexcept {
   return {};
 }
 
-// simdjson_really_inline void value::log_value(const char *type) const noexcept {
-//   char json_char[]{char(json[0]), '\0'};
-//   logger::log_value(*iter, type, json_char);
-// }
-// simdjson_really_inline void value::log_error(const char *message) const noexcept {
-//   char json_char[]{char(json[0]), '\0'};
-//   logger::log_error(*iter, message, json_char);
-// }
+simdjson_really_inline simdjson_result<value> value::operator[](std::string_view key) & noexcept {
+  return get_object()[key];
+}
+simdjson_really_inline simdjson_result<value> value::operator[](std::string_view key) && noexcept {
+  return std::forward<value>(*this).get_object()[key];
+}
+simdjson_really_inline simdjson_result<value> value::operator[](const char *key) & noexcept {
+  return get_object()[key];
+}
+simdjson_really_inline simdjson_result<value> value::operator[](const char *key) && noexcept {
+  return std::forward<value>(*this).get_object()[key];
+}
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
@@ -184,75 +188,92 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_
   return {};
 }
 
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](std::string_view key) & noexcept {
+  if (error()) { return error(); }
+  return first[key];
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](std::string_view key) && noexcept {
+  if (error()) { return error(); }
+  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first)[key];
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](const char *key) & noexcept {
+  if (error()) { return error(); }
+  return first[key];
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](const char *key) && noexcept {
+  if (error()) { return error(); }
+  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first)[key];
+}
+
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() & noexcept {
+  if (error()) { return error(); }
+  return first.get_array();
+}
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_array();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() & noexcept {
   if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_array();
+  return first.get_object();
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_object();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() & noexcept {
+simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() & noexcept {
   if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_object();
+  return first.get_uint64();
 }
 simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_uint64();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() & noexcept {
+simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() & noexcept {
   if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_uint64();
+  return first.get_int64();
 }
 simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_int64();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() & noexcept {
+simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() & noexcept {
   if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_int64();
+  return first.get_double();
 }
 simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_double();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() & noexcept {
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() & noexcept {
   if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_double();
+  return first.get_string();
 }
 simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_string();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() & noexcept {
   if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_string();
+  return first.get_raw_json_string();
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() & noexcept {
+simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() & noexcept {
   if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_raw_json_string();
+  return first.get_bool();
 }
 simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_bool();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() & noexcept {
-  if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_bool();
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() & noexcept {
+  if (error()) { return false; }
+  return first.is_null();
 }
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() && noexcept {
-  if (error()) { return false; }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).is_null();
-}
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() & noexcept {
   if (error()) { return false; }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).is_null();
 }
@@ -287,65 +308,65 @@ template<> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTA
 }
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
-}
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
+  return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() & noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
+  return first;
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
+  return first;
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
+  return first;
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
+  return first;
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
+  return first;
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() & noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -2,130 +2,63 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline value::value(json_iterator_ref && _iter, const uint8_t *_json) noexcept
-  : iter{std::forward<json_iterator_ref>(_iter)},
-    json{_json}
+simdjson_really_inline value::value(const value_iterator &_iter) noexcept
+  : iter{_iter}
 {
-  iter.assert_is_active();
-  SIMDJSON_ASSUME(json);
-}
-
-simdjson_really_inline value::value(value &&other) noexcept
-  : iter{std::move(other.iter)},
-    json{other.json} {
-  other.json = nullptr;
-}
-simdjson_really_inline value &value::operator=(value && other) noexcept {
-  iter = std::move(other.iter);
-  json = other.json;
-  other.json = nullptr;
-  return *this;
-}
-
-simdjson_really_inline value::~value() noexcept {
-  // If the user didn't actually use the value, we need to check if it's an array/object and bump
-  // depth so that the array/object iteration routines will work correctly.
-  // PERF TODO this better be elided entirely when people actually use the value. Don't care if it
-  // gets bumped on the error path unless that's costing us something important.
-  if (json) {
-    switch (*json) {
-      case '[': {
-        logger::log_start_value(*iter, "unused array");
-        if (iter->started_array()) { iter.started_container(); }
-        break;
-      }
-      case '{': {
-        logger::log_start_value(*iter, "unused object");
-        if (iter->started_object()) { iter.started_container(); }
-        break;
-      }
-      default: logger::log_value(*iter, "unused");
-    }
-  }
-}
-
-simdjson_really_inline value value::start(json_iterator_ref &&iter) noexcept {
-  return { std::forward<json_iterator_ref>(iter), iter->advance() };
-}
-
-simdjson_really_inline const uint8_t *value::consume() noexcept {
-  auto old_json = json;
-  json = nullptr;
-  return old_json;
-}
-simdjson_really_inline json_iterator_ref value::consume_container() noexcept {
-  consume();
-  return std::move(iter);
-}
-template<typename T>
-simdjson_really_inline simdjson_result<T> value::consume_if_success(simdjson_result<T> &&result) noexcept {
-  if (!result.error()) { consume(); }
-  return std::forward<simdjson_result<T>>(result);
-}
-simdjson_really_inline error_code value::consume_if_success(error_code error) noexcept {
-  if (!error) { consume(); }
-  return error;
-}
-
-simdjson_really_inline simdjson_result<array> value::get_array() & noexcept {
-  if (*json != '[') { return INCORRECT_TYPE; }
-  return array::started(consume_container());
 }
 simdjson_really_inline simdjson_result<array> value::get_array() && noexcept {
-  return array::start(json, consume_container());
+  return array::start(iter);
 }
-simdjson_really_inline simdjson_result<object> value::get_object() & noexcept {
-  if (*json != '{') { return INCORRECT_TYPE; }
-  return object::started(consume_container());
+simdjson_really_inline simdjson_result<array> value::get_array() & noexcept {
+  return array::try_start(iter);
 }
 simdjson_really_inline simdjson_result<object> value::get_object() && noexcept {
-  return object::start(json, consume_container());
+  return object::start(iter);
+}
+simdjson_really_inline simdjson_result<object> value::get_object() & noexcept {
+  return object::try_start(iter);
 }
 simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() && noexcept {
-  return iter->consume_raw_json_string();
+  return iter.require_raw_json_string();
 }
 simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() & noexcept {
-  return consume_if_success( iter->parse_raw_json_string(json) );
+  return iter.try_get_raw_json_string();
 }
 simdjson_really_inline simdjson_result<std::string_view> value::get_string() && noexcept {
-  auto result = iter->parse_string(json);
-  consume();
-  return result;
+  return iter.require_string();
 }
 simdjson_really_inline simdjson_result<std::string_view> value::get_string() & noexcept {
-  return consume_if_success( iter->parse_string(json) );
+  return iter.try_get_string();
 }
 simdjson_really_inline simdjson_result<double> value::get_double() && noexcept {
-  return iter->parse_double(consume());
+  return iter.require_double();
 }
 simdjson_really_inline simdjson_result<double> value::get_double() & noexcept {
-  return consume_if_success( iter->parse_double(json) );
+  return iter.try_get_double();
 }
 simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() && noexcept {
-  return iter->parse_uint64(consume());
+  return iter.require_uint64();
 }
 simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() & noexcept {
-  return consume_if_success( iter->parse_uint64(json) );
+  return iter.try_get_uint64();
 }
 simdjson_really_inline simdjson_result<int64_t> value::get_int64() && noexcept {
-  return iter->parse_int64(consume());
+  return iter.require_int64();
 }
 simdjson_really_inline simdjson_result<int64_t> value::get_int64() & noexcept {
-  return consume_if_success( iter->parse_int64(json) );
+  return iter.try_get_int64();
 }
 simdjson_really_inline simdjson_result<bool> value::get_bool() && noexcept {
-  return iter->parse_bool(consume());
+  return iter.require_bool();
 }
 simdjson_really_inline simdjson_result<bool> value::get_bool() & noexcept {
-  return consume_if_success( iter->parse_bool(json) );
+  return iter.try_get_bool();
 }
 simdjson_really_inline bool value::is_null() && noexcept {
-  return iter->is_null(consume());
+  return iter.require_null();
 }
 simdjson_really_inline bool value::is_null() & noexcept {
-  if (!iter->is_null(json)) { return false; }
-  consume();
-  return true;
+  return iter.is_null();
 }
 
 template<> simdjson_really_inline simdjson_result<array> value::get() & noexcept { return get_array(); }
@@ -205,46 +138,21 @@ simdjson_really_inline value::operator bool() & noexcept(false) {
 }
 #endif
 
-simdjson_really_inline simdjson_result<array_iterator<value>> value::begin() & noexcept {
-  return consume_if_success( array_iterator<value>::start(*this, json) );
+simdjson_really_inline simdjson_result<array_iterator> value::begin() & noexcept {
+  return get_array().begin();
 }
-simdjson_really_inline simdjson_result<array_iterator<value>> value::end() & noexcept {
+simdjson_really_inline simdjson_result<array_iterator> value::end() & noexcept {
   return {};
 }
 
-simdjson_really_inline void value::log_value(const char *type) const noexcept {
-  char json_char[]{char(json[0]), '\0'};
-  logger::log_value(*iter, type, json_char);
-}
-simdjson_really_inline void value::log_error(const char *message) const noexcept {
-  char json_char[]{char(json[0]), '\0'};
-  logger::log_error(*iter, message, json_char);
-}
-
-//
-// For array_iterator
-//
-simdjson_really_inline json_iterator &value::get_iterator() noexcept {
-  return *iter;
-}
-simdjson_really_inline json_iterator_ref value::borrow_iterator_child() noexcept {
-  return iter.borrow();
-}
-simdjson_really_inline bool value::is_iterator_alive() const noexcept {
-  return iter.is_alive();
-}
-simdjson_really_inline void value::start_iterator() noexcept {
-  iter.started_container();
-}
-simdjson_really_inline void value::finish_iterator() noexcept {
-  iter.finished_container();
-}
-simdjson_really_inline void value::abandon_iterator() noexcept {
-  iter.abandon();
-}
-simdjson_warn_unused simdjson_really_inline error_code value::finish_iterator_child() noexcept {
-  return iter.finish_child();
-}
+// simdjson_really_inline void value::log_value(const char *type) const noexcept {
+//   char json_char[]{char(json[0]), '\0'};
+//   logger::log_value(*iter, type, json_char);
+// }
+// simdjson_really_inline void value::log_error(const char *message) const noexcept {
+//   char json_char[]{char(json[0]), '\0'};
+//   logger::log_error(*iter, message, json_char);
+// }
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
@@ -267,11 +175,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::begin() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::end() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::end() & noexcept {
   if (error()) { return error(); }
   return {};
 }

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -295,12 +295,19 @@ template<typename T> simdjson_really_inline error_code simdjson_result<SIMDJSON_
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get<T>(out);
 }
 
-template<> simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>() & noexcept = delete;
+template<> simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>() & noexcept  {
+  if (error()) { return error(); }
+  return std::move(first);
+}
 template<> simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-template<> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>(SIMDJSON_IMPLEMENTATION::ondemand::value &out) & noexcept = delete;
+template<> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>(SIMDJSON_IMPLEMENTATION::ondemand::value &out) & noexcept {
+  if (error()) { return error(); }
+  out = first;
+  return SUCCESS;
+}
 template<> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>(SIMDJSON_IMPLEMENTATION::ondemand::value &out) && noexcept {
   if (error()) { return error(); }
   out = std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -22,8 +22,8 @@ public:
    */
   simdjson_really_inline value() noexcept = default;
 
-  simdjson_really_inline value(value &&other) noexcept = default;
-  simdjson_really_inline value &operator=(value && other) noexcept = default;
+  simdjson_really_inline value(value &&other) noexcept;
+  simdjson_really_inline value &operator=(value && other) noexcept;
   simdjson_really_inline value(const value &) noexcept = delete;
   simdjson_really_inline value &operator=(const value &) noexcept = delete;
 
@@ -63,7 +63,9 @@ public:
    * @returns An object that can be used to iterate the array.
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array> get_array() noexcept;
+  simdjson_really_inline simdjson_result<array> get_array() && noexcept;
+  /** @overload simdjson_really_inline operator get_array() && noexcept(false); */
+  simdjson_really_inline simdjson_result<array> get_array() & noexcept;
 
   /**
    * Cast this JSON value to an object.
@@ -71,7 +73,9 @@ public:
    * @returns An object that can be used to look up or iterate fields.
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    */
-  simdjson_really_inline simdjson_result<object> get_object() noexcept;
+  simdjson_really_inline simdjson_result<object> get_object() && noexcept;
+  /** @overload simdjson_really_inline operator object() && noexcept(false); */
+  simdjson_really_inline simdjson_result<object> get_object() & noexcept;
 
   // PERF NOTE: get_XXX() methods generally have both && and & variants because performance is demonstrably better on clang.
   // Specifically, in typical cases where you use a temporary value (like doc["x"].get_double()) the && version is faster
@@ -160,14 +164,18 @@ public:
    * @returns An object that can be used to iterate the array.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an array.
    */
-  simdjson_really_inline operator array() noexcept(false);
+  simdjson_really_inline operator array() && noexcept(false);
+  /** @overload simdjson_really_inline operator array() && noexcept(false); */
+  simdjson_really_inline operator array() & noexcept(false);
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an object.
    */
-  simdjson_really_inline operator object() noexcept(false);
+  simdjson_really_inline operator object() && noexcept(false);
+  /** @overload simdjson_really_inline operator object() && noexcept(false); */
+  simdjson_really_inline operator object() & noexcept(false);
   /**
    * Cast this JSON value to an unsigned integer.
    *
@@ -275,12 +283,18 @@ protected:
   // For array_iterator
   //
   simdjson_really_inline json_iterator &get_iterator() noexcept;
-  simdjson_really_inline json_iterator_ref borrow_iterator() noexcept;
+  simdjson_really_inline json_iterator_ref borrow_iterator_child() noexcept;
   simdjson_really_inline bool is_iterator_alive() const noexcept;
-  simdjson_really_inline void iteration_finished() noexcept;
+  simdjson_really_inline void start_iterator() noexcept;
+  simdjson_really_inline void finish_iterator() noexcept;
+  simdjson_really_inline void abandon_iterator() noexcept;
+  simdjson_warn_unused simdjson_really_inline error_code finish_iterator_child() noexcept;
+
   simdjson_really_inline const uint8_t *consume() noexcept;
+  simdjson_really_inline json_iterator_ref consume_container() noexcept;
   template<typename T>
   simdjson_really_inline simdjson_result<T> consume_if_success(simdjson_result<T> &&result) noexcept;
+  simdjson_warn_unused simdjson_really_inline error_code consume_if_success(error_code error) noexcept;
 
   json_iterator_ref iter{};
   const uint8_t *json{}; // The JSON text of the value
@@ -310,9 +324,11 @@ public:
   simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() && noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
 
   simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
   simdjson_really_inline simdjson_result<uint64_t> get_uint64() & noexcept;
@@ -342,8 +358,10 @@ public:
   template<typename T> simdjson_really_inline error_code get(T &out) && noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() && noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
   simdjson_really_inline operator uint64_t() && noexcept(false);
   simdjson_really_inline operator uint64_t() & noexcept(false);
   simdjson_really_inline operator int64_t() && noexcept(false);

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -22,15 +22,11 @@ public:
    */
   simdjson_really_inline value() noexcept = default;
 
-  simdjson_really_inline value(value &&other) noexcept;
-  simdjson_really_inline value &operator=(value && other) noexcept;
-  simdjson_really_inline value(const value &) noexcept = delete;
-  simdjson_really_inline value &operator=(const value &) noexcept = delete;
-
-  /**
-   * Skips the value if the value was not successfully parsed or used.
-   */
-  simdjson_really_inline ~value() noexcept;
+  simdjson_really_inline value(value &&other) noexcept = default;
+  simdjson_really_inline value &operator=(value && other) noexcept = default;
+  simdjson_really_inline value(const value &) noexcept = default;
+  simdjson_really_inline value &operator=(const value &) noexcept = default;
+  simdjson_really_inline ~value() noexcept = default;
 
   /**
    * Get this value as the given type.
@@ -246,13 +242,13 @@ public:
    *
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array_iterator<value>> begin() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator<value>> end() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
 
 protected:
   /**
@@ -260,47 +256,20 @@ protected:
    *
    * Use value::read() instead of this.
    */
-  simdjson_really_inline value(json_iterator_ref &&iter, const uint8_t *json) noexcept;
-
-  /**
-   * Read a value.
-   *
-   * If the value is an array or object, only the opening brace will be consumed.
-   *
-   * @param doc The document containing the value. Iterator must be at the value start position.
-   */
-  static simdjson_really_inline value start(json_iterator_ref &&iter) noexcept;
+  simdjson_really_inline value(const value_iterator &iter) noexcept;
 
   /**
    * Skip this value, allowing iteration to continue.
    */
   simdjson_really_inline void skip() noexcept;
 
-  simdjson_really_inline void log_value(const char *type) const noexcept;
-  simdjson_really_inline void log_error(const char *message) const noexcept;
+  // simdjson_really_inline void log_value(const char *type) const noexcept;
+  // simdjson_really_inline void log_error(const char *message) const noexcept;
 
-  //
-  // For array_iterator
-  //
-  simdjson_really_inline json_iterator &get_iterator() noexcept;
-  simdjson_really_inline json_iterator_ref borrow_iterator_child() noexcept;
-  simdjson_really_inline bool is_iterator_alive() const noexcept;
-  simdjson_really_inline void start_iterator() noexcept;
-  simdjson_really_inline void finish_iterator() noexcept;
-  simdjson_really_inline void abandon_iterator() noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code finish_iterator_child() noexcept;
-
-  simdjson_really_inline const uint8_t *consume() noexcept;
-  simdjson_really_inline json_iterator_ref consume_container() noexcept;
-  template<typename T>
-  simdjson_really_inline simdjson_result<T> consume_if_success(simdjson_result<T> &&result) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code consume_if_success(error_code error) noexcept;
-
-  json_iterator_ref iter{};
-  const uint8_t *json{}; // The JSON text of the value
+  value_iterator iter{};
 
   friend class document;
-  template<typename T> friend class array_iterator;
+  friend class array_iterator;
   friend class field;
   friend class object;
   friend struct simdjson_result<value>;
@@ -376,8 +345,8 @@ public:
   simdjson_really_inline operator bool() & noexcept(false);
 #endif
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator<SIMDJSON_IMPLEMENTATION::ondemand::value>> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -252,14 +252,14 @@ public:
 
   /**
    * Look up a field by name on an object.
-   * 
+   *
    * Important notes:
-   * 
+   *
    * * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    *   e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
    * * **Once Only:** You may only look up a single field on a value. To look up multiple fields,
    *   you must cast to object or call `.get_object()`.
-   * 
+   *
    * @param key The key to look up.
    * @returns The value of the field, NO_SUCH_FIELD if the field is not in the object, or
    *          INCORRECT_TYPE if the JSON value is not an array.
@@ -372,14 +372,14 @@ public:
 
   /**
    * Look up a field by name on an object.
-   * 
+   *
    * Important notes:
-   * 
+   *
    * * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    *   e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
    * * **Once Only:** You may only look up a single field on a value. To look up multiple fields,
    *   you must cast to object or call `.get_object()`.
-   * 
+   *
    * @param key The key to look up.
    * @returns The value of the field, NO_SUCH_FIELD if the field is not in the object, or
    *          INCORRECT_TYPE if the JSON value is not an array.

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -250,6 +250,28 @@ public:
    */
   simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
 
+  /**
+   * Look up a field by name on an object.
+   * 
+   * Important notes:
+   * 
+   * * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
+   *   e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
+   * * **Once Only:** You may only look up a single field on a value. To look up multiple fields,
+   *   you must cast to object or call `.get_object()`.
+   * 
+   * @param key The key to look up.
+   * @returns The value of the field, NO_SUCH_FIELD if the field is not in the object, or
+   *          INCORRECT_TYPE if the JSON value is not an array.
+   */
+  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
+  /** @overload simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept; */
+  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept; */
+  simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
+  /** @overload simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept; */
+  simdjson_really_inline simdjson_result<value> operator[](const char *key) && noexcept;
+
 protected:
   /**
    * Create a value.
@@ -347,6 +369,28 @@ public:
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+
+  /**
+   * Look up a field by name on an object.
+   * 
+   * Important notes:
+   * 
+   * * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
+   *   e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
+   * * **Once Only:** You may only look up a single field on a value. To look up multiple fields,
+   *   you must cast to object or call `.get_object()`.
+   * 
+   * @param key The key to look up.
+   * @returns The value of the field, NO_SUCH_FIELD if the field is not in the object, or
+   *          INCORRECT_TYPE if the JSON value is not an array.
+   */
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
+  /** @overload simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept; */
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
+  /** @overload simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept; */
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
+  /** @overload simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept; */
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) && noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -22,12 +22,6 @@ public:
    */
   simdjson_really_inline value() noexcept = default;
 
-  simdjson_really_inline value(value &&other) noexcept = default;
-  simdjson_really_inline value &operator=(value && other) noexcept = default;
-  simdjson_really_inline value(const value &) noexcept = default;
-  simdjson_really_inline value &operator=(const value &) noexcept = default;
-  simdjson_really_inline ~value() noexcept = default;
-
   /**
    * Get this value as the given type.
    *
@@ -310,10 +304,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> : public SIMDJS
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() && noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -9,13 +9,13 @@ simdjson_really_inline value_iterator::value_iterator(json_iterator *json_iter, 
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_object() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
 
   if (*_json_iter->advance() != '{') { logger::log_error(*_json_iter, "Not an object"); return INCORRECT_TYPE; }
   return started_object();
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_start_object() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
 
   if (*_json_iter->peek() != '{') { logger::log_error(*_json_iter, "Not an object"); return INCORRECT_TYPE; }
   _json_iter->advance();
@@ -23,7 +23,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline bool value_iterator::started_object() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
 
   if (*_json_iter->peek() == '}') {
     logger::log_value(*_json_iter, "empty object");
@@ -37,7 +37,7 @@ simdjson_warn_unused simdjson_really_inline bool value_iterator::started_object(
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_field() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth );
 
   switch (*_json_iter->advance()) {
     case '}':
@@ -54,7 +54,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_raw(const char *key) noexcept {
   // We assume we are sitting at a key: at "key": <value>
-  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
 
   bool has_next;
   do {
@@ -81,7 +81,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::field_key() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
 
   const uint8_t *key = _json_iter->advance();
   if (*(key++) != '"') { return _json_iter->report_error(TAPE_ERROR, "Object key is not a string"); }
@@ -89,21 +89,21 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
 }
 
 simdjson_warn_unused simdjson_really_inline error_code value_iterator::field_value() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
 
   if (*_json_iter->advance() != ':') { return _json_iter->report_error(TAPE_ERROR, "Missing colon in object field"); }
   return SUCCESS;
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_array() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0);
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0);
 
   if (*_json_iter->advance() != '[') { logger::log_error(*_json_iter, "Not an array"); return INCORRECT_TYPE; }
   return started_array();
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_start_array() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0);
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0);
 
   if (*_json_iter->peek() != '[') { logger::log_error(*_json_iter, "Not an array"); return INCORRECT_TYPE; }
   _json_iter->advance();
@@ -111,7 +111,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline bool value_iterator::started_array() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
 
   if (*_json_iter->peek() == ']') {
     logger::log_value(*_json_iter, "empty array");
@@ -125,7 +125,7 @@ simdjson_warn_unused simdjson_really_inline bool value_iterator::started_array()
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_element() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth );
 
   switch (*_json_iter->advance()) {
     case ']':
@@ -147,7 +147,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> va
   return require_raw_json_string().unescape(_json_iter->string_buf_loc());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::try_get_raw_json_string() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
 
   logger::log_value(*_json_iter, "string", "", 0);
   auto json = _json_iter->peek();
@@ -157,7 +157,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
   return raw_json_string(json+1);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::require_raw_json_string() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
 
   logger::log_value(*_json_iter, "string", "", 0);
   auto json = _json_iter->advance();
@@ -166,7 +166,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
   return raw_json_string(json+1);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   logger::log_value(*_json_iter, "uint64", "", 0);
   uint64_t result;
@@ -176,14 +176,14 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   logger::log_value(*_json_iter, "uint64", "", 0);
   _json_iter->ascend_to(depth()-1);
   return numberparsing::parse_unsigned(_json_iter->advance());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   logger::log_value(*_json_iter, "int64", "", 0);
   int64_t result;
@@ -193,14 +193,14 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   logger::log_value(*_json_iter, "int64", "", 0);
   _json_iter->ascend_to(depth()-1);
   return numberparsing::parse_integer(_json_iter->advance());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   logger::log_value(*_json_iter, "double", "", 0);
   double result;
@@ -210,7 +210,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   logger::log_value(*_json_iter, "double", "", 0);
   _json_iter->ascend_to(depth()-1);
@@ -225,7 +225,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return simdjson_result<bool>(!not_true);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   bool result;
   SIMDJSON_TRY( parse_bool(_json_iter->peek()).get(result) );
@@ -234,7 +234,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   _json_iter->ascend_to(depth()-1);
   return parse_bool(_json_iter->advance());
@@ -247,7 +247,7 @@ simdjson_really_inline bool value_iterator::is_null(const uint8_t *json) const n
   return false;
 }
 simdjson_really_inline bool value_iterator::is_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   if (is_null(_json_iter->peek())) {
     _json_iter->advance();
@@ -257,7 +257,7 @@ simdjson_really_inline bool value_iterator::is_null() noexcept {
   return false;
 }
 simdjson_really_inline bool value_iterator::require_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
 
   _json_iter->ascend_to(depth()-1);
   return is_null(_json_iter->advance());
@@ -266,7 +266,7 @@ simdjson_really_inline bool value_iterator::require_null() noexcept {
 constexpr const uint32_t MAX_INT_LENGTH = 1024;
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::parse_root_uint64(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
@@ -276,7 +276,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_root_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   uint64_t result;
   SIMDJSON_TRY( parse_root_uint64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -284,13 +284,13 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_root_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   auto max_len = _json_iter->peek_length();
   return parse_root_uint64(_json_iter->advance(), max_len);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
@@ -300,7 +300,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_root_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   int64_t result;
   SIMDJSON_TRY( parse_root_int64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -308,13 +308,13 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_root_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   auto max_len = _json_iter->peek_length();
   return parse_root_int64(_json_iter->advance(), max_len);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest number: -0.<fraction>e-308.
   uint8_t tmpbuf[1074+8+1];
@@ -325,7 +325,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_root_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   double result;
   SIMDJSON_TRY( parse_root_double(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -333,20 +333,20 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_root_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   auto max_len = _json_iter->peek_length();
   return parse_root_double(_json_iter->advance(), max_len);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::parse_root_bool(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   uint8_t tmpbuf[5+1];
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Not a boolean"); return INCORRECT_TYPE; }
   return parse_bool(tmpbuf);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_root_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   bool result;
   SIMDJSON_TRY( parse_root_bool(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -354,27 +354,27 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_root_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   auto max_len = _json_iter->peek_length();
   return parse_root_bool(_json_iter->advance(), max_len);
 }
 simdjson_really_inline bool value_iterator::is_root_null(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   uint8_t tmpbuf[4+1];
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { return false; }
   return is_null(tmpbuf);
 }
 simdjson_really_inline bool value_iterator::is_root_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   if (!is_root_null(_json_iter->peek(), _json_iter->peek_length())) { return false; }
   _json_iter->advance();
   return true;
 }
 simdjson_really_inline bool value_iterator::require_root_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
 
   auto max_len = _json_iter->peek_length();
   return is_root_null(_json_iter->advance(), max_len);
@@ -384,7 +384,7 @@ simdjson_warn_unused simdjson_really_inline error_code value_iterator::skip_chil
   return _json_iter->skip_child(depth());
 }
 simdjson_really_inline value_iterator value_iterator::child() const noexcept {
-  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
   return { _json_iter, depth()+1 };
 }
 

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -149,7 +149,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> va
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::try_get_raw_json_string() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
 
-  logger::log_value(*_json_iter, "string", "");
+  logger::log_value(*_json_iter, "string", "", 0);
   auto json = _json_iter->peek();
   if (*json != '"') { logger::log_error(*_json_iter, "Not a string"); return INCORRECT_TYPE; }
   _json_iter->advance();
@@ -159,7 +159,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::require_raw_json_string() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
 
-  logger::log_value(*_json_iter, "string", "");
+  logger::log_value(*_json_iter, "string", "", 0);
   auto json = _json_iter->advance();
   if (*json != '"') { logger::log_error(*_json_iter, "Not a string"); return INCORRECT_TYPE; }
   _json_iter->ascend_to(depth()-1);
@@ -168,7 +168,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_uint64() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
 
-  logger::log_value(*_json_iter, "uint64", "");
+  logger::log_value(*_json_iter, "uint64", "", 0);
   uint64_t result;
   SIMDJSON_TRY( numberparsing::parse_unsigned(_json_iter->peek()).get(result) );
   _json_iter->advance();
@@ -178,14 +178,14 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_uint64() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
 
-  logger::log_value(*_json_iter, "uint64", "");
+  logger::log_value(*_json_iter, "uint64", "", 0);
   _json_iter->ascend_to(depth()-1);
   return numberparsing::parse_unsigned(_json_iter->advance());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_int64() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
 
-  logger::log_value(*_json_iter, "int64", "");
+  logger::log_value(*_json_iter, "int64", "", 0);
   int64_t result;
   SIMDJSON_TRY( numberparsing::parse_integer(_json_iter->peek()).get(result) );
   _json_iter->advance();
@@ -195,14 +195,14 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_int64() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
 
-  logger::log_value(*_json_iter, "int64", "");
+  logger::log_value(*_json_iter, "int64", "", 0);
   _json_iter->ascend_to(depth()-1);
   return numberparsing::parse_integer(_json_iter->advance());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_double() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
 
-  logger::log_value(*_json_iter, "double", "");
+  logger::log_value(*_json_iter, "double", "", 0);
   double result;
   SIMDJSON_TRY( numberparsing::parse_double(_json_iter->peek()).get(result) );
   _json_iter->advance();
@@ -212,7 +212,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_double() noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
 
-  logger::log_value(*_json_iter, "double", "");
+  logger::log_value(*_json_iter, "double", "", 0);
   _json_iter->ascend_to(depth()-1);
   return numberparsing::parse_double(_json_iter->advance());
 }
@@ -270,7 +270,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
 
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
-  logger::log_value(*_json_iter, "uint64", "");
+  logger::log_value(*_json_iter, "uint64", "", 0);
   auto result = numberparsing::parse_unsigned(tmpbuf);
   if (result.error()) { logger::log_error(*_json_iter, "Error parsing unsigned integer"); }
   return result;
@@ -294,7 +294,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
 
   uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
-  logger::log_value(*_json_iter, "int64", "");
+  logger::log_value(*_json_iter, "int64", "", 0);
   auto result = numberparsing::parse_integer(tmpbuf);
   if (result.error()) { logger::log_error(*_json_iter, "Error parsing integer"); }
   return result;
@@ -319,7 +319,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest number: -0.<fraction>e-308.
   uint8_t tmpbuf[1074+8+1];
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 1082 characters"); return NUMBER_ERROR; }
-  logger::log_value(*_json_iter, "double", "");
+  logger::log_value(*_json_iter, "double", "", 0);
   auto result = numberparsing::parse_double(tmpbuf);
   if (result.error()) { logger::log_error(*_json_iter, "Error parsing double"); }
   return result;
@@ -382,9 +382,6 @@ simdjson_really_inline bool value_iterator::require_root_null() noexcept {
 
 simdjson_warn_unused simdjson_really_inline error_code value_iterator::skip_child() noexcept {
   return _json_iter->skip_child(depth());
-}
-simdjson_warn_unused simdjson_really_inline error_code value_iterator::finish_child() noexcept {
-  return _json_iter->finish_child(depth());
 }
 simdjson_really_inline value_iterator value_iterator::child() const noexcept {
   SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -1,0 +1,430 @@
+namespace simdjson {
+namespace SIMDJSON_IMPLEMENTATION {
+namespace ondemand {
+
+simdjson_really_inline value_iterator::value_iterator(json_iterator *json_iter, depth_t depth) noexcept
+  : _json_iter{json_iter},
+    _depth{depth}
+{
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_object() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+
+  if (*_json_iter->advance() != '{') { logger::log_error(*_json_iter, "Not an object"); return INCORRECT_TYPE; }
+  return started_object();
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_start_object() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+
+  if (*_json_iter->peek() != '{') { logger::log_error(*_json_iter, "Not an object"); return INCORRECT_TYPE; }
+  _json_iter->advance();
+  return started_object();
+}
+
+simdjson_warn_unused simdjson_really_inline bool value_iterator::started_object() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+
+  if (*_json_iter->peek() == '}') {
+    logger::log_value(*_json_iter, "empty object");
+    _json_iter->advance();
+    _json_iter->ascend_to(depth()-1);
+    return false;
+  }
+  _json_iter->descend_to(depth()+1);
+  logger::log_start_value(*_json_iter, "object");
+  return true;
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_field() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() );
+
+  switch (*_json_iter->advance()) {
+    case '}':
+      logger::log_end_value(*_json_iter, "object");
+      _json_iter->ascend_to(depth()-1);
+      return false;
+    case ',':
+      _json_iter->descend_to(depth()+1);
+      return true;
+    default:
+      return _json_iter->report_error(TAPE_ERROR, "Missing comma between object fields");
+  }
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_raw(const char *key) noexcept {
+  // We assume we are sitting at a key: at "key": <value>
+  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+
+  bool has_next;
+  do {
+    // Get the key
+    raw_json_string actual_key;
+    SIMDJSON_TRY( require_raw_json_string().get(actual_key) );
+    if (*_json_iter->advance() != ':') { return _json_iter->report_error(TAPE_ERROR, "Missing colon in object field"); }
+
+    // Check if the key matches, and return if so
+    if (actual_key == key) {
+      logger::log_event(*_json_iter, "match", key);
+      return true;
+    }
+
+    // Skip the value so we can look at the next key
+    logger::log_event(*_json_iter, "non-match", key);
+    SIMDJSON_TRY( skip_child() );
+
+    // Check whether the next token is , or }
+    SIMDJSON_TRY( has_next_field().get(has_next) );
+  } while (has_next);
+  logger::log_event(*_json_iter, "no matches", key);
+  return false;
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::field_key() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+
+  const uint8_t *key = _json_iter->advance();
+  if (*(key++) != '"') { return _json_iter->report_error(TAPE_ERROR, "Object key is not a string"); }
+  return raw_json_string(key);
+}
+
+simdjson_warn_unused simdjson_really_inline error_code value_iterator::field_value() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+
+  if (*_json_iter->advance() != ':') { return _json_iter->report_error(TAPE_ERROR, "Missing colon in object field"); }
+  return SUCCESS;
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_array() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0);
+
+  if (*_json_iter->advance() != '[') { logger::log_error(*_json_iter, "Not an array"); return INCORRECT_TYPE; }
+  return started_array();
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_start_array() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0);
+
+  if (*_json_iter->peek() != '[') { logger::log_error(*_json_iter, "Not an array"); return INCORRECT_TYPE; }
+  _json_iter->advance();
+  return started_array();
+}
+
+simdjson_warn_unused simdjson_really_inline bool value_iterator::started_array() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+
+  if (*_json_iter->peek() == ']') {
+    logger::log_value(*_json_iter, "empty array");
+    _json_iter->advance();
+    _json_iter->ascend_to(depth()-1);
+    return false;
+  }
+  logger::log_start_value(*_json_iter, "array");
+  _json_iter->descend_to(depth()+1);
+  return true;
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_element() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() );
+
+  switch (*_json_iter->advance()) {
+    case ']':
+      logger::log_end_value(*_json_iter, "array");
+      _json_iter->ascend_to(depth()-1);
+      return false;
+    case ',':
+      _json_iter->descend_to(depth()+1);
+      return true;
+    default:
+      return _json_iter->report_error(TAPE_ERROR, "Missing comma between array elements");
+  }
+}
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> value_iterator::try_get_string() noexcept {
+  return try_get_raw_json_string().unescape(_json_iter->string_buf_loc());
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> value_iterator::require_string() noexcept {
+  return require_raw_json_string().unescape(_json_iter->string_buf_loc());
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::try_get_raw_json_string() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+
+  logger::log_value(*_json_iter, "string", "");
+  auto json = _json_iter->peek();
+  if (*json != '"') { logger::log_error(*_json_iter, "Not a string"); return INCORRECT_TYPE; }
+  _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return raw_json_string(json+1);
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::require_raw_json_string() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 0 );
+
+  logger::log_value(*_json_iter, "string", "");
+  auto json = _json_iter->advance();
+  if (*json != '"') { logger::log_error(*_json_iter, "Not a string"); return INCORRECT_TYPE; }
+  _json_iter->ascend_to(depth()-1);
+  return raw_json_string(json+1);
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_uint64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  logger::log_value(*_json_iter, "uint64", "");
+  uint64_t result;
+  SIMDJSON_TRY( numberparsing::parse_unsigned(_json_iter->peek()).get(result) );
+  _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_uint64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  logger::log_value(*_json_iter, "uint64", "");
+  _json_iter->ascend_to(depth()-1);
+  return numberparsing::parse_unsigned(_json_iter->advance());
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_int64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  logger::log_value(*_json_iter, "int64", "");
+  int64_t result;
+  SIMDJSON_TRY( numberparsing::parse_integer(_json_iter->peek()).get(result) );
+  _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_int64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  logger::log_value(*_json_iter, "int64", "");
+  _json_iter->ascend_to(depth()-1);
+  return numberparsing::parse_integer(_json_iter->advance());
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_double() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  logger::log_value(*_json_iter, "double", "");
+  double result;
+  SIMDJSON_TRY( numberparsing::parse_double(_json_iter->peek()).get(result) );
+  _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_double() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  logger::log_value(*_json_iter, "double", "");
+  _json_iter->ascend_to(depth()-1);
+  return numberparsing::parse_double(_json_iter->advance());
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::parse_bool(const uint8_t *json) const noexcept {
+  logger::log_value(*_json_iter, "bool", "");
+  auto not_true = atomparsing::str4ncmp(json, "true");
+  auto not_false = atomparsing::str4ncmp(json, "fals") | (json[4] ^ 'e');
+  bool error = (not_true && not_false) || jsoncharutils::is_not_structural_or_whitespace(json[not_true ? 5 : 4]);
+  if (error) { logger::log_error(*_json_iter, "Not a boolean"); return INCORRECT_TYPE; }
+  return simdjson_result<bool>(!not_true);
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_bool() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  bool result;
+  SIMDJSON_TRY( parse_bool(_json_iter->peek()).get(result) );
+  _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_bool() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  _json_iter->ascend_to(depth()-1);
+  return parse_bool(_json_iter->advance());
+}
+simdjson_really_inline bool value_iterator::is_null(const uint8_t *json) const noexcept {
+  if (!atomparsing::str4ncmp(json, "null")) {
+    logger::log_value(*_json_iter, "null", "");
+    return true;
+  }
+  return false;
+}
+simdjson_really_inline bool value_iterator::is_null() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  if (is_null(_json_iter->peek())) {
+    _json_iter->advance();
+    _json_iter->ascend_to(depth()-1);
+    return true;
+  }
+  return false;
+}
+simdjson_really_inline bool value_iterator::require_null() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() > 1 );
+
+  _json_iter->ascend_to(depth()-1);
+  return is_null(_json_iter->advance());
+}
+
+constexpr const uint32_t MAX_INT_LENGTH = 1024;
+
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::parse_root_uint64(const uint8_t *json, uint32_t max_len) const noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
+  logger::log_value(*_json_iter, "uint64", "");
+  auto result = numberparsing::parse_unsigned(tmpbuf);
+  if (result.error()) { logger::log_error(*_json_iter, "Error parsing unsigned integer"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_root_uint64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  uint64_t result;
+  SIMDJSON_TRY( parse_root_uint64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
+  _json_iter->advance();
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_root_uint64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  auto max_len = _json_iter->peek_length();
+  return parse_root_uint64(_json_iter->advance(), max_len);
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
+  logger::log_value(*_json_iter, "int64", "");
+  auto result = numberparsing::parse_integer(tmpbuf);
+  if (result.error()) { logger::log_error(*_json_iter, "Error parsing integer"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_root_int64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  int64_t result;
+  SIMDJSON_TRY( parse_root_int64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
+  _json_iter->advance();
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_root_int64() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  auto max_len = _json_iter->peek_length();
+  return parse_root_int64(_json_iter->advance(), max_len);
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest number: -0.<fraction>e-308.
+  uint8_t tmpbuf[1074+8+1];
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 1082 characters"); return NUMBER_ERROR; }
+  logger::log_value(*_json_iter, "double", "");
+  auto result = numberparsing::parse_double(tmpbuf);
+  if (result.error()) { logger::log_error(*_json_iter, "Error parsing double"); }
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_root_double() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  double result;
+  SIMDJSON_TRY( parse_root_double(_json_iter->peek(), _json_iter->peek_length()).get(result) );
+  _json_iter->advance();
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_root_double() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  auto max_len = _json_iter->peek_length();
+  return parse_root_double(_json_iter->advance(), max_len);
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::parse_root_bool(const uint8_t *json, uint32_t max_len) const noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  uint8_t tmpbuf[5+1];
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Not a boolean"); return INCORRECT_TYPE; }
+  return parse_bool(tmpbuf);
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_root_bool() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  bool result;
+  SIMDJSON_TRY( parse_root_bool(_json_iter->peek(), _json_iter->peek_length()).get(result) );
+  _json_iter->advance();
+  return result;
+}
+simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_root_bool() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  auto max_len = _json_iter->peek_length();
+  return parse_root_bool(_json_iter->advance(), max_len);
+}
+simdjson_really_inline bool value_iterator::is_root_null(const uint8_t *json, uint32_t max_len) const noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  uint8_t tmpbuf[4+1];
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { return false; }
+  return is_null(tmpbuf);
+}
+simdjson_really_inline bool value_iterator::is_root_null() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  if (!is_root_null(_json_iter->peek(), _json_iter->peek_length())) { return false; }
+  _json_iter->advance();
+  return true;
+}
+simdjson_really_inline bool value_iterator::require_root_null() noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth() && depth() == 1 );
+
+  auto max_len = _json_iter->peek_length();
+  return is_root_null(_json_iter->advance(), max_len);
+}
+
+simdjson_warn_unused simdjson_really_inline error_code value_iterator::skip_child() noexcept {
+  return _json_iter->skip_child(depth());
+}
+simdjson_warn_unused simdjson_really_inline error_code value_iterator::finish_child() noexcept {
+  return _json_iter->finish_child(depth());
+}
+simdjson_really_inline value_iterator value_iterator::child() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->depth() == depth()+1 );
+  return { _json_iter, depth()+1 };
+}
+
+simdjson_really_inline bool value_iterator::is_open() const noexcept {
+  return _json_iter->depth() >= depth();
+}
+
+simdjson_really_inline void value_iterator::abandon() noexcept {
+  _json_iter->abandon();
+}
+
+
+simdjson_warn_unused simdjson_really_inline depth_t value_iterator::depth() const noexcept {
+  return _depth;
+}
+simdjson_warn_unused simdjson_really_inline error_code value_iterator::error() const noexcept {
+  return _json_iter->error;
+}
+simdjson_warn_unused simdjson_really_inline uint8_t *&value_iterator::string_buf_loc() noexcept {
+  return _json_iter->string_buf_loc();
+}
+simdjson_warn_unused simdjson_really_inline const json_iterator &value_iterator::json_iter() const noexcept {
+  return *_json_iter;
+}
+simdjson_warn_unused simdjson_really_inline json_iterator &value_iterator::json_iter() noexcept {
+  return *_json_iter;
+}
+
+} // namespace ondemand
+} // namespace SIMDJSON_IMPLEMENTATION
+} // namespace simdjson
+
+namespace simdjson {
+
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value_iterator &&value) noexcept
+    : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>(value)) {}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>::simdjson_result(error_code error) noexcept
+    : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>(error) {}
+
+} // namespace simdjson

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -11,7 +11,7 @@ class parser;
 
 /**
  * Iterates through a single JSON value at a particular depth.
- * 
+ *
  * Does not keep track of the type of value: provides methods for objects, arrays and scalars and expects
  * the caller to call the right ones.
  *
@@ -37,16 +37,11 @@ public:
   simdjson_really_inline void start_document() noexcept;
 
   /**
-   * Skips a non-iterated JSON value, whether it is a scalar, array or object.
-   * 
+   * Skips a non-iterated or partially-iterated JSON value, whether it is a scalar, array or object.
+   *
    * Optimized for scalars.
    */
   simdjson_warn_unused simdjson_really_inline error_code skip_child() noexcept;
-
-  /**
-   * Skips a possibly-partially-iterated JSON value, whether it is a scalar, array or object.
-   */
-  simdjson_warn_unused simdjson_really_inline error_code finish_child() noexcept;
 
   /**
    * Tell whether the iterator is at the EOF mark
@@ -75,10 +70,10 @@ public:
 
   /**
    * @addtogroup object Object iteration
-   * 
+   *
    * Methods to iterate and find object fields. These methods generally *assume* the value is
    * actually an object; the caller is responsible for keeping track of that fact.
-   * 
+   *
    * @{
    */
 
@@ -131,9 +126,9 @@ public:
    * Find the next field with the given key.
    *
    * Assumes you have called next_field() or otherwise matched the previous value.
-   * 
+   *
    * This means the iterator must be sitting at the next key:
-   * 
+   *
    * ```
    * { "a": 1, "b": 2 }
    *           ^
@@ -149,9 +144,9 @@ public:
    * Find the next field with the given key, *without* unescaping.
    *
    * Assumes you have called next_field() or otherwise matched the previous value.
-   * 
+   *
    * This means the iterator must be sitting at the next key:
-   * 
+   *
    * ```
    * { "a": 1, "b": 2 }
    *           ^

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -1,0 +1,290 @@
+namespace simdjson {
+namespace SIMDJSON_IMPLEMENTATION {
+namespace ondemand {
+
+class document;
+class object;
+class array;
+class value;
+class raw_json_string;
+class parser;
+
+/**
+ * Iterates through a single JSON value at a particular depth.
+ * 
+ * Does not keep track of the type of value: provides methods for objects, arrays and scalars and expects
+ * the caller to call the right ones.
+ *
+ * @private This is not intended for external use.
+ */
+class value_iterator {
+protected:
+  /** The underlying JSON iterator */
+  json_iterator *_json_iter{};
+  /** The depth of this value */
+  depth_t _depth{};
+
+public:
+  simdjson_really_inline value_iterator() noexcept = default;
+  simdjson_really_inline value_iterator(value_iterator &&other) noexcept = default;
+  simdjson_really_inline value_iterator &operator=(value_iterator &&other) noexcept = default;
+  simdjson_really_inline value_iterator(const value_iterator &other) noexcept = default;
+  simdjson_really_inline value_iterator &operator=(const value_iterator &other) noexcept = default;
+
+  /**
+   * Denote that we're starting a document.
+   */
+  simdjson_really_inline void start_document() noexcept;
+
+  /**
+   * Skips a non-iterated JSON value, whether it is a scalar, array or object.
+   * 
+   * Optimized for scalars.
+   */
+  simdjson_warn_unused simdjson_really_inline error_code skip_child() noexcept;
+
+  /**
+   * Skips a possibly-partially-iterated JSON value, whether it is a scalar, array or object.
+   */
+  simdjson_warn_unused simdjson_really_inline error_code finish_child() noexcept;
+
+  /**
+   * Tell whether the iterator is at the EOF mark
+   */
+  simdjson_really_inline bool at_eof() const noexcept;
+
+  /**
+   * Tell whether the value is open--if the value has not been used, or the array/object is still open.
+   */
+  simdjson_really_inline bool is_open() const noexcept;
+
+  /**
+   * Abandon all iteration.
+   */
+  simdjson_really_inline void abandon() noexcept;
+
+  /**
+   * Get the child value as a value_iterator.
+   */
+  simdjson_really_inline value_iterator child_value() const noexcept;
+
+  /**
+   * Get the depth of this value.
+   */
+  simdjson_really_inline depth_t depth() const noexcept;
+
+  /**
+   * @addtogroup object Object iteration
+   * 
+   * Methods to iterate and find object fields. These methods generally *assume* the value is
+   * actually an object; the caller is responsible for keeping track of that fact.
+   * 
+   * @{
+   */
+
+  /**
+   * Start an object iteration.
+   *
+   * @returns Whether the object had any fields (returns false for empty).
+   * @error INCORRECT_TYPE if there is no opening {
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_object() noexcept;
+  /**
+   * Check for an opening { and start an object iteration.
+   *
+   * @returns Whether the object had any fields (returns false for empty).
+   * @error INCORRECT_TYPE if there is no opening {
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> try_start_object() noexcept;
+
+  /**
+   * Start an object iteration after the user has already checked and moved past the {.
+   *
+   * Does not move the iterator.
+   *
+   * @returns Whether the object had any fields (returns false for empty).
+   */
+  simdjson_warn_unused simdjson_really_inline bool started_object() noexcept;
+
+  /**
+   * Moves to the next field in an object.
+   *
+   * Looks for , and }. If } is found, the object is finished and the iterator advances past it.
+   * Otherwise, it advances to the next value.
+   *
+   * @return whether there is another field in the object.
+   * @error TAPE_ERROR If there is a comma missing between fields.
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> has_next_field() noexcept;
+
+  /**
+   * Get the current field's key.
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> field_key() noexcept;
+
+  /**
+   * Pass the : in the field and move to its value.
+   */
+  simdjson_warn_unused simdjson_really_inline error_code field_value() noexcept;
+
+  /**
+   * Find the next field with the given key.
+   *
+   * Assumes you have called next_field() or otherwise matched the previous value.
+   * 
+   * This means the iterator must be sitting at the next key:
+   * 
+   * ```
+   * { "a": 1, "b": 2 }
+   *           ^
+   * ```
+   *
+   * Key is *raw JSON,* meaning it will be matched against the verbatim JSON without attempting to
+   * unescape it. This works well for typical ASCII and UTF-8 keys (almost all of them), but may
+   * fail to match some keys with escapes (\u, \n, etc.).
+   */
+  simdjson_warn_unused simdjson_really_inline error_code find_field(const std::string_view key) noexcept;
+
+  /**
+   * Find the next field with the given key, *without* unescaping.
+   *
+   * Assumes you have called next_field() or otherwise matched the previous value.
+   * 
+   * This means the iterator must be sitting at the next key:
+   * 
+   * ```
+   * { "a": 1, "b": 2 }
+   *           ^
+   * ```
+   *
+   * Key is *raw JSON,* meaning it will be matched against the verbatim JSON without attempting to
+   * unescape it. This works well for typical ASCII and UTF-8 keys (almost all of them), but may
+   * fail to match some keys with escapes (\u, \n, etc.).
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> find_field_raw(const char *key) noexcept;
+
+  /** @} */
+
+  /**
+   * @addtogroup array Array iteration
+   * Methods to iterate over array elements. These methods generally *assume* the value is actually
+   * an object; the caller is responsible for keeping track of that fact.
+   * @{
+   */
+
+  /**
+   * Check for an opening [ and start an array iteration.
+   *
+   * @param json A pointer to the potential [.
+   * @returns Whether the array had any elements (returns false for empty).
+   * @error INCORRECT_TYPE If there is no [.
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_array() noexcept;
+  /**
+   * Check for an opening [ and start an array iteration.
+   *
+   * @returns Whether the array had any elements (returns false for empty).
+   * @error INCORRECT_TYPE If there is no [.
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> try_start_array() noexcept;
+
+  /**
+   * Start an array iteration after the user has already checked and moved past the [.
+   *
+   * Does not move the iterator.
+   *
+   * @returns Whether the array had any elements (returns false for empty).
+   */
+  simdjson_warn_unused simdjson_really_inline bool started_array() noexcept;
+
+  /**
+   * Moves to the next element in an array.
+   *
+   * Looks for , and ]. If ] is found, the array is finished and the iterator advances past it.
+   * Otherwise, it advances to the next value.
+   *
+   * @return Whether there is another element in the array.
+   * @error TAPE_ERROR If there is a comma missing between elements.
+   */
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> has_next_element() noexcept;
+
+  /**
+   * Get a child value iterator.
+   */
+  simdjson_warn_unused simdjson_really_inline value_iterator child() const noexcept;
+
+  /** @} */
+
+  /**
+   * @defgroup scalar Scalar values
+   * @addtogroup scalar
+   * @{
+   */
+
+  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> try_get_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> require_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> try_get_raw_json_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> require_raw_json_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> try_get_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> require_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> try_get_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> require_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> try_get_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> require_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> try_get_bool() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> require_bool() noexcept;
+  simdjson_really_inline bool require_null() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
+
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> try_get_root_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> require_root_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> try_get_root_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> require_root_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> try_get_root_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> require_root_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> try_get_root_bool() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> require_root_bool() noexcept;
+  simdjson_really_inline bool require_root_null() noexcept;
+  simdjson_really_inline bool is_root_null() noexcept;
+
+  simdjson_really_inline error_code error() const noexcept;
+  simdjson_really_inline uint8_t *&string_buf_loc() noexcept;
+  simdjson_really_inline const json_iterator &json_iter() const noexcept;
+  simdjson_really_inline json_iterator &json_iter() noexcept;
+
+  /** @} */
+
+protected:
+  simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth) noexcept;
+  simdjson_really_inline bool is_null(const uint8_t *json) const noexcept;
+  simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) const noexcept;
+  simdjson_really_inline bool is_root_null(const uint8_t *json, uint32_t max_len) const noexcept;
+  simdjson_really_inline simdjson_result<bool> parse_root_bool(const uint8_t *json, uint32_t max_len) const noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> parse_root_uint64(const uint8_t *json, uint32_t max_len) const noexcept;
+  simdjson_really_inline simdjson_result<int64_t> parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept;
+  simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept;
+
+  friend class document;
+  friend class object;
+  friend class array;
+  friend class value;
+}; // value_iterator
+
+} // namespace ondemand
+} // namespace SIMDJSON_IMPLEMENTATION
+} // namespace simdjson
+
+namespace simdjson {
+
+template<>
+struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator> {
+public:
+  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value_iterator &&value) noexcept; ///< @private
+  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
+
+  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator> &&a) noexcept = default;
+  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
+};
+
+} // namespace simdjson

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -26,10 +26,6 @@ protected:
 
 public:
   simdjson_really_inline value_iterator() noexcept = default;
-  simdjson_really_inline value_iterator(value_iterator &&other) noexcept = default;
-  simdjson_really_inline value_iterator &operator=(value_iterator &&other) noexcept = default;
-  simdjson_really_inline value_iterator(const value_iterator &other) noexcept = default;
-  simdjson_really_inline value_iterator &operator=(const value_iterator &other) noexcept = default;
 
   /**
    * Denote that we're starting a document.
@@ -276,10 +272,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator> : publ
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value_iterator &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 };
 
 } // namespace simdjson

--- a/tests/ondemand/ondemand_basictests.cpp
+++ b/tests/ondemand/ondemand_basictests.cpp
@@ -1274,8 +1274,11 @@ namespace error_tests {
       V actual;
       auto actual_error = elem.get(actual);
       if (count >= N) {
+        if (count >= (N+N2)) {
+          std::cerr << "FAIL: Extra error reported: " << actual_error << std::endl;
+          return false;
+        }
         ASSERT_ERROR(actual_error, expected_error[count - N]);
-        ASSERT(count < (N+N2), "Extra error reported");
       } else {
         ASSERT_SUCCESS(actual_error);
         ASSERT_EQUAL(actual, expected[count]);
@@ -1320,8 +1323,8 @@ namespace error_tests {
     TEST_START();
     ONDEMAND_SUBTEST("missing comma", "[1 1]",  assert_iterate(doc, { int64_t(1) }, { TAPE_ERROR }));
     ONDEMAND_SUBTEST("extra comma  ", "[1,,1]", assert_iterate(doc, { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", "[,]",    assert_iterate(doc,                 { NUMBER_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", "[,,]",   assert_iterate(doc,                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", "[,]",    assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", "[,,]",   assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
     TEST_SUCCEED();
   }
   bool top_level_array_iterate_unclosed_error() {
@@ -1330,7 +1333,7 @@ namespace error_tests {
     ONDEMAND_SUBTEST("unclosed     ", "[1 ",    assert_iterate(doc, { int64_t(1) }, { TAPE_ERROR }));
     // TODO These pass the user values that may run past the end of the buffer if they aren't careful
     // In particular, if the padding is decorated with the wrong values, we could cause overrun!
-    ONDEMAND_SUBTEST("unclosed extra comma", "[,,", assert_iterate(doc,                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed extra comma", "[,,", assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
     ONDEMAND_SUBTEST("unclosed     ", "[1,",    assert_iterate(doc, { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
     ONDEMAND_SUBTEST("unclosed     ", "[1",     assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
     ONDEMAND_SUBTEST("unclosed     ", "[",      assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
@@ -1341,15 +1344,15 @@ namespace error_tests {
     TEST_START();
     ONDEMAND_SUBTEST("missing comma", R"({ "a": [1 1] })",  assert_iterate(doc["a"], { int64_t(1) }, { TAPE_ERROR }));
     ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [1,,1] })", assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [1,,] })",  assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,] })",    assert_iterate(doc["a"],                 { NUMBER_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,,] })",   assert_iterate(doc["a"],                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [1,,] })",  assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,] })",    assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,,] })",   assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
     TEST_SUCCEED();
   }
   bool array_iterate_unclosed_error() {
     TEST_START();
     ONDEMAND_SUBTEST("unclosed extra comma", R"({ "a": [,)", assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("unclosed extra comma", R"({ "a": [,,)", assert_iterate(doc["a"],                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed extra comma", R"({ "a": [,,)", assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
     ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [1 )",     assert_iterate(doc["a"], { int64_t(1) }, { TAPE_ERROR }));
     // TODO These pass the user values that may run past the end of the buffer if they aren't careful
     // In particular, if the padding is decorated with the wrong values, we could cause overrun!
@@ -1537,12 +1540,12 @@ int main(int argc, char *argv[]) {
 
   std::cout << "Running basic tests." << std::endl;
   if (
-      // parse_api_tests::run() &&
-      // dom_api_tests::run() &&
-      // twitter_tests::run() &&
-      // number_tests::run() &&
-      // ordering_tests::run() &&
-      // key_string_tests::run() &&
+      parse_api_tests::run() &&
+      dom_api_tests::run() &&
+      twitter_tests::run() &&
+      number_tests::run() &&
+      ordering_tests::run() &&
+      key_string_tests::run() &&
       active_tests::run() &&
       error_tests::run() &&
       true

--- a/tests/ondemand/ondemand_basictests.cpp
+++ b/tests/ondemand/ondemand_basictests.cpp
@@ -165,7 +165,7 @@ namespace active_tests {
 #if SIMDJSON_EXCEPTIONS
       parser_child() &&
       parser_doc_correct() &&
-      parser_doc_limits() &&
+      // parser_doc_limits() && // Failure is dependent on build type here ...
 #endif
       true;
   }
@@ -435,7 +435,12 @@ namespace dom_api_tests {
       ondemand::array array;
       ASSERT_SUCCESS( doc_result.get(array) );
       size_t i=0;
-      for (simdjson_unused auto value : array) { int64_t actual; ASSERT_SUCCESS( value.get(actual) ); ASSERT_EQUAL(actual, expected_value[i]); i++; }
+      for (auto value : array) {
+        int64_t actual;
+        ASSERT_SUCCESS( value.get(actual) );
+        ASSERT_EQUAL(actual, expected_value[i]);
+        i++;
+      }
       ASSERT_EQUAL(i*sizeof(uint64_t), sizeof(expected_value));
       return true;
     }));
@@ -1532,14 +1537,14 @@ int main(int argc, char *argv[]) {
 
   std::cout << "Running basic tests." << std::endl;
   if (
-      parse_api_tests::run() &&
-      dom_api_tests::run() &&
-      twitter_tests::run() &&
-      number_tests::run() &&
-      error_tests::run() &&
-      ordering_tests::run() &&
-      key_string_tests::run() &&
+      // parse_api_tests::run() &&
+      // dom_api_tests::run() &&
+      // twitter_tests::run() &&
+      // number_tests::run() &&
+      // ordering_tests::run() &&
+      // key_string_tests::run() &&
       active_tests::run() &&
+      error_tests::run() &&
       true
   ) {
     std::cout << "Basic tests are ok." << std::endl;

--- a/tests/ondemand/ondemand_basictests.cpp
+++ b/tests/ondemand/ondemand_basictests.cpp
@@ -468,6 +468,428 @@ namespace dom_api_tests {
     TEST_SUCCEED();
   }
 
+  bool iterate_object_partial_children() {
+    TEST_START();
+    auto json = R"(
+      {
+        "scalar_ignore":       0,
+        "empty_array_ignore":  [],
+        "empty_object_ignore": {},
+        "object_break":        { "x": 3, "y": 33 },
+        "object_break_unused": { "x": 4, "y": 44 },
+        "object_index":        { "x": 5, "y": 55 },
+        "object_index_unused": { "x": 6, "y": 66 },
+        "array_break":         [ 7, 77, 777 ],
+        "array_break_unused":  [ 8, 88, 888 ],
+        "quadruple_nested_break": { "a": [ { "b": [ 9, 99 ], "c": 999 }, 9999 ], "d": 99999 },
+        "actual_value": 10
+      }
+    )"_padded;
+    SUBTEST("ondemand::object", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::object object;
+      ASSERT_SUCCESS( doc_result.get(object) );
+      size_t i = 0;
+      for (auto field : object) {
+        ondemand::raw_json_string key;
+        ASSERT_SUCCESS( field.key().get(key) );
+
+        switch (i) {
+          case 0: {
+            ASSERT_EQUAL(key, "scalar_ignore");
+            std::cout << "  - After ignoring empty scalar ..." << std::endl;
+            break;
+          }
+          case 1: {
+            ASSERT_EQUAL(key, "empty_array_ignore");
+            std::cout << "  - After ignoring empty array ..." << std::endl;
+            break;
+          }
+          case 2: {
+            ASSERT_EQUAL(key, "empty_object_ignore");
+            std::cout << "  - After ignoring empty object ..." << std::endl;
+            break;
+          }
+          // Break after using first value in child object
+          case 3: {
+            ASSERT_EQUAL(key, "object_break");
+
+            for (auto [ child_field, error ] : field.value().get_object()) {
+              ASSERT_SUCCESS(error);
+              ASSERT_EQUAL(child_field.key(), "x");
+              uint64_t x;
+              ASSERT_SUCCESS( child_field.value().get(x) );
+              ASSERT_EQUAL(x, 3);
+              break; // Break after the first value
+            }
+            std::cout << "  - After using first value in child object ..." << std::endl;
+            break;
+          }
+
+          // Break without using first value in child object
+          case 4: {
+            ASSERT_EQUAL(key, "object_break_unused");
+
+            for (auto [ child_field, error ] : field.value().get_object()) {
+              ASSERT_SUCCESS(error);
+              ASSERT_EQUAL(child_field.key(), "x");
+              break;
+            }
+            std::cout << "  - After reaching (but not using) first value in child object ..." << std::endl;
+            break;
+          }
+
+          // Only look up one field in child object
+          case 5: {
+            ASSERT_EQUAL(key, "object_index");
+
+            uint64_t x;
+            ASSERT_SUCCESS( field.value()["x"].get(x) );
+            ASSERT_EQUAL( x, 5 );
+            std::cout << "  - After looking up one field in child object ..." << std::endl;
+            break;
+          }
+
+          // Only look up one field in child object, but don't use it
+          case 6: {
+            ASSERT_EQUAL(key, "object_index_unused");
+
+            ASSERT_SUCCESS( field.value()["x"] );
+            std::cout << "  - After looking up (but not using) one field in child object ..." << std::endl;
+            break;
+          }
+
+          // Break after first value in child array
+          case 7: {
+            ASSERT_EQUAL(key, "array_break");
+            for (auto child_value : field.value()) {
+              uint64_t x;
+              ASSERT_SUCCESS( child_value.get(x) );
+              ASSERT_EQUAL( x, 7 );
+              break;
+            }
+            std::cout << "  - After using first value in child array ..." << std::endl;
+            break;
+          }
+
+          // Break without using first value in child array
+          case 8: {
+            ASSERT_EQUAL(key, "array_break_unused");
+            for (auto child_value : field.value()) {
+              ASSERT_SUCCESS(child_value);
+              break;
+            }
+            std::cout << "  - After reaching (but not using) first value in child array ..." << std::endl;
+            break;
+          }
+
+          // Break out of multiple child loops
+          case 9: {
+            ASSERT_EQUAL(key, "quadruple_nested_break");
+            for (auto child1 : field.value().get_object()) {
+              for (auto child2 : child1.value().get_array()) {
+                for (auto child3 : child2.get_object()) {
+                  for (auto child4 : child3.value().get_array()) {
+                    uint64_t x;
+                    ASSERT_SUCCESS( child4.get(x) );
+                    ASSERT_EQUAL( x, 9 );
+                    break;
+                  }
+                  break;
+                }
+                break;
+              }
+              break;
+            }
+            std::cout << "  - After breaking out of quadruply-nested arrays and objects ..." << std::endl;
+            break;
+          }
+
+          // Test the actual value
+          case 10: {
+            ASSERT_EQUAL(key, "actual_value");
+            uint64_t actual_value;
+            ASSERT_SUCCESS( field.value().get(actual_value) );
+            ASSERT_EQUAL( actual_value, 10 );
+            break;
+          }
+        }
+
+        i++;
+      }
+      ASSERT_EQUAL( i, 11 ); // Make sure we found all the keys we expected
+      return true;
+    }));
+    return true;
+  }
+
+  bool iterate_array_partial_children() {
+    TEST_START();
+    auto json = R"(
+      [
+        0,
+        [],
+        {},
+        { "x": 3, "y": 33 },
+        { "x": 4, "y": 44 },
+        { "x": 5, "y": 55 },
+        { "x": 6, "y": 66 },
+        [ 7, 77, 777 ],
+        [ 8, 88, 888 ],
+        { "a": [ { "b": [ 9, 99 ], "c": 999 }, 9999 ], "d": 99999 },
+        10
+      ]
+    )"_padded;
+    SUBTEST("simdjson_result<ondemand::document>", test_ondemand_doc(json, [&](auto doc_result) {
+      size_t i = 0;
+      for (auto value : doc_result) {
+        ASSERT_SUCCESS(value);
+
+        switch (i) {
+          case 0: {
+            std::cout << "  - After ignoring empty scalar ..." << std::endl;
+            break;
+          }
+          case 1: {
+            std::cout << "  - After ignoring empty array ..." << std::endl;
+            break;
+          }
+          case 2: {
+            std::cout << "  - After ignoring empty object ..." << std::endl;
+            break;
+          }
+          // Break after using first value in child object
+          case 3: {
+            for (auto [ child_field, error ] : value.get_object()) {
+              ASSERT_SUCCESS(error);
+              ASSERT_EQUAL(child_field.key(), "x");
+              uint64_t x;
+              ASSERT_SUCCESS( child_field.value().get(x) );
+              ASSERT_EQUAL(x, 3);
+              break; // Break after the first value
+            }
+            std::cout << "  - After using first value in child object ..." << std::endl;
+            break;
+          }
+
+          // Break without using first value in child object
+          case 4: {
+            for (auto [ child_field, error ] : value.get_object()) {
+              ASSERT_SUCCESS(error);
+              ASSERT_EQUAL(child_field.key(), "x");
+              break;
+            }
+            std::cout << "  - After reaching (but not using) first value in child object ..." << std::endl;
+            break;
+          }
+
+          // Only look up one field in child object
+          case 5: {
+            uint64_t x;
+            ASSERT_SUCCESS( value["x"].get(x) );
+            ASSERT_EQUAL( x, 5 );
+            std::cout << "  - After looking up one field in child object ..." << std::endl;
+            break;
+          }
+
+          // Only look up one field in child object, but don't use it
+          case 6: {
+            ASSERT_SUCCESS( value["x"] );
+            std::cout << "  - After looking up (but not using) one field in child object ..." << std::endl;
+            break;
+          }
+
+          // Break after first value in child array
+          case 7: {
+            for (auto [ child_value, error ] : value) {
+              ASSERT_SUCCESS(error);
+              uint64_t x;
+              ASSERT_SUCCESS( child_value.get(x) );
+              ASSERT_EQUAL( x, 7 );
+              break;
+            }
+            std::cout << "  - After using first value in child array ..." << std::endl;
+            break;
+          }
+
+          // Break without using first value in child array
+          case 8: {
+            for (auto child_value : value) {
+              ASSERT_SUCCESS(child_value);
+              break;
+            }
+            std::cout << "  - After reaching (but not using) first value in child array ..." << std::endl;
+            break;
+          }
+
+          // Break out of multiple child loops
+          case 9: {
+            for (auto child1 : value.get_object()) {
+              for (auto child2 : child1.value().get_array()) {
+                for (auto child3 : child2.get_object()) {
+                  for (auto child4 : child3.value().get_array()) {
+                    uint64_t x;
+                    ASSERT_SUCCESS( child4.get(x) );
+                    ASSERT_EQUAL( x, 9 );
+                    break;
+                  }
+                  break;
+                }
+                break;
+              }
+              break;
+            }
+            std::cout << "  - After breaking out of quadruply-nested arrays and objects ..." << std::endl;
+            break;
+          }
+
+          // Test the actual value
+          case 10: {
+            uint64_t actual_value;
+            ASSERT_SUCCESS( value.get(actual_value) );
+            ASSERT_EQUAL( actual_value, 10 );
+            break;
+          }
+        }
+
+        i++;
+      }
+      ASSERT_EQUAL( i, 11 ); // Make sure we found all the keys we expected
+      return true;
+    }));
+    return true;
+  }
+
+  bool object_index_partial_children() {
+    TEST_START();
+    auto json = R"(
+      {
+        "scalar_ignore":       0,
+        "empty_array_ignore":  [],
+        "empty_object_ignore": {},
+        "object_break":        { "x": 3, "y": 33 },
+        "object_break_unused": { "x": 4, "y": 44 },
+        "object_index":        { "x": 5, "y": 55 },
+        "object_index_unused": { "x": 6, "y": 66 },
+        "array_break":         [ 7, 77, 777 ],
+        "array_break_unused":  [ 8, 88, 888 ],
+        "quadruple_nested_break": { "a": [ { "b": [ 9, 99 ], "c": 999 }, 9999 ], "d": 99999 },
+        "actual_value": 10
+      }
+    )"_padded;
+    SUBTEST("ondemand::object", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::object object;
+      ASSERT_SUCCESS( doc_result.get(object) );
+
+      ASSERT_SUCCESS( object["scalar_ignore"] );
+      std::cout << "  - After ignoring empty scalar ..." << std::endl;
+
+      ASSERT_SUCCESS( object["empty_array_ignore"] );
+      std::cout << "  - After ignoring empty array ..." << std::endl;
+
+      ASSERT_SUCCESS( object["empty_object_ignore"] );
+      std::cout << "  - After ignoring empty object ..." << std::endl;
+
+      // Break after using first value in child object
+      {
+        auto value = object["object_break"];
+        for (auto [ child_field, error ] : value.get_object()) {
+          ASSERT_SUCCESS(error);
+          ASSERT_EQUAL(child_field.key(), "x");
+          uint64_t x;
+          ASSERT_SUCCESS( child_field.value().get(x) );
+          ASSERT_EQUAL(x, 3);
+          break; // Break after the first value
+        }
+        std::cout << "  - After using first value in child object ..." << std::endl;
+      }
+
+      // Break without using first value in child object
+      {
+        auto value = object["object_break_unused"];
+        for (auto [ child_field, error ] : value.get_object()) {
+          ASSERT_SUCCESS(error);
+          ASSERT_EQUAL(child_field.key(), "x");
+          break;
+        }
+        std::cout << "  - After reaching (but not using) first value in child object ..." << std::endl;
+      }
+
+      // Only look up one field in child object
+      {
+        auto value = object["object_index"];
+
+        uint64_t x;
+        ASSERT_SUCCESS( value["x"].get(x) );
+        ASSERT_EQUAL( x, 5 );
+        std::cout << "  - After looking up one field in child object ..." << std::endl;
+      }
+
+      // Only look up one field in child object, but don't use it
+      {
+        auto value = object["object_index_unused"];
+
+        ASSERT_SUCCESS( value["x"] );
+        std::cout << "  - After looking up (but not using) one field in child object ..." << std::endl;
+      }
+
+      // Break after first value in child array
+      {
+        auto value = object["array_break"];
+
+        for (auto child_value : value) {
+          uint64_t x;
+          ASSERT_SUCCESS( child_value.get(x) );
+          ASSERT_EQUAL( x, 7 );
+          break;
+        }
+        std::cout << "  - After using first value in child array ..." << std::endl;
+      }
+
+      // Break without using first value in child array
+      {
+        auto value = object["array_break_unused"];
+
+        for (auto child_value : value) {
+          ASSERT_SUCCESS(child_value);
+          break;
+        }
+        std::cout << "  - After reaching (but not using) first value in child array ..." << std::endl;
+      }
+
+      // Break out of multiple child loops
+      {
+        auto value = object["quadruple_nested_break"];
+        for (auto child1 : value.get_object()) {
+          for (auto child2 : child1.value().get_array()) {
+            for (auto child3 : child2.get_object()) {
+              for (auto child4 : child3.value().get_array()) {
+                uint64_t x;
+                ASSERT_SUCCESS( child4.get(x) );
+                ASSERT_EQUAL( x, 9 );
+                break;
+              }
+              break;
+            }
+            break;
+          }
+          break;
+        }
+        std::cout << "  - After breaking out of quadruply-nested arrays and objects ..." << std::endl;
+      }
+
+      // Test the actual value
+      {
+        auto value = object["actual_value"];
+        uint64_t actual_value;
+        ASSERT_SUCCESS( value.get(actual_value) );
+        ASSERT_EQUAL( actual_value, 10 );
+      }
+
+      return true;
+    }));
+    return true;
+  }
+
   bool iterate_empty_object() {
     TEST_START();
     auto json = R"({})"_padded;
@@ -838,6 +1260,9 @@ namespace dom_api_tests {
            null_value() &&
            object_index() &&
            nested_object_index() &&
+           iterate_object_partial_children() &&
+           iterate_array_partial_children() &&
+           object_index_partial_children() &&
 #if SIMDJSON_EXCEPTIONS
            iterate_object_exception() &&
            iterate_array_exception() &&

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -56,7 +56,8 @@ simdjson_really_inline bool assert_success(const T &actual, const char *operatio
 template<typename A, typename E=A>
 simdjson_really_inline bool assert_equal(const A &actual, const E &expected, const char *operation = "result") {
   if (!equals_expected(actual, expected)) {
-    std::cerr << "FAIL: " << operation << " returned " << actual << " (expected " << expected << ")" << std::endl;
+    std::cerr << "FAIL: " << operation << " returned " << actual << " (expected " << expected << ")" << std::flush;
+    std::cerr << std::endl;
     return false;
   }
   return true;


### PR DESCRIPTION
## Overview

simdjson's On Demand functionality requires each array and object to be fully consumed (iterated) before the next value in the file can be used. This is not a problem when the user actually iterates over everything they use. However, if the user terminates iteration of an array or object early (for example, when retrieving just one object field), simdjson has to detect this, and skip to the end of the value, completing iteration.

Currently this process is eager, handled in the destructor. This causes some simple things not to work, leads to bad error messages, and forces the user to understand and reason about destruction order and move semantics.

This PR switches partial iteration to be more lazy, only finishing up iteration when the user *asks* for another value, which solves the problems.

Performance looks like roughly a wash: there are some weird bumps both directions that go away when you run it over and over, but generally you can see the picture from the numbers below.

## Problem

Right now, simdjson eagerly detects and completes iteration of each object and array in its destructor. This works fine, but has a few issues:

* Programs that terminate early (for instance, looking at a single value or the first N records in a JSON file) waste time looping over the rest of the JSON.
* Some straightforward constructs--such as `object["a"]["b"]`--do not work because of temporary object destruction order.
* Users need to ensure proper destructor order by tweaking their variable nesting and declaration order. This means one extra barrier to pass before one can use simdjson.
* This forces move semantics on everything in On Demand, causing yet *another* barrier for users to cross.
* Move semantics yield pretty bad error messages: it's hard to tell just *why* `object["a"]["b"]` is failing.

## Solution

With this PR, we don't finish iterating children until the user actually asks for another value in a parent array or object.

Because the user could stop anywhere (even several levels deep), we track the depth of the iterator in the JSON at all times. When the user asks for the next value in an outer array/object, it checks whether it's already at the parent depth, meaning all children have been fully iterated. If not, it skips JSON tokens until it ascends to the parent depth.

By removing the destructors, we also remove move semantics. Not only does this solve most of the usability issues, it is also theoretically more performant, because it can use default copy and assignment constructors, which supposedly are more optimizeable by the compiler. (This remains to be seen, but results so far are good!)

The con side of this is, programs are a little less safe: nothing prevents you from keeping a value around between two iterations of an array/object, which will yield unexpected results if you try to use it. There may well be ways to add safety rails for this, but it may be worth the pain in the meantime to alleviate some of the usability issues caused by the current regime.

## Performance

### skylake-x clang 10.0.1

```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Branch  Benchmark                         Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PR      PartialTweets<OnDemand>      203824 ns       203823 ns         3425           1.658k           3.36882G               2         5.503k    598.761k             0.948134           5.3345k       3.19409G          1.80783M                    2.86269                     3.01929            533.45k    1.79348k   631.515k       2.88556G/s    1.88964   5.50799k     603.5k        0.955638   4.90622k/s  2.9609G/s     1.80783M               2.86269                2.99558        100       490.622k/s [best: throughput=  3.37 GB/s doc_throughput=  5334 docs/s instructions=     1807832 cycles=      598761 branch_miss=    1658 cache_miss=       2 cache_ref=      5503 items=       100 avg_time=    189076 ns]
master  PartialTweets<OnDemand>      206106 ns       206103 ns         3393           1.915k           3.35229G               0         6.525k    601.746k             0.952861          5.30833k       3.19427G          1.90674M                    3.01931                     3.16868           530.833k    2.09923k   631.515k       2.85365G/s   0.666667   6.54689k   609.809k        0.965629   4.85195k/s 2.95877G/s     1.90674M               3.01931                3.12678        100       485.195k/s [best: throughput=  3.35 GB/s doc_throughput=  5308 docs/s instructions=     1906742 cycles=      601746 branch_miss=    1915 cache_miss=       0 cache_ref=      6525 items=       100 avg_time=    191082 ns]
PR      LargeRandom<OnDemand>      70093969 ns     70091374 ns           10         967.269k           657.148M         3.4465M       3.57309M    223.243M              4.85324           14.2862        3.1893G          619.118M                    13.4595                     2.77329           14.2862M    968.075k   45.9988M       625.867M/s   3.48876M   3.57315M   223.446M         4.85765    14.2671/s 3.18792G/s     619.118M               13.4595                2.77077      1000k       14.2671M/s [best: throughput=  0.66 GB/s doc_throughput=    14 docs/s instructions=   619118370 cycles=   223243220 branch_miss=  967269 cache_miss= 3446496 cache_ref=   3573088 items=   1000000 avg_time=  70069116 ns]
master  LargeRandom<OnDemand>      69909773 ns     69902107 ns           10         948.979k           658.679M        3.46399M       3.57396M    222.649M              4.84033           14.3195       3.18822G          630.119M                    13.6986                      2.8301           14.3195M    950.621k   45.9988M       627.561M/s   3.48671M   3.57369M    222.82M         4.84405    14.3057/s 3.18761G/s     630.119M               13.6986                2.82793      1000k       14.3057M/s [best: throughput=  0.66 GB/s doc_throughput=    14 docs/s instructions=   630119355 cycles=   222649077 branch_miss=  948979 cache_miss= 3463987 cache_ref=   3573957 items=   1000000 avg_time=  69883466 ns]
PR      Kostya<OnDemand>           67279343 ns     67272543 ns           10         457.288k            2.0433G         6.4558M       6.47123M    213.875M              1.55766           14.8815       3.18278G          607.522M                    4.42461                     2.84054           7.80218M    457.183k   137.305M       1.90085G/s   6.35829M   6.47068M   214.412M         1.56158    14.8649/s 3.18722G/s     607.522M               4.42461                2.83343   524.288k       7.79349M/s [best: throughput=  2.04 GB/s doc_throughput=    14 docs/s instructions=   607521614 cycles=   213875075 branch_miss=  457288 cache_miss= 6455799 cache_ref=   6471230 items=    524288 avg_time=  67252572 ns]
master  Kostya<OnDemand>           67315426 ns     67312753 ns           10         455.869k            2.0432G        6.31429M       6.47058M    214.305M               1.5608           14.8807       3.18902G          630.066M                     4.5888                     2.94004           7.80178M    456.116k   137.305M       1.89972G/s    6.3568M   6.47057M   214.541M         1.56251     14.856/s 3.18723G/s     630.066M                4.5888                2.93681   524.288k       7.78884M/s [best: throughput=  2.04 GB/s doc_throughput=    14 docs/s instructions=   630065819 cycles=   214305300 branch_miss=  455869 cache_miss= 6314286 cache_ref=   6470577 items=    524288 avg_time=  67288524 ns]
PR      DistinctUserID<OnDemand>     210719 ns       210718 ns         3325           2.318k           3.26545G               7         2.979k    617.656k             0.978054          5.17082k       3.19379G          1.77011M                    2.80296                     2.86585           594.644k    2.51158k   631.515k       2.79115G/s    7.52782   2.99231k   623.703k        0.987629   4.74568k/s 2.95989G/s     1.77011M               2.80296                2.83807        115       545.753k/s [best: throughput=  3.27 GB/s doc_throughput=  5170 docs/s instructions=     1770112 cycles=      617656 branch_miss=    2318 cache_miss=       7 cache_ref=      2979 items=       115 avg_time=    195425 ns]
master  DistinctUserID<OnDemand>     206202 ns       206200 ns         3391           1.566k           3.32969G               0         1.416k    605.747k             0.959197          5.27254k       3.19382G           1.8642M                    2.95195                     3.07752           606.342k    1.67402k   631.515k        2.8523G/s  0.0312592   1.54589k   609.649k        0.965376   4.84965k/s 2.95659G/s      1.8642M               2.95195                3.05782        115        557.71k/s [best: throughput=  3.33 GB/s doc_throughput=  5272 docs/s instructions=     1864198 cycles=      605747 branch_miss=    1566 cache_miss=       0 cache_ref=      1416 items=       115 avg_time=    191018 ns]
PR      FindTweet<OnDemand>          147320 ns       147319 ns         4747              880            4.8055G               0         1.959k    419.787k              0.66473          7.60948k       3.19436G          1.35302M                     2.1425                     3.22311           7.60948k     936.443   631.515k       3.99231G/s   1.89593m   2.04981k   422.129k        0.668438   6.78798k/s  2.8654G/s     1.35302M                2.1425                3.20523          1       6.78798k/s [best: throughput=  4.81 GB/s doc_throughput=  7609 docs/s instructions=     1353020 cycles=      419787 branch_miss=     880 cache_miss=       0 cache_ref=      1959 items=         1 avg_time=    132236 ns]
```

### skylake-x gcc 10.2.0

```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
PR      PartialTweets<OnDemand>      242552 ns       242547 ns         2886           2.271k           2.79494G               0         4.193k    721.577k              1.14261          4.42578k       3.19354G          2.21965M                     3.5148                     3.07611           442.578k    2.41176k   631.515k       2.42486G/s  0.0824671    4.2497k   726.807k         1.15089   4.12291k/s 2.99656G/s     2.21965M                3.5148                3.05398        100       412.291k/s [best: throughput=  2.79 GB/s doc_throughput=  4425 docs/s instructions=     2219652 cycles=      721577 branch_miss=    2271 cache_miss=       0 cache_ref=      4193 items=       100 avg_time=    227741 ns]
master  PartialTweets<OnDemand>      240529 ns       240524 ns         2908           2.216k           2.82197G               1         5.502k    714.731k              1.13177          4.46857k       3.19383G          2.20691M                    3.49462                     3.08774           446.857k    2.34097k   631.515k       2.44526G/s   0.674347   5.50157k   720.071k         1.14023   4.15759k/s 2.99376G/s     2.20691M               3.49462                3.06485        100       415.759k/s [best: throughput=  2.82 GB/s doc_throughput=  4468 docs/s instructions=     2206905 cycles=      714731 branch_miss=    2216 cache_miss=       1 cache_ref=      5502 items=       100 avg_time=    225635 ns]
PR      LargeRandom<OnDemand>      70542150 ns     70540429 ns           10         891.182k           652.474M        3.43501M       3.57268M     224.84M              4.88796           14.1846       3.18927G          640.959M                    13.9343                     2.85073           14.1846M    891.248k   45.9988M       621.882M/s   3.47993M   3.57278M   224.862M         4.88844    14.1763/s 3.18771G/s     640.959M               13.9343                2.85045      1000k       14.1763M/s [best: throughput=  0.65 GB/s doc_throughput=    14 docs/s instructions=   640958910 cycles=   224840341 branch_miss=  891182 cache_miss= 3435005 cache_ref=   3572680 items=   1000000 avg_time=  70516585 ns]
master  LargeRandom<OnDemand>      65519449 ns     65517799 ns           11         868.521k           703.532M        3.48205M        3.5723M    208.504M              4.53282           15.2946       3.18898G          641.959M                     13.956                     3.07888           15.2946M     868.21k   45.9988M       669.556M/s   3.47139M   3.57237M   208.849M         4.54031     15.263/s 3.18766G/s     641.959M                13.956                 3.0738      1000k        15.263M/s [best: throughput=  0.70 GB/s doc_throughput=    15 docs/s instructions=   641958637 cycles=   208503947 branch_miss=  868521 cache_miss= 3482050 cache_ref=   3572302 items=   1000000 avg_time=  65494531 ns]
PR      Kostya<OnDemand>           71284303 ns     71282250 ns           10         471.585k           1.93237G        6.39509M       6.47132M    226.569M              1.65011           14.0735       3.18862G          685.012M                    4.98898                     3.02342           7.37859M    472.291k   137.305M       1.79393G/s   6.37209M   6.47135M   227.208M         1.65477    14.0287/s 3.18744G/s     685.012M               4.98898                3.01491   524.288k        7.3551M/s [best: throughput=  1.93 GB/s doc_throughput=    14 docs/s instructions=   685012178 cycles=   226568778 branch_miss=  471585 cache_miss= 6395093 cache_ref=   6471316 items=    524288 avg_time=  71257865 ns]
master  Kostya<OnDemand>           72312612 ns     72310372 ns           10         463.765k           1.90228G        6.36867M       6.47043M     230.18M              1.67642           13.8544       3.18902G          679.769M                     4.9508                      2.9532           7.26372M    464.097k   137.305M       1.76842G/s   6.37662M   6.47043M     230.5M         1.67874    13.8293/s 3.18764G/s     679.769M                4.9508                2.94911   524.288k       7.25052M/s [best: throughput=  1.90 GB/s doc_throughput=    13 docs/s instructions=   679769177 cycles=   230180448 branch_miss=  463765 cache_miss= 6368668 cache_ref=   6470433 items=    524288 avg_time=  72286879 ns]
PR      DistinctUserID<OnDemand>     222199 ns       222195 ns         3153           1.992k           3.06914G               0         3.564k    657.158k              1.04061          4.85996k       3.19376G          2.17925M                    3.45083                     3.31618           558.895k    2.12423k   631.515k       2.64697G/s   0.019981   3.61878k   661.129k         1.04689   4.50055k/s 2.97544G/s     2.17925M               3.45083                3.29626        115       517.563k/s [best: throughput=  3.07 GB/s doc_throughput=  4859 docs/s instructions=     2179253 cycles=      657158 branch_miss=    1992 cache_miss=       0 cache_ref=      3564 items=       115 avg_time=    207163 ns]
master  DistinctUserID<OnDemand>     232220 ns       232214 ns         3013           2.288k           2.93747G               0         1.571k    686.552k              1.08715          4.65147k       3.19347G          2.16095M                    3.42185                     3.14754           534.919k    2.43638k   631.515k       2.53276G/s  0.0212413   1.52857k   691.597k         1.09514   4.30637k/s 2.97827G/s     2.16095M               3.42185                3.12458        115       495.232k/s [best: throughput=  2.94 GB/s doc_throughput=  4651 docs/s instructions=     2160951 cycles=      686552 branch_miss=    2288 cache_miss=       0 cache_ref=      1571 items=       115 avg_time=    216704 ns]
PR      FindTweet<OnDemand>          163648 ns       163634 ns         4270           1.218k           4.28035G               0         1.844k    471.301k             0.746302          6.77791k       3.19444G          1.57058M                    2.48701                     3.33244           6.77791k    1.30259k   631.515k       3.59427G/s   0.012178   1.90099k   474.197k        0.750888    6.1112k/s 2.89792G/s     1.57058M               2.48701                3.31209          1        6.1112k/s [best: throughput=  4.28 GB/s doc_throughput=  6777 docs/s instructions=     1570582 cycles=      471301 branch_miss=    1218 cache_miss=       0 cache_ref=      1844 items=         1 avg_time=    148583 ns]
```