### PR TITLE
[skip ci] Skip CI for Github

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -11,7 +11,10 @@ on:
     - cron: 23 */8 * * *
 
 jobs:
-  build:    
+  build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-latest
     env:
       # fuzzers that change behaviour with SIMDJSON_FORCE_IMPLEMENTATION

--- a/.github/workflows/mingw-ci.yml
+++ b/.github/workflows/mingw-ci.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   ci:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: windows-gcc
     runs-on: windows-2016
 

--- a/.github/workflows/mingw64-ci.yml
+++ b/.github/workflows/mingw64-ci.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
   ci:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: windows-gcc
     runs-on: windows-2016
 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   windows-mingw:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: ${{ matrix.msystem }}
     runs-on: windows-latest
     defaults:

--- a/.github/workflows/power-fuzz.yml
+++ b/.github/workflows/power-fuzz.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   armv7_job:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     # The host should always be Linux
     runs-on: ubuntu-20.04
     name: Build on ubuntu-20.04 ppc64le

--- a/.github/workflows/ubuntu18-checkperf.yml
+++ b/.github/workflows/ubuntu18-checkperf.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu18-threadsani.yml
+++ b/.github/workflows/ubuntu18-threadsani.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu20-checkperf.yml
+++ b/.github/workflows/ubuntu20-checkperf.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu20-threadsani.yml
+++ b/.github/workflows/ubuntu20-threadsani.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ci:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: windows-vs16
     runs-on: windows-latest
     steps:

--- a/.github/workflows/vs16-clang-ci.yml
+++ b/.github/workflows/vs16-clang-ci.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ci:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: windows-vs16
     runs-on: windows-latest
     steps:

--- a/.github/workflows/vs16-ninja-ci.yml
+++ b/.github/workflows/vs16-ninja-ci.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   ci:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     name: windows-vs16
     runs-on: windows-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,8 @@ Pull requests are always invited. However, we ask that you follow these guidelin
 - Changes should be focused and minimal. You should change as few lines of code as possible. Please do not reformat or touch files needlessly.
 - New features must be accompanied of new tests, in general.
 - Your code should pass our continuous-integration tests. It is your responsability to ensure that your proposal pass the tests. We do not merge pull requests that would break our build.
+   - An exception to this would be changes to non-code files, such as documentation and assets, or trivial changes to code, such as comments, where it is encouraged to explicitly ask for skipping a CI run using the `[skip ci]` prefix in your Pull Request title **and** in the first line of the most recent commit in a push. Example for such a commit: `[skip ci] Fixed typo in power_of_ten's docs`  
+   This benefits the project in such a way that the CI pipeline is not burdened by running jobs on changes that don't change any behavior in the code, which reduces wait times for other Pull Requests that do change behavior and require testing.
 
 If the benefits of your proposed code remain unclear, we may choose to discard your code: that is not an insult, we frequently discard our own code. We may also consider various alternatives and choose another path. Again, that is not an insult or a sign that you have wasted your time.
 


### PR DESCRIPTION
This will enable usage of `[skip ci]` and `[skip github]` for Github workflows and documents it in the contribution guidelines for changes that are not necessary to be tested in CI.

Fixes https://github.com/simdjson/simdjson/issues/1313