### PR TITLE
Fixing issue 1337

### DIFF
--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -117,7 +117,7 @@ use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
 #endif
 
 // Is threading enabled?
-#if defined(BOOST_HAS_THREADS) || defined(_REENTRANT) || defined(_MT)
+#if defined(_REENTRANT) || defined(_MT)
 #ifndef SIMDJSON_THREADS_ENABLED
 #define SIMDJSON_THREADS_ENABLED
 #endif

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -507,7 +507,6 @@ namespace document_stream_tests {
     }
     auto json = simdjson::padded_string(input,2049);
     simdjson::dom::parser parser;
-    parser.threaded = false;
     size_t count = 0;
     size_t window_size = 1024; // deliberately too small
     simdjson::dom::document_stream stream;

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -497,7 +497,6 @@ namespace document_stream_tests {
     return true;
   }
 
-#ifdef SIMDJSON_THREADS_ENABLED
   bool threaded_disabled() {
     std::cout << "Running " << __func__ << std::endl;
     char input[2049];
@@ -521,12 +520,11 @@ namespace document_stream_tests {
       count++;
     }
     if(count == 2) {
-      std::cerr << "Expected a capacity error " << std::endl;
+      std::cerr << "Expected a single document " << std::endl;
       return false;
     }
     return true;
   }
-#endif
 
   bool large_window() {
     std::cout << "Running " << __func__ << std::endl;


### PR DESCRIPTION
We will no longer enable threaded execution when BOOST_HAS_THREADS is defined since some users compile some of their code with BOOST_HAS_THREADS set and some with BOOST_HAS_THREADS unset.

Fixes https://github.com/simdjson/simdjson/issues/1337
