### PR TITLE
Safety: assert in debug mode when on demand values are used out of order

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,7 +19,7 @@ environment:
     - job_name: VS2017 (Static, No Threads)
       image: Visual Studio 2017
       CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_ENABLE_THREADS=OFF
-      CTEST_ARGS: -E checkperf
+      CTEST_ARGS: -LE explicitonly
     - job_name: VS2019 (Win32)
       platform: Win32
       CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_ENABLE_THREADS=ON # This should be the default. Testing anyway.
@@ -31,7 +31,7 @@ environment:
     - job_name: VS2015
       image: Visual Studio 2015
       CMAKE_ARGS:  -A %Platform% -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_ENABLE_THREADS=OFF
-      CTEST_ARGS: -E checkperf
+      CTEST_ARGS: -LE explicitonly
 
 build_script:
   - mkdir build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,13 +105,12 @@ commands:
           ctest $CTEST_FLAGS -L acceptance &&
           ctest $CTEST_FLAGS -LE acceptance -LE explicitonly
 
-  cmake_test:
+  cmake_assert_test:
     steps:
       - run: |
           cd build &&
           tools/json2json -h &&
-          ctest $CTEST_FLAGS -L assert  &&
-          ctest $CTEST_FLAGS -LE acceptance -LE explicitonly
+          ctest $CTEST_FLAGS -L assert
 
   cmake_test_all:
     steps:
@@ -155,12 +154,12 @@ jobs:
   assert-gcc10:
     description: Build the library with asserts on, install it and run tests
     executor: gcc10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DCXX_CMAKE_FLAGS_RELEASE=-O3 }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DCMAKE_CXX_FLAGS_RELEASE=-O3 }
     steps: [ cmake_test, cmake_assert_test ]
   assert-clang10:
     description: Build just the library, install it and do a basic test
     executor: clang10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DCXX_CMAKE_FLAGS_RELEASE=-O3 }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DCMAKE_CXX_FLAGS_RELEASE=-O3 }
     steps: [ cmake_test, cmake_assert_test ]
   gcc10-perftest:
     description: Build and run performance tests on GCC 10 and AVX 2 with a cmake static build, this test performance regression

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,15 @@ commands:
           cd build &&
           tools/json2json -h &&
           ctest $CTEST_FLAGS -L acceptance &&
-          ctest $CTEST_FLAGS -LE acceptance -E checkperf
+          ctest $CTEST_FLAGS -LE acceptance -LE explicitonly
+
+  cmake_test:
+    steps:
+      - run: |
+          cd build &&
+          tools/json2json -h &&
+          ctest $CTEST_FLAGS -L assert  &&
+          ctest $CTEST_FLAGS -LE acceptance -LE explicitonly
 
   cmake_test_all:
     steps:
@@ -112,9 +120,9 @@ commands:
           cd build &&
           tools/json2json -h &&
           ctest $CTEST_FLAGS -DSIMDJSON_IMPLEMENTATION="haswell;westmere;fallback" -L acceptance -LE per_implementation &&
-          SIMDJSON_FORCE_IMPLEMENTATION=haswell ctest $CTEST_FLAGS -L per_implementation -E checkperf &&
-          SIMDJSON_FORCE_IMPLEMENTATION=westmere ctest $CTEST_FLAGS -L per_implementation -E checkperf &&
-          SIMDJSON_FORCE_IMPLEMENTATION=fallback ctest $CTEST_FLAGS -L per_implementation -E checkperf &&
+          SIMDJSON_FORCE_IMPLEMENTATION=haswell ctest $CTEST_FLAGS -L per_implementation -LE explicitonly &&
+          SIMDJSON_FORCE_IMPLEMENTATION=westmere ctest $CTEST_FLAGS -L per_implementation -LE explicitonly &&
+          SIMDJSON_FORCE_IMPLEMENTATION=fallback ctest $CTEST_FLAGS -L per_implementation -LE explicitonly &&
           ctest $CTEST_FLAGS -LE "acceptance|per_implementation" # Everything we haven't run yet, run now.
 
 
@@ -144,6 +152,16 @@ jobs:
     executor: gcc10
     environment: { CMAKE_FLAGS: -DSIMDJSON_JUST_LIBRARY=ON }
     steps: [ cmake_build, cmake_install_test, cmake_installed_test_cxx20 ]
+  assert-gcc10:
+    description: Build the library with asserts on, install it and run tests
+    executor: gcc10
+    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DCXX_CMAKE_FLAGS_RELEASE=-O3 }
+    steps: [ cmake_test, cmake_assert_test ]
+  assert-clang10:
+    description: Build just the library, install it and do a basic test
+    executor: clang10
+    environment: { CMAKE_FLAGS: -DSIMDJSON_GOOGLE_BENCHMARKS=OFF -DCXX_CMAKE_FLAGS_RELEASE=-O3 }
+    steps: [ cmake_test, cmake_assert_test ]
   gcc10-perftest:
     description: Build and run performance tests on GCC 10 and AVX 2 with a cmake static build, this test performance regression
     executor: gcc10
@@ -174,22 +192,22 @@ jobs:
   sanitize-gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake sanitize build
     executor: gcc10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -LE explicitonly }
     steps: [ cmake_test ]
   sanitize-clang10:
     description: Build and run tests on clang 10 and AVX 2 with a cmake sanitize build
     executor: clang10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: --output-on-failure -LE explicitonly }
     steps: [ cmake_test ]
   threadsanitize-gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake sanitize build
     executor: gcc10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE_THREADS=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE_THREADS=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -LE explicitonly }
     steps: [ cmake_test ]
   threadsanitize-clang10:
     description: Build and run tests on clang 10 and AVX 2 with a cmake sanitize build
     executor: clang10
-    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE_THREADS=ON, CTEST_FLAGS: --output-on-failure -E checkperf }
+    environment: { CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE_THREADS=ON, CTEST_FLAGS: --output-on-failure -LE explicitonly }
     steps: [ cmake_test ]
   # dynamic
   dynamic-gcc10:
@@ -245,12 +263,12 @@ jobs:
   sanitize-haswell-gcc10:
     description: Build and run tests on GCC 10 and AVX 2 with a cmake sanitize build
     executor: gcc10
-    environment: {  CXXFLAGS: -march=haswell, CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -E checkperf }
+    environment: {  CXXFLAGS: -march=haswell, CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, BUILD_FLAGS: "", CTEST_FLAGS: --output-on-failure -LE explicitonly }
     steps: [ cmake_test ]
   sanitize-haswell-clang10:
     description: Build and run tests on clang 10 and AVX 2 with a cmake sanitize build
     executor: clang10
-    environment: { CXXFLAGS: -march=haswell, CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: --output-on-failure -E checkperf }
+    environment: { CXXFLAGS: -march=haswell, CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF -DSIMDJSON_SANITIZE=ON, CTEST_FLAGS: --output-on-failure -LE explicitonly }
     steps: [ cmake_test ]
 
 workflows:
@@ -291,5 +309,9 @@ workflows:
 
       # testing "just the library"
       - justlib-gcc10
+
+      # testing asserts
+      - assert-gcc10
+      - assert-clang10
 
       # TODO add windows: https://circleci.com/docs/2.0/configuration-reference/#windows

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,4 +23,4 @@ task:
     - make
   test_script:
     - cd build
-    - ctest --output-on-failure -E checkperf
+    - ctest --output-on-failure -LE explicitonly

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ steps:
     CXX: g++
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf 
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly 
   commands:
     - scripts/addcmakeppa.sh "$(env -i sh -c '. /etc/os-release; echo $VERSION_CODENAME')"
     - apt-get install -y g++ cmake gcc git
@@ -30,7 +30,7 @@ steps:
     CXX: clang++-6.0
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf 
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly 
   commands:
     - scripts/addcmakeppa.sh "$(env -i sh -c '. /etc/os-release; echo $VERSION_CODENAME')"
     - apt-get install -y clang++-6.0 cmake git
@@ -51,7 +51,7 @@ steps:
     CXX: g++
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_IMPLEMENTATION=haswell;westmere;fallback
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
     - apt-get update -qq
@@ -78,7 +78,7 @@ steps:
     CXX: clang++-6.0
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_IMPLEMENTATION=haswell;westmere;fallback
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - mkdir build
     - cd build
@@ -101,7 +101,7 @@ steps:
     CXX: g++
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
     - apt-get update -qq
@@ -124,7 +124,7 @@ steps:
     CXX: clang++-9
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF
     BUILD_FLAGS: -- -j
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - mkdir build
     - cd build
@@ -143,7 +143,7 @@ steps:
     CXX: g++
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_IMPLEMENTATION=haswell;westmere;fallback
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
     - apt-get update -qq
@@ -170,7 +170,7 @@ steps:
     CXX: clang++-9
     CMAKE_FLAGS: -DSIMDJSON_SANITIZE=ON -DSIMDJSON_IMPLEMENTATION=haswell;westmere;fallback
     BUILD_FLAGS: -- -j
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - mkdir build
     - cd build
@@ -194,7 +194,7 @@ steps:
     CXX: clang++-11
     CMAKE_FLAGS: -GNinja
     BUILD_FLAGS:
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
     CXXFLAGS: -std=c++20 -stdlib=libc++
   commands:
     - mkdir build
@@ -214,7 +214,7 @@ steps:
     CXX: g++
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_IMPLEMENTATION=arm64;fallback
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
     - apt-get update -qq
@@ -239,7 +239,7 @@ steps:
     CXX: clang++-6.0
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF
     BUILD_FLAGS: -- -j
-    CTEST_FLAGS: -j4 --output-on-failure  -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure  -LE explicitonly
   commands:
     - apt-get -qq update
     - apt-get -t buster-backports install -y cmake
@@ -261,7 +261,7 @@ steps:
     CXX: g++
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
     - apt-get update -qq
@@ -283,7 +283,7 @@ steps:
     CXX: clang++-6.0
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=OFF
     BUILD_FLAGS: -- -j
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - apt-get -qq update
     - apt-get -t buster-backports install -y cmake
@@ -303,7 +303,7 @@ steps:
   environment:
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_IMPLEMENTATION=arm64;fallback
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
     CC: gcc
     CXX: g++
   commands:
@@ -331,7 +331,7 @@ steps:
     CXX: clang++-6.0
     CMAKE_FLAGS: -DSIMDJSON_SANITIZE=ON -DSIMDJSON_IMPLEMENTATION=arm64;fallback
     BUILD_FLAGS: -- -j
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - apt-get -qq update
     - apt-get -t buster-backports install -y cmake
@@ -357,7 +357,7 @@ steps:
     CXX: clang++-9
     BUILD_FLAGS: -- -j 4
     CMAKE_FLAGS: -GNinja -DSIMDJSON_BUILD_STATIC=ON
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
     CXXFLAGS: -stdlib=libc++
   commands:
     - mkdir build
@@ -378,7 +378,7 @@ steps:
     CXX: clang++-9
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
     CXXFLAGS: -stdlib=libc++
   commands:
     - mkdir build
@@ -399,7 +399,7 @@ steps:
     CXX: clang++-7
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_BUILD_STATIC=ON
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
     CXXFLAGS: -stdlib=libc++
   commands:
     - mkdir build
@@ -419,7 +419,7 @@ steps:
     CXX: g++
     BUILD_FLAGS: -- -j
     CMAKE_FLAGS: -DSIMDJSON_EXCEPTIONS=OFF
-    CTEST_FLAGS: -j4 --output-on-failure -E checkperf
+    CTEST_FLAGS: -j4 --output-on-failure -LE explicitonly
   commands:
     - echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
     - apt-get update -qq

--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -34,4 +34,4 @@ jobs:
           ./alpine.sh cmake --build build_for_alpine
       - name: test
         run: |
-          ./alpine.sh bash -c "cd build_for_alpine && ctest  -E checkperf"
+          ./alpine.sh bash -c "cd build_for_alpine && ctest  -LE explicitonly"

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -51,4 +51,4 @@ jobs:
           cd build
           cmake -DCMAKE_BUILD_TYPE=${{ matrix.type }} -DSIMDJSON_BUILD_STATIC=ON -DSIMDJSON_DO_NOT_USE_THREADS_NO_MATTER_WHAT=ON ..
           cmake --build . --verbose
-          ctest -j4 --output-on-failure -E checkperf
+          ctest -j4 --output-on-failure -LE explicitonly

--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -23,6 +23,6 @@ jobs:
           cd build &&
           cmake  -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DSIMDJSON_BUILD_STATIC=ON -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
           cmake --build .   &&
-          ctest -j --output-on-failure -E checkperf   &&
+          ctest -j --output-on-failure -LE explicitonly   &&
           make install  &&
           echo -e '#include <simdjson.h>\nint main(int argc,char**argv) {simdjson::dom::parser parser;simdjson::dom::element tweets = parser.load(argv[1]); }' > tmp.cpp && c++ -Idestination/include -Ldestination/lib -std=c++17 -Wl,-rpath,destination/lib -o linkandrun tmp.cpp -lsimdjson && ./linkandrun jsonexamples/twitter.json

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -23,6 +23,6 @@ jobs:
           cd build &&
           cmake  -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DSIMDJSON_BUILD_STATIC=ON -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
           cmake --build .   &&
-          ctest -j --output-on-failure -E checkperf   &&
+          ctest -j --output-on-failure -LE explicitonly   &&
           make install  &&
           echo -e '#include <simdjson.h>\nint main(int argc,char**argv) {simdjson::dom::parser parser;simdjson::dom::element tweets = parser.load(argv[1]); }' > tmp.cpp && c++ -Idestination/include -Ldestination/lib -std=c++17 -Wl,-rpath,destination/lib -o linkandrun tmp.cpp -lsimdjson && ./linkandrun jsonexamples/twitter.json

--- a/.github/workflows/vs16-ci.yml
+++ b/.github/workflows/vs16-ci.yml
@@ -31,6 +31,6 @@ jobs:
         buildWithCMakeArgs: --config Release  
         
     - name: 'Run CTest'
-      run: ctest -C Release  -E checkperf  --output-on-failure 
+      run: ctest -C Release  -LE explicitonly  --output-on-failure 
       working-directory: "${{ github.workspace }}/../../_temp/windows"
   

--- a/.github/workflows/vs16-clang-ci.yml
+++ b/.github/workflows/vs16-clang-ci.yml
@@ -31,5 +31,5 @@ jobs:
         buildWithCMakeArgs: --config Release  
         
     - name: 'Run CTest'
-      run: ctest -C Release -E checkperf  --output-on-failure 
+      run: ctest -C Release -LE explicitonly  --output-on-failure 
       working-directory: "${{ github.workspace }}/../../_temp/windows"

--- a/.github/workflows/vs16-ninja-ci.yml
+++ b/.github/workflows/vs16-ninja-ci.yml
@@ -31,6 +31,6 @@ jobs:
         buildWithCMakeArgs: --config Release  
         
     - name: 'Run CTest'
-      run: ctest -C Release  -E checkperf  --output-on-failure 
+      run: ctest -C Release  -LE explicitonly  --output-on-failure 
       working-directory: "${{ github.workspace }}/../../_temp/windows"
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -176,7 +176,7 @@ install:
   - if [[ "${STATIC}" == "on" ]]; then
       export CMAKE_FLAGS="${CMAKE_FLAGS} -DSIMDJSON_BUILD_STATIC=ON";
     fi
-  - export CTEST_FLAGS="-j4 --output-on-failure -E checkperf"
+  - export CTEST_FLAGS="-j4 --output-on-failure -LE explicitonly"
 
 script:
   - mkdir build

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@
 #
 # Next you can test it as follows:
 #
-# docker run -it -v $(pwd):/project:Z   simdjson sh -c "cd dockerbuild && ctest . --output-on-failure -E checkperf"
+# docker run -it -v $(pwd):/project:Z   simdjson sh -c "cd dockerbuild && ctest . --output-on-failure -LE explicitonly"
 #
 # The run the complete tests requires you to have built all of simdjson.
 #

--- a/benchmark/checkperf.cmake
+++ b/benchmark/checkperf.cmake
@@ -89,7 +89,7 @@ if (Git_FOUND AND (GIT_VERSION_STRING VERSION_GREATER  "2.1.4") AND (NOT CMAKE_G
     # COMMAND ECHO $<TARGET_FILE:perfdiff> \"$<TARGET_FILE:parse> -t ${SIMDJSON_CHECKPERF_ARGS}\" \"${CHECKPERF_PARSE} -t ${SIMDJSON_CHECKPERF_ARGS}\" }
     COMMAND $<TARGET_FILE:perfdiff> $<TARGET_FILE:parse> ${CHECKPERF_PARSE} -H -t ${SIMDJSON_CHECKPERF_ARGS}
   )
-  set_property(TEST checkperf APPEND PROPERTY LABELS per_implementation)
+  set_property(TEST checkperf APPEND PROPERTY LABELS per_implementation explicitonly)
   set_property(TEST checkperf APPEND PROPERTY DEPENDS parse perfdiff ${SIMDJSON_USER_CMAKECACHE})
   set_property(TEST checkperf PROPERTY RUN_SERIAL TRUE)
 else()

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -72,24 +72,24 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 option(SIMDJSON_VISUAL_STUDIO_BUILD_WITH_DEBUG_INFO_FOR_PROFILING "Under Visual Studio, add Zi to the compile flag and DEBUG to the link file to add debugging information to the release build for easier profiling inside tools like VTune" OFF)
 if(MSVC)
-if("${MSVC_TOOLSET_VERSION}" STREQUAL "140")
-  # Visual Studio 2015 issues warnings and we tolerate it,  cmake -G"Visual Studio 14" ..
-  target_compile_options(simdjson-internal-flags INTERFACE /W0 /sdl)
-else()
-  # Recent version of Visual Studio expected (2017, 2019...). Prior versions are unsupported.
-  target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl /w34714) # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4714?view=vs-2019
-endif()
-if(SIMDJSON_VISUAL_STUDIO_BUILD_WITH_DEBUG_INFO_FOR_PROFILING)
-  target_link_options(simdjson-flags  INTERFACE    /DEBUG )
-  target_compile_options(simdjson-flags INTERFACE  /Zi)
-endif()
-else()
+  if("${MSVC_TOOLSET_VERSION}" STREQUAL "140")
+    # Visual Studio 2015 issues warnings and we tolerate it,  cmake -G"Visual Studio 14" ..
+    target_compile_options(simdjson-internal-flags INTERFACE /W0 /sdl)
+  else()
+    # Recent version of Visual Studio expected (2017, 2019...). Prior versions are unsupported.
+    target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl /w34714) # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4714?view=vs-2019
+  endif()
+  if(SIMDJSON_VISUAL_STUDIO_BUILD_WITH_DEBUG_INFO_FOR_PROFILING)
+    target_link_options(simdjson-flags  INTERFACE    /DEBUG )
+    target_compile_options(simdjson-flags INTERFACE  /Zi)
+  endif(SIMDJSON_VISUAL_STUDIO_BUILD_WITH_DEBUG_INFO_FOR_PROFILING)
+else(MSVC)
   if(NOT WIN32)
     target_compile_options(simdjson-internal-flags INTERFACE -fPIC)
   endif()
   target_compile_options(simdjson-internal-flags INTERFACE -Werror -Wall -Wextra -Weffc++)
   target_compile_options(simdjson-internal-flags INTERFACE -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
-endif()
+endif(MSVC)
 
 #
 # Optional flags
@@ -231,6 +231,10 @@ endif(SIMDJSON_USE_LIBCPP)
 if(${CMAKE_C_COMPILER_ID} MATCHES "Intel") # icc / icpc
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-intel")
 endif()
+
+include (CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(fork unistd.h HAVE_POSIX_FORK)
+CHECK_SYMBOL_EXISTS(wait sys/wait.h HAVE_POSIX_WAIT)
 
 install(TARGETS simdjson-flags EXPORT simdjson-config)
 install(TARGETS simdjson-internal-flags EXPORT simdjson-config)

--- a/include/simdjson/generic/implementation_simdjson_result_base-inl.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base-inl.h
@@ -5,13 +5,6 @@ namespace SIMDJSON_IMPLEMENTATION {
 // internal::implementation_simdjson_result_base<T> inline implementation
 //
 
-/**
- * Create a new empty result with error = UNINITIALIZED.
- */
-template<typename T>
-simdjson_really_inline implementation_simdjson_result_base<T>::~implementation_simdjson_result_base() noexcept {
-}
-
 template<typename T>
 simdjson_really_inline void implementation_simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
   // on the clang compiler that comes with current macOS (Apple clang version 11.0.0),
@@ -70,9 +63,6 @@ simdjson_really_inline implementation_simdjson_result_base<T>::implementation_si
 template<typename T>
 simdjson_really_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(T &&value) noexcept
     : implementation_simdjson_result_base(std::forward<T>(value), SUCCESS) {}
-template<typename T>
-simdjson_really_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base() noexcept
-    : implementation_simdjson_result_base(T{}, UNINITIALIZED) {}
 
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson

--- a/include/simdjson/generic/implementation_simdjson_result_base.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base.h
@@ -48,16 +48,6 @@ struct implementation_simdjson_result_base {
   simdjson_really_inline implementation_simdjson_result_base(T &&value, error_code error) noexcept;
 
   /**
-   * Move a result.
-   */
-  simdjson_really_inline implementation_simdjson_result_base(implementation_simdjson_result_base<T> &&value) noexcept = default;
-
-  /**
-   * Copy a result.
-   */
-  simdjson_really_inline implementation_simdjson_result_base(const implementation_simdjson_result_base<T> &value) = default;
-
-  /**
    * Create a new empty result with error = UNINITIALIZED.
    */
   simdjson_really_inline ~implementation_simdjson_result_base() noexcept;

--- a/include/simdjson/generic/implementation_simdjson_result_base.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base.h
@@ -30,7 +30,7 @@ struct implementation_simdjson_result_base {
   /**
    * Create a new empty result with error = UNINITIALIZED.
    */
-  simdjson_really_inline implementation_simdjson_result_base() noexcept;
+  simdjson_really_inline implementation_simdjson_result_base() noexcept = default;
 
   /**
    * Create a new error result.
@@ -46,11 +46,6 @@ struct implementation_simdjson_result_base {
    * Create a new result with both things (use if you don't want to branch when creating the result).
    */
   simdjson_really_inline implementation_simdjson_result_base(T &&value, error_code error) noexcept;
-
-  /**
-   * Create a new empty result with error = UNINITIALIZED.
-   */
-  simdjson_really_inline ~implementation_simdjson_result_base() noexcept;
 
   /**
    * Move the value and the error to the provided variables.
@@ -104,8 +99,8 @@ struct implementation_simdjson_result_base {
 
 #endif // SIMDJSON_EXCEPTIONS
 
-  T first;
-  error_code second;
+  T first{};
+  error_code second{UNINITIALIZED};
 }; // struct implementation_simdjson_result_base
 
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -8,8 +8,8 @@ simdjson_really_inline document::document(ondemand::json_iterator &&_iter) noexc
   logger::log_start_value(iter, "document");
 }
 
-simdjson_really_inline void document::assert_at_start() const noexcept {
-  iter.assert_at_start();
+simdjson_really_inline void document::assert_at_root() const noexcept {
+  iter.assert_at_root();
 }
 simdjson_really_inline document document::start(json_iterator &&iter) noexcept {
   return document(std::forward<json_iterator>(iter));
@@ -19,8 +19,8 @@ simdjson_really_inline value document::as_value() noexcept {
   return as_value_iterator();
 }
 simdjson_really_inline value_iterator document::as_value_iterator() noexcept {
-  assert_at_start();
-  return value_iterator(&iter, 1);
+  assert_at_root();
+  return value_iterator(&iter, 1, iter.token.checkpoint());
 }
 
 simdjson_really_inline simdjson_result<array> document::get_array() & noexcept {
@@ -30,15 +30,12 @@ simdjson_really_inline simdjson_result<object> document::get_object() & noexcept
   return as_value().get_object();
 }
 simdjson_really_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
-  assert_at_start();
   return as_value_iterator().require_root_uint64();
 }
 simdjson_really_inline simdjson_result<int64_t> document::get_int64() noexcept {
-  assert_at_start();
   return as_value_iterator().require_root_int64();
 }
 simdjson_really_inline simdjson_result<double> document::get_double() noexcept {
-  assert_at_start();
   return as_value_iterator().require_root_double();
 }
 simdjson_really_inline simdjson_result<std::string_view> document::get_string() & noexcept {
@@ -48,11 +45,9 @@ simdjson_really_inline simdjson_result<raw_json_string> document::get_raw_json_s
   return as_value().get_raw_json_string();
 }
 simdjson_really_inline simdjson_result<bool> document::get_bool() noexcept {
-  assert_at_start();
   return as_value_iterator().require_root_bool();
 }
 simdjson_really_inline bool document::is_null() noexcept {
-  assert_at_start();
   return as_value_iterator().is_root_null();
 }
 

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -230,9 +230,8 @@ protected:
 
   simdjson_really_inline value as_value() noexcept;
   simdjson_really_inline value_iterator as_value_iterator() noexcept;
+  simdjson_really_inline value_iterator as_non_root_value_iterator() noexcept;
   static simdjson_really_inline document start(ondemand::json_iterator &&iter) noexcept;
-
-  simdjson_really_inline void assert_at_root() const noexcept;
 
   //
   // Fields
@@ -261,10 +260,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> : public SIM
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -20,17 +20,16 @@ class array_iterator;
  */
 class document {
 public:
-  simdjson_really_inline document(document &&other) noexcept = default;
-  simdjson_really_inline document &operator=(document &&other) noexcept = default;
-
   /**
    * Create a new invalid document.
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
   simdjson_really_inline document() noexcept = default;
-  simdjson_really_inline document(const document &other) = delete;
-  simdjson_really_inline document &operator=(const document &other) = delete;
+  simdjson_really_inline document(const document &other) noexcept = delete;
+  simdjson_really_inline document(document &&other) noexcept = default;
+  simdjson_really_inline document &operator=(const document &other) noexcept = delete;
+  simdjson_really_inline document &operator=(document &&other) noexcept = default;
 
   /**
    * Cast this JSON value to an array.

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -232,7 +232,7 @@ protected:
   simdjson_really_inline value_iterator as_value_iterator() noexcept;
   static simdjson_really_inline document start(ondemand::json_iterator &&iter) noexcept;
 
-  simdjson_really_inline void assert_at_start() const noexcept;
+  simdjson_really_inline void assert_at_root() const noexcept;
 
   //
   // Fields

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -91,7 +91,11 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
 }
 
 simdjson_really_inline bool json_iterator::at_root() const noexcept {
-  return token.index == parser->dom_parser.structural_indexes.get();
+  return token.checkpoint() == root_checkpoint();
+}
+
+simdjson_really_inline const uint32_t *json_iterator::root_checkpoint() const noexcept {
+  return parser->dom_parser.structural_indexes.get();
 }
 
 simdjson_really_inline void json_iterator::assert_at_root() const noexcept {

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -90,11 +90,11 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
   return report_error(TAPE_ERROR, "not enough close braces");
 }
 
-simdjson_really_inline bool json_iterator::at_start() const noexcept {
-  return token.index == &parser->dom_parser.structural_indexes[0];
+simdjson_really_inline bool json_iterator::at_root() const noexcept {
+  return token.index == parser->dom_parser.structural_indexes.get();
 }
 
-simdjson_really_inline void json_iterator::assert_at_start() const noexcept {
+simdjson_really_inline void json_iterator::assert_at_root() const noexcept {
   SIMDJSON_ASSUME( _depth == 1 );
   // Visual Studio Clang treats unique_ptr.get() as "side effecting."
 #ifndef SIMDJSON_CLANG_VISUAL_STUDIO

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -63,6 +63,11 @@ public:
   simdjson_really_inline bool at_root() const noexcept;
 
   /**
+   * Get the root value iterator
+   */
+  simdjson_really_inline const uint32_t *root_checkpoint() const noexcept;
+
+  /**
    * Assert if the iterator is not at the start
    */
   simdjson_really_inline void assert_at_root() const noexcept;
@@ -184,8 +189,6 @@ public:
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
 
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -60,12 +60,12 @@ public:
   /**
    * Tell whether the iterator is still at the start
    */
-  simdjson_really_inline bool at_start() const noexcept;
+  simdjson_really_inline bool at_root() const noexcept;
 
   /**
    * Assert if the iterator is not at the start
    */
-  simdjson_really_inline void assert_at_start() const noexcept;
+  simdjson_really_inline void assert_at_root() const noexcept;
 
   /**
    * Tell whether the iterator is at the EOF mark

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -71,9 +71,12 @@ simdjson_really_inline object object::started(value_iterator &iter) noexcept {
   simdjson_unused bool has_value = iter.started_object();
   return iter;
 }
+simdjson_really_inline object object::resume(const value_iterator &iter) noexcept {
+  return { iter, false };
+}
 
-simdjson_really_inline object::object(const value_iterator &_iter) noexcept
-  : iter{_iter}
+simdjson_really_inline object::object(const value_iterator &_iter, bool _at_start) noexcept
+  : iter{_iter, _at_start}    
 {
 }
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -50,11 +50,11 @@ protected:
   static simdjson_really_inline simdjson_result<object> try_start(value_iterator &iter) noexcept;
   static simdjson_really_inline object started(value_iterator &iter) noexcept;
   static simdjson_really_inline object resume(const value_iterator &iter) noexcept;
-  simdjson_really_inline object(const value_iterator &iter, bool at_start = true) noexcept;
+  simdjson_really_inline object(const value_iterator &iter) noexcept;
 
   simdjson_warn_unused simdjson_really_inline error_code find_field_raw(const std::string_view key) noexcept;
 
-  object_iterator iter{};
+  value_iterator iter{};
 
   friend class value;
   friend class document;

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -49,7 +49,8 @@ protected:
   static simdjson_really_inline simdjson_result<object> start(value_iterator &iter) noexcept;
   static simdjson_really_inline simdjson_result<object> try_start(value_iterator &iter) noexcept;
   static simdjson_really_inline object started(value_iterator &iter) noexcept;
-  simdjson_really_inline object(const value_iterator &_iter) noexcept;
+  static simdjson_really_inline object resume(const value_iterator &iter) noexcept;
+  simdjson_really_inline object(const value_iterator &iter, bool at_start = true) noexcept;
 
   simdjson_warn_unused simdjson_really_inline error_code find_field_raw(const std::string_view key) noexcept;
 

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -6,9 +6,9 @@ namespace ondemand {
 // object_iterator
 //
 
-simdjson_really_inline object_iterator::object_iterator(const value_iterator &_iter) noexcept
+simdjson_really_inline object_iterator::object_iterator(const value_iterator &_iter, bool _at_start) noexcept
   : iter{_iter},
-    at_start{true}
+    at_start{_at_start}
 {}
 
 simdjson_really_inline simdjson_result<field> object_iterator::operator*() noexcept {

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -52,7 +52,7 @@ private:
    */
   bool at_start{};
 
-  simdjson_really_inline object_iterator(const value_iterator &iter) noexcept;
+  simdjson_really_inline object_iterator(const value_iterator &iter, bool at_start = true) noexcept;
   friend struct simdjson_result<object_iterator>;
   friend class object;
 };

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -29,11 +29,6 @@ public:
   // Checks for ']' and ','
   simdjson_really_inline object_iterator &operator++() noexcept;
 
-  /**
-   * Find the field with the given key. May be used in place of ++.
-   */
-  simdjson_warn_unused simdjson_really_inline error_code find_field_raw(const std::string_view key) noexcept;
-
 private:
   /**
    * The underlying JSON iterator.
@@ -42,17 +37,8 @@ private:
    * is first used, and never changes afterwards.
    */
   value_iterator iter{};
-  /**
-   * Whether we are at the start.
-   *
-   * PERF NOTE: this should be elided into inline control flow: it is only used for the first []
-   * or * call, and SSA optimizers commonly do first-iteration loop optimization.
-   *
-   * SAFETY: this is not safe; the object_iterator can be copied freely, so the state CAN be lost.
-   */
-  bool at_start{};
 
-  simdjson_really_inline object_iterator(const value_iterator &iter, bool at_start = true) noexcept;
+  simdjson_really_inline object_iterator(const value_iterator &iter) noexcept;
   friend struct simdjson_result<object_iterator>;
   friend class object;
 };

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -130,10 +130,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::parser> : public SIMDJ
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::parser &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::parser> &&a) noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -109,9 +109,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> : pub
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> &a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 
   simdjson_really_inline simdjson_result<const char *> raw() const noexcept;

--- a/include/simdjson/generic/ondemand/token_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/token_iterator-inl.h
@@ -39,6 +39,10 @@ simdjson_really_inline bool token_iterator::operator<=(const token_iterator &oth
   return index <= other.index;
 }
 
+simdjson_really_inline const uint32_t *token_iterator::checkpoint() const noexcept {
+  return index;
+}
+
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/token_iterator.h
+++ b/include/simdjson/generic/ondemand/token_iterator.h
@@ -83,6 +83,7 @@ protected:
 
   friend class json_iterator;
   friend class value_iterator;
+  friend class object;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
 };
 

--- a/include/simdjson/generic/ondemand/token_iterator.h
+++ b/include/simdjson/generic/ondemand/token_iterator.h
@@ -97,9 +97,7 @@ struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator> : publ
 public:
   simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::token_iterator &&value) noexcept; ///< @private
   simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-
   simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline simdjson_result(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator> &&a) noexcept = default;
   simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
 };
 

--- a/include/simdjson/generic/ondemand/token_iterator.h
+++ b/include/simdjson/generic/ondemand/token_iterator.h
@@ -49,6 +49,11 @@ public:
    */
   simdjson_really_inline const uint8_t *advance() noexcept;
 
+  /**
+   * Save the current index to be restored later.
+   */
+  simdjson_really_inline const uint32_t *checkpoint() const noexcept;
+
   // NOTE: we don't support a full C++ iterator interface, because we expect people to make
   // different calls to advance the iterator based on *their own* state.
 
@@ -77,6 +82,7 @@ protected:
   const uint32_t *index{};
 
   friend class json_iterator;
+  friend class value_iterator;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
 };
 

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -80,7 +80,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::field_key() noexcept {
-  logger::log_event(*this, "hi");
   assert_at_child();
 
   const uint8_t *key = _json_iter->advance();

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -2,20 +2,21 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline value_iterator::value_iterator(json_iterator *json_iter, depth_t depth) noexcept
+simdjson_really_inline value_iterator::value_iterator(json_iterator *json_iter, depth_t depth, const uint32_t *start_index) noexcept
   : _json_iter{json_iter},
-    _depth{depth}
+    _depth{depth},
+    _start_index{start_index}
 {
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_object() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
+  assert_at_start();
 
   if (*_json_iter->advance() != '{') { logger::log_error(*_json_iter, "Not an object"); return INCORRECT_TYPE; }
   return started_object();
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_start_object() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
+  assert_at_start();
 
   if (*_json_iter->peek() != '{') { logger::log_error(*_json_iter, "Not an object"); return INCORRECT_TYPE; }
   _json_iter->advance();
@@ -23,8 +24,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline bool value_iterator::started_object() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
-
   if (*_json_iter->peek() == '}') {
     logger::log_value(*_json_iter, "empty object");
     _json_iter->advance();
@@ -37,7 +36,7 @@ simdjson_warn_unused simdjson_really_inline bool value_iterator::started_object(
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_field() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth );
+  assert_at_next();
 
   switch (*_json_iter->advance()) {
     case '}':
@@ -54,7 +53,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_raw(const char *key) noexcept {
   // We assume we are sitting at a key: at "key": <value>
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
+  assert_at_child();
 
   bool has_next;
   do {
@@ -81,7 +80,8 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::field_key() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
+  logger::log_event(*this, "hi");
+  assert_at_child();
 
   const uint8_t *key = _json_iter->advance();
   if (*(key++) != '"') { return _json_iter->report_error(TAPE_ERROR, "Object key is not a string"); }
@@ -89,21 +89,21 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
 }
 
 simdjson_warn_unused simdjson_really_inline error_code value_iterator::field_value() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
+  assert_at_child();
 
   if (*_json_iter->advance() != ':') { return _json_iter->report_error(TAPE_ERROR, "Missing colon in object field"); }
   return SUCCESS;
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_array() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0);
+  assert_at_start();
 
   if (*_json_iter->advance() != '[') { logger::log_error(*_json_iter, "Not an array"); return INCORRECT_TYPE; }
   return started_array();
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_start_array() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0);
+  assert_at_start();
 
   if (*_json_iter->peek() != '[') { logger::log_error(*_json_iter, "Not an array"); return INCORRECT_TYPE; }
   _json_iter->advance();
@@ -111,8 +111,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 
 simdjson_warn_unused simdjson_really_inline bool value_iterator::started_array() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
-
   if (*_json_iter->peek() == ']') {
     logger::log_value(*_json_iter, "empty array");
     _json_iter->advance();
@@ -125,7 +123,7 @@ simdjson_warn_unused simdjson_really_inline bool value_iterator::started_array()
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_element() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth );
+  assert_at_next();
 
   switch (*_json_iter->advance()) {
     case ']':
@@ -147,7 +145,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> va
   return require_raw_json_string().unescape(_json_iter->string_buf_loc());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::try_get_raw_json_string() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
+  assert_at_start();
 
   logger::log_value(*_json_iter, "string", "", 0);
   auto json = _json_iter->peek();
@@ -157,7 +155,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
   return raw_json_string(json+1);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::require_raw_json_string() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 0 );
+  assert_at_start();
 
   logger::log_value(*_json_iter, "string", "", 0);
   auto json = _json_iter->advance();
@@ -166,7 +164,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
   return raw_json_string(json+1);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   logger::log_value(*_json_iter, "uint64", "", 0);
   uint64_t result;
@@ -176,14 +174,14 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   logger::log_value(*_json_iter, "uint64", "", 0);
   _json_iter->ascend_to(depth()-1);
   return numberparsing::parse_unsigned(_json_iter->advance());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   logger::log_value(*_json_iter, "int64", "", 0);
   int64_t result;
@@ -193,14 +191,14 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   logger::log_value(*_json_iter, "int64", "", 0);
   _json_iter->ascend_to(depth()-1);
   return numberparsing::parse_integer(_json_iter->advance());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   logger::log_value(*_json_iter, "double", "", 0);
   double result;
@@ -210,7 +208,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   logger::log_value(*_json_iter, "double", "", 0);
   _json_iter->ascend_to(depth()-1);
@@ -225,7 +223,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return simdjson_result<bool>(!not_true);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   bool result;
   SIMDJSON_TRY( parse_bool(_json_iter->peek()).get(result) );
@@ -234,7 +232,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   _json_iter->ascend_to(depth()-1);
   return parse_bool(_json_iter->advance());
@@ -247,7 +245,7 @@ simdjson_really_inline bool value_iterator::is_null(const uint8_t *json) const n
   return false;
 }
 simdjson_really_inline bool value_iterator::is_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   if (is_null(_json_iter->peek())) {
     _json_iter->advance();
@@ -257,7 +255,7 @@ simdjson_really_inline bool value_iterator::is_null() noexcept {
   return false;
 }
 simdjson_really_inline bool value_iterator::require_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth > 1 );
+  assert_at_non_root_start();
 
   _json_iter->ascend_to(depth()-1);
   return is_null(_json_iter->advance());
@@ -266,8 +264,6 @@ simdjson_really_inline bool value_iterator::require_null() noexcept {
 constexpr const uint32_t MAX_INT_LENGTH = 1024;
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::parse_root_uint64(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
-
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
   logger::log_value(*_json_iter, "uint64", "", 0);
@@ -276,7 +272,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_root_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   uint64_t result;
   SIMDJSON_TRY( parse_root_uint64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -284,14 +280,12 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_root_uint64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   auto max_len = _json_iter->peek_length();
   return parse_root_uint64(_json_iter->advance(), max_len);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
-
   uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
   logger::log_value(*_json_iter, "int64", "", 0);
@@ -300,7 +294,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_root_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   int64_t result;
   SIMDJSON_TRY( parse_root_int64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -308,14 +302,12 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_root_int64() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   auto max_len = _json_iter->peek_length();
   return parse_root_int64(_json_iter->advance(), max_len);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
-
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest number: -0.<fraction>e-308.
   uint8_t tmpbuf[1074+8+1];
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 1082 characters"); return NUMBER_ERROR; }
@@ -325,7 +317,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_root_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   double result;
   SIMDJSON_TRY( parse_root_double(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -333,20 +325,18 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_root_double() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   auto max_len = _json_iter->peek_length();
   return parse_root_double(_json_iter->advance(), max_len);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::parse_root_bool(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
-
   uint8_t tmpbuf[5+1];
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Not a boolean"); return INCORRECT_TYPE; }
   return parse_bool(tmpbuf);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_root_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   bool result;
   SIMDJSON_TRY( parse_root_bool(_json_iter->peek(), _json_iter->peek_length()).get(result) );
@@ -354,38 +344,39 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_root_bool() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   auto max_len = _json_iter->peek_length();
   return parse_root_bool(_json_iter->advance(), max_len);
 }
 simdjson_really_inline bool value_iterator::is_root_null(const uint8_t *json, uint32_t max_len) const noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
-
   uint8_t tmpbuf[4+1];
   if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { return false; }
   return is_null(tmpbuf);
 }
 simdjson_really_inline bool value_iterator::is_root_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   if (!is_root_null(_json_iter->peek(), _json_iter->peek_length())) { return false; }
   _json_iter->advance();
   return true;
 }
 simdjson_really_inline bool value_iterator::require_root_null() noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth && _depth == 1 );
+  assert_at_root();
 
   auto max_len = _json_iter->peek_length();
   return is_root_null(_json_iter->advance(), max_len);
 }
 
 simdjson_warn_unused simdjson_really_inline error_code value_iterator::skip_child() noexcept {
+  SIMDJSON_ASSUME( _json_iter->token.index > _start_index );
+  SIMDJSON_ASSUME( _json_iter->_depth >= _depth );
+
   return _json_iter->skip_child(depth());
 }
 simdjson_really_inline value_iterator value_iterator::child() const noexcept {
-  SIMDJSON_ASSUME( _json_iter->_depth == _depth+1 );
-  return { _json_iter, depth()+1 };
+  assert_at_child();
+  return { _json_iter, depth()+1, _json_iter->token.checkpoint() };
 }
 
 simdjson_really_inline bool value_iterator::is_open() const noexcept {
@@ -412,6 +403,35 @@ simdjson_warn_unused simdjson_really_inline const json_iterator &value_iterator:
 simdjson_warn_unused simdjson_really_inline json_iterator &value_iterator::json_iter() noexcept {
   return *_json_iter;
 }
+
+simdjson_really_inline void value_iterator::assert_at_start() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->token.index == _start_index );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth );
+  SIMDJSON_ASSUME( _depth > 0 );
+}
+
+simdjson_really_inline void value_iterator::assert_at_next() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->token.index > _start_index );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth );
+  SIMDJSON_ASSUME( _depth > 0 );
+}
+
+simdjson_really_inline void value_iterator::assert_at_child() const noexcept {
+  SIMDJSON_ASSUME( _json_iter->token.index > _start_index );
+  SIMDJSON_ASSUME( _json_iter->_depth == _depth + 1 );
+  SIMDJSON_ASSUME( _depth > 0 );
+}
+
+simdjson_really_inline void value_iterator::assert_at_root() const noexcept {
+  assert_at_start();
+  SIMDJSON_ASSUME( _depth == 1 );
+}
+
+simdjson_really_inline void value_iterator::assert_at_non_root_start() const noexcept {
+  assert_at_start();
+  SIMDJSON_ASSUME( _depth > 1 );
+}
+
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -56,6 +56,11 @@ public:
   simdjson_really_inline bool is_open() const noexcept;
 
   /**
+   * Tell whether the value is at an object's first field (just after the {).
+   */
+  simdjson_really_inline bool at_first_field() const noexcept;
+
+  /**
    * Abandon all iteration.
    */
   simdjson_really_inline void abandon() noexcept;
@@ -158,7 +163,7 @@ public:
    * unescape it. This works well for typical ASCII and UTF-8 keys (almost all of them), but may
    * fail to match some keys with escapes (\u, \n, etc.).
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> find_field_raw(const char *key) noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> find_field_raw(const std::string_view key) noexcept;
 
   /** @} */
 
@@ -262,10 +267,10 @@ protected:
   simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept;
 
   simdjson_really_inline void assert_at_start() const noexcept;
-  simdjson_really_inline void assert_at_root() const noexcept; 
+  simdjson_really_inline void assert_at_root() const noexcept;
   simdjson_really_inline void assert_at_child() const noexcept;
-  simdjson_really_inline void assert_at_next() const noexcept; 
-  simdjson_really_inline void assert_at_non_root_start() const noexcept; 
+  simdjson_really_inline void assert_at_next() const noexcept;
+  simdjson_really_inline void assert_at_non_root_start() const noexcept;
 
   friend class document;
   friend class object;

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -23,7 +23,11 @@ protected:
   json_iterator *_json_iter{};
   /** The depth of this value */
   depth_t _depth{};
-  /** The starting token index for this value */
+  /**
+   * The starting token index for this value
+   *
+   * PERF NOTE: this is a safety check; we expect this to be elided in release builds.
+   */
   const uint32_t *_start_index{};
 
 public:

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -23,6 +23,8 @@ protected:
   json_iterator *_json_iter{};
   /** The depth of this value */
   depth_t _depth{};
+  /** The starting token index for this value */
+  const uint32_t *_start_index{};
 
 public:
   simdjson_really_inline value_iterator() noexcept = default;
@@ -246,7 +248,7 @@ public:
   /** @} */
 
 protected:
-  simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth) noexcept;
+  simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth, const uint32_t *start_index) noexcept;
   simdjson_really_inline bool is_null(const uint8_t *json) const noexcept;
   simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) const noexcept;
   simdjson_really_inline bool is_root_null(const uint8_t *json, uint32_t max_len) const noexcept;
@@ -254,6 +256,12 @@ protected:
   simdjson_really_inline simdjson_result<uint64_t> parse_root_uint64(const uint8_t *json, uint32_t max_len) const noexcept;
   simdjson_really_inline simdjson_result<int64_t> parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept;
   simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept;
+
+  simdjson_really_inline void assert_at_start() const noexcept;
+  simdjson_really_inline void assert_at_root() const noexcept; 
+  simdjson_really_inline void assert_at_child() const noexcept;
+  simdjson_really_inline void assert_at_next() const noexcept; 
+  simdjson_really_inline void assert_at_non_root_start() const noexcept; 
 
   friend class document;
   friend class object;

--- a/tests/ondemand/CMakeLists.txt
+++ b/tests/ondemand/CMakeLists.txt
@@ -2,4 +2,6 @@
 link_libraries(simdjson)
 include_directories(..)
 add_cpp_test(ondemand_basictests LABELS acceptance per_implementation)
-
+if(HAVE_POSIX_FORK AND HAVE_POSIX_WAIT) # assert tests use fork and wait, which aren't on MSVC
+  add_cpp_test(ondemand_assert_out_of_order_values LABELS per_implementation explicitonly assert)
+endif()

--- a/tests/ondemand/ondemand_assert_out_of_order_values.cpp
+++ b/tests/ondemand/ondemand_assert_out_of_order_values.cpp
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include "simdjson.h"
+
+using namespace simdjson;
+using namespace simdjson::builtin;
+
+// This ensures the compiler can't rearrange them into the proper order (which causes it to work!)
+simdjson_never_inline int check_point(simdjson_result<ondemand::value> xval, simdjson_result<ondemand::value> yval) {
+  // Verify the expected release behavior 
+  error_code error;
+  uint64_t x = 0;
+  if ((error = xval.get(x))) { std::cerr << "error getting x: " << error << std::endl; }
+  else if (x != 2) { std::cerr << "expected x to (wrongly) be 2, was " << x << std::endl; }
+  uint64_t y = 0;
+  if ((error = yval.get(y))) { std::cerr << "error getting y: " << error << std::endl; }
+  else if (y != 3) { std::cerr << "expected y to (wrongly) be 3, was " << y << std::endl; }
+  return 0;
+}
+
+int main(void) {
+  pid_t pid = fork();
+  if (pid == -1) { std::cerr << "fork failed" << std::endl; return 1; }
+  if (pid) {
+    // Parent - wait child and interpret its result
+    int status = 0;
+    wait(&status);
+    if(!WIFSIGNALED(status)) {
+      std::cerr << "Expected program to abort, but it exited successfully with status " << status << std::endl;
+      return 1;
+    }
+    return 0; // Signal-terminated means success
+  } else {
+    auto json = R"(
+      {
+        "x": 1,
+        "y": 2 3
+    )"_padded;
+    ondemand::parser parser;
+    auto doc = parser.iterate(json);
+    return check_point(doc["x"], doc["y"]);
+  }
+}

--- a/tests/ondemand/ondemand_assert_out_of_order_values.cpp
+++ b/tests/ondemand/ondemand_assert_out_of_order_values.cpp
@@ -10,7 +10,7 @@ using namespace simdjson::builtin;
 
 // This ensures the compiler can't rearrange them into the proper order (which causes it to work!)
 simdjson_never_inline int check_point(simdjson_result<ondemand::value> xval, simdjson_result<ondemand::value> yval) {
-  // Verify the expected release behavior 
+  // Verify the expected release behavior
   error_code error;
   uint64_t x = 0;
   if ((error = xval.get(x))) { std::cerr << "error getting x: " << error << std::endl; }
@@ -21,26 +21,36 @@ simdjson_never_inline int check_point(simdjson_result<ondemand::value> xval, sim
   return 0;
 }
 
+int test_check_point() {
+  auto json = R"(
+    {
+      "x": 1,
+      "y": 2 3
+  )"_padded;
+  ondemand::parser parser;
+  auto doc = parser.iterate(json);
+  return check_point(doc["x"], doc["y"]);
+}
+
+bool fork_failed_with_assert() {
+  int status = 0;
+  wait(&status);
+  return WIFSIGNALED(status);
+}
+
 int main(void) {
+
+  // To verify that the program asserts (which sends a signal), we fork a new process and use wait()
+  // to check the resulting error code. If it's a signal error code, we consider the
+  // test to have passed.
+  // From https://stackoverflow.com/a/33694733
+
   pid_t pid = fork();
   if (pid == -1) { std::cerr << "fork failed" << std::endl; return 1; }
   if (pid) {
     // Parent - wait child and interpret its result
-    int status = 0;
-    wait(&status);
-    if(!WIFSIGNALED(status)) {
-      std::cerr << "Expected program to abort, but it exited successfully with status " << status << std::endl;
-      return 1;
-    }
-    return 0; // Signal-terminated means success
+    return fork_failed_with_assert() ? 0 : 1;
   } else {
-    auto json = R"(
-      {
-        "x": 1,
-        "y": 2 3
-    )"_padded;
-    ondemand::parser parser;
-    auto doc = parser.iterate(json);
-    return check_point(doc["x"], doc["y"]);
+    test_check_point();
   }
 }


### PR DESCRIPTION
Right now, on demand will exhibit bad behavior when you do this:

```c++
  auto json = R"(
    {
      "x": 1,
      "y": 2
    )"_padded;
  ondemand::parser parser;
  auto doc = parser.iterate(json);
  auto x = doc["x"];
  auto y = doc["y"];
  std::cout << "(" << uint64_t(x) << ", " << uint64_t(y)  << ")" << std::endl;
```

Essentially, you are delaying the parsing of "x" until the cout line, but then you go and grab the "y" field in between, which *skips* "x". Then when you do `uint64_t(x)`, you actually get the value of "y" (2) because that's where the iterator is now.

This PR adds an assert that occurs when this happens. I have verified it has no impact on performance on Skylake. In fact, I have verified that if you enable asserts in release mode, it *still* has no impact on performance. I'd actually like to turn these asserts on for release builds, but release mode in cmake passes -DNDEBUG by default, turning off *all* asserts, and we also have a no-assert policy for embedded-system reasons.