### PR TITLE
By default, it seems that optimized kernels are disabled (patch release)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ project(simdjson
 
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 7)
-set(PROJECT_VERSION_PATCH 0)
-set(SIMDJSON_SEMANTIC_VERSION "0.7.0" CACHE STRING "simdjson semantic version")
+set(PROJECT_VERSION_PATCH 1)
+set(SIMDJSON_SEMANTIC_VERSION "0.7.1" CACHE STRING "simdjson semantic version")
 set(SIMDJSON_LIB_VERSION "5.0.0" CACHE STRING "simdjson library version")
 set(SIMDJSON_LIB_SOVERSION "5" CACHE STRING "simdjson library soversion")
 set(SIMDJSON_GITHUB_REPOSITORY https://github.com/simdjson/simdjson)

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = simdjson
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.7.0"
+PROJECT_NUMBER         = "0.7.1"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/simdjson/arm64.h
+++ b/include/simdjson/arm64.h
@@ -6,7 +6,11 @@
 #endif
 
 #include "simdjson/portability.h"
-
+// Default Haswell to on if this is x86-64. Even if we're not compiled for it, it could be selected
+// at runtime.
+#ifndef SIMDJSON_IMPLEMENTATION_ARM64
+#define SIMDJSON_IMPLEMENTATION_ARM64 (SIMDJSON_IS_ARM64)
+#endif
 #include "simdjson/internal/isadetection.h"
 #include "simdjson/internal/jsoncharutils_tables.h"
 #include "simdjson/internal/numberparsing_tables.h"

--- a/include/simdjson/arm64.h
+++ b/include/simdjson/arm64.h
@@ -6,11 +6,11 @@
 #endif
 
 #include "simdjson/portability.h"
-// Default Haswell to on if this is x86-64. Even if we're not compiled for it, it could be selected
-// at runtime.
+
 #ifndef SIMDJSON_IMPLEMENTATION_ARM64
 #define SIMDJSON_IMPLEMENTATION_ARM64 (SIMDJSON_IS_ARM64)
 #endif
+
 #include "simdjson/internal/isadetection.h"
 #include "simdjson/internal/jsoncharutils_tables.h"
 #include "simdjson/internal/numberparsing_tables.h"

--- a/include/simdjson/arm64.h
+++ b/include/simdjson/arm64.h
@@ -9,8 +9,8 @@
 
 #ifndef SIMDJSON_IMPLEMENTATION_ARM64
 #define SIMDJSON_IMPLEMENTATION_ARM64 (SIMDJSON_IS_ARM64)
-#define SIMDJSON_CAN_ALWAYS_RUN_ARM64 (SIMDJSON_IS_ARM64)
 #endif
+#define SIMDJSON_CAN_ALWAYS_RUN_ARM64 SIMDJSON_IMPLEMENTATION_ARM64 && SIMDJSON_IS_ARM64
 
 #include "simdjson/internal/isadetection.h"
 #include "simdjson/internal/jsoncharutils_tables.h"

--- a/include/simdjson/arm64.h
+++ b/include/simdjson/arm64.h
@@ -9,6 +9,7 @@
 
 #ifndef SIMDJSON_IMPLEMENTATION_ARM64
 #define SIMDJSON_IMPLEMENTATION_ARM64 (SIMDJSON_IS_ARM64)
+#define SIMDJSON_CAN_ALWAYS_RUN_ARM64 (SIMDJSON_IS_ARM64)
 #endif
 
 #include "simdjson/internal/isadetection.h"

--- a/include/simdjson/ppc64.h
+++ b/include/simdjson/ppc64.h
@@ -7,6 +7,10 @@
 
 #include "simdjson/portability.h"
 
+#ifndef SIMDJSON_IMPLEMENTATION_PPC64
+#define SIMDJSON_IMPLEMENTATION_PPC64 (SIMDJSON_IS_PPC64)
+#endif
+
 #include "simdjson/internal/isadetection.h"
 #include "simdjson/internal/jsoncharutils_tables.h"
 #include "simdjson/internal/numberparsing_tables.h"

--- a/include/simdjson/ppc64.h
+++ b/include/simdjson/ppc64.h
@@ -9,8 +9,8 @@
 
 #ifndef SIMDJSON_IMPLEMENTATION_PPC64
 #define SIMDJSON_IMPLEMENTATION_PPC64 (SIMDJSON_IS_PPC64)
-#define SIMDJSON_CAN_ALWAYS_RUN_PPC64 (SIMDJSON_IS_PPC64)
 #endif
+#define SIMDJSON_CAN_ALWAYS_RUN_PPC64 SIMDJSON_IMPLEMENTATION_PPC64 && SIMDJSON_IS_PPC64
 
 #include "simdjson/internal/isadetection.h"
 #include "simdjson/internal/jsoncharutils_tables.h"

--- a/include/simdjson/ppc64.h
+++ b/include/simdjson/ppc64.h
@@ -9,6 +9,7 @@
 
 #ifndef SIMDJSON_IMPLEMENTATION_PPC64
 #define SIMDJSON_IMPLEMENTATION_PPC64 (SIMDJSON_IS_PPC64)
+#define SIMDJSON_CAN_ALWAYS_RUN_PPC64 (SIMDJSON_IS_PPC64)
 #endif
 
 #include "simdjson/internal/isadetection.h"

--- a/include/simdjson/simdjson_version.h
+++ b/include/simdjson/simdjson_version.h
@@ -4,7 +4,7 @@
 #define SIMDJSON_SIMDJSON_VERSION_H
 
 /** The version of simdjson being used (major.minor.revision) */
-#define SIMDJSON_VERSION 0.7.0
+#define SIMDJSON_VERSION 0.7.1
 
 namespace simdjson {
 enum {
@@ -19,7 +19,7 @@ enum {
   /**
    * The revision (major.minor.REVISION) of simdjson being used.
    */
-  SIMDJSON_VERSION_REVISION = 0
+  SIMDJSON_VERSION_REVISION = 1
 };
 } // namespace simdjson
 

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2020-12-03 13:16:45 -0500. Do not edit! */
+/* auto-generated on 2020-12-13 20:01:10 -0500. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2020-12-03 13:16:45 -0500. Do not edit! */
+/* auto-generated on 2020-12-13 20:01:10 -0500. Do not edit! */
 /* begin file include/simdjson.h */
 #ifndef SIMDJSON_H
 #define SIMDJSON_H
@@ -2015,7 +2015,7 @@ SIMDJSON_DISABLE_UNDESIRED_WARNINGS
 #define SIMDJSON_SIMDJSON_VERSION_H
 
 /** The version of simdjson being used (major.minor.revision) */
-#define SIMDJSON_VERSION 0.7.0
+#define SIMDJSON_VERSION 0.7.1
 
 namespace simdjson {
 enum {
@@ -2030,7 +2030,7 @@ enum {
   /**
    * The revision (major.minor.REVISION) of simdjson being used.
    */
-  SIMDJSON_VERSION_REVISION = 0
+  SIMDJSON_VERSION_REVISION = 1
 };
 } // namespace simdjson
 
@@ -8788,6 +8788,11 @@ extern SIMDJSON_DLLIMPORTEXPORT const uint64_t thintable_epi8[256];
 #error "arm64.h must be included before fallback.h"
 #endif
 
+
+#ifndef SIMDJSON_IMPLEMENTATION_ARM64
+#define SIMDJSON_IMPLEMENTATION_ARM64 (SIMDJSON_IS_ARM64)
+#endif
+#define SIMDJSON_CAN_ALWAYS_RUN_ARM64 SIMDJSON_IMPLEMENTATION_ARM64 && SIMDJSON_IS_ARM64
 
 
 #if SIMDJSON_IMPLEMENTATION_ARM64
@@ -26310,6 +26315,11 @@ SIMDJSON_UNTARGET_REGION
 #error "ppc64.h must be included before fallback.h"
 #endif
 
+
+#ifndef SIMDJSON_IMPLEMENTATION_PPC64
+#define SIMDJSON_IMPLEMENTATION_PPC64 (SIMDJSON_IS_PPC64)
+#endif
+#define SIMDJSON_CAN_ALWAYS_RUN_PPC64 SIMDJSON_IMPLEMENTATION_PPC64 && SIMDJSON_IS_PPC64
 
 
 #if SIMDJSON_IMPLEMENTATION_PPC64


### PR DESCRIPTION
It seems that we mistakenly disabled by default the optimized kernels under ARM and PPC. I think we need to push a v0.7.1 release to correct this mistake.