### PR TITLE
This might make the fuzzer errors more debuggable.

### DIFF
--- a/fuzz/fuzz_utf8.cpp
+++ b/fuzz/fuzz_utf8.cpp
@@ -45,6 +45,12 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             const bool current=utf8verify(e);
             std::cerr<<e->name()<<" returns "<<current<<std::endl;
         }
+        std::cerr << "Offending input: \"";
+        for(size_t i = 0; i < Size; i++) {
+            std::cerr << "\\x" << std::hex << std::setw(2) << std::setfill('0')  << uint32_t(Data[i]);
+        }
+        std::cerr << "\"" <<std::endl;
+
         std::abort();
     }
 


### PR DESCRIPTION
Currently, the fuzzers are difficult to run locally and when they fail, they appear not to output a reproducible case. At least for UTF-8, we would like to see what the offending input is. This is my attempt at doing so.  
