### PR TITLE
fix memory malloc/free mismatch in minifiercompetition.cpp

### DIFF
--- a/benchmark/minifiercompetition.cpp
+++ b/benchmark/minifiercompetition.cpp
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]) {
             simdjson::SUCCESS, memcpy(buffer, mini_buffer, p.size()), repeat, volume,
             !just_data);
 
-  free(buffer);
+  delete [] buffer;
   free(ast_buffer);
-  free(mini_buffer);
+  delete [] mini_buffer;
 }


### PR DESCRIPTION
as described in the description for the allocate_padded_buffer function: // The caller is responsible to free the memory (e.g., delete [] (...)).
but your code used the function free.
I propose to fix this error.



Our tests check whether you have introduced trailing white space. If such a test fails, please check the "artifacts button" above, which if you click it gives a link to a downloadable file to help you identify the issue. You can also run scripts/remove_trailing_whitespace.sh locally if you have a bash shell and the sed command available on your system.

If you plan to contribute to simdjson, please read our

CONTRIBUTING guide: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md and our
HACKING guide: https://github.com/simdjson/simdjson/blob/master/HACKING.md
