### PR TITLE
Debug only test option

### DIFF
--- a/cmake/add_cpp_test.cmake
+++ b/cmake/add_cpp_test.cmake
@@ -1,38 +1,69 @@
 # Helper so we don't have to repeat ourselves so much
-# Usage: add_cpp_test(testname [COMPILE_ONLY] [SOURCES a.cpp b.cpp ...] [LABELS acceptance per_implementation ...])
-# SOURCES defaults to testname.cpp if not specified.
+# Usage: add_cpp_test(<testname>
+#                     [COMPILE_ONLY]
+#                     [DEBUG_ONLY]
+#                     [WILL_FAIL]
+#                     [LIBRARY]
+#                     [SOURCES a.cpp b.cpp ...]
+#                     [LABELS acceptance per_implementation ...]
+#                     [DEPENDENCY_OF ...])
+# SOURCES defaults to <testname>.cpp if not specified.
 function(add_cpp_test TEST_NAME)
   # Parse arguments
-  cmake_parse_arguments(PARSE_ARGV 1 ARGS "COMPILE_ONLY;LIBRARY;WILL_FAIL" "" "SOURCES;LABELS;DEPENDENCY_OF")
-  if (NOT ARGS_SOURCES)
+  cmake_parse_arguments(PARSE_ARGV 1 ARGS "COMPILE_ONLY;LIBRARY;WILL_FAIL;DEBUG_ONLY" "" "SOURCES;LABELS;DEPENDENCY_OF")
+
+  # Is generator multi-config?
+  get_cmake_property(is_multi_config GENERATOR_IS_MULTI_CONFIG)
+
+  # Return if debug only test
+  if(NOT is_multi_config AND ARGS_DEBUG_ONLY AND NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    return()
+  endif()
+
+  # Set configurations
+  set(config_args)
+  if(is_multi_config AND ARGS_DEBUG_ONLY)
+    set(config_args CONFIGURATIONS Debug)
+  endif()
+
+  if(NOT ARGS_SOURCES)
     list(APPEND ARGS_SOURCES ${TEST_NAME}.cpp)
   endif()
-  if (ARGS_COMPILE_ONLY)
-    list(APPEND ${ARGS_LABELS} compile_only)
+
+  # Wrap sources in a generator expression and provide a dummy source
+  if(is_multi_config AND ARGS_DEBUG_ONLY)
+    list(TRANSFORM ARGS_SOURCES PREPEND "$<$<CONFIG:Debug>:")
+    list(TRANSFORM ARGS_SOURCES APPEND ">")
+    list(PREPEND ARGS_SOURCES "$<$<NOT:$<CONFIG:Debug>>:${simdjson_SOURCE_DIR}/cmake/empty.cpp>")
+  endif()
+
+  if(ARGS_COMPILE_ONLY)
+    list(APPEND ARGS_LABELS compile)
   endif()
 
   # Add the compile target
-  if (ARGS_LIBRARY)
+  if(ARGS_LIBRARY)
     add_library(${TEST_NAME} STATIC ${ARGS_SOURCES})
-  else(ARGS_LIBRARY)
+  else()
     add_executable(${TEST_NAME} ${ARGS_SOURCES})
-  endif(ARGS_LIBRARY)
+  endif()
 
   # Add test
-  if (ARGS_COMPILE_ONLY OR ARGS_LIBRARY)
+  if(ARGS_COMPILE_ONLY OR ARGS_LIBRARY)
     add_test(
       NAME ${TEST_NAME}
       COMMAND ${CMAKE_COMMAND} --build . --target ${TEST_NAME} --config $<CONFIGURATION>
       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+      ${config_args}
     )
     set_target_properties(${TEST_NAME} PROPERTIES EXCLUDE_FROM_ALL TRUE EXCLUDE_FROM_DEFAULT_BUILD TRUE)
   else()
-    add_test(${TEST_NAME} ${TEST_NAME})
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME} ${config_args})
 
     # Add to <label>_tests make targets
-    foreach(label ${ARGS_LABELS})
+    foreach(label IN LISTS ARGS_LABELS)
       list(APPEND ARGS_DEPENDENCY_OF ${label})
-    endforeach(label ${ARGS_LABELS})
+    endforeach()
   endif()
 
   # Add to test labels
@@ -41,13 +72,13 @@ function(add_cpp_test TEST_NAME)
   endif()
 
   # Add as a dependency of given targets
-  foreach(dependency_of ${ARGS_DEPENDENCY_OF})
+  foreach(dependency_of IN LISTS ARGS_DEPENDENCY_OF)
     if (NOT TARGET ${dependency_of}_tests)
       add_custom_target(${dependency_of}_tests)
       add_dependencies(all_tests ${dependency_of}_tests)
-    endif(NOT TARGET ${dependency_of}_tests)
+    endif()
     add_dependencies(${dependency_of}_tests ${TEST_NAME})
-  endforeach(dependency_of ${ARGS_DEPENDENCY_OF})
+  endforeach()
 
   # If it will fail, mark the test as such
   if (ARGS_WILL_FAIL)

--- a/cmake/empty.cpp
+++ b/cmake/empty.cpp
@@ -1,0 +1,5 @@
+// Empty C++ file
+
+int main() {
+  return 0;
+}

--- a/tests/ondemand/CMakeLists.txt
+++ b/tests/ondemand/CMakeLists.txt
@@ -13,7 +13,7 @@ add_cpp_test(ondemand_parse_api_tests   LABELS ondemand acceptance per_implement
 add_cpp_test(ondemand_twitter_tests     LABELS ondemand acceptance per_implementation)
 
 if(HAVE_POSIX_FORK AND HAVE_POSIX_WAIT) # assert tests use fork and wait, which aren't on MSVC
-  add_cpp_test(ondemand_assert_out_of_order_values LABELS assert per_implementation explicitonly ondemand)
+  add_cpp_test(ondemand_assert_out_of_order_values DEBUG_ONLY LABELS assert per_implementation explicitonly ondemand)
 endif()
 
 # Copy the simdjson dll into the tests directory


### PR DESCRIPTION
This is in reference to https://github.com/simdjson/simdjson/pull/1352#issuecomment-750321197

Adds a `DEBUG_ONLY` option argument to `add_cpp_test`, which will just turn the function into a noop if the build system generator is a single configuration generator and `CMAKE_BUILD_TYPE` is not set to `Debug` and when the build system generator is multi-config, then will constrain the source set using a `$<CONFIG:Debug>` generator expression, but also add an empty cpp source for every other configuration, so the compiled binary is minimal, and also sets the `add_test(... CONFIGURATIONS Debug)` argument, so the test only runs in debug configuration.

@jkeiser Since you added the test that got fixed with #1352 I would like to ask you on what to do with CI and labels. CI would need some changes how CMake is invoked to properly cover all cases:
```bash
cmake -S <source> -B <build> -D CMAKE_BUILD_TYPE=$BUILD_TYPE ...
cmake --build <build> --config $BUILD_TYPE ...
ctest -C $BUILD_TYPE ...
```
In the above snippet a build type argument is present at every step, so it doesn't matter what build system is actually in use. Consistent invocation would mean that the necessary build type information is always present instead of relying on some potentially wrong default.