### PR TITLE
Add yyjson_insitu tests, make insitu tests more accurate

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -315,7 +315,7 @@ struct benchmarker {
     // We always allocate at least 64KB. Smaller allocations may actually be slower under some systems.
     error_code error = parser.allocate(json.size() < 65536 ? 65536 : json.size());
     if (error) {
-      exit_error(string("Unable to allocate_stage ") + to_string(json.size()) + " bytes for the JSON result: " + error_message(error));
+      exit_error(string("Unable to allocate_stage ") + to_string(json.size()) + " bytes for the JSON text: " + error_message(error));
     }
     event_count allocate_count = collector.end();
     allocate_stage << allocate_count;

--- a/benchmark/distinct_user_id/distinct_user_id.h
+++ b/benchmark/distinct_user_id/distinct_user_id.h
@@ -15,6 +15,7 @@ struct runner : public json_benchmark::file_runner<I> {
   }
 
   bool before_run(benchmark::State &state) {
+    if (!json_benchmark::file_runner<I>::before_run(state)) { return false; }
     ids.clear();
     return true;
   }
@@ -24,6 +25,7 @@ struct runner : public json_benchmark::file_runner<I> {
   }
 
   bool after_run(benchmark::State &state) {
+    if (!json_benchmark::file_runner<I>::after_run(state)) { return false; }
     std::sort(ids.begin(), ids.end());
     auto last = std::unique(ids.begin(), ids.end());
     ids.erase(last, ids.end());

--- a/benchmark/distinct_user_id/distinct_user_id.h
+++ b/benchmark/distinct_user_id/distinct_user_id.h
@@ -8,7 +8,7 @@ namespace distinct_user_id {
 
 template<typename I>
 struct runner : public json_benchmark::file_runner<I> {
-  std::vector<uint64_t> ids{};
+  std::vector<uint64_t> result{};
 
   bool setup(benchmark::State &state) {
     return this->load_json(state, json_benchmark::TWITTER_JSON);
@@ -16,29 +16,29 @@ struct runner : public json_benchmark::file_runner<I> {
 
   bool before_run(benchmark::State &state) {
     if (!json_benchmark::file_runner<I>::before_run(state)) { return false; }
-    ids.clear();
+    result.clear();
     return true;
   }
 
   bool run(benchmark::State &) {
-    return this->implementation.run(this->json, ids);
+    return this->implementation.run(this->json, result);
   }
 
   bool after_run(benchmark::State &state) {
     if (!json_benchmark::file_runner<I>::after_run(state)) { return false; }
-    std::sort(ids.begin(), ids.end());
-    auto last = std::unique(ids.begin(), ids.end());
-    ids.erase(last, ids.end());
+    std::sort(result.begin(), result.end());
+    auto last = std::unique(result.begin(), result.end());
+    result.erase(last, result.end());
     return true;
   }
 
   template<typename R>
   bool diff(benchmark::State &state, runner<R> &reference) {
-    return diff_results(state, ids, reference.ids);
+    return diff_results(state, result, reference.result);
   }
 
   size_t items_per_iteration() {
-    return ids.size();
+    return result.size();
   }
 };
 

--- a/benchmark/distinct_user_id/rapidjson.h
+++ b/benchmark/distinct_user_id/rapidjson.h
@@ -43,7 +43,7 @@ struct rapidjson : public rapidjson_base {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), ids);
   }
 };
-BENCHMARK_TEMPLATE(distinct_user_id, rapidjson);
+BENCHMARK_TEMPLATE(distinct_user_id, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
   bool run(const padded_string &json, std::vector<uint64_t> &ids) {
@@ -51,7 +51,7 @@ struct rapidjson_insitu : public rapidjson_base {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), ids);
   }
 };
-BENCHMARK_TEMPLATE(distinct_user_id, rapidjson_insitu);
+BENCHMARK_TEMPLATE(distinct_user_id, rapidjson_insitu)->UseManualTime();
 
 } // namespace partial_tweets
 

--- a/benchmark/distinct_user_id/rapidjson.h
+++ b/benchmark/distinct_user_id/rapidjson.h
@@ -39,14 +39,14 @@ struct rapidjson_base {
   }
 };
 
-struct rapidjson : public rapidjson_base {
+struct rapidjson : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, rapidjson)->UseManualTime();
 
-struct rapidjson_insitu : public rapidjson_base {
+struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
   }

--- a/benchmark/distinct_user_id/rapidjson.h
+++ b/benchmark/distinct_user_id/rapidjson.h
@@ -12,24 +12,25 @@ struct rapidjson_base {
   Document doc{};
 
   bool run(Document &root, std::vector<uint64_t> &ids) {
-    if (root.HasParseError() || !root.IsObject()) { return false; }
+    if (root.HasParseError()) { printf("parse error\n"); return false; }
+    if (!root.IsObject()) { printf("root is not an object\n"); return false; }
     auto statuses = root.FindMember("statuses");
-    if (statuses == root.MemberEnd() || !statuses->value.IsArray()) { return false; }
+    if (statuses == root.MemberEnd() || !statuses->value.IsArray()) { printf("statuses is not an array\n"); return false; }
     for (auto &tweet : statuses->value.GetArray()) {
       if (!tweet.IsObject()) { return false; }
       auto user = tweet.FindMember("user");
-      if (user == tweet.MemberEnd() || !user->value.IsObject()) { return false; }
+      if (user == tweet.MemberEnd() || !user->value.IsObject()) { printf("user is not an object\n"); return false; }
       auto id = user->value.FindMember("id");
-      if (id == user->value.MemberEnd() || !id->value.IsUint64()) { return false; }
+      if (id == user->value.MemberEnd() || !id->value.IsUint64()) { printf("id is not an int\n"); return false; }
       ids.push_back(id->value.GetUint64());
 
       auto retweet = tweet.FindMember("retweeted_status");
       if (retweet != tweet.MemberEnd()) {
-        if (!retweet->value.IsObject()) { return false; }
+        if (!retweet->value.IsObject()) { printf("retweet is not an object\n"); return false; }
         user = retweet->value.FindMember("user");
-        if (user == retweet->value.MemberEnd() || !user->value.IsObject()) { return false; }
+        if (user == retweet->value.MemberEnd() || !user->value.IsObject()) { printf("rewtweet.user is not an object\n"); return false; }
         id = user->value.FindMember("id");
-        if (id == user->value.MemberEnd() || !id->value.IsUint64()) { return false; }
+        if (id == user->value.MemberEnd() || !id->value.IsUint64()) { printf("retweet.id is not an int\n"); return false; }
         ids.push_back(id->value.GetUint64());
       }
     }
@@ -39,16 +40,15 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(const padded_string &json, std::vector<uint64_t> &ids) {
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), ids);
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(const padded_string &json, std::vector<uint64_t> &ids) {
-    padded_string json_copy{json.data(), json.size()};
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), ids);
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), ids);
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, rapidjson_insitu)->UseManualTime();

--- a/benchmark/distinct_user_id/simdjson_dom.h
+++ b/benchmark/distinct_user_id/simdjson_dom.h
@@ -11,7 +11,7 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(const simdjson::padded_string &json, std::vector<uint64_t> &ids) {
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
     // Walk the document, parsing as we go
     auto doc = parser.parse(json);
     for (dom::object tweet : doc["statuses"]) {

--- a/benchmark/distinct_user_id/simdjson_dom.h
+++ b/benchmark/distinct_user_id/simdjson_dom.h
@@ -11,18 +11,18 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
     // Walk the document, parsing as we go
     auto doc = parser.parse(json);
     for (dom::object tweet : doc["statuses"]) {
       // We believe that all statuses have a matching
       // user, and we are willing to throw when they do not.
-      ids.push_back(tweet["user"]["id"]);
+      result.push_back(tweet["user"]["id"]);
       // Not all tweets have a "retweeted_status", but when they do
       // we want to go and find the user within.
       auto retweet = tweet["retweeted_status"];
       if (retweet.error() != NO_SUCH_FIELD) {
-        ids.push_back(retweet["user"]["id"]);
+        result.push_back(retweet["user"]["id"]);
       }
     }
     return true;

--- a/benchmark/distinct_user_id/simdjson_dom.h
+++ b/benchmark/distinct_user_id/simdjson_dom.h
@@ -29,7 +29,7 @@ struct simdjson_dom {
   }
 };
 
-BENCHMARK_TEMPLATE(distinct_user_id, simdjson_dom);
+BENCHMARK_TEMPLATE(distinct_user_id, simdjson_dom)->UseManualTime();
 
 } // namespace distinct_user_id
 

--- a/benchmark/distinct_user_id/simdjson_ondemand.h
+++ b/benchmark/distinct_user_id/simdjson_ondemand.h
@@ -12,7 +12,7 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(const simdjson::padded_string &json, std::vector<uint64_t> &ids) {
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
     // Walk the document, parsing as we go
     auto doc = parser.iterate(json);
     for (ondemand::object tweet : doc.find_field("statuses")) {

--- a/benchmark/distinct_user_id/simdjson_ondemand.h
+++ b/benchmark/distinct_user_id/simdjson_ondemand.h
@@ -31,7 +31,7 @@ struct simdjson_ondemand {
   }
 };
 
-BENCHMARK_TEMPLATE(distinct_user_id, simdjson_ondemand);
+BENCHMARK_TEMPLATE(distinct_user_id, simdjson_ondemand)->UseManualTime();
 
 } // namespace distinct_user_id
 

--- a/benchmark/distinct_user_id/simdjson_ondemand.h
+++ b/benchmark/distinct_user_id/simdjson_ondemand.h
@@ -12,18 +12,18 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
     // Walk the document, parsing as we go
     auto doc = parser.iterate(json);
     for (ondemand::object tweet : doc.find_field("statuses")) {
       // We believe that all statuses have a matching
       // user, and we are willing to throw when they do not.
-      ids.push_back(tweet.find_field("user").find_field("id"));
+      result.push_back(tweet.find_field("user").find_field("id"));
       // Not all tweets have a "retweeted_status", but when they do
       // we want to go and find the user within.
       auto retweet = tweet.find_field("retweeted_status");
       if (!retweet.error()) {
-        ids.push_back(retweet.find_field("user").find_field("id"));
+        result.push_back(retweet.find_field("user").find_field("id"));
       }
     }
 

--- a/benchmark/distinct_user_id/yyjson.h
+++ b/benchmark/distinct_user_id/yyjson.h
@@ -7,7 +7,7 @@
 namespace distinct_user_id {
 
 struct yyjson {
-  bool run(const simdjson::padded_string &json, std::vector<uint64_t> &ids) {
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }

--- a/benchmark/distinct_user_id/yyjson.h
+++ b/benchmark/distinct_user_id/yyjson.h
@@ -7,7 +7,7 @@
 namespace distinct_user_id {
 
 struct yyjson {
-  bool run(simdjson::padded_string &json, std::vector<uint64_t> &ids) {
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }
@@ -23,7 +23,7 @@ struct yyjson {
       if (!yyjson_is_obj(user)) { return false; }
       auto id = yyjson_obj_get(user, "id");
       if (!yyjson_is_uint(id)) { return false; }
-      ids.push_back(yyjson_get_uint(id));
+      result.push_back(yyjson_get_uint(id));
 
       // Not all tweets have a "retweeted_status", but when they do
       // we want to go and find the user within.
@@ -34,7 +34,7 @@ struct yyjson {
         if (!yyjson_is_obj(user)) { return false; }
         id = yyjson_obj_get(user, "id");
         if (!yyjson_is_uint(id)) { return false; }
-        ids.push_back(yyjson_get_sint(id));
+        result.push_back(yyjson_get_sint(id));
       }
     }
 

--- a/benchmark/distinct_user_id/yyjson.h
+++ b/benchmark/distinct_user_id/yyjson.h
@@ -43,7 +43,7 @@ struct yyjson {
 
 };
 
-BENCHMARK_TEMPLATE(distinct_user_id, yyjson);
+BENCHMARK_TEMPLATE(distinct_user_id, yyjson)->UseManualTime();
 
 } // namespace distinct_user_id
 

--- a/benchmark/find_tweet/find_tweet.h
+++ b/benchmark/find_tweet/find_tweet.h
@@ -14,6 +14,7 @@ struct runner : public json_benchmark::file_runner<I> {
   }
 
   bool before_run(benchmark::State &state) {
+    if (!json_benchmark::file_runner<I>::before_run(state)) { return false; }
     text = "";
     return true;
   }

--- a/benchmark/find_tweet/find_tweet.h
+++ b/benchmark/find_tweet/find_tweet.h
@@ -7,7 +7,7 @@ namespace find_tweet {
 
 template<typename I>
 struct runner : public json_benchmark::file_runner<I> {
-  std::string_view text;
+  std::string_view result;
 
   bool setup(benchmark::State &state) {
     return this->load_json(state, json_benchmark::TWITTER_JSON);
@@ -15,17 +15,17 @@ struct runner : public json_benchmark::file_runner<I> {
 
   bool before_run(benchmark::State &state) {
     if (!json_benchmark::file_runner<I>::before_run(state)) { return false; }
-    text = "";
+    result = "";
     return true;
   }
 
   bool run(benchmark::State &) {
-    return this->implementation.run(this->json, 505874901689851900ULL, text);
+    return this->implementation.run(this->json, 505874901689851900ULL, result);
   }
 
   template<typename R>
   bool diff(benchmark::State &state, runner<R> &reference) {
-    return diff_results(state, text, reference.text);
+    return diff_results(state, result, reference.result);
   }
 };
 

--- a/benchmark/find_tweet/rapidjson.h
+++ b/benchmark/find_tweet/rapidjson.h
@@ -36,7 +36,7 @@ struct rapidjson : public rapidjson_base {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), find_id, text);
   }
 };
-BENCHMARK_TEMPLATE(find_tweet, rapidjson);
+BENCHMARK_TEMPLATE(find_tweet, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
   bool run(const padded_string &json, uint64_t find_id, std::string_view &text) {
@@ -44,7 +44,7 @@ struct rapidjson_insitu : public rapidjson_base {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), find_id, text);
   }
 };
-BENCHMARK_TEMPLATE(find_tweet, rapidjson_insitu);
+BENCHMARK_TEMPLATE(find_tweet, rapidjson_insitu)->UseManualTime();
 
 } // namespace partial_tweets
 

--- a/benchmark/find_tweet/rapidjson.h
+++ b/benchmark/find_tweet/rapidjson.h
@@ -31,14 +31,14 @@ struct rapidjson_base {
   }
 };
 
-struct rapidjson : public rapidjson_base {
+struct rapidjson : rapidjson_base {
   bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), find_id, result);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson)->UseManualTime();
 
-struct rapidjson_insitu : public rapidjson_base {
+struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), find_id, result);
   }

--- a/benchmark/find_tweet/rapidjson.h
+++ b/benchmark/find_tweet/rapidjson.h
@@ -32,16 +32,15 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(const padded_string &json, uint64_t find_id, std::string_view &text) {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), find_id, text);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(const padded_string &json, uint64_t find_id, std::string_view &text) {
-    padded_string json_copy{json.data(), json.size()};
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), find_id, text);
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), find_id, text);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson_insitu)->UseManualTime();

--- a/benchmark/find_tweet/rapidjson.h
+++ b/benchmark/find_tweet/rapidjson.h
@@ -11,7 +11,7 @@ using namespace rapidjson;
 struct rapidjson_base {
   Document doc{};
 
-  bool run(Document &root, uint64_t find_id, std::string_view &text) {
+  bool run(Document &root, uint64_t find_id, std::string_view &result) {
     if (root.HasParseError() || !root.IsObject()) { return false; }
     auto statuses = root.FindMember("statuses");
     if (statuses == root.MemberEnd() || !statuses->value.IsArray()) { return false; }
@@ -20,9 +20,9 @@ struct rapidjson_base {
       auto id = tweet.FindMember("id");
       if (id == tweet.MemberEnd() || !id->value.IsUint64()) { return false; }
       if (id->value.GetUint64() == find_id) {
-        auto _text = tweet.FindMember("text");
-        if (_text == tweet.MemberEnd() || !_text->value.IsString()) { return false; }
-        text = { _text->value.GetString(), _text->value.GetStringLength() };
+        auto text = tweet.FindMember("text");
+        if (text == tweet.MemberEnd() || !text->value.IsString()) { return false; }
+        result = { text->value.GetString(), text->value.GetStringLength() };
         return true;
       }
     }
@@ -32,15 +32,15 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
-    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), find_id, text);
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
+    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), find_id, result);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), find_id, text);
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), find_id, result);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson_insitu)->UseManualTime();

--- a/benchmark/find_tweet/simdjson_dom.h
+++ b/benchmark/find_tweet/simdjson_dom.h
@@ -11,7 +11,7 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(const simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
     text = "";
     auto doc = parser.parse(json);
     for (auto tweet : doc["statuses"]) {

--- a/benchmark/find_tweet/simdjson_dom.h
+++ b/benchmark/find_tweet/simdjson_dom.h
@@ -11,12 +11,12 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
-    text = "";
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
+    result = "";
     auto doc = parser.parse(json);
     for (auto tweet : doc["statuses"]) {
       if (uint64_t(tweet["id"]) == find_id) {
-        text = tweet["text"];
+        result = tweet["text"];
         return true;
       }
     }

--- a/benchmark/find_tweet/simdjson_dom.h
+++ b/benchmark/find_tweet/simdjson_dom.h
@@ -24,7 +24,7 @@ struct simdjson_dom {
   }
 };
 
-BENCHMARK_TEMPLATE(find_tweet, simdjson_dom);
+BENCHMARK_TEMPLATE(find_tweet, simdjson_dom)->UseManualTime();
 
 } // namespace find_tweet
 

--- a/benchmark/find_tweet/simdjson_ondemand.h
+++ b/benchmark/find_tweet/simdjson_ondemand.h
@@ -12,7 +12,7 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(const simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
     // Walk the document, parsing as we go
     auto doc = parser.iterate(json);
     for (auto tweet : doc.find_field("statuses")) {

--- a/benchmark/find_tweet/simdjson_ondemand.h
+++ b/benchmark/find_tweet/simdjson_ondemand.h
@@ -12,12 +12,12 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
     // Walk the document, parsing as we go
     auto doc = parser.iterate(json);
     for (auto tweet : doc.find_field("statuses")) {
       if (uint64_t(tweet.find_field("id")) == find_id) {
-        text = tweet.find_field("text");
+        result = tweet.find_field("text");
         return true;
       }
     }

--- a/benchmark/find_tweet/simdjson_ondemand.h
+++ b/benchmark/find_tweet/simdjson_ondemand.h
@@ -25,7 +25,7 @@ struct simdjson_ondemand {
   }
 };
 
-BENCHMARK_TEMPLATE(find_tweet, simdjson_ondemand);
+BENCHMARK_TEMPLATE(find_tweet, simdjson_ondemand)->UseManualTime();
 
 } // namespace find_tweet
 

--- a/benchmark/find_tweet/yyjson.h
+++ b/benchmark/find_tweet/yyjson.h
@@ -7,7 +7,7 @@
 namespace find_tweet {
 
 struct yyjson {
-  bool run(const simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }

--- a/benchmark/find_tweet/yyjson.h
+++ b/benchmark/find_tweet/yyjson.h
@@ -33,7 +33,7 @@ struct yyjson {
   }
 };
 
-BENCHMARK_TEMPLATE(find_tweet, yyjson);
+BENCHMARK_TEMPLATE(find_tweet, yyjson)->UseManualTime();
 
 } // namespace find_tweet
 

--- a/benchmark/find_tweet/yyjson.h
+++ b/benchmark/find_tweet/yyjson.h
@@ -7,7 +7,7 @@
 namespace find_tweet {
 
 struct yyjson {
-  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &text) {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }
@@ -23,9 +23,9 @@ struct yyjson {
       auto id = yyjson_obj_get(tweet, "id");
       if (!yyjson_is_uint(id)) { return false; }
       if (yyjson_get_uint(id) == find_id) {
-        auto _text = yyjson_obj_get(tweet, "text");
+        auto text = yyjson_obj_get(tweet, "text");
         if (yyjson_is_str(id)) { return false; }
-        text = yyjson_get_str(_text);
+        result = yyjson_get_str(text);
         return true;
       }
     }

--- a/benchmark/find_tweet/yyjson.h
+++ b/benchmark/find_tweet/yyjson.h
@@ -6,16 +6,15 @@
 
 namespace find_tweet {
 
-struct yyjson {
-  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
-    // Walk the document, parsing the tweets as we go
-    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+struct yyjson_base {
+  bool run(yyjson_doc *doc, uint64_t find_id, std::string_view &result) {
     if (!doc) { return false; }
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!yyjson_is_obj(root)) { return false; }
     yyjson_val *statuses = yyjson_obj_get(root, "statuses");
     if (!yyjson_is_arr(statuses)) { return "Statuses is not an array!"; }
 
+    // Walk the document, parsing the tweets as we go
     size_t tweet_idx, tweets_max;
     yyjson_val *tweet;
     yyjson_arr_foreach(statuses, tweet_idx, tweets_max, tweet) {
@@ -25,7 +24,7 @@ struct yyjson {
       if (yyjson_get_uint(id) == find_id) {
         auto text = yyjson_obj_get(tweet, "text");
         if (yyjson_is_str(id)) { return false; }
-        result = yyjson_get_str(text);
+        result = { yyjson_get_str(text), yyjson_get_len(text) };
         return true;
       }
     }
@@ -33,7 +32,19 @@ struct yyjson {
   }
 };
 
+struct yyjson : yyjson_base {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
+    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), find_id, result);
+  }
+};
 BENCHMARK_TEMPLATE(find_tweet, yyjson)->UseManualTime();
+
+struct yyjson_insitu : yyjson_base {
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
+    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), find_id, result);
+  }
+};
+BENCHMARK_TEMPLATE(find_tweet, yyjson_insitu)->UseManualTime();
 
 } // namespace find_tweet
 

--- a/benchmark/json_benchmark/file_runner.h
+++ b/benchmark/json_benchmark/file_runner.h
@@ -7,16 +7,25 @@ namespace json_benchmark {
 
 template<typename I>
 struct file_runner : public runner_base<I> {
+  simdjson::padded_string original_json{};
   simdjson::padded_string json{};
 
-  bool load_json(benchmark::State &state, const char *file) {
+  simdjson_warn_unused bool load_json(benchmark::State &state, const char *file) {
     simdjson::error_code error;
-    if ((error = simdjson::padded_string::load(file).get(json))) {
+    if ((error = simdjson::padded_string::load(file).get(original_json))) {
       std::stringstream err;
       err << "error loading " << file << ": " << error;
       state.SkipWithError(err.str().data());
       return false;
     }
+    json = simdjson::padded_string(original_json.data(), original_json.size());
+    return true;
+  }
+
+  simdjson_warn_unused bool before_run(benchmark::State &state) {
+    if (!runner_base<I>::after_run(state)) { return false; };
+    // Copy the original json in case we did *in situ* last time
+    std::memcpy(json.data(), original_json.data(), original_json.size());
     return true;
   }
 

--- a/benchmark/json_benchmark/run_json_benchmark.h
+++ b/benchmark/json_benchmark/run_json_benchmark.h
@@ -37,7 +37,9 @@ template<typename B, typename R> static void run_json_benchmark(benchmark::State
     if (!bench.before_run(state)) { state.SkipWithError("before_run failed"); };
     collector.start();
     if (!bench.run(state)) { state.SkipWithError("run failed"); return; }
-    events << collector.end();
+    auto event = collector.end();
+    events << event;
+    state.SetIterationTime(event.elapsed_sec());
     if (!bench.after_run(state)) { state.SkipWithError("after_run failed"); return; };
   }
 

--- a/benchmark/json_benchmark/run_json_benchmark.h
+++ b/benchmark/json_benchmark/run_json_benchmark.h
@@ -24,11 +24,15 @@ template<typename B, typename R> static void run_json_benchmark(benchmark::State
   // Warmup and equality check (make sure the data is right!)
   B bench;
   if (!bench.setup(state)) { return; }
+  if (!bench.before_run(state)) { state.SkipWithError("warmup document before_run failed"); return; }
   if (!bench.run(state)) { state.SkipWithError("warmup document reading failed"); return; }
+  if (!bench.after_run(state)) { state.SkipWithError("warmup document after_run failed"); return; }
   {
     R reference;
     if (!reference.setup(state)) { return; }
+    if (!reference.before_run(state)) { state.SkipWithError("reference before_run failed"); };
     if (!reference.run(state)) { state.SkipWithError("reference document reading failed"); return; }
+    if (!reference.after_run(state)) { state.SkipWithError("reference before_run failed"); };
     if (!bench.diff(state, reference)) { return; }
   }
 

--- a/benchmark/json_benchmark/string_runner.h
+++ b/benchmark/json_benchmark/string_runner.h
@@ -6,9 +6,17 @@
 namespace json_benchmark {
 
 template<typename I>
-struct const_json_runner : public runner_base<I> {
-  const simdjson::padded_string &json;
-  const_json_runner(const simdjson::padded_string &_json) : json{_json} {}
+struct string_runner : public runner_base<I> {
+  const simdjson::padded_string &original_json;
+  simdjson::padded_string json;
+  string_runner(const simdjson::padded_string &_json) : original_json{_json}, json(original_json.data(), original_json.size()) {}
+
+  simdjson_warn_unused bool before_run(benchmark::State &state) {
+    if (!runner_base<I>::after_run(state)) { return false; };
+    // Copy the original json in case we did *in situ*
+    std::memcpy(json.data(), original_json.data(), original_json.size());
+    return true;
+  }
 
   /** Get the total number of bytes processed in each iteration. Used for metrics like bytes/second. */
   size_t bytes_per_iteration() {

--- a/benchmark/kostya/kostya.h
+++ b/benchmark/kostya/kostya.h
@@ -2,7 +2,7 @@
 
 #if SIMDJSON_EXCEPTIONS
 
-#include "json_benchmark/const_json_runner.h"
+#include "json_benchmark/string_runner.h"
 #include <vector>
 #include <random>
 
@@ -27,12 +27,13 @@ simdjson_unused static std::ostream &operator<<(std::ostream &o, const point &p)
 }
 
 template<typename I>
-struct runner : public json_benchmark::const_json_runner<I> {
+struct runner : public json_benchmark::string_runner<I> {
   std::vector<point> points;
 
-  runner() : json_benchmark::const_json_runner<I>(get_built_json_array()) {}
+  runner() : json_benchmark::string_runner<I>(get_built_json_array()) {}
 
   bool before_run(benchmark::State &state) {
+    if (!json_benchmark::string_runner<I>::before_run(state)) { return false; }
     points.clear();
     return true;
   }

--- a/benchmark/kostya/kostya.h
+++ b/benchmark/kostya/kostya.h
@@ -28,27 +28,27 @@ simdjson_unused static std::ostream &operator<<(std::ostream &o, const point &p)
 
 template<typename I>
 struct runner : public json_benchmark::string_runner<I> {
-  std::vector<point> points;
+  std::vector<point> result;
 
   runner() : json_benchmark::string_runner<I>(get_built_json_array()) {}
 
   bool before_run(benchmark::State &state) {
     if (!json_benchmark::string_runner<I>::before_run(state)) { return false; }
-    points.clear();
+    result.clear();
     return true;
   }
 
   bool run(benchmark::State &) {
-    return this->implementation.run(this->json, points);
+    return this->implementation.run(this->json, result);
   }
 
   template<typename R>
   bool diff(benchmark::State &state, runner<R> &reference) {
-    return diff_results(state, points, reference.points);
+    return diff_results(state, result, reference.result);
   }
 
   size_t items_per_iteration() {
-    return points.size();
+    return result.size();
   }
 };
 

--- a/benchmark/kostya/rapidjson.h
+++ b/benchmark/kostya/rapidjson.h
@@ -34,23 +34,22 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(const padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), points);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson)->UseManualTime();
 
 struct rapidjson_lossless : public rapidjson_base {
-  bool run(const padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), points);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(const padded_string &json, std::vector<point> &points) {
-    padded_string json_copy{json.data(), json.size()};
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), points);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson_insitu)->UseManualTime();

--- a/benchmark/kostya/rapidjson.h
+++ b/benchmark/kostya/rapidjson.h
@@ -33,21 +33,21 @@ struct rapidjson_base {
   }
 };
 
-struct rapidjson : public rapidjson_base {
+struct rapidjson : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson)->UseManualTime();
 
-struct rapidjson_lossless : public rapidjson_base {
+struct rapidjson_lossless : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson_lossless)->UseManualTime();
 
-struct rapidjson_insitu : public rapidjson_base {
+struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
   }

--- a/benchmark/kostya/rapidjson.h
+++ b/benchmark/kostya/rapidjson.h
@@ -18,7 +18,7 @@ struct rapidjson_base {
     return field->value.GetDouble();
   }
 
-  bool run(Document &root, std::vector<point> &points) {
+  bool run(Document &root, std::vector<point> &result) {
     if (root.HasParseError()) { return false; }
     if (!root.IsObject()) { return false; }
     auto coords = root.FindMember("coordinates");
@@ -26,7 +26,7 @@ struct rapidjson_base {
     if (!coords->value.IsArray()) { return false; }
     for (auto &coord : coords->value.GetArray()) {
       if (!coord.IsObject()) { return false; }
-      points.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
+      result.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
     }
 
     return true;
@@ -34,22 +34,22 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
-    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson)->UseManualTime();
 
 struct rapidjson_lossless : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
-    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson_insitu)->UseManualTime();

--- a/benchmark/kostya/rapidjson.h
+++ b/benchmark/kostya/rapidjson.h
@@ -38,14 +38,14 @@ struct rapidjson : public rapidjson_base {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), points);
   }
 };
-BENCHMARK_TEMPLATE(kostya, rapidjson);
+BENCHMARK_TEMPLATE(kostya, rapidjson)->UseManualTime();
 
 struct rapidjson_lossless : public rapidjson_base {
   bool run(const padded_string &json, std::vector<point> &points) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), points);
   }
 };
-BENCHMARK_TEMPLATE(kostya, rapidjson_lossless);
+BENCHMARK_TEMPLATE(kostya, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
   bool run(const padded_string &json, std::vector<point> &points) {
@@ -53,7 +53,7 @@ struct rapidjson_insitu : public rapidjson_base {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), points);
   }
 };
-BENCHMARK_TEMPLATE(kostya, rapidjson_insitu);
+BENCHMARK_TEMPLATE(kostya, rapidjson_insitu)->UseManualTime();
 
 } // namespace kostya
 

--- a/benchmark/kostya/simdjson_dom.h
+++ b/benchmark/kostya/simdjson_dom.h
@@ -11,7 +11,7 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     for (auto point : parser.parse(json)["coordinates"]) {
       points.emplace_back(kostya::point{point["x"], point["y"], point["z"]});
     }

--- a/benchmark/kostya/simdjson_dom.h
+++ b/benchmark/kostya/simdjson_dom.h
@@ -19,7 +19,7 @@ struct simdjson_dom {
   }
 };
 
-BENCHMARK_TEMPLATE(kostya, simdjson_dom);
+BENCHMARK_TEMPLATE(kostya, simdjson_dom)->UseManualTime();
 
 } // namespace kostya
 

--- a/benchmark/kostya/simdjson_dom.h
+++ b/benchmark/kostya/simdjson_dom.h
@@ -11,9 +11,9 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
     for (auto point : parser.parse(json)["coordinates"]) {
-      points.emplace_back(kostya::point{point["x"], point["y"], point["z"]});
+      result.emplace_back(kostya::point{point["x"], point["y"], point["z"]});
     }
     return true;
   }

--- a/benchmark/kostya/simdjson_ondemand.h
+++ b/benchmark/kostya/simdjson_ondemand.h
@@ -12,7 +12,7 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     auto doc = parser.iterate(json);
     for (ondemand::object point : doc.find_field("coordinates")) {
       points.emplace_back(kostya::point{point.find_field("x"), point.find_field("y"), point.find_field("z")});

--- a/benchmark/kostya/simdjson_ondemand.h
+++ b/benchmark/kostya/simdjson_ondemand.h
@@ -21,7 +21,7 @@ struct simdjson_ondemand {
   }
 };
 
-BENCHMARK_TEMPLATE(kostya, simdjson_ondemand);
+BENCHMARK_TEMPLATE(kostya, simdjson_ondemand)->UseManualTime();
 
 } // namespace kostya
 

--- a/benchmark/kostya/simdjson_ondemand.h
+++ b/benchmark/kostya/simdjson_ondemand.h
@@ -12,10 +12,10 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
     auto doc = parser.iterate(json);
     for (ondemand::object point : doc.find_field("coordinates")) {
-      points.emplace_back(kostya::point{point.find_field("x"), point.find_field("y"), point.find_field("z")});
+      result.emplace_back(kostya::point{point.find_field("x"), point.find_field("y"), point.find_field("z")});
     }
     return true;
   }

--- a/benchmark/kostya/yyjson.h
+++ b/benchmark/kostya/yyjson.h
@@ -24,7 +24,7 @@ struct yyjson {
     }
   }
 
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }
     yyjson_val *root = yyjson_doc_get_root(doc);

--- a/benchmark/kostya/yyjson.h
+++ b/benchmark/kostya/yyjson.h
@@ -6,7 +6,7 @@
 
 namespace kostya {
 
-struct yyjson {
+struct yyjson_base {
   simdjson_really_inline double get_double(yyjson_val *obj, std::string_view key) {
     yyjson_val *val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!val) { throw "missing point field!"; }
@@ -24,8 +24,7 @@ struct yyjson {
     }
   }
 
-  bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+  bool run(yyjson_doc *doc, std::vector<point> &result) {
     if (!doc) { return false; }
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!yyjson_is_obj(root)) { return false; }
@@ -44,7 +43,19 @@ struct yyjson {
 
 };
 
+struct yyjson : yyjson_base {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), result);
+  }
+};
 BENCHMARK_TEMPLATE(kostya, yyjson)->UseManualTime();
+
+struct yyjson_insitu : yyjson_base {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
+  }
+};
+BENCHMARK_TEMPLATE(kostya, yyjson_insitu)->UseManualTime();
 
 } // namespace kostya
 

--- a/benchmark/kostya/yyjson.h
+++ b/benchmark/kostya/yyjson.h
@@ -44,7 +44,7 @@ struct yyjson {
 
 };
 
-BENCHMARK_TEMPLATE(kostya, yyjson);
+BENCHMARK_TEMPLATE(kostya, yyjson)->UseManualTime();
 
 } // namespace kostya
 

--- a/benchmark/kostya/yyjson.h
+++ b/benchmark/kostya/yyjson.h
@@ -24,7 +24,7 @@ struct yyjson {
     }
   }
 
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }
     yyjson_val *root = yyjson_doc_get_root(doc);
@@ -36,7 +36,7 @@ struct yyjson {
     yyjson_val *coord;
     yyjson_arr_foreach(coords, idx, max, coord) {
       if (!yyjson_is_obj(coord)) { return false; }
-      points.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
+      result.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
     }
 
     return true;

--- a/benchmark/large_random/large_random.h
+++ b/benchmark/large_random/large_random.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "json_benchmark/const_json_runner.h"
+#include "json_benchmark/string_runner.h"
 #include <random>
 
 namespace large_random {
@@ -24,12 +24,13 @@ simdjson_unused static std::ostream &operator<<(std::ostream &o, const point &p)
 }
 
 template<typename I>
-struct runner : public json_benchmark::const_json_runner<I> {
+struct runner : public json_benchmark::string_runner<I> {
   std::vector<point> points;
 
-  runner() : json_benchmark::const_json_runner<I>(get_built_json_array()) {}
+  runner() : json_benchmark::string_runner<I>(get_built_json_array()) {}
 
   bool before_run(benchmark::State &state) {
+    if (!json_benchmark::string_runner<I>::before_run(state)) { return false; }
     points.clear();
     return true;
   }

--- a/benchmark/large_random/large_random.h
+++ b/benchmark/large_random/large_random.h
@@ -25,27 +25,27 @@ simdjson_unused static std::ostream &operator<<(std::ostream &o, const point &p)
 
 template<typename I>
 struct runner : public json_benchmark::string_runner<I> {
-  std::vector<point> points;
+  std::vector<point> result;
 
   runner() : json_benchmark::string_runner<I>(get_built_json_array()) {}
 
   bool before_run(benchmark::State &state) {
     if (!json_benchmark::string_runner<I>::before_run(state)) { return false; }
-    points.clear();
+    result.clear();
     return true;
   }
 
   bool run(benchmark::State &) {
-    return this->implementation.run(this->json, points);
+    return this->implementation.run(this->json, result);
   }
 
   template<typename R>
   bool diff(benchmark::State &state, runner<R> &reference) {
-    return diff_results(state, points, reference.points);
+    return diff_results(state, result, reference.result);
   }
 
   size_t items_per_iteration() {
-    return points.size();
+    return result.size();
   }
 };
 

--- a/benchmark/large_random/rapidjson.h
+++ b/benchmark/large_random/rapidjson.h
@@ -31,23 +31,22 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), points);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson)->UseManualTime();
 
 struct rapidjson_lossless : public rapidjson_base {
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), points);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
-    padded_string json_copy{json.data(), json.size()};
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), points);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson_insitu)->UseManualTime();

--- a/benchmark/large_random/rapidjson.h
+++ b/benchmark/large_random/rapidjson.h
@@ -18,12 +18,12 @@ struct rapidjson_base {
     return field->value.GetDouble();
   }
 
-  bool run(Document &coords, std::vector<point> &points) {
+  bool run(Document &coords, std::vector<point> &result) {
     if (coords.HasParseError()) { return false; }
     if (!coords.IsArray()) { return false; }
     for (auto &coord : coords.GetArray()) {
       if (!coord.IsObject()) { return false; }
-      points.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
+      result.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
     }
 
     return true;
@@ -31,22 +31,22 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
-    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson)->UseManualTime();
 
 struct rapidjson_lossless : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
-    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), points);
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson_insitu)->UseManualTime();

--- a/benchmark/large_random/rapidjson.h
+++ b/benchmark/large_random/rapidjson.h
@@ -35,14 +35,14 @@ struct rapidjson : public rapidjson_base {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), points);
   }
 };
-BENCHMARK_TEMPLATE(large_random, rapidjson);
+BENCHMARK_TEMPLATE(large_random, rapidjson)->UseManualTime();
 
 struct rapidjson_lossless : public rapidjson_base {
   bool run(const simdjson::padded_string &json, std::vector<point> &points) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), points);
   }
 };
-BENCHMARK_TEMPLATE(large_random, rapidjson_lossless);
+BENCHMARK_TEMPLATE(large_random, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
   bool run(const simdjson::padded_string &json, std::vector<point> &points) {
@@ -50,7 +50,7 @@ struct rapidjson_insitu : public rapidjson_base {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), points);
   }
 };
-BENCHMARK_TEMPLATE(large_random, rapidjson_insitu);
+BENCHMARK_TEMPLATE(large_random, rapidjson_insitu)->UseManualTime();
 
 
 } // namespace large_random

--- a/benchmark/large_random/rapidjson.h
+++ b/benchmark/large_random/rapidjson.h
@@ -30,21 +30,21 @@ struct rapidjson_base {
   }
 };
 
-struct rapidjson : public rapidjson_base {
+struct rapidjson : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson)->UseManualTime();
 
-struct rapidjson_lossless : public rapidjson_base {
+struct rapidjson_lossless : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson_lossless)->UseManualTime();
 
-struct rapidjson_insitu : public rapidjson_base {
+struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
   }

--- a/benchmark/large_random/simdjson_dom.h
+++ b/benchmark/large_random/simdjson_dom.h
@@ -11,7 +11,7 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     for (auto point : parser.parse(json)) {
       points.emplace_back(large_random::point{point["x"], point["y"], point["z"]});
     }

--- a/benchmark/large_random/simdjson_dom.h
+++ b/benchmark/large_random/simdjson_dom.h
@@ -19,7 +19,7 @@ struct simdjson_dom {
   }
 };
 
-BENCHMARK_TEMPLATE(large_random, simdjson_dom);
+BENCHMARK_TEMPLATE(large_random, simdjson_dom)->UseManualTime();
 
 } // namespace large_random
 

--- a/benchmark/large_random/simdjson_dom.h
+++ b/benchmark/large_random/simdjson_dom.h
@@ -11,9 +11,9 @@ using namespace simdjson;
 struct simdjson_dom {
   dom::parser parser{};
 
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
     for (auto point : parser.parse(json)) {
-      points.emplace_back(large_random::point{point["x"], point["y"], point["z"]});
+      result.emplace_back(large_random::point{point["x"], point["y"], point["z"]});
     }
     return true;
   }

--- a/benchmark/large_random/simdjson_ondemand.h
+++ b/benchmark/large_random/simdjson_ondemand.h
@@ -12,7 +12,7 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     auto doc = parser.iterate(json);
     for (ondemand::object coord : doc) {
       points.emplace_back(point{coord.find_field("x"), coord.find_field("y"), coord.find_field("z")});

--- a/benchmark/large_random/simdjson_ondemand.h
+++ b/benchmark/large_random/simdjson_ondemand.h
@@ -12,10 +12,10 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand {
   ondemand::parser parser{};
 
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
     auto doc = parser.iterate(json);
     for (ondemand::object coord : doc) {
-      points.emplace_back(point{coord.find_field("x"), coord.find_field("y"), coord.find_field("z")});
+      result.emplace_back(point{coord.find_field("x"), coord.find_field("y"), coord.find_field("z")});
     }
     return true;
   }

--- a/benchmark/large_random/simdjson_ondemand.h
+++ b/benchmark/large_random/simdjson_ondemand.h
@@ -21,7 +21,7 @@ struct simdjson_ondemand {
   }
 };
 
-BENCHMARK_TEMPLATE(large_random, simdjson_ondemand);
+BENCHMARK_TEMPLATE(large_random, simdjson_ondemand)->UseManualTime();
 
 } // namespace large_random
 

--- a/benchmark/large_random/simdjson_ondemand_unordered.h
+++ b/benchmark/large_random/simdjson_ondemand_unordered.h
@@ -12,7 +12,7 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand_unordered {
   ondemand::parser parser{};
 
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     auto doc = parser.iterate(json);
     for (ondemand::object coord : doc) {
       points.emplace_back(large_random::point{coord["x"], coord["y"], coord["z"]});

--- a/benchmark/large_random/simdjson_ondemand_unordered.h
+++ b/benchmark/large_random/simdjson_ondemand_unordered.h
@@ -12,10 +12,10 @@ using namespace simdjson::builtin;
 struct simdjson_ondemand_unordered {
   ondemand::parser parser{};
 
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
     auto doc = parser.iterate(json);
     for (ondemand::object coord : doc) {
-      points.emplace_back(large_random::point{coord["x"], coord["y"], coord["z"]});
+      result.emplace_back(large_random::point{coord["x"], coord["y"], coord["z"]});
     }
     return true;
   }

--- a/benchmark/large_random/simdjson_ondemand_unordered.h
+++ b/benchmark/large_random/simdjson_ondemand_unordered.h
@@ -21,7 +21,7 @@ struct simdjson_ondemand_unordered {
   }
 };
 
-BENCHMARK_TEMPLATE(large_random, simdjson_ondemand_unordered);
+BENCHMARK_TEMPLATE(large_random, simdjson_ondemand_unordered)->UseManualTime();
 
 } // namespace large_random
 

--- a/benchmark/large_random/yyjson.h
+++ b/benchmark/large_random/yyjson.h
@@ -24,7 +24,7 @@ struct yyjson {
     }
   }
 
-  bool run(const simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &points) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }

--- a/benchmark/large_random/yyjson.h
+++ b/benchmark/large_random/yyjson.h
@@ -41,7 +41,7 @@ struct yyjson {
   }
 };
 
-BENCHMARK_TEMPLATE(large_random, yyjson);
+BENCHMARK_TEMPLATE(large_random, yyjson)->UseManualTime();
 
 } // namespace large_random
 

--- a/benchmark/large_random/yyjson.h
+++ b/benchmark/large_random/yyjson.h
@@ -6,7 +6,7 @@
 
 namespace large_random {
 
-struct yyjson {
+struct yyjson_base {
   simdjson_really_inline double get_double(yyjson_val *obj, std::string_view key) {
     yyjson_val *val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!val) { throw "missing point field!"; }
@@ -24,24 +24,36 @@ struct yyjson {
     }
   }
 
-  bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    // Walk the document, parsing the tweets as we go
-    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+  bool run(yyjson_doc *doc, std::vector<point> &result) {
     if (!doc) { return false; }
     yyjson_val *coords = yyjson_doc_get_root(doc);
     if (!yyjson_is_arr(coords)) { return false; }
 
+    // Walk the document, parsing the tweets as we go
     size_t idx, max;
     yyjson_val *coord;
     yyjson_arr_foreach(coords, idx, max, coord) {
       if (!yyjson_is_obj(coord)) { return false; }
       result.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
     }
+
     return true;
   }
 };
 
+struct yyjson : yyjson_base {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), result);
+  }
+};
 BENCHMARK_TEMPLATE(large_random, yyjson)->UseManualTime();
+
+struct yyjson_insitu : yyjson_base {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
+  }
+};
+BENCHMARK_TEMPLATE(large_random, yyjson_insitu)->UseManualTime();
 
 } // namespace large_random
 

--- a/benchmark/large_random/yyjson.h
+++ b/benchmark/large_random/yyjson.h
@@ -24,7 +24,7 @@ struct yyjson {
     }
   }
 
-  bool run(simdjson::padded_string &json, std::vector<point> &points) {
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }
@@ -35,7 +35,7 @@ struct yyjson {
     yyjson_val *coord;
     yyjson_arr_foreach(coords, idx, max, coord) {
       if (!yyjson_is_obj(coord)) { return false; }
-      points.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
+      result.emplace_back(point{get_double(coord, "x"), get_double(coord, "y"), get_double(coord, "z")});
     }
     return true;
   }

--- a/benchmark/linux/linux-perf-events.h
+++ b/benchmark/linux/linux-perf-events.h
@@ -28,7 +28,7 @@ template <int TYPE = PERF_TYPE_HARDWARE> class LinuxEvents {
   perf_event_attr attribs{};
   size_t num_events{};
   std::vector<uint64_t> temp_result_vec{};
-  std::vector<uint64_t> ids{};
+  std::vector<uint64_t> result{};
   bool quiet;
 
 public:
@@ -48,7 +48,7 @@ public:
 
     int group = -1; // no group
     num_events = config_vec.size();
-    ids.resize(config_vec.size());
+    result.resize(config_vec.size());
     uint32_t i = 0;
     for (auto config : config_vec) {
       attribs.config = config;
@@ -56,7 +56,7 @@ public:
       if (fd == -1) {
         report_error("perf_event_open");
       }
-      ioctl(fd, PERF_EVENT_IOC_ID, &ids[i++]);
+      ioctl(fd, PERF_EVENT_IOC_ID, &result[i++]);
       if (group == -1) {
         group = fd;
       }
@@ -90,7 +90,7 @@ public:
       }
     }
     // our actual results are in slots 1,3,5, ... of this structure
-    // we really should be checking our ids obtained earlier to be safe
+    // we really should be checking our result obtained earlier to be safe
     for (uint32_t i = 1; i < temp_result_vec.size(); i += 2) {
       results[i / 2] = temp_result_vec[i];
     }

--- a/benchmark/partial_tweets/partial_tweets.h
+++ b/benchmark/partial_tweets/partial_tweets.h
@@ -16,6 +16,7 @@ struct runner : public json_benchmark::file_runner<I> {
   }
 
   bool before_run(benchmark::State &state) {
+    if (!json_benchmark::file_runner<I>::before_run(state)) { return false; }
     tweets.clear();
     return true;
   }

--- a/benchmark/partial_tweets/partial_tweets.h
+++ b/benchmark/partial_tweets/partial_tweets.h
@@ -9,7 +9,7 @@ namespace partial_tweets {
 
 template<typename I>
 struct runner : public json_benchmark::file_runner<I> {
-  std::vector<tweet> tweets{};
+  std::vector<tweet> result{};
 
   bool setup(benchmark::State &state) {
     return this->load_json(state, json_benchmark::TWITTER_JSON);
@@ -17,21 +17,21 @@ struct runner : public json_benchmark::file_runner<I> {
 
   bool before_run(benchmark::State &state) {
     if (!json_benchmark::file_runner<I>::before_run(state)) { return false; }
-    tweets.clear();
+    result.clear();
     return true;
   }
 
   bool run(benchmark::State &) {
-    return this->implementation.run(this->json, tweets);
+    return this->implementation.run(this->json, result);
   }
 
   template<typename R>
   bool diff(benchmark::State &state, runner<R> &reference) {
-    return diff_results(state, tweets, reference.tweets);
+    return diff_results(state, result, reference.result);
   }
 
   size_t items_per_iteration() {
-    return tweets.size();
+    return result.size();
   }
 };
 

--- a/benchmark/partial_tweets/rapidjson.h
+++ b/benchmark/partial_tweets/rapidjson.h
@@ -64,16 +64,15 @@ struct rapidjson : public rapidjson_base {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), tweets);
   }
 };
-BENCHMARK_TEMPLATE(partial_tweets, rapidjson);
+BENCHMARK_TEMPLATE(partial_tweets, rapidjson)->UseManualTime();
 
 // TODO this fails!
 // struct rapidjson_insitu : public rapidjson_base {
-//   bool run(const padded_string &json, std::vector<tweet> &tweets) {
-//     padded_string json_copy{json.data(), json.size()};
-//     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json_copy.data()), tweets);
+//   bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
+//     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), tweets);
 //   }
 // };
-// BENCHMARK_TEMPLATE(partial_tweets, rapidjson_insitu);
+// BENCHMARK_TEMPLATE(partial_tweets, rapidjson_insitu)->UseManualTime();
 
 } // namespace partial_tweets
 

--- a/benchmark/partial_tweets/rapidjson.h
+++ b/benchmark/partial_tweets/rapidjson.h
@@ -60,19 +60,18 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(const padded_string &json, std::vector<tweet> &tweets) {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), tweets);
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, rapidjson)->UseManualTime();
 
-// TODO this fails!
-// struct rapidjson_insitu : public rapidjson_base {
-//   bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
-//     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), tweets);
-//   }
-// };
-// BENCHMARK_TEMPLATE(partial_tweets, rapidjson_insitu)->UseManualTime();
+struct rapidjson_insitu : public rapidjson_base {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), tweets);
+  }
+};
+BENCHMARK_TEMPLATE(partial_tweets, rapidjson_insitu)->UseManualTime();
 
 } // namespace partial_tweets
 

--- a/benchmark/partial_tweets/rapidjson.h
+++ b/benchmark/partial_tweets/rapidjson.h
@@ -59,14 +59,14 @@ struct rapidjson_base {
   }
 };
 
-struct rapidjson : public rapidjson_base {
+struct rapidjson : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, rapidjson)->UseManualTime();
 
-struct rapidjson_insitu : public rapidjson_base {
+struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
   }

--- a/benchmark/partial_tweets/rapidjson.h
+++ b/benchmark/partial_tweets/rapidjson.h
@@ -38,13 +38,13 @@ struct rapidjson_base {
     return { get_uint64(field->value, "id"), get_string_view(field->value, "screen_name") };
   }
 
-  bool run(Document &root, std::vector<tweet> &tweets) {
+  bool run(Document &root, std::vector<tweet> &result) {
     if (root.HasParseError() || !root.IsObject()) { return false; }
     auto statuses = root.FindMember("statuses");
     if (statuses == root.MemberEnd() || !statuses->value.IsArray()) { return false; }
     for (auto &tweet : statuses->value.GetArray()) {
       if (!tweet.IsObject()) { return false; }
-      tweets.emplace_back(partial_tweets::tweet{
+      result.emplace_back(partial_tweets::tweet{
         get_string_view(tweet, "created_at"),
         get_uint64     (tweet, "id"),
         get_string_view(tweet, "text"),
@@ -60,15 +60,15 @@ struct rapidjson_base {
 };
 
 struct rapidjson : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
-    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), tweets);
+  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
+    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : public rapidjson_base {
-  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), tweets);
+  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, rapidjson_insitu)->UseManualTime();

--- a/benchmark/partial_tweets/simdjson_dom.h
+++ b/benchmark/partial_tweets/simdjson_dom.h
@@ -16,7 +16,7 @@ struct simdjson_dom {
     return element;
   }
 
-  bool run(const padded_string &json, std::vector<tweet> &tweets) {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
     for (dom::element tweet : parser.parse(json)["statuses"]) {
       auto user = tweet["user"];
       tweets.emplace_back(partial_tweets::tweet{

--- a/benchmark/partial_tweets/simdjson_dom.h
+++ b/benchmark/partial_tweets/simdjson_dom.h
@@ -16,10 +16,10 @@ struct simdjson_dom {
     return element;
   }
 
-  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
     for (dom::element tweet : parser.parse(json)["statuses"]) {
       auto user = tweet["user"];
-      tweets.emplace_back(partial_tweets::tweet{
+      result.emplace_back(partial_tweets::tweet{
         tweet["created_at"],
         tweet["id"],
         tweet["text"],

--- a/benchmark/partial_tweets/simdjson_dom.h
+++ b/benchmark/partial_tweets/simdjson_dom.h
@@ -34,7 +34,7 @@ struct simdjson_dom {
   }
 };
 
-BENCHMARK_TEMPLATE(partial_tweets, simdjson_dom);
+BENCHMARK_TEMPLATE(partial_tweets, simdjson_dom)->UseManualTime();
 
 } // namespace partial_tweets
 

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -21,7 +21,7 @@ struct simdjson_ondemand {
     return { user.find_field("id"), user.find_field("screen_name") };
   }
 
-  bool run(const padded_string &json, std::vector<tweet> &tweets) {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
     // Walk the document, parsing the tweets as we go
     auto doc = parser.iterate(json);
     for (ondemand::object tweet : doc.find_field("statuses")) {

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -40,7 +40,7 @@ struct simdjson_ondemand {
   }
 };
 
-BENCHMARK_TEMPLATE(partial_tweets, simdjson_ondemand);
+BENCHMARK_TEMPLATE(partial_tweets, simdjson_ondemand)->UseManualTime();
 
 } // namespace partial_tweets
 

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -21,11 +21,11 @@ struct simdjson_ondemand {
     return { user.find_field("id"), user.find_field("screen_name") };
   }
 
-  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
     // Walk the document, parsing the tweets as we go
     auto doc = parser.iterate(json);
     for (ondemand::object tweet : doc.find_field("statuses")) {
-      tweets.emplace_back(partial_tweets::tweet{
+      result.emplace_back(partial_tweets::tweet{
         tweet.find_field("created_at"),
         tweet.find_field("id"),
         tweet.find_field("text"),

--- a/benchmark/partial_tweets/tweet.h
+++ b/benchmark/partial_tweets/tweet.h
@@ -25,7 +25,7 @@ namespace partial_tweets {
 struct tweet {
   std::string_view created_at{};
   uint64_t id{};
-  std::string_view text{};
+  std::string_view result{};
   uint64_t in_reply_to_status_id{};
   twitter_user user{};
   uint64_t retweet_count{};
@@ -33,7 +33,7 @@ struct tweet {
   simdjson_really_inline bool operator==(const tweet &other) const {
     return created_at == other.created_at &&
            id == other.id &&
-           text == other.text &&
+           result == other.result &&
            in_reply_to_status_id == other.in_reply_to_status_id &&
            user == other.user &&
            retweet_count == other.retweet_count &&
@@ -45,7 +45,7 @@ struct tweet {
 simdjson_unused static std::ostream &operator<<(std::ostream &o, const tweet &t) {
   o << "created_at: " << t.created_at << std::endl;
   o << "id: " << t.id << std::endl;
-  o << "text: " << t.text << std::endl;
+  o << "result: " << t.result << std::endl;
   o << "in_reply_to_status_id: " << t.in_reply_to_status_id << std::endl;
   o << "user.id: " << t.user.id << std::endl;
   o << "user.screen_name: " << t.user.screen_name << std::endl;

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -30,7 +30,7 @@ struct yyjson {
     return { get_uint64(user, "id"), get_string_view(user, "screen_name") };
   }
 
-  bool run(const padded_string &json, std::vector<tweet> &tweets) {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -30,7 +30,7 @@ struct yyjson {
     return { get_uint64(user, "id"), get_string_view(user, "screen_name") };
   }
 
-  bool run(simdjson::padded_string &json, std::vector<tweet> &tweets) {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
     // Walk the document, parsing the tweets as we go
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     if (!doc) { return false; }
@@ -44,7 +44,7 @@ struct yyjson {
     yyjson_arr_foreach(statuses, tweet_idx, tweets_max, tweet) {
       if (!yyjson_is_obj(tweet)) { return false; }
       // TODO these can't actually handle errors
-      tweets.emplace_back(partial_tweets::tweet{
+      result.emplace_back(partial_tweets::tweet{
         get_string_view(tweet, "created_at"),
         get_uint64     (tweet, "id"),
         get_string_view(tweet, "text"),

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -6,7 +6,7 @@
 
 namespace partial_tweets {
 
-struct yyjson {
+struct yyjson_base {
   simdjson_really_inline std::string_view get_string_view(yyjson_val *obj, std::string_view key) {
     auto val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!yyjson_is_str(val)) { throw "field is not uint64 or null!"; }
@@ -30,15 +30,14 @@ struct yyjson {
     return { get_uint64(user, "id"), get_string_view(user, "screen_name") };
   }
 
-  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
-    // Walk the document, parsing the tweets as we go
-    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+  bool run(yyjson_doc *doc, std::vector<tweet> &result) {
     if (!doc) { return false; }
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!yyjson_is_obj(root)) { return false; }
     yyjson_val *statuses = yyjson_obj_get(root, "statuses");
     if (!yyjson_is_arr(statuses)) { return "Statuses is not an array!"; }
 
+    // Walk the document, parsing the tweets as we go
     size_t tweet_idx, tweets_max;
     yyjson_val *tweet;
     yyjson_arr_foreach(statuses, tweet_idx, tweets_max, tweet) {
@@ -59,7 +58,19 @@ struct yyjson {
   }
 };
 
+struct yyjson : yyjson_base {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
+    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), result);
+  }
+};
 BENCHMARK_TEMPLATE(partial_tweets, yyjson)->UseManualTime();
+
+struct yyjson_insitu : yyjson_base {
+  bool run(simdjson::padded_string &json, std::vector<tweet> &result) {
+    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
+  }
+};
+BENCHMARK_TEMPLATE(partial_tweets, yyjson_insitu)->UseManualTime();
 
 } // namespace partial_tweets
 

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -59,7 +59,7 @@ struct yyjson {
   }
 };
 
-BENCHMARK_TEMPLATE(partial_tweets, yyjson);
+BENCHMARK_TEMPLATE(partial_tweets, yyjson)->UseManualTime();
 
 } // namespace partial_tweets
 


### PR DESCRIPTION
This adds yyjson insitu tests.

It also:
* Fixes partial_tweets<rapidjson_insitu>. Turns out we weren't calling before_run/after_run on the initial benchmark comparison.
* Removes the memcpy from the benchmarked region. It also probably adds a bit more consistency, memory and cache-wise, since it forces the document to be most recently written thing in memory, every time. The difference is significant: on Skylake / clang10, the kostya<rapidjson_insitu> benchmark goes from 0.43 GB/s to 0.51 GB/s.
* Adds the Google ManualTime / SetIterationTime, so that Google Benchmarks sees the same iteration time we do. It makes the test names look less awesome :/

### Skylake / Clang 10

```
simdjson::dom implementation:      haswell
simdjson::ondemand implementation: haswell
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
partial_tweets<simdjson_dom>/manual_time                  268571 ns       297385 ns         2606           3.267k           2.36536G               0        93.225k    985.909k              1.56118          3.74553k       3.69275G          2.99617M                    4.74442                     3.03899           374.553k    3.40524k   631.515k        2.1899G/s    1.01343   93.1638k   991.228k          1.5696   3.72341k/s 3.69074G/s     2.99617M               4.74442                3.02269        100       372.341k/s [BEST: throughput=  2.37 GB/s doc_throughput=  3745 docs/s instructions=     2996170 cycles=      985909 branch_miss=    3267 cache_miss=       0 cache_ref=     93225 items=       100 avg_time=    268571 ns]
partial_tweets<simdjson_ondemand>/manual_time             167772 ns       196211 ns         4214           1.521k           3.79525G               0         58.96k    614.524k             0.973095          6.00976k       3.69314G          1.94802M                    3.08467                     3.16996           600.976k    1.64784k   631.515k       3.50562G/s  0.0759374   58.8853k   619.296k        0.980651   5.96048k/s  3.6913G/s     1.94802M               3.08467                3.14554        100       596.048k/s [BEST: throughput=  3.80 GB/s doc_throughput=  6009 docs/s instructions=     1948018 cycles=      614524 branch_miss=    1521 cache_miss=       0 cache_ref=     58960 items=       100 avg_time=    167771 ns]
partial_tweets<yyjson>/manual_time                        633835 ns       663812 ns         1108          10.076k           1.76406G             142        78.256k    1.32196M              2.09331          2.79337k       3.69272G          2.90305M                    4.59695                     2.19602           279.337k    7.69779k   631.515k       950.184M/s    1050.15   52.0313k   1.53484M         2.43041    1.5777k/s 2.42152G/s     2.90353M               4.59773                1.89175        100        157.77k/s [BEST: throughput=  1.76 GB/s doc_throughput=  2793 docs/s instructions=     2903046 cycles=     1321956 branch_miss=   10076 cache_miss=     142 cache_ref=     78256 items=       100 avg_time=    633834 ns]
partial_tweets<yyjson_insitu>/manual_time                 431006 ns       460352 ns         1624           7.112k            1.9985G             319        48.242k    1.16323M              1.84196          3.16462k       3.68116G          2.90272M                    4.59645                     2.49541           316.462k    7.49587k   631.515k       1.36459G/s    47.2537   33.8331k   1.25834M         1.99257   2.32016k/s 2.91954G/s     2.90299M               4.59687                  2.307        100       232.016k/s [BEST: throughput=  2.00 GB/s doc_throughput=  3164 docs/s instructions=     2902725 cycles=     1163226 branch_miss=    7112 cache_miss=     319 cache_ref=     48242 items=       100 avg_time=    431005 ns]
partial_tweets<rapidjson>/manual_time                    2159310 ns      2188524 ns          325          31.779k            320.74M          8.983k        54.684k    7.26828M              11.5093            507.89       3.69149G          21.8988M                    34.6766                     3.01292            50.789k    32.0586k   631.515k       278.913M/s    572.068    35.015k   7.40226M         11.7214    463.111/s 3.42807G/s     21.8994M               34.6776                2.95848        100       46.3111k/s [BEST: throughput=  0.32 GB/s doc_throughput=   507 docs/s instructions=    21898779 cycles=     7268281 branch_miss=   31779 cache_miss=    8983 cache_ref=     54684 items=       100 avg_time=   2159309 ns]
partial_tweets<rapidjson_insitu>/manual_time             1537554 ns      1566521 ns          457          25.278k           439.308M          7.357k        46.481k    5.30675M               8.4032           695.641       3.69159G          13.3149M                    21.0841                     2.50905           69.5641k    25.0408k   631.515k         391.7M/s     204.49    35.562k   5.34345M         8.46132    650.383/s 3.47529G/s     13.3153M               21.0847                2.49189        100       65.0383k/s [BEST: throughput=  0.44 GB/s doc_throughput=   695 docs/s instructions=    13314908 cycles=     5306749 branch_miss=   25278 cache_miss=    7357 cache_ref=     46481 items=       100 avg_time=   1537554 ns]

Creating a source file spanning 44921 KB 
large_random<simdjson_dom>/manual_time                  89661632 ns     93089783 ns            8         932.931k           513.959M        11.1635M       15.6289M    330.166M              7.17772           11.1733       3.68905G          1039.39M                    22.5961                     3.14809           11.1733M     933.97k   45.9988M        489.26M/s   11.1823M   15.6286M   330.765M         7.19074     11.153/s 3.68904G/s     1039.39M               22.5961                3.14239      1000k        11.153M/s [BEST: throughput=  0.51 GB/s doc_throughput=    11 docs/s instructions=  1039392796 cycles=   330166365 branch_miss=  932931 cache_miss=11163491 cache_ref=  15628914 items=   1000000 avg_time=  89661631 ns]
large_random<simdjson_ondemand>/manual_time             67310987 ns     70720702 ns           10         913.261k           683.951M        5.78417M       8.10458M    248.118M              5.39402           14.8689       3.68925G          684.848M                    14.8884                     2.76017           14.8689M    914.353k   45.9988M       651.719M/s   5.81099M   8.10527M   248.316M         5.39832    14.8564/s 3.68908G/s     684.848M               14.8884                2.75797      1000k       14.8564M/s [BEST: throughput=  0.68 GB/s doc_throughput=    14 docs/s instructions=   684847925 cycles=   248118318 branch_miss=  913261 cache_miss= 5784174 cache_ref=   8104576 items=   1000000 avg_time=  67310986 ns]
large_random<simdjson_ondemand_unordered>/manual_time   67139476 ns     70559993 ns           10         907.441k           685.626M         5.8088M       8.10406M    247.517M              5.38094           14.9053       3.68932G          690.848M                    15.0188                     2.79111           14.9053M    907.539k   45.9988M       653.384M/s   5.81662M   8.10403M    247.69M          5.3847    14.8944/s 3.68918G/s     690.848M               15.0188                2.78917      1000k       14.8944M/s [BEST: throughput=  0.69 GB/s doc_throughput=    14 docs/s instructions=   690847916 cycles=   247516842 branch_miss=  907441 cache_miss= 5808797 cache_ref=   8104056 items=   1000000 avg_time=  67139475 ns]
large_random<yyjson>/manual_time                       120972238 ns    124455939 ns            6         669.467k           380.584M        5.93517M       9.24696M    329.012M              7.15262           8.27378       2.72217G           866.68M                    18.8414                     2.63419           8.27378M    669.581k   45.9988M       362.627M/s   5.93152M   9.23835M   329.184M         7.15636    8.26636/s 2.72115G/s      866.68M               18.8414                2.63282      1000k       8.26636M/s [BEST: throughput=  0.38 GB/s doc_throughput=     8 docs/s instructions=   866680094 cycles=   329011831 branch_miss=  669467 cache_miss= 5935172 cache_ref=   9246963 items=   1000000 avg_time= 120972238 ns]
large_random<yyjson_insitu>/manual_time                103296447 ns    106761271 ns            7         667.329k           445.674M        5.04037M       7.86722M    297.193M              6.46089           9.68882       2.87945G          860.559M                    18.7083                     2.89562           9.68882M    669.313k   45.9988M       424.679M/s    5.0405M    7.8717M    297.49M         6.46734    9.68088/s 2.87996G/s     860.559M               18.7083                2.89274      1000k       9.68088M/s [BEST: throughput=  0.45 GB/s doc_throughput=     9 docs/s instructions=   860559427 cycles=   297193192 branch_miss=  667329 cache_miss= 5040370 cache_ref=   7867222 items=   1000000 avg_time= 103296446 ns]
large_random<rapidjson>/manual_time                    214211833 ns    217672778 ns            3         601.178k           220.613M         7.1007M       10.9775M    712.528M              15.4901           4.79607       3.41733G          2.01615G                    43.8305                     2.82957           4.79607M    600.727k   45.9988M       204.787M/s   6.60309M    10.305M   715.337M         15.5512    4.66828/s 3.33939G/s     2.01616G               43.8307                2.81847      1000k       4.66828M/s [BEST: throughput=  0.22 GB/s doc_throughput=     4 docs/s instructions=  2016148594 cycles=   712527512 branch_miss=  601178 cache_miss= 7100705 cache_ref=  10977519 items=   1000000 avg_time= 214211833 ns]
large_random<rapidjson_lossless>/manual_time           247078823 ns    250567908 ns            3         620.972k           190.681M        7.08019M       10.9866M    833.332M              18.1164           4.14535       3.45445G          2.47512G                    53.8083                     2.97015           4.14535M    615.326k   45.9988M       177.546M/s   6.59081M   10.3181M   836.527M         18.1859    4.04729/s 3.38567G/s     2.47512G               53.8085                2.95881      1000k       4.04729M/s [BEST: throughput=  0.19 GB/s doc_throughput=     4 docs/s instructions=  2475115877 cycles=   833331531 branch_miss=  620972 cache_miss= 7080190 cache_ref=  10986566 items=   1000000 avg_time= 247078823 ns]
large_random<rapidjson_insitu>/manual_time             236658827 ns    240122849 ns            3         593.566k           198.778M        8.18786M       12.5933M    797.141M              17.3296           4.32138       3.44475G          1.74115G                    37.8521                     2.18424           4.32138M    592.435k   45.9988M       185.363M/s   7.72914M   11.9255M   798.213M         17.3529    4.22549/s 3.37284G/s     1.74116G               37.8523                2.18132      1000k       4.22549M/s [BEST: throughput=  0.20 GB/s doc_throughput=     4 docs/s instructions=  1741148615 cycles=   797141222 branch_miss=  593566 cache_miss= 8187860 cache_ref=  12593317 items=   1000000 avg_time= 236658826 ns]

Creating a source file spanning 134087 KB 
kostya<simdjson_dom>/manual_time                        92605782 ns    103050926 ns            8         1029.69k            1.4846G        16.1179M       22.8706M    341.201M              2.48499           10.8124       3.68921G          985.296M                    7.17596                     2.88773           5.66882M    1030.28k   137.305M       1.38086G/s   16.1595M   22.7507M   341.623M         2.48806    10.7985/s   3.689G/s     985.296M               7.17596                2.88416   524.288k        5.6615M/s [BEST: throughput=  1.48 GB/s doc_throughput=    10 docs/s instructions=   985295807 cycles=   341201249 branch_miss= 1029694 cache_miss=16117864 cache_ref=  22870561 items=    524288 avg_time=  92605781 ns]
kostya<simdjson_ondemand>/manual_time                   61299185 ns     71797904 ns           11         473.627k           2.24152G        10.3268M       14.3307M    225.983M              1.64584           16.3251        3.6892G          658.901M                    4.79882                     2.91572           8.55907M    473.509k   137.305M       2.08608G/s   10.3394M   14.2531M   226.142M           1.647    16.3134/s 3.68915G/s     658.901M               4.79882                2.91366   524.288k       8.55294M/s [BEST: throughput=  2.24 GB/s doc_throughput=    16 docs/s instructions=   658901371 cycles=   225982508 branch_miss=  473627 cache_miss=10326777 cache_ref=  14330684 items=    524288 avg_time=  61299184 ns]
kostya<yyjson>/manual_time                             176933965 ns    187415329 ns            4         421.932k           776.494M        11.5626M       16.8126M    459.067M              3.34341           5.65525       2.59614G          978.903M                     7.1294                     2.13238           2.96498M    421.705k   137.305M       740.074M/s   11.5644M   16.7947M   459.163M         3.34411    5.65183/s 2.59511G/s     978.903M                7.1294                2.13193   524.288k       2.96318M/s [BEST: throughput=  0.78 GB/s doc_throughput=     5 docs/s instructions=   978902796 cycles=   459066540 branch_miss=  421932 cache_miss=11562580 cache_ref=  16812603 items=    524288 avg_time= 176933965 ns]
kostya<yyjson_insitu>/manual_time                      123915882 ns    134305090 ns            6         414.546k           1.10846G        8.96674M       12.7118M     363.48M              2.64724           8.07296       2.93436G          960.633M                    6.99635                     2.64288           4.23255M    415.135k   137.305M       1056.72M/s   8.96778M    12.738M   363.596M         2.64809    8.06999/s 2.93421G/s     960.633M               6.99635                2.64204   524.288k         4.231M/s [BEST: throughput=  1.11 GB/s doc_throughput=     8 docs/s instructions=   960633121 cycles=   363479693 branch_miss=  414546 cache_miss= 8966738 cache_ref=  12711825 items=    524288 avg_time= 123915882 ns]
kostya<rapidjson>/manual_time                          280224719 ns    290759737 ns            3             968k           495.722M        8.49649M       12.5151M    941.011M              6.85344           3.61037        3.3974G           2.7424G                     19.973                     2.91431           1.89287M    968.654k   137.305M       467.283M/s   8.20411M   12.0693M   943.614M         6.87239    3.56856/s 3.36735G/s      2.7424G               19.9731                2.90627   524.288k       1.87096M/s [BEST: throughput=  0.50 GB/s doc_throughput=     3 docs/s instructions=  2742398461 cycles=   941011346 branch_miss=  968000 cache_miss= 8496494 cache_ref=  12515084 items=    524288 avg_time= 280224719 ns]
kostya<rapidjson_lossless>/manual_time                 287388309 ns    297836801 ns            2         945.406k           481.751M        8.49102M       12.5235M    970.557M              7.06862           3.50862       3.40532G          3.00768G                    21.9051                     3.09892           1.83953M    945.903k   137.305M       455.635M/s   8.27233M   12.2409M   972.234M         7.08083    3.47961/s   3.383G/s     3.00768G               21.9051                3.09358   524.288k       1.82432M/s [BEST: throughput=  0.48 GB/s doc_throughput=     3 docs/s instructions=  3007678907 cycles=   970556948 branch_miss=  945406 cache_miss= 8491016 cache_ref=  12523506 items=    524288 avg_time= 287388309 ns]
kostya<rapidjson_insitu>/manual_time                   272138735 ns    282598865 ns            3         1015.21k           510.373M        12.2725M       16.4017M    911.813M              6.64078           3.71707       3.38927G          2.22149G                    16.1793                     2.43635           1.94882M    1015.75k   137.305M       481.167M/s   12.0087M   16.0587M   913.855M         6.65566     3.6746/s 3.35805G/s      2.2215G               16.1793                2.43091   524.288k       1.92655M/s [BEST: throughput=  0.51 GB/s doc_throughput=     3 docs/s instructions=  2221493045 cycles=   911812707 branch_miss= 1015207 cache_miss=12272479 cache_ref=  16401703 items=    524288 avg_time= 272138735 ns]

distinct_user_id<simdjson_dom>/manual_time                262226 ns       292863 ns         2670           3.401k            2.4251G               0        93.774k    961.598k              1.52268          3.84013k       3.69266G          2.93045M                    4.64034                     3.04747           441.615k     3.5682k   631.515k       2.24289G/s   0.306742    93.929k   967.814k         1.53253    3.8135k/s 3.69076G/s     2.93045M               4.64034                 3.0279        115       438.552k/s [BEST: throughput=  2.43 GB/s doc_throughput=  3840 docs/s instructions=     2930445 cycles=      961598 branch_miss=    3401 cache_miss=       0 cache_ref=     93774 items=       115 avg_time=    262226 ns]
distinct_user_id<simdjson_ondemand>/manual_time           149311 ns       179066 ns         4675           1.573k           4.26472G               0        55.792k    546.946k             0.866086          6.75315k       3.69361G          1.89752M                    3.00471                      3.4693           776.612k    1.72699k   631.515k       3.93906G/s  0.0124064   55.7811k   551.178k        0.872787   6.69744k/s 3.69148G/s     1.89752M               3.00471                3.44266        115       770.205k/s [BEST: throughput=  4.26 GB/s doc_throughput=  6753 docs/s instructions=     1897519 cycles=      546946 branch_miss=    1573 cache_miss=       0 cache_ref=     55792 items=       115 avg_time=    149310 ns]
distinct_user_id<yyjson>/manual_time                      630197 ns       663645 ns         1324          10.064k           1.78437G             384        76.916k    1.30696M              2.06957          2.82555k       3.69288G          2.86114M                     4.5306                     2.18916           324.938k    7.84115k   631.515k       955.669M/s     1066.6   50.6449k   1.52281M         2.41137   1.58681k/s 2.41641G/s     2.86163M               4.53138                1.87917        115       182.483k/s [BEST: throughput=  1.78 GB/s doc_throughput=  2825 docs/s instructions=     2861143 cycles=     1306962 branch_miss=   10064 cache_miss=     384 cache_ref=     76916 items=       115 avg_time=    630196 ns]
distinct_user_id<yyjson_insitu>/manual_time               427635 ns       460317 ns         1637           7.226k            2.0289G             275        46.875k    1.14599M              1.81466          3.21275k       3.68176G          2.86082M                    4.53009                     2.49638           369.466k    7.61894k   631.515k       1.37534G/s    45.7954   32.4016k   1.24533M         1.97197   2.33844k/s 2.91213G/s     2.86109M               4.53052                2.29746        115       268.921k/s [BEST: throughput=  2.03 GB/s doc_throughput=  3212 docs/s instructions=     2860822 cycles=     1145986 branch_miss=    7226 cache_miss=     275 cache_ref=     46875 items=       115 avg_time=    427635 ns]
distinct_user_id<rapidjson>/manual_time                  2136306 ns      2166801 ns          327           31.86k           322.828M             243        54.837k     7.2214M               11.435           511.196       3.69155G          21.8276M                    34.5639                     3.02263           58.7875k    32.0691k   631.515k       281.916M/s   2.48987k   37.2351k   7.36195M         11.6576    468.098/s 3.44611G/s     21.8284M               34.5652                2.96503        115       53.8312k/s [BEST: throughput=  0.32 GB/s doc_throughput=   511 docs/s instructions=    21827636 cycles=     7221399 branch_miss=   31860 cache_miss=     243 cache_ref=     54837 items=       115 avg_time=   2136306 ns]
distinct_user_id<rapidjson_insitu>/manual_time           1559910 ns      1590279 ns          431          25.203k           438.188M         12.784k         46.58k    5.32029M              8.42465           693.869       3.69158G          13.2483M                    20.9786                     2.49015           79.7949k    31.8909k   631.515k       386.086M/s    3.2221k   38.1908k   5.50216M         8.71263    641.062/s 3.52723G/s     13.2488M               20.9794                2.40793        115       73.7222k/s [BEST: throughput=  0.44 GB/s doc_throughput=   693 docs/s instructions=    13248314 cycles=     5320292 branch_miss=   25203 cache_miss=   12784 cache_ref=     46580 items=       115 avg_time=   1559910 ns]

find_tweet<simdjson_dom>/manual_time                      249889 ns       279185 ns         2799           3.052k           2.54144G               0         83.48k    917.592k                1.453          4.02436k       3.69272G          2.84527M                    4.50547                      3.1008           4.02436k    3.19057k   631.515k       2.35362G/s   0.186138   83.3835k    922.31k         1.46047   4.00177k/s 3.69087G/s     2.84527M               4.50547                3.08494          1       4.00177k/s [BEST: throughput=  2.54 GB/s doc_throughput=  4024 docs/s instructions=     2845271 cycles=      917592 branch_miss=    3052 cache_miss=       0 cache_ref=     83480 items=         1 avg_time=    249889 ns]
find_tweet<simdjson_ondemand>/manual_time                 109208 ns       137689 ns         6404              646           5.81077G               0        31.847k    401.514k             0.635795          9.20132k       3.69446G          1.39034M                     2.2016                     3.46275           9.20132k     698.574   631.515k       5.38556G/s  0.0249844   32.1588k   403.247k        0.638539   9.15686k/s 3.69248G/s     1.39034M                2.2016                3.44787          1       9.15686k/s [BEST: throughput=  5.81 GB/s doc_throughput=  9201 docs/s instructions=     1390341 cycles=      401514 branch_miss=     646 cache_miss=       0 cache_ref=     31847 items=         1 avg_time=    109207 ns]
find_tweet<yyjson>/manual_time                            619703 ns       650455 ns         1222           9.797k           1.83605G             179        69.133k    1.27019M              2.01133          2.90737k       3.69291G          2.80059M                    4.43472                     2.20487           2.90737k    7.53762k   631.515k       971.853M/s   1.10719k   41.7268k   1.48459M         2.35084   1.61368k/s 2.39565G/s     2.80108M                4.4355                1.88677          1       1.61368k/s [BEST: throughput=  1.84 GB/s doc_throughput=  2907 docs/s instructions=     2800594 cycles=     1270186 branch_miss=    9797 cache_miss=     179 cache_ref=     69133 items=         1 avg_time=    619702 ns]
find_tweet<yyjson_insitu>/manual_time                     417357 ns       447665 ns         1677           6.947k           2.09877G             675        38.328k    1.10775M              1.75412           3.3234k        3.6815G          2.80027M                    4.43421                     2.52789            3.3234k    7.37052k   631.515k       1.40921G/s    15.6213   23.5845k   1.20784M         1.91261   2.39603k/s 2.89402G/s     2.80054M               4.43464                2.31863          1       2.39603k/s [BEST: throughput=  2.10 GB/s doc_throughput=  3323 docs/s instructions=     2800273 cycles=     1107751 branch_miss=    6947 cache_miss=     675 cache_ref=     38328 items=         1 avg_time=    417356 ns]
find_tweet<rapidjson>/manual_time                        2129212 ns      2158294 ns          329          31.381k           323.275M         15.056k        48.643k    7.21133M              11.4191           511.904       3.69151G          21.7439M                    34.4314                     3.01524            511.904    32.0226k   631.515k       282.856M/s   2.09257k   29.5168k   7.33664M         11.6175    469.657/s 3.44571G/s     21.7448M               34.4327                2.96386          1        469.657/s [BEST: throughput=  0.32 GB/s doc_throughput=   511 docs/s instructions=    21743932 cycles=     7211333 branch_miss=   31381 cache_miss=   15056 cache_ref=     48643 items=         1 avg_time=   2129211 ns]
find_tweet<rapidjson_insitu>/manual_time                 1526941 ns      1556867 ns          447          24.783k           448.822M         12.789k        37.475k    5.19419M              8.22496           710.707       3.69154G            13.17M                    20.8545                     2.53552            710.707    31.6043k   631.515k       394.422M/s   2.99446k   28.9875k   5.37975M          8.5188    654.904/s 3.52322G/s     13.1702M                20.855                2.44811          1        654.904/s [BEST: throughput=  0.45 GB/s doc_throughput=   710 docs/s instructions=    13169952 cycles=     5194188 branch_miss=   24783 cache_miss=   12789 cache_ref=     37475 items=         1 avg_time=   1526941 ns]
```