### PR TITLE
This makes the float errors explicit.

### DIFF
--- a/.github/workflows/vs16-noexcept-ci.yml
+++ b/.github/workflows/vs16-noexcept-ci.yml
@@ -1,0 +1,36 @@
+name: VS16-NoExcept-CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+    name: windows-vs16
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: dependencies/.cache
+        key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
+    - name: 'Run CMake with VS16'
+      uses: lukka/run-cmake@v2
+      with:
+        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+        cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+        buildDirectory: "${{ github.workspace }}/../../_temp/windows"
+        cmakeBuildType: Release   
+        buildWithCMake: true
+        cmakeGenerator: VS16Win64 
+        cmakeAppendedArgs: -DSIMDJSON_COMPETITION=OFF  -DSIMDJSON_EXCEPTIONS=OFF
+        buildWithCMakeArgs: --config Release  
+        
+    - name: 'Run CTest'
+      run: ctest -C Release  -LE explicitonly  --output-on-failure 
+      working-directory: "${{ github.workspace }}/../../_temp/windows"
+  

--- a/benchmark/json_benchmark/diff_results.h
+++ b/benchmark/json_benchmark/diff_results.h
@@ -21,8 +21,7 @@ struct result_differ {
 };
 
 template<>
-struct result_differ {
-  static bool diff(benchmark::State &state, const double &result, const double &reference) {
+bool result_differ<double>::diff(benchmark::State &state, const double &result, const double &reference) {
     if (result != reference) {
       std::stringstream str;
       // We print it out using full precision.
@@ -36,8 +35,7 @@ struct result_differ {
       return false;
     }
     return true;
-  }
-};
+}
 
 
 template<typename T>

--- a/benchmark/json_benchmark/diff_results.h
+++ b/benchmark/json_benchmark/diff_results.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <sstream>
+#include <limits>
 
 template<typename T>
 static bool diff_results(benchmark::State &state, const T &result, const T &reference);
@@ -18,6 +19,26 @@ struct result_differ {
     return true;
   }
 };
+
+template<>
+struct result_differ {
+  static bool diff(benchmark::State &state, const double &result, const double &reference) {
+    if (result != reference) {
+      std::stringstream str;
+      // We print it out using full precision.
+      auto prior_precision = str.precision(std::numeric_limits<double>::max_digits10);
+      str << "result incorrect: " << result << " ... reference: " << reference;
+      str.precision(prior_precision); // reset to prior state
+      str << std::hexfloat; // If there are floats, we want to see them in hexadecimal form!
+      str << "result incorrect (hexadecimal notation): " << result << " ... reference: " << reference;
+      str << std::defaultfloat; // reset to prior state
+      state.SkipWithError(str.str().data());
+      return false;
+    }
+    return true;
+  }
+};
+
 
 template<typename T>
 struct result_differ<std::vector<T>> {


### PR DESCRIPTION
If x and y differ as numbers, it is not true that their naive string representation will differ. We need to be careful.
