### PR TITLE
Use runtime-selected implementation for stage 1 on demand

### DIFF
--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -19,8 +19,8 @@ simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&o
   return *this;
 }
 
-simdjson_really_inline json_iterator::json_iterator(ondemand::parser *_parser) noexcept
-  : token(_parser->dom_parser.buf, _parser->dom_parser.structural_indexes.get()),
+simdjson_really_inline json_iterator::json_iterator(const uint8_t *buf, ondemand::parser *_parser) noexcept
+  : token(buf, _parser->dom_parser->structural_indexes.get()),
     parser{_parser},
     _string_buf_loc{parser->string_buf.get()},
     _depth{1}
@@ -69,7 +69,7 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
   }
 
   // Now that we've considered the first value, we only increment/decrement for arrays/objects
-  auto end = &parser->dom_parser.structural_indexes[parser->dom_parser.n_structural_indexes];
+  auto end = &parser->dom_parser->structural_indexes[parser->dom_parser->n_structural_indexes];
   while (token.index <= end) {
     switch (*advance()) {
       case '[': case '{':
@@ -102,19 +102,19 @@ simdjson_really_inline bool json_iterator::at_root() const noexcept {
 }
 
 simdjson_really_inline const uint32_t *json_iterator::root_checkpoint() const noexcept {
-  return parser->dom_parser.structural_indexes.get();
+  return parser->dom_parser->structural_indexes.get();
 }
 
 simdjson_really_inline void json_iterator::assert_at_root() const noexcept {
   SIMDJSON_ASSUME( _depth == 1 );
   // Visual Studio Clang treats unique_ptr.get() as "side effecting."
 #ifndef SIMDJSON_CLANG_VISUAL_STUDIO
-  SIMDJSON_ASSUME( token.index == parser->dom_parser.structural_indexes.get() );
+  SIMDJSON_ASSUME( token.index == parser->dom_parser->structural_indexes.get() );
 #endif
 }
 
 simdjson_really_inline bool json_iterator::at_eof() const noexcept {
-  return token.index == &parser->dom_parser.structural_indexes[parser->dom_parser.n_structural_indexes];
+  return token.index == &parser->dom_parser->structural_indexes[parser->dom_parser->n_structural_indexes];
 }
 
 simdjson_really_inline bool json_iterator::is_alive() const noexcept {

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -167,7 +167,7 @@ public:
   simdjson_really_inline void restore_checkpoint(const uint32_t *target_checkpoint) noexcept;
 
 protected:
-  simdjson_really_inline json_iterator(ondemand::parser *parser) noexcept;
+  simdjson_really_inline json_iterator(const uint8_t *buf, ondemand::parser *parser) noexcept;
 
   friend class document;
   friend class object;

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -104,7 +104,8 @@ public:
   simdjson_warn_unused simdjson_result<json_iterator> iterate_raw(const padded_string &json) & noexcept;
 
 private:
-  dom_parser_implementation dom_parser{};
+  /** @private [for benchmarking access] The implementation to use */
+  std::unique_ptr<internal::dom_parser_implementation> dom_parser{};
   size_t _capacity{0};
   size_t _max_depth{0};
   std::unique_ptr<uint8_t[]> string_buf{};


### PR DESCRIPTION
Fixes #1358.

It's clearly better. In fact, it's unequivocally better, in all circumstances. Oddly, in a couple of important cases, the *fallback* frontend beats the haswell frontend. Not sure what to think of that. Maybe jitters. I ran all of them twice to check (all 4 once, then all 4 again).

| Branch | Stage 1 | On Demand | partial tweets | large random | large random unordered | kostya | distinct user id | find tweet | Host | Compiler | cmake |
|---|---|---|---|---|---|---|---|---|---|---|---|
| PR | haswell | haswell | **4.10 GB/s** | 0.69 GB/s | 0.70 GB/s | 2.25 GB/s | 3.97 GB/s | 5.80 GB/s | Skylake | Clang 10 | CXX_FLAGS=-march=native |
| PR | haswell | fallback | 3.55 GB/s | **0.70 GB/s** | **0.71 GB/s** | **2.27 GB/s** | **4.23 GB/s** | **5.83 GB/s** | Skylake | Clang 10 | |
| Before | haswell | haswell |  3.94 GB/s | 0.69 GB/s | 0.69 GB/s | 2.15 GB/s | 4.07 GB/s | 5.64 GB/s | Skylake | Clang 10 | CXX_FLAGS=-march=native |
| Before | haswell | fallback | 0.51 GB/s | 0.42 GB/s | 0.42 GB/s | 0.69 GB/s | 0.53 GB/s | 0.55 GB/s | Skylake | Clang 10 | |