### PR TITLE
Allow JSON values to be parsed later / out of order

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -62,4 +62,11 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "find_tweet/rapidjson.h"
 #include "find_tweet/nlohmann_json.h"
 
+#include "top_tweet/simdjson_dom.h"
+#include "top_tweet/simdjson_ondemand.h"
+#include "top_tweet/yyjson.h"
+#include "top_tweet/sajson.h"
+#include "top_tweet/rapidjson.h"
+#include "top_tweet/nlohmann_json.h"
+
 BENCHMARK_MAIN();

--- a/benchmark/distinct_user_id/yyjson.h
+++ b/benchmark/distinct_user_id/yyjson.h
@@ -12,7 +12,7 @@ struct yyjson_base {
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!yyjson_is_obj(root)) { return false; }
     yyjson_val *statuses = yyjson_obj_get(root, "statuses");
-    if (!yyjson_is_arr(statuses)) { return "Statuses is not an array!"; }
+    if (!yyjson_is_arr(statuses)) { return false; }
 
     // Walk the document, parsing the tweets as we go
     size_t tweet_idx, tweets_max;

--- a/benchmark/find_tweet/yyjson.h
+++ b/benchmark/find_tweet/yyjson.h
@@ -14,7 +14,7 @@ struct yyjson_base {
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!yyjson_is_obj(root)) { return false; }
     yyjson_val *statuses = yyjson_obj_get(root, "statuses");
-    if (!yyjson_is_arr(statuses)) { return "Statuses is not an array!"; }
+    if (!yyjson_is_arr(statuses)) { return false; }
 
     // Walk the document, parsing the tweets as we go
     size_t tweet_idx, tweets_max;

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -37,7 +37,7 @@ struct yyjson_base {
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!yyjson_is_obj(root)) { return false; }
     yyjson_val *statuses = yyjson_obj_get(root, "statuses");
-    if (!yyjson_is_arr(statuses)) { return "Statuses is not an array!"; }
+    if (!yyjson_is_arr(statuses)) { return false; }
 
     // Walk the document, parsing the tweets as we go
     size_t tweet_idx, tweets_max;

--- a/benchmark/top_tweet/README.md
+++ b/benchmark/top_tweet/README.md
@@ -1,0 +1,49 @@
+# Top Tweet Benchmark
+
+The top_tweet benchmark finds the most-retweeted tweet in a twitter API response.
+
+## Purpose
+
+This scenario tends to measure an implementation's laziness: its ability to avoid parsing unneeded
+values, without knowing beforehand which values are needed.
+
+To find the top tweet, an implementation needs to iterate through all tweets, remembering which one
+had the highest retweet count. While it scans, it will find many "candidate" tweets with the highest
+retweet count *up to that point.* However, While the implementation iterates through tweets, it will
+have many "candidate" tweets. Essentially, it has to keep track of the "top tweet so far" while it
+searches. However, only the text and screen_name of the *final* top tweet need to be parsed.
+Therefore, JSON parsers that can only parse values on the first pass (such as DOM or streaming
+parsers) will be forced to parse text and screen_name of every candidate (if not every single
+tweet). Parsers which can delay parsing of values until later will therefore shine in scenarios like
+this.
+
+## Rules
+
+The benchmark will be called with `run(padded_string &json, int64_t max_retweet_count, top_tweet_result &result)`.
+The benchmark must:
+- Find the tweet with the highest retweet_count at the top level of the "statuses" array.
+- Find the *last* such tweet: if multiple tweets have the same top retweet_count, the last one
+  should be returned.
+- Exclude tweets with retweet_count above max_retweet_count. This restriction is solely here because
+  the default twitter.json has a rather high retweet count in the third tweet, and to test laziness
+  the matching tweet needs to be further down in the file.
+- Fill in top_tweet_result with the corresponding fields from the matching tweet.
+
+### Abridged Schema
+
+The abridged schema (objects contain more fields than listed here):
+
+```json
+{
+  "statuses": [
+    {
+      "text": "i like to tweet", // text containing UTF-8 and escape characters
+      "user": {
+        "screen_name": "AlexanderHamilton" // string containing UTF-8 (and escape characters?)
+      },
+      "retweet_count": 2, // uint32
+    },
+    ...
+  ]
+}
+```

--- a/benchmark/top_tweet/nlohmann_json.h
+++ b/benchmark/top_tweet/nlohmann_json.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#if SIMDJSON_COMPETITION_NLOHMANN_JSON
+
+#include "top_tweet.h"
+
+namespace top_tweet {
+
+using namespace simdjson;
+
+struct nlohmann_json {
+  using StringType=std::string;
+
+  dom::parser parser{};
+
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    result.retweet_count = -1;
+    nlohmann::json top_tweet{};
+
+    auto root = nlohmann::json::parse(json.data(), json.data() + json.size());
+    for (auto tweet : root["statuses"]) {
+      int64_t retweet_count = tweet["retweet_count"];
+      if (retweet_count <= max_retweet_count && retweet_count >= result.retweet_count) {
+        result.retweet_count = retweet_count;
+        top_tweet = tweet;
+      }
+    }
+
+    result.text = top_tweet["text"];
+    result.screen_name = top_tweet["user"]["screen_name"];
+    return result.retweet_count != -1;
+  }
+};
+
+BENCHMARK_TEMPLATE(top_tweet, nlohmann_json)->UseManualTime();
+
+} // namespace top_tweet
+
+#endif // SIMDJSON_COMPETITION_NLOHMANN_JSON

--- a/benchmark/top_tweet/rapidjson.h
+++ b/benchmark/top_tweet/rapidjson.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_RAPIDJSON
+
+#include "top_tweet.h"
+
+namespace top_tweet {
+
+using namespace rapidjson;
+
+struct rapidjson_base {
+  using StringType=std::string_view;
+
+  Document doc{};
+
+  bool run(Document &root, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    result.retweet_count = -1;
+
+    // Loop over the tweets
+    if (root.HasParseError() || !root.IsObject()) { return false; }
+    const auto &statuses = root.FindMember("statuses");
+    if (statuses == root.MemberEnd() || !statuses->value.IsArray()) { return false; }
+    for (const Value &tweet : statuses->value.GetArray()) {
+      if (!tweet.IsObject()) { return false; }
+
+      // Check if this tweet has a higher retweet count than the current top tweet
+      const auto &retweet_count_json = tweet.FindMember("retweet_count");
+      if (retweet_count_json == tweet.MemberEnd() || !retweet_count_json->value.IsInt64()) { return false; }
+      int64_t retweet_count = retweet_count_json->value.GetInt64();
+      if (retweet_count <= max_retweet_count && retweet_count >= result.retweet_count) {
+        result.retweet_count = retweet_count;
+
+        // TODO I can't figure out if there's a way to keep the Value to use outside the loop ...
+
+        // Get text and screen_name of top tweet
+        const auto &text = tweet.FindMember("text");
+        if (text == tweet.MemberEnd() || !text->value.IsString()) { return false; }
+        result.text = { text->value.GetString(), text->value.GetStringLength() };
+
+        const auto &user = tweet.FindMember("user");
+        if (user == tweet.MemberEnd() || !user->value.IsObject()) { return false; }
+        const auto &screen_name = user->value.FindMember("screen_name");
+        if (screen_name == user->value.MemberEnd() || !screen_name->value.IsString()) { return false; }
+        result.screen_name = { screen_name->value.GetString(), screen_name->value.GetStringLength() };
+
+      }
+    }
+
+    return result.retweet_count != -1;
+  }
+};
+
+struct rapidjson : rapidjson_base {
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), max_retweet_count, result);
+  }
+};
+BENCHMARK_TEMPLATE(top_tweet, rapidjson)->UseManualTime();
+
+struct rapidjson_insitu : rapidjson_base {
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), max_retweet_count, result);
+  }
+};
+BENCHMARK_TEMPLATE(top_tweet, rapidjson_insitu)->UseManualTime();
+
+} // namespace partial_tweets
+
+#endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/top_tweet/sajson.h
+++ b/benchmark/top_tweet/sajson.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_SAJSON
+
+#include "top_tweet.h"
+
+namespace top_tweet {
+
+struct sajson {
+  using StringType=std::string_view;
+
+  size_t ast_buffer_size{0};
+  size_t *ast_buffer{nullptr};
+
+  bool run(simdjson::padded_string &json, int32_t max_retweet_count, top_tweet_result<StringType> &result) {
+    if (!ast_buffer) {
+      ast_buffer_size = json.size();
+      ast_buffer = (size_t *)std::malloc(ast_buffer_size * sizeof(size_t));
+    }
+    auto doc = ::sajson::parse(
+      ::sajson::bounded_allocation(ast_buffer, ast_buffer_size),
+      ::sajson::mutable_string_view(json.size(), json.data())
+    );
+    if (!doc.is_valid()) { return false; }
+
+    auto root = doc.get_root();
+    if (root.get_type() != ::sajson::TYPE_OBJECT) { return false; }
+    auto statuses = root.get_value_of_key({ "statuses", strlen("statuses") });
+    if (statuses.get_type() != ::sajson::TYPE_ARRAY) { return false; }
+
+    for (size_t i=0; i<statuses.get_length(); i++) {
+      auto tweet = statuses.get_array_element(i);
+      if (tweet.get_type() != ::sajson::TYPE_OBJECT) { return false; }
+
+      // We can't keep a copy of "value" around, so AFAICT we can't lazily parse
+      auto retweet_count_val = tweet.get_value_of_key({ "retweet_count", strlen("retweet_count") });
+      if (retweet_count_val.get_type() != ::sajson::TYPE_INTEGER) { return false; }
+      int32_t retweet_count = retweet_count_val.get_integer_value();
+      if (retweet_count <= max_retweet_count && retweet_count >= result.retweet_count) {
+        result.retweet_count = retweet_count;
+
+        auto text = tweet.get_value_of_key({ "text", strlen("text") });
+        if (text.get_type() != ::sajson::TYPE_STRING) { return false; }
+        result.text = { text.as_cstring(), text.get_string_length() };
+
+        auto user = tweet.get_value_of_key({ "user", strlen("user") });
+        if (user.get_type() != ::sajson::TYPE_OBJECT) { return false; }
+        auto screen_name = user.get_value_of_key({ "screen_name", strlen("screen_name") });
+        if (screen_name.get_type() != ::sajson::TYPE_STRING) { return false; }
+        result.screen_name = { screen_name.as_cstring(), screen_name.get_string_length() };
+      }
+    }
+
+    return result.retweet_count != -1;
+  }
+};
+
+BENCHMARK_TEMPLATE(top_tweet, sajson)->UseManualTime();
+
+} // namespace top_tweet
+
+#endif // SIMDJSON_COMPETITION_SAJSON

--- a/benchmark/top_tweet/simdjson_dom.h
+++ b/benchmark/top_tweet/simdjson_dom.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "top_tweet.h"
+
+namespace top_tweet {
+
+using namespace simdjson;
+
+struct simdjson_dom {
+  using StringType=std::string_view;
+
+  dom::parser parser{};
+
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    result.retweet_count = -1;
+    dom::element top_tweet{};
+
+    auto doc = parser.parse(json);
+    for (auto tweet : doc["statuses"]) {
+      int64_t retweet_count = tweet["retweet_count"];
+      if (retweet_count <= max_retweet_count && retweet_count >= result.retweet_count) {
+        result.retweet_count = retweet_count;
+        top_tweet = tweet;
+      }
+    }
+
+    result.text = top_tweet["text"];
+    result.screen_name = top_tweet["user"]["screen_name"];
+    return result.retweet_count != -1;
+  }
+};
+
+BENCHMARK_TEMPLATE(top_tweet, simdjson_dom)->UseManualTime();
+
+} // namespace top_tweet
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/top_tweet/simdjson_ondemand.h
+++ b/benchmark/top_tweet/simdjson_ondemand.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "top_tweet.h"
+
+namespace top_tweet {
+
+using namespace simdjson;
+using namespace simdjson::builtin;
+
+struct simdjson_ondemand {
+  using StringType=std::string_view;
+
+  ondemand::parser parser{};
+
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    result.retweet_count = -1;
+    // We save these DOM values for later so we don't have to parse them
+    // into string_views until we're sure which ones we want to parse
+    // NOTE: simdjson does not presently support reuse of objects or arrays--just scalars. This is
+    // why we have to grab the text and screen_name fields instead of just saving the tweet object.
+    ondemand::value screen_name, text;
+
+    auto doc = parser.iterate(json);
+    for (auto tweet : doc["statuses"]) {
+      // Since text, user.screen_name, and retweet_count generally appear in order, it's nearly free
+      // for us to retrieve them here (and will cost a bit more if we do it in the if
+      // statement).
+      auto tweet_text = tweet["text"];
+      auto tweet_screen_name = tweet["user"]["screen_name"];
+      int64_t retweet_count = tweet["retweet_count"];
+      if (retweet_count <= max_retweet_count && retweet_count >= result.retweet_count) {
+        result.retweet_count = retweet_count;
+        // TODO std::move should not be necessary
+        text = std::move(tweet_text);
+        screen_name = std::move(tweet_screen_name);
+      }
+    }
+
+    // Now that we know which was the most retweeted, parse the values in it
+    result.screen_name = screen_name;
+    result.text = text;
+    return result.retweet_count != -1;
+  }
+};
+
+BENCHMARK_TEMPLATE(top_tweet, simdjson_ondemand)->UseManualTime();
+
+struct simdjson_ondemand_forward_only {
+  using StringType=std::string_view;
+
+  ondemand::parser parser{};
+
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    result.retweet_count = -1;
+
+    auto doc = parser.iterate(json);
+    for (auto tweet : doc["statuses"]) {
+      // Since text, user.screen_name, and retweet_count generally appear in order, it's nearly free
+      // for us to retrieve them here (and will cost a bit more if we do it in the if
+      // statement).
+      auto tweet_text = tweet["text"];
+      auto tweet_screen_name = tweet["user"]["screen_name"];
+      int64_t retweet_count = tweet["retweet_count"];
+      if (retweet_count <= max_retweet_count && retweet_count >= result.retweet_count) {
+        result.retweet_count = retweet_count;
+        result.text = tweet_text;
+        result.screen_name = tweet_screen_name;
+      }
+    }
+
+    return result.retweet_count != -1;
+  }
+};
+
+BENCHMARK_TEMPLATE(top_tweet, simdjson_ondemand_forward_only)->UseManualTime();
+
+} // namespace top_tweet
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/top_tweet/top_tweet.h
+++ b/benchmark/top_tweet/top_tweet.h
@@ -1,0 +1,67 @@
+
+#pragma once
+
+#include "json_benchmark/file_runner.h"
+
+namespace top_tweet {
+
+using namespace json_benchmark;
+
+template<typename StringType>
+struct top_tweet_result {
+  int64_t retweet_count{};
+  StringType screen_name{};
+  StringType text{};
+  template<typename OtherStringType>
+  simdjson_really_inline bool operator==(const top_tweet_result<OtherStringType> &other) const {
+    return retweet_count == other.retweet_count &&
+           screen_name == other.screen_name &&
+           text == other.text;
+  }
+  template<typename OtherStringType>
+  simdjson_really_inline bool operator!=(const top_tweet_result<OtherStringType> &other) const { return !(*this == other); }
+};
+
+template<typename StringType>
+simdjson_unused static std::ostream &operator<<(std::ostream &o, const top_tweet_result<StringType> &t) {
+  o << "retweet_count: " << t.retweet_count << std::endl;
+  o << "screen_name: " << t.screen_name << std::endl;
+  o << "text: " << t.text << std::endl;
+  return o;
+}
+
+template<typename I>
+struct runner : public file_runner<I> {
+  top_tweet_result<typename I::StringType> result{};
+
+  bool setup(benchmark::State &state) {
+    return this->load_json(state, TWITTER_JSON);
+  }
+
+  bool before_run(benchmark::State &state) {
+    if (!file_runner<I>::before_run(state)) { return false; }
+    result.retweet_count = -1;
+    return true;
+  }
+
+  bool run(benchmark::State &) {
+    return this->implementation.run(this->json, 60, result);
+  }
+
+  template<typename R>
+  bool diff(benchmark::State &state, runner<R> &reference) {
+    return diff_results(state, result, reference.result, diff_flags::NONE);
+  }
+
+  size_t items_per_iteration() {
+    return 1;
+  }
+};
+
+struct simdjson_dom;
+
+template<typename I> simdjson_really_inline static void top_tweet(benchmark::State &state) {
+  json_benchmark::run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
+}
+
+} // namespace top_tweet

--- a/benchmark/top_tweet/yyjson.h
+++ b/benchmark/top_tweet/yyjson.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_YYJSON
+
+#include "top_tweet.h"
+
+namespace top_tweet {
+
+struct yyjson_base {
+  using StringType=std::string_view;
+
+  bool run(yyjson_doc *doc, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    result.retweet_count = -1;
+
+    yyjson_val *top_tweet{};
+
+    if (!doc) { return false; }
+    yyjson_val *root = yyjson_doc_get_root(doc);
+    if (!yyjson_is_obj(root)) { return false; }
+    yyjson_val *statuses = yyjson_obj_get(root, "statuses");
+    if (!yyjson_is_arr(statuses)) { return false; }
+
+    // Walk the document, parsing the tweets as we go
+    size_t tweet_idx, tweets_max;
+    yyjson_val *tweet;
+    yyjson_arr_foreach(statuses, tweet_idx, tweets_max, tweet) {
+      if (!yyjson_is_obj(tweet)) { return false; }
+
+      auto retweet_count_val = yyjson_obj_get(tweet, "retweet_count");
+      if (!yyjson_is_uint(retweet_count_val)) { return false; }
+      int64_t retweet_count = yyjson_get_uint(retweet_count_val);
+      if (retweet_count <= max_retweet_count && retweet_count >= result.retweet_count) {
+        result.retweet_count = retweet_count;
+        top_tweet = tweet;
+      }
+    }
+
+    auto text = yyjson_obj_get(top_tweet, "text");
+    if (!yyjson_is_str(text)) { return false; }
+    result.text = { yyjson_get_str(text), yyjson_get_len(text) };
+
+    auto user = yyjson_obj_get(top_tweet, "user");
+    if (!yyjson_is_obj(user)) { return false; }
+    auto screen_name = yyjson_obj_get(user, "screen_name");
+    if (!yyjson_is_str(screen_name)) { return false; }
+    result.screen_name = { yyjson_get_str(screen_name), yyjson_get_len(screen_name) };
+
+    return result.retweet_count != -1;
+  }
+};
+
+struct yyjson : yyjson_base {
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), max_retweet_count, result);
+  }
+};
+BENCHMARK_TEMPLATE(top_tweet, yyjson)->UseManualTime();
+
+struct yyjson_insitu : yyjson_base {
+  bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
+    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), max_retweet_count, result);
+  }
+};
+BENCHMARK_TEMPLATE(top_tweet, yyjson_insitu)->UseManualTime();
+
+} // namespace top_tweet
+
+#endif // SIMDJSON_COMPETITION_YYJSON

--- a/include/simdjson/generic/ondemand.h
+++ b/include/simdjson/generic/ondemand.h
@@ -6,12 +6,15 @@ namespace SIMDJSON_IMPLEMENTATION {
  * Designed for maximum speed and a lower memory profile.
  */
 namespace ondemand {
-    /** Represents the depth of a JSON value (number of nested arrays/objects). */
-    using depth_t = int32_t;
+
+/** Represents the depth of a JSON value (number of nested arrays/objects). */
+using depth_t = int32_t;
+
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
 
+#include "simdjson/generic/ondemand/token_position.h"
 #include "simdjson/generic/ondemand/logger.h"
 #include "simdjson/generic/ondemand/raw_json_string.h"
 #include "simdjson/generic/ondemand/token_iterator.h"

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -16,7 +16,6 @@ simdjson_really_inline value_iterator document::resume_value_iterator() noexcept
   return value_iterator(&iter, 1, iter.root_checkpoint());
 }
 simdjson_really_inline value_iterator document::get_root_value_iterator() noexcept {
-  iter.assert_at_root();
   return resume_value_iterator();
 }
 simdjson_really_inline value document::resume_value() noexcept {
@@ -33,22 +32,22 @@ simdjson_really_inline simdjson_result<object> document::get_object() & noexcept
   return get_root_value().get_object();
 }
 simdjson_really_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
-  return get_root_value_iterator().require_root_uint64();
+  return get_root_value_iterator().get_root_uint64();
 }
 simdjson_really_inline simdjson_result<int64_t> document::get_int64() noexcept {
-  return get_root_value_iterator().require_root_int64();
+  return get_root_value_iterator().get_root_int64();
 }
 simdjson_really_inline simdjson_result<double> document::get_double() noexcept {
-  return get_root_value_iterator().require_root_double();
+  return get_root_value_iterator().get_root_double();
 }
-simdjson_really_inline simdjson_result<std::string_view> document::get_string() & noexcept {
-  return get_root_value().get_string();
+simdjson_really_inline simdjson_result<std::string_view> document::get_string() noexcept {
+  return get_root_value_iterator().get_root_string();
 }
-simdjson_really_inline simdjson_result<raw_json_string> document::get_raw_json_string() & noexcept {
-  return get_root_value().get_raw_json_string();
+simdjson_really_inline simdjson_result<raw_json_string> document::get_raw_json_string() noexcept {
+  return get_root_value_iterator().get_root_raw_json_string();
 }
 simdjson_really_inline simdjson_result<bool> document::get_bool() noexcept {
-  return get_root_value_iterator().require_root_bool();
+  return get_root_value_iterator().get_root_bool();
 }
 simdjson_really_inline bool document::is_null() noexcept {
   return get_root_value_iterator().is_root_null();
@@ -63,6 +62,8 @@ template<> simdjson_really_inline simdjson_result<uint64_t> document::get() & no
 template<> simdjson_really_inline simdjson_result<int64_t> document::get() & noexcept { return get_int64(); }
 template<> simdjson_really_inline simdjson_result<bool> document::get() & noexcept { return get_bool(); }
 
+template<> simdjson_really_inline simdjson_result<raw_json_string> document::get() && noexcept { return get_raw_json_string(); }
+template<> simdjson_really_inline simdjson_result<std::string_view> document::get() && noexcept { return get_string(); }
 template<> simdjson_really_inline simdjson_result<double> document::get() && noexcept { return std::forward<document>(*this).get_double(); }
 template<> simdjson_really_inline simdjson_result<uint64_t> document::get() && noexcept { return std::forward<document>(*this).get_uint64(); }
 template<> simdjson_really_inline simdjson_result<int64_t> document::get() && noexcept { return std::forward<document>(*this).get_int64(); }
@@ -81,8 +82,8 @@ simdjson_really_inline document::operator object() & noexcept(false) { return ge
 simdjson_really_inline document::operator uint64_t() noexcept(false) { return get_uint64(); }
 simdjson_really_inline document::operator int64_t() noexcept(false) { return get_int64(); }
 simdjson_really_inline document::operator double() noexcept(false) { return get_double(); }
-simdjson_really_inline document::operator std::string_view() & noexcept(false) { return get_string(); }
-simdjson_really_inline document::operator raw_json_string() & noexcept(false) { return get_raw_json_string(); }
+simdjson_really_inline document::operator std::string_view() noexcept(false) { return get_string(); }
+simdjson_really_inline document::operator raw_json_string() noexcept(false) { return get_raw_json_string(); }
 simdjson_really_inline document::operator bool() noexcept(false) { return get_bool(); }
 #endif
 
@@ -186,11 +187,11 @@ simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMEN
   if (error()) { return error(); }
   return first.get_double();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_string() & noexcept {
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_string() noexcept {
   if (error()) { return error(); }
   return first.get_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_raw_json_string() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_raw_json_string() noexcept {
   if (error()) { return error(); }
   return first.get_raw_json_string();
 }
@@ -257,11 +258,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::docume
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator std::string_view() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator std::string_view() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -77,7 +77,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() & noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
   /**
    * Cast this JSON value to a raw_json_string.
    *
@@ -86,7 +86,7 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() & noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
   /**
    * Cast this JSON value to a bool.
    *
@@ -173,7 +173,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator std::string_view() & noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
   /**
    * Cast this JSON value to a raw_json_string.
    *
@@ -182,7 +182,7 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator raw_json_string() & noexcept(false);
+  simdjson_really_inline operator raw_json_string() noexcept(false);
   /**
    * Cast this JSON value to a bool.
    *
@@ -300,8 +300,8 @@ public:
   simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
   simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
   simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() & noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
   simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
   simdjson_really_inline bool is_null() noexcept;
 
@@ -317,8 +317,8 @@ public:
   simdjson_really_inline operator uint64_t() noexcept(false);
   simdjson_really_inline operator int64_t() noexcept(false);
   simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() & noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() & noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
   simdjson_really_inline operator bool() noexcept(false);
 #endif
 

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -191,7 +191,7 @@ template<int N>
 simdjson_warn_unused simdjson_really_inline bool json_iterator::copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept {
   // Truncate whitespace to fit the buffer.
   if (max_len > N-1) {
-    if (jsoncharutils::is_not_structural_or_whitespace(json[N])) { return false; }
+    if (jsoncharutils::is_not_structural_or_whitespace(json[N-1])) { return false; }
     max_len = N-1;
   }
 

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -98,10 +98,10 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
 SIMDJSON_POP_DISABLE_WARNINGS
 
 simdjson_really_inline bool json_iterator::at_root() const noexcept {
-  return token.checkpoint() == root_checkpoint();
+  return token.position() == root_checkpoint();
 }
 
-simdjson_really_inline const uint32_t *json_iterator::root_checkpoint() const noexcept {
+simdjson_really_inline token_position json_iterator::root_checkpoint() const noexcept {
   return parser->dom_parser->structural_indexes.get();
 }
 
@@ -138,6 +138,14 @@ simdjson_really_inline uint32_t json_iterator::peek_length(int32_t delta) const 
   return token.peek_length(delta);
 }
 
+simdjson_really_inline const uint8_t *json_iterator::peek(token_position position) const noexcept {
+  return token.peek(position);
+}
+
+simdjson_really_inline uint32_t json_iterator::peek_length(token_position position) const noexcept {
+  return token.peek_length(position);
+}
+
 simdjson_really_inline void json_iterator::ascend_to(depth_t parent_depth) noexcept {
   SIMDJSON_ASSUME(parent_depth >= 0 && parent_depth < INT32_MAX - 1);
   SIMDJSON_ASSUME(_depth == parent_depth + 1);
@@ -165,11 +173,11 @@ simdjson_really_inline error_code json_iterator::report_error(error_code _error,
   return error;
 }
 
-simdjson_really_inline const uint32_t *json_iterator::checkpoint() const noexcept {
-  return token.checkpoint();
+simdjson_really_inline token_position json_iterator::position() const noexcept {
+  return token.position();
 }
-simdjson_really_inline void json_iterator::restore_checkpoint(const uint32_t *target_checkpoint) noexcept {
-  token.restore_checkpoint(target_checkpoint);
+simdjson_really_inline void json_iterator::set_position(token_position target_checkpoint) noexcept {
+  token.set_position(target_checkpoint);
 }
 
 

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -177,6 +177,7 @@ protected:
   friend class parser;
   friend class value_iterator;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
+  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
 }; // json_iterator
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -65,7 +65,7 @@ public:
   /**
    * Get the root value iterator
    */
-  simdjson_really_inline const uint32_t *root_checkpoint() const noexcept;
+  simdjson_really_inline token_position root_checkpoint() const noexcept;
 
   /**
    * Assert if the iterator is not at the start
@@ -93,10 +93,6 @@ public:
   simdjson_really_inline const uint8_t *advance() noexcept;
 
   /**
-   * Whether we are at the start of an object.
-   */
-
-  /**
    * Get the JSON text for a given token (relative).
    *
    * This is not null-terminated; it is a view into the JSON.
@@ -108,13 +104,32 @@ public:
    */
   simdjson_really_inline const uint8_t *peek(int32_t delta=0) const noexcept;
   /**
-   * Get the maximum length of the JSON text for a given token.
+   * Get the maximum length of the JSON text for the current token (or relative).
    *
    * The length will include any whitespace at the end of the token.
    *
    * @param delta The relative position of the token to retrieve. e.g. 0 = next token, -1 = prev token.
    */
   simdjson_really_inline uint32_t peek_length(int32_t delta=0) const noexcept;
+  /**
+   * Get the JSON text for a given token.
+   *
+   * This is not null-terminated; it is a view into the JSON.
+   *
+   * @param index The position of the token to retrieve.
+   *
+   * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
+   * it isn't used ...
+   */
+  simdjson_really_inline const uint8_t *peek(token_position position) const noexcept;
+  /**
+   * Get the maximum length of the JSON text for the current token (or relative).
+   *
+   * The length will include any whitespace at the end of the token.
+   *
+   * @param index The position of the token to retrieve.
+   */
+  simdjson_really_inline uint32_t peek_length(token_position position) const noexcept;
 
   /**
    * Ascend one level.
@@ -163,8 +178,8 @@ public:
   template<int N> simdjson_warn_unused simdjson_really_inline bool peek_to_buffer(uint8_t (&tmpbuf)[N]) noexcept;
   template<int N> simdjson_warn_unused simdjson_really_inline bool advance_to_buffer(uint8_t (&tmpbuf)[N]) noexcept;
 
-  simdjson_really_inline const uint32_t *checkpoint() const noexcept;
-  simdjson_really_inline void restore_checkpoint(const uint32_t *target_checkpoint) noexcept;
+  simdjson_really_inline token_position position() const noexcept;
+  simdjson_really_inline void set_position(token_position target_checkpoint) noexcept;
 
 protected:
   simdjson_really_inline json_iterator(const uint8_t *buf, ondemand::parser *parser) noexcept;
@@ -177,7 +192,7 @@ protected:
   friend class parser;
   friend class value_iterator;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
-  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
+  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
 }; // json_iterator
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/logger-inl.h
+++ b/include/simdjson/generic/ondemand/logger-inl.h
@@ -24,7 +24,7 @@ simdjson_really_inline void log_event(const json_iterator &iter, const char *typ
 simdjson_really_inline void log_value(const json_iterator &iter, const char *type, std::string_view detail, int delta, int depth_delta) noexcept {
   log_line(iter, "", type, detail, delta, depth_delta);
 }
-simdjson_really_inline void log_value(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *type, std::string_view detail) noexcept {
+simdjson_really_inline void log_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail) noexcept {
   log_line(iter, index, depth, "", type, detail);
 }
 simdjson_really_inline void log_start_value(const json_iterator &iter, const char *type, int delta, int depth_delta) noexcept {
@@ -38,7 +38,7 @@ simdjson_really_inline void log_end_value(const json_iterator &iter, const char 
 simdjson_really_inline void log_error(const json_iterator &iter, const char *error, const char *detail, int delta, int depth_delta) noexcept {
   log_line(iter, "ERROR: ", error, detail, delta, depth_delta);
 }
-simdjson_really_inline void log_error(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *error, const char *detail) noexcept {
+simdjson_really_inline void log_error(const json_iterator &iter, token_position index, depth_t depth, const char *error, const char *detail) noexcept {
   log_line(iter, index, depth, "ERROR: ", error, detail);
 }
 
@@ -84,7 +84,7 @@ simdjson_really_inline void log_headers() noexcept {
 simdjson_really_inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept {
   log_line(iter, iter.token.index+delta, depth_t(iter.depth()+depth_delta), title_prefix, title, detail);
 }
-simdjson_really_inline void log_line(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept {
+simdjson_really_inline void log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept {
   if (LOG_ENABLED) {
     const int indent = depth*2;
     const auto buf = iter.token.buf;

--- a/include/simdjson/generic/ondemand/logger.h
+++ b/include/simdjson/generic/ondemand/logger.h
@@ -15,14 +15,14 @@ namespace logger {
 
 static simdjson_really_inline void log_headers() noexcept;
 static simdjson_really_inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
-static simdjson_really_inline void log_line(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
+static simdjson_really_inline void log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
 static simdjson_really_inline void log_event(const json_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_value(const json_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_value(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *type, std::string_view detail="") noexcept;
+static simdjson_really_inline void log_value(const json_iterator &iter, token_position index, depth_t depth, const char *type, std::string_view detail="") noexcept;
 static simdjson_really_inline void log_start_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_end_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_error(const json_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
-static simdjson_really_inline void log_error(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *error, const char *detail="") noexcept;
+static simdjson_really_inline void log_error(const json_iterator &iter, token_position index, depth_t depth, const char *error, const char *detail="") noexcept;
 
 static simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_value(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;

--- a/include/simdjson/generic/ondemand/logger.h
+++ b/include/simdjson/generic/ondemand/logger.h
@@ -15,11 +15,14 @@ namespace logger {
 
 static simdjson_really_inline void log_headers() noexcept;
 static simdjson_really_inline void log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
+static simdjson_really_inline void log_line(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
 static simdjson_really_inline void log_event(const json_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_value(const json_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_value(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *type, std::string_view detail="") noexcept;
 static simdjson_really_inline void log_start_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_end_value(const json_iterator &iter, const char *type, int delta=-1, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_error(const json_iterator &iter, const char *error, const char *detail="", int delta=-1, int depth_delta=0) noexcept;
+static simdjson_really_inline void log_error(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *error, const char *detail="") noexcept;
 
 static simdjson_really_inline void log_event(const value_iterator &iter, const char *type, std::string_view detail="", int delta=0, int depth_delta=0) noexcept;
 static simdjson_really_inline void log_value(const value_iterator &iter, const char *type, std::string_view detail="", int delta=-1, int depth_delta=0) noexcept;

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -58,7 +58,7 @@ simdjson_really_inline object::object(const value_iterator &_iter) noexcept
 
 simdjson_really_inline object_iterator object::begin() noexcept {
   // Expanded version of SIMDJSON_ASSUME( iter.at_field_start() || !iter.is_open() )
-  SIMDJSON_ASSUME( (iter._json_iter->token.index == iter._start_index + 1) || (iter._json_iter->_depth < iter._depth) );
+  SIMDJSON_ASSUME( (iter._json_iter->token.index == iter._start_position + 1) || (iter._json_iter->_depth < iter._depth) );
   return iter;
 }
 simdjson_really_inline object_iterator object::end() noexcept {

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -6,6 +6,7 @@ namespace ondemand {
 
 class object;
 class parser;
+class json_iterator;
 
 /**
  * A string escaped per JSON rules, terminated with quote ("). They are used to represent

--- a/include/simdjson/generic/ondemand/token_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/token_iterator-inl.h
@@ -2,22 +2,40 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline token_iterator::token_iterator(const uint8_t *_buf, uint32_t *_index) noexcept
+simdjson_really_inline token_iterator::token_iterator(const uint8_t *_buf, token_position _index) noexcept
   : buf{_buf}, index{_index}
 {
 }
 
-simdjson_really_inline const uint8_t *token_iterator::peek(int32_t delta) const noexcept {
-  return &buf[*(index+delta)];
-}
 simdjson_really_inline const uint8_t *token_iterator::advance() noexcept {
   return &buf[*(index++)];
+}
+
+simdjson_really_inline const uint8_t *token_iterator::peek(token_position position) const noexcept {
+  return &buf[*position];
+}
+simdjson_really_inline uint32_t token_iterator::peek_index(token_position position) const noexcept {
+  return *position;
+}
+simdjson_really_inline uint32_t token_iterator::peek_length(token_position position) const noexcept {
+  return *(position+1) - *position;
+}
+
+simdjson_really_inline const uint8_t *token_iterator::peek(int32_t delta) const noexcept {
+  return &buf[*(index+delta)];
 }
 simdjson_really_inline uint32_t token_iterator::peek_index(int32_t delta) const noexcept {
   return *(index+delta);
 }
 simdjson_really_inline uint32_t token_iterator::peek_length(int32_t delta) const noexcept {
   return *(index+delta+1) - *(index+delta);
+}
+
+simdjson_really_inline token_position token_iterator::position() const noexcept {
+  return index;
+}
+simdjson_really_inline void token_iterator::set_position(token_position target_checkpoint) noexcept {
+  index = target_checkpoint;
 }
 
 simdjson_really_inline bool token_iterator::operator==(const token_iterator &other) const noexcept {
@@ -37,14 +55,6 @@ simdjson_really_inline bool token_iterator::operator<(const token_iterator &othe
 }
 simdjson_really_inline bool token_iterator::operator<=(const token_iterator &other) const noexcept {
   return index <= other.index;
-}
-
-simdjson_really_inline const uint32_t *token_iterator::checkpoint() const noexcept {
-  return index;
-}
-
-simdjson_really_inline void token_iterator::restore_checkpoint(const uint32_t *target_checkpoint) noexcept {
-  index = target_checkpoint;
 }
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/token_iterator.h
+++ b/include/simdjson/generic/ondemand/token_iterator.h
@@ -90,6 +90,7 @@ protected:
   friend class value_iterator;
   friend class object;
   friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
+  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const uint32_t *index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
 };
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/token_position.h
+++ b/include/simdjson/generic/ondemand/token_position.h
@@ -1,0 +1,10 @@
+namespace simdjson {
+namespace SIMDJSON_IMPLEMENTATION {
+namespace ondemand {
+
+/** @private Position in the JSON buffer indexes */
+using token_position = const uint32_t *;
+
+} // namespace ondemand
+} // namespace SIMDJSON_IMPLEMENTATION
+} // namespace simdjson

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -40,46 +40,25 @@ simdjson_really_inline simdjson_result<object> value::start_or_resume_object() &
   }
 }
 
-simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() && noexcept {
-  return iter.require_raw_json_string();
+simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() noexcept {
+  return iter.get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() & noexcept {
-  return iter.try_get_raw_json_string();
+simdjson_really_inline simdjson_result<std::string_view> value::get_string() noexcept {
+  return iter.get_string();
 }
-simdjson_really_inline simdjson_result<std::string_view> value::get_string() && noexcept {
-  return iter.require_string();
+simdjson_really_inline simdjson_result<double> value::get_double() noexcept {
+  return iter.get_double();
 }
-simdjson_really_inline simdjson_result<std::string_view> value::get_string() & noexcept {
-  return iter.try_get_string();
+simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() noexcept {
+  return iter.get_uint64();
 }
-simdjson_really_inline simdjson_result<double> value::get_double() && noexcept {
-  return iter.require_double();
+simdjson_really_inline simdjson_result<int64_t> value::get_int64() noexcept {
+  return iter.get_int64();
 }
-simdjson_really_inline simdjson_result<double> value::get_double() & noexcept {
-  return iter.try_get_double();
+simdjson_really_inline simdjson_result<bool> value::get_bool() noexcept {
+  return iter.get_bool();
 }
-simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() && noexcept {
-  return iter.require_uint64();
-}
-simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() & noexcept {
-  return iter.try_get_uint64();
-}
-simdjson_really_inline simdjson_result<int64_t> value::get_int64() && noexcept {
-  return iter.require_int64();
-}
-simdjson_really_inline simdjson_result<int64_t> value::get_int64() & noexcept {
-  return iter.try_get_int64();
-}
-simdjson_really_inline simdjson_result<bool> value::get_bool() && noexcept {
-  return iter.require_bool();
-}
-simdjson_really_inline simdjson_result<bool> value::get_bool() & noexcept {
-  return iter.try_get_bool();
-}
-simdjson_really_inline bool value::is_null() && noexcept {
-  return iter.require_null();
-}
-simdjson_really_inline bool value::is_null() & noexcept {
+simdjson_really_inline bool value::is_null() noexcept {
   return iter.is_null();
 }
 
@@ -122,41 +101,23 @@ simdjson_really_inline value::operator object() && noexcept(false) {
 simdjson_really_inline value::operator object() & noexcept(false) {
   return std::forward<value>(*this).get_object();
 }
-simdjson_really_inline value::operator uint64_t() && noexcept(false) {
-  return std::forward<value>(*this).get_uint64();
+simdjson_really_inline value::operator uint64_t() noexcept(false) {
+  return get_uint64();
 }
-simdjson_really_inline value::operator uint64_t() & noexcept(false) {
-  return std::forward<value>(*this).get_uint64();
+simdjson_really_inline value::operator int64_t() noexcept(false) {
+  return get_int64();
 }
-simdjson_really_inline value::operator int64_t() && noexcept(false) {
-  return std::forward<value>(*this).get_int64();
+simdjson_really_inline value::operator double() noexcept(false) {
+  return get_double();
 }
-simdjson_really_inline value::operator int64_t() & noexcept(false) {
-  return std::forward<value>(*this).get_int64();
+simdjson_really_inline value::operator std::string_view() noexcept(false) {
+  return get_string();
 }
-simdjson_really_inline value::operator double() && noexcept(false) {
-  return std::forward<value>(*this).get_double();
+simdjson_really_inline value::operator raw_json_string() noexcept(false) {
+  return get_raw_json_string();
 }
-simdjson_really_inline value::operator double() & noexcept(false) {
-  return std::forward<value>(*this).get_double();
-}
-simdjson_really_inline value::operator std::string_view() && noexcept(false) {
-  return std::forward<value>(*this).get_string();
-}
-simdjson_really_inline value::operator std::string_view() & noexcept(false) {
-  return std::forward<value>(*this).get_string();
-}
-simdjson_really_inline value::operator raw_json_string() && noexcept(false) {
-  return std::forward<value>(*this).get_raw_json_string();
-}
-simdjson_really_inline value::operator raw_json_string() & noexcept(false) {
-  return std::forward<value>(*this).get_raw_json_string();
-}
-simdjson_really_inline value::operator bool() && noexcept(false) {
-  return std::forward<value>(*this).get_bool();
-}
-simdjson_really_inline value::operator bool() & noexcept(false) {
-  return std::forward<value>(*this).get_bool();
+simdjson_really_inline value::operator bool() noexcept(false) {
+  return get_bool();
 }
 #endif
 
@@ -303,61 +264,33 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_object();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() & noexcept {
+simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() noexcept {
   if (error()) { return error(); }
   return first.get_uint64();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() && noexcept {
-  if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_uint64();
-}
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() & noexcept {
+simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() noexcept {
   if (error()) { return error(); }
   return first.get_int64();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() && noexcept {
-  if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_int64();
-}
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() & noexcept {
+simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() noexcept {
   if (error()) { return error(); }
   return first.get_double();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() && noexcept {
-  if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_double();
-}
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() & noexcept {
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() noexcept {
   if (error()) { return error(); }
   return first.get_string();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() && noexcept {
-  if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_string();
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() & noexcept {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() noexcept {
   if (error()) { return error(); }
   return first.get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() && noexcept {
-  if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_raw_json_string();
-}
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() & noexcept {
+simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() noexcept {
   if (error()) { return error(); }
   return first.get_bool();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() && noexcept {
-  if (error()) { return error(); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).get_bool();
-}
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() & noexcept {
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() noexcept {
   if (error()) { return false; }
   return first.is_null();
-}
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() && noexcept {
-  if (error()) { return false; }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first).is_null();
 }
 
 template<typename T> simdjson_really_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get() & noexcept {
@@ -413,53 +346,29 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
   if (error()) { throw simdjson_error(error()); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() && noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() && noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() && noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() && noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() && noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() & noexcept(false) {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
-}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() & noexcept(false) {
-  if (error()) { throw simdjson_error(error()); }
-  return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value>(first);
 }
 #endif
 

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -67,19 +67,13 @@ public:
   /** @overload simdjson_really_inline operator object() && noexcept(false); */
   simdjson_really_inline simdjson_result<object> get_object() & noexcept;
 
-  // PERF NOTE: get_XXX() methods generally have both && and & variants because performance is demonstrably better on clang.
-  // Specifically, in typical cases where you use a temporary value (like doc["x"].get_double()) the && version is faster
-  // because the & version has to branch to check whether the parse failed or not before deciding whether the value was consumed.
-
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
-  /** @overload simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() & noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
 
   /**
    * Cast this JSON value to a signed integer.
@@ -87,9 +81,7 @@ public:
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
-  /** @overload simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept */
-  simdjson_really_inline simdjson_result<int64_t> get_int64() & noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
 
   /**
    * Cast this JSON value to a double.
@@ -97,9 +89,7 @@ public:
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
-  /** @overload simdjson_really_inline simdjson_result<double> get_double() && noexcept */
-  simdjson_really_inline simdjson_result<double> get_double() & noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
 
   /**
    * Cast this JSON value to a string.
@@ -112,9 +102,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
-  /** @overload simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() & noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
 
   /**
    * Cast this JSON value to a raw_json_string.
@@ -124,9 +112,7 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() && noexcept;
-  /** @overload simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() && noexcept */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() & noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
 
   /**
    * Cast this JSON value to a bool.
@@ -134,18 +120,14 @@ public:
    * @returns A bool value.
    * @returns INCORRECT_TYPE if the JSON value is not true or false.
    */
-  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
-  /** @overload simdjson_really_inline simdjson_result<bool> get_bool() && noexcept */
-  simdjson_really_inline simdjson_result<bool> get_bool() & noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
 
   /**
    * Checks if this JSON value is null.
    *
    * @returns Whether the value is null.
    */
-  simdjson_really_inline bool is_null() && noexcept;
-  /** @overload simdjson_really_inline bool is_null() && noexcept */
-  simdjson_really_inline bool is_null() & noexcept;
+  simdjson_really_inline bool is_null() noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -172,27 +154,21 @@ public:
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline operator uint64_t() && noexcept(false);
-  /** @overload simdjson_really_inline operator uint64_t() && noexcept(false); */
-  simdjson_really_inline operator uint64_t() & noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline operator int64_t() && noexcept(false);
-  /** @overload simdjson_really_inline operator int64_t() && noexcept(false); */
-  simdjson_really_inline operator int64_t() & noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline operator double() && noexcept(false);
-  /** @overload simdjson_really_inline operator double() && noexcept(false); */
-  simdjson_really_inline operator double() & noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
   /**
    * Cast this JSON value to a string.
    *
@@ -204,9 +180,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator std::string_view() && noexcept(false);
-  /** @overload simdjson_really_inline operator std::string_view() && noexcept(false); */
-  simdjson_really_inline operator std::string_view() & noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
   /**
    * Cast this JSON value to a raw_json_string.
    *
@@ -215,18 +189,14 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator raw_json_string() && noexcept(false);
-  /** @overload simdjson_really_inline operator raw_json_string() && noexcept(false); */
-  simdjson_really_inline operator raw_json_string() & noexcept(false);
+  simdjson_really_inline operator raw_json_string() noexcept(false);
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not true or false.
    */
-  simdjson_really_inline operator bool() && noexcept(false);
-  /** @overload simdjson_really_inline operator bool() && noexcept(false); */
-  simdjson_really_inline operator bool() & noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
 #endif
 
   /**
@@ -370,26 +340,13 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() && noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
 
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() && noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() & noexcept;
-
-  simdjson_really_inline simdjson_result<int64_t> get_int64() && noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() & noexcept;
-
-  simdjson_really_inline simdjson_result<double> get_double() && noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() & noexcept;
-
-  simdjson_really_inline simdjson_result<std::string_view> get_string() && noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() & noexcept;
-
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() & noexcept;
-
-  simdjson_really_inline simdjson_result<bool> get_bool() && noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() & noexcept;
-
-  simdjson_really_inline bool is_null() && noexcept;
-  simdjson_really_inline bool is_null() & noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
 
   template<typename T> simdjson_really_inline simdjson_result<T> get() & noexcept;
   template<typename T> simdjson_really_inline simdjson_result<T> get() && noexcept;
@@ -402,18 +359,12 @@ public:
   simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
   simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() && noexcept(false);
   simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
-  simdjson_really_inline operator uint64_t() && noexcept(false);
-  simdjson_really_inline operator uint64_t() & noexcept(false);
-  simdjson_really_inline operator int64_t() && noexcept(false);
-  simdjson_really_inline operator int64_t() & noexcept(false);
-  simdjson_really_inline operator double() && noexcept(false);
-  simdjson_really_inline operator double() & noexcept(false);
-  simdjson_really_inline operator std::string_view() && noexcept(false);
-  simdjson_really_inline operator std::string_view() & noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() && noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() & noexcept(false);
-  simdjson_really_inline operator bool() && noexcept(false);
-  simdjson_really_inline operator bool() & noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
 #endif
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -305,209 +305,142 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> va
   return require_raw_json_string().unescape(_json_iter->string_buf_loc());
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::try_get_raw_json_string() noexcept {
-  assert_at_start();
-
-  logger::log_value(*_json_iter, "string", "", 0);
-  auto json = _json_iter->peek();
-  if (*json != '"') { logger::log_error(*_json_iter, "Not a string"); return INCORRECT_TYPE; }
-  _json_iter->advance();
-  _json_iter->ascend_to(depth()-1);
+  auto json = peek_scalar();
+  if (*json != '"') { return incorrect_type_error("Not a string"); }
+  advance_scalar("string");
   return raw_json_string(json+1);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::require_raw_json_string() noexcept {
-  assert_at_start();
-
-  logger::log_value(*_json_iter, "string", "", 0);
-  auto json = _json_iter->advance();
-  if (*json != '"') { logger::log_error(*_json_iter, "Not a string"); return INCORRECT_TYPE; }
-  _json_iter->ascend_to(depth()-1);
+  auto json = advance_scalar("string");
+  if (*json != '"') { return incorrect_type_error("Not a string"); }
   return raw_json_string(json+1);
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_uint64() noexcept {
-  assert_at_non_root_start();
 
-  logger::log_value(*_json_iter, "uint64", "", 0);
+simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_uint64() noexcept {
   uint64_t result;
-  SIMDJSON_TRY( numberparsing::parse_unsigned(_json_iter->peek()).get(result) );
-  _json_iter->advance();
-  _json_iter->ascend_to(depth()-1);
+  SIMDJSON_TRY( numberparsing::parse_unsigned(peek_scalar()).get(result) );
+  advance_non_root_scalar("uint64");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_uint64() noexcept {
-  assert_at_non_root_start();
-
-  logger::log_value(*_json_iter, "uint64", "", 0);
-  _json_iter->ascend_to(depth()-1);
-  return numberparsing::parse_unsigned(_json_iter->advance());
+  return numberparsing::parse_unsigned(advance_non_root_scalar("uint64"));
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_int64() noexcept {
-  assert_at_non_root_start();
 
-  logger::log_value(*_json_iter, "int64", "", 0);
+simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_int64() noexcept {
   int64_t result;
-  SIMDJSON_TRY( numberparsing::parse_integer(_json_iter->peek()).get(result) );
-  _json_iter->advance();
-  _json_iter->ascend_to(depth()-1);
+  SIMDJSON_TRY( numberparsing::parse_integer(peek_scalar()).get(result) );
+  advance_non_root_scalar("int64");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_int64() noexcept {
-  assert_at_non_root_start();
-
-  logger::log_value(*_json_iter, "int64", "", 0);
-  _json_iter->ascend_to(depth()-1);
-  return numberparsing::parse_integer(_json_iter->advance());
+  return numberparsing::parse_integer(advance_non_root_scalar("int64"));
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_double() noexcept {
-  assert_at_non_root_start();
 
-  logger::log_value(*_json_iter, "double", "", 0);
+simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_double() noexcept {
   double result;
-  SIMDJSON_TRY( numberparsing::parse_double(_json_iter->peek()).get(result) );
-  _json_iter->advance();
-  _json_iter->ascend_to(depth()-1);
+  SIMDJSON_TRY( numberparsing::parse_double(peek_scalar()).get(result) );
+  advance_non_root_scalar("double");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_double() noexcept {
-  assert_at_non_root_start();
-
-  logger::log_value(*_json_iter, "double", "", 0);
-  _json_iter->ascend_to(depth()-1);
-  return numberparsing::parse_double(_json_iter->advance());
+  return numberparsing::parse_double(advance_non_root_scalar("double"));
 }
+
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::parse_bool(const uint8_t *json) const noexcept {
-  logger::log_value(*_json_iter, "bool", "");
   auto not_true = atomparsing::str4ncmp(json, "true");
   auto not_false = atomparsing::str4ncmp(json, "fals") | (json[4] ^ 'e');
   bool error = (not_true && not_false) || jsoncharutils::is_not_structural_or_whitespace(json[not_true ? 5 : 4]);
-  if (error) { logger::log_error(*_json_iter, "Not a boolean"); return INCORRECT_TYPE; }
+  if (error) { return incorrect_type_error("Not a boolean"); }
   return simdjson_result<bool>(!not_true);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_bool() noexcept {
-  assert_at_non_root_start();
-
   bool result;
-  SIMDJSON_TRY( parse_bool(_json_iter->peek()).get(result) );
-  _json_iter->advance();
-  _json_iter->ascend_to(depth()-1);
+  SIMDJSON_TRY( parse_bool(peek_scalar()).get(result) );
+  advance_non_root_scalar("bool");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_bool() noexcept {
-  assert_at_non_root_start();
-
-  _json_iter->ascend_to(depth()-1);
-  return parse_bool(_json_iter->advance());
+  return parse_bool(advance_non_root_scalar("bool"));
 }
 simdjson_really_inline bool value_iterator::is_null(const uint8_t *json) const noexcept {
-  if (!atomparsing::str4ncmp(json, "null")) {
-    logger::log_value(*_json_iter, "null", "");
-    return true;
-  }
-  return false;
+  return !atomparsing::str4ncmp(json, "null");
 }
 simdjson_really_inline bool value_iterator::is_null() noexcept {
-  assert_at_non_root_start();
-
-  if (is_null(_json_iter->peek())) {
-    _json_iter->advance();
-    _json_iter->ascend_to(depth()-1);
+  if (is_null(peek_scalar())) {
+    advance_non_root_scalar("null");
     return true;
   }
   return false;
 }
 simdjson_really_inline bool value_iterator::require_null() noexcept {
-  assert_at_non_root_start();
-
-  _json_iter->ascend_to(depth()-1);
-  return is_null(_json_iter->advance());
+  return is_null(advance_non_root_scalar("null"));
 }
 
 constexpr const uint32_t MAX_INT_LENGTH = 1024;
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::parse_root_uint64(const uint8_t *json, uint32_t max_len) const noexcept {
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
-  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
-  logger::log_value(*_json_iter, "uint64", "", 0);
-  auto result = numberparsing::parse_unsigned(tmpbuf);
-  if (result.error()) { logger::log_error(*_json_iter, "Error parsing unsigned integer"); }
-  return result;
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, _start_index, depth(), "Root number more than 20 characters"); return NUMBER_ERROR; }
+  return numberparsing::parse_unsigned(tmpbuf);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::try_get_root_uint64() noexcept {
-  assert_at_root();
-
   uint64_t result;
-  SIMDJSON_TRY( parse_root_uint64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
-  _json_iter->advance();
+  SIMDJSON_TRY( parse_root_uint64(peek_scalar(), peek_scalar_length()).get(result) );
+  advance_root_scalar("uint64");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::require_root_uint64() noexcept {
-  assert_at_root();
-
-  auto max_len = _json_iter->peek_length();
-  return parse_root_uint64(_json_iter->advance(), max_len);
+  auto max_len = peek_scalar_length();
+  return parse_root_uint64(advance_root_scalar("uint64"), max_len);
 }
+
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept {
   uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
-  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 20 characters"); return NUMBER_ERROR; }
-  logger::log_value(*_json_iter, "int64", "", 0);
-  auto result = numberparsing::parse_integer(tmpbuf);
-  if (result.error()) { logger::log_error(*_json_iter, "Error parsing integer"); }
-  return result;
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, _start_index, depth(), "Root number more than 20 characters"); return NUMBER_ERROR; }
+  return numberparsing::parse_integer(tmpbuf);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::try_get_root_int64() noexcept {
-  assert_at_root();
-
   int64_t result;
-  SIMDJSON_TRY( parse_root_int64(_json_iter->peek(), _json_iter->peek_length()).get(result) );
-  _json_iter->advance();
+  SIMDJSON_TRY( parse_root_int64(peek_scalar(), peek_scalar_length()).get(result) );
+  advance_root_scalar("int64");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::require_root_int64() noexcept {
-  assert_at_root();
-
-  auto max_len = _json_iter->peek_length();
-  return parse_root_int64(_json_iter->advance(), max_len);
+  auto max_len = peek_scalar_length();
+  return parse_root_int64(advance_root_scalar("int64"), max_len);
 }
+
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept {
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/, 1074 is the maximum number of significant fractional digits. Add 8 more digits for the biggest number: -0.<fraction>e-308.
   uint8_t tmpbuf[1074+8+1];
-  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Root number more than 1082 characters"); return NUMBER_ERROR; }
-  logger::log_value(*_json_iter, "double", "", 0);
-  auto result = numberparsing::parse_double(tmpbuf);
-  if (result.error()) { logger::log_error(*_json_iter, "Error parsing double"); }
-  return result;
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, _start_index, depth(), "Root number more than 1082 characters"); return NUMBER_ERROR; }
+  return numberparsing::parse_double(tmpbuf);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::try_get_root_double() noexcept {
-  assert_at_root();
-
   double result;
-  SIMDJSON_TRY( parse_root_double(_json_iter->peek(), _json_iter->peek_length()).get(result) );
-  _json_iter->advance();
+  SIMDJSON_TRY( parse_root_double(peek_scalar(), peek_scalar_length()).get(result) );
+  advance_root_scalar("double");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::require_root_double() noexcept {
-  assert_at_root();
-
-  auto max_len = _json_iter->peek_length();
-  return parse_root_double(_json_iter->advance(), max_len);
+  auto max_len = peek_scalar_length();
+  return parse_root_double(advance_root_scalar("double"), max_len);
 }
+
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::parse_root_bool(const uint8_t *json, uint32_t max_len) const noexcept {
   uint8_t tmpbuf[5+1];
-  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { logger::log_error(*_json_iter, "Not a boolean"); return INCORRECT_TYPE; }
+  if (!_json_iter->copy_to_buffer(json, max_len, tmpbuf)) { return incorrect_type_error("Not a boolean"); }
   return parse_bool(tmpbuf);
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::try_get_root_bool() noexcept {
-  assert_at_root();
-
   bool result;
-  SIMDJSON_TRY( parse_root_bool(_json_iter->peek(), _json_iter->peek_length()).get(result) );
-  _json_iter->advance();
+  SIMDJSON_TRY( parse_root_bool(peek_scalar(), peek_scalar_length()).get(result) );
+  advance_root_scalar("bool");
   return result;
 }
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::require_root_bool() noexcept {
-  assert_at_root();
-
-  auto max_len = _json_iter->peek_length();
-  return parse_root_bool(_json_iter->advance(), max_len);
+  auto max_len = peek_scalar_length();
+  return parse_root_bool(advance_root_scalar("bool"), max_len);
 }
 simdjson_really_inline bool value_iterator::is_root_null(const uint8_t *json, uint32_t max_len) const noexcept {
   uint8_t tmpbuf[4+1];
@@ -515,17 +448,13 @@ simdjson_really_inline bool value_iterator::is_root_null(const uint8_t *json, ui
   return is_null(tmpbuf);
 }
 simdjson_really_inline bool value_iterator::is_root_null() noexcept {
-  assert_at_root();
-
-  if (!is_root_null(_json_iter->peek(), _json_iter->peek_length())) { return false; }
-  _json_iter->advance();
+  if (!is_root_null(peek_scalar(), peek_scalar_length())) { return false; }
+  advance_root_scalar("null");
   return true;
 }
 simdjson_really_inline bool value_iterator::require_root_null() noexcept {
-  assert_at_root();
-
-  auto max_len = _json_iter->peek_length();
-  return is_root_null(_json_iter->advance(), max_len);
+  auto max_len = peek_scalar_length();
+  return is_root_null(advance_root_scalar("null"), max_len);
 }
 
 simdjson_warn_unused simdjson_really_inline error_code value_iterator::skip_child() noexcept {
@@ -575,6 +504,50 @@ simdjson_warn_unused simdjson_really_inline const json_iterator &value_iterator:
 }
 simdjson_warn_unused simdjson_really_inline json_iterator &value_iterator::json_iter() noexcept {
   return *_json_iter;
+}
+
+simdjson_really_inline const uint8_t *value_iterator::peek_scalar() const noexcept {
+  return &_json_iter->token.buf[*_start_index];
+}
+simdjson_really_inline uint32_t value_iterator::peek_scalar_length() const noexcept {
+  return *(_start_index+1) - *_start_index;
+}
+
+simdjson_really_inline const uint8_t *value_iterator::advance_scalar(const char *type) const noexcept {
+  logger::log_value(*_json_iter, _start_index, depth(), type);
+  if (!is_at_start()) { return peek_scalar(); }
+
+  assert_at_start();
+  auto result = _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return result;
+}
+simdjson_really_inline const uint8_t *value_iterator::advance_root_scalar(const char *type) const noexcept {
+  logger::log_value(*_json_iter, _start_index, depth(), type);
+  if (is_at_start()) { return peek_scalar(); }
+
+  assert_at_root();
+  auto result = _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return result;
+}
+simdjson_really_inline const uint8_t *value_iterator::advance_non_root_scalar(const char *type) const noexcept {
+  logger::log_value(*_json_iter, _start_index, depth(), type);
+  if (is_at_start()) { return peek_scalar(); }
+
+  assert_at_non_root_start();
+  auto result = _json_iter->advance();
+  _json_iter->ascend_to(depth()-1);
+  return result;
+}
+
+simdjson_really_inline error_code value_iterator::incorrect_type_error(const char *message) const noexcept {
+  logger::log_error(*_json_iter, _start_index, depth(), message);
+  return INCORRECT_TYPE;
+}
+
+simdjson_really_inline bool value_iterator::is_at_start() const noexcept {
+  return _json_iter->token.index == _start_index;
 }
 
 simdjson_really_inline void value_iterator::assert_at_start() const noexcept {

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -292,6 +292,15 @@ protected:
   simdjson_really_inline simdjson_result<int64_t> parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept;
   simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept;
 
+  simdjson_really_inline const uint8_t *peek_scalar() const noexcept;
+  simdjson_really_inline uint32_t peek_scalar_length() const noexcept;
+  simdjson_really_inline const uint8_t *advance_scalar(const char *type) const noexcept;
+  simdjson_really_inline const uint8_t *advance_root_scalar(const char *type) const noexcept;
+  simdjson_really_inline const uint8_t *advance_non_root_scalar(const char *type) const noexcept;
+
+  simdjson_really_inline error_code incorrect_type_error(const char *message) const noexcept;
+
+  simdjson_really_inline bool is_at_start() const noexcept;
   simdjson_really_inline void assert_at_start() const noexcept;
   simdjson_really_inline void assert_at_root() const noexcept;
   simdjson_really_inline void assert_at_child() const noexcept;

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -28,7 +28,7 @@ protected:
    *
    * PERF NOTE: this is a safety check; we expect this to be elided in release builds.
    */
-  const uint32_t *_start_index{};
+  token_position _start_index{};
 
 public:
   simdjson_really_inline value_iterator() noexcept = default;
@@ -283,7 +283,7 @@ public:
   /** @} */
 
 protected:
-  simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth, const uint32_t *start_index) noexcept;
+  simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth, token_position start_index) noexcept;
   simdjson_really_inline bool is_null(const uint8_t *json) const noexcept;
   simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) const noexcept;
   simdjson_really_inline bool is_root_null(const uint8_t *json, uint32_t max_len) const noexcept;

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -28,7 +28,7 @@ protected:
    *
    * PERF NOTE: this is a safety check; we expect this to be elided in release builds.
    */
-  token_position _start_index{};
+  token_position _start_position{};
 
 public:
   simdjson_really_inline value_iterator() noexcept = default;
@@ -249,30 +249,20 @@ public:
    * @{
    */
 
-  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> try_get_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> require_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> try_get_raw_json_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> require_raw_json_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> try_get_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> require_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> try_get_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> require_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> try_get_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> require_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> try_get_bool() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> require_bool() noexcept;
-  simdjson_really_inline bool require_null() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
   simdjson_really_inline bool is_null() noexcept;
 
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> try_get_root_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> require_root_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> try_get_root_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> require_root_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> try_get_root_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> require_root_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> try_get_root_bool() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> require_root_bool() noexcept;
-  simdjson_really_inline bool require_root_null() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> get_root_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> get_root_raw_json_string() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_root_uint64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_root_int64() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_root_double() noexcept;
+  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> get_root_bool() noexcept;
   simdjson_really_inline bool is_root_null() noexcept;
 
   simdjson_really_inline error_code error() const noexcept;
@@ -284,13 +274,9 @@ public:
 
 protected:
   simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth, token_position start_index) noexcept;
-  simdjson_really_inline bool is_null(const uint8_t *json) const noexcept;
+
+  simdjson_really_inline bool parse_null(const uint8_t *json) const noexcept;
   simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) const noexcept;
-  simdjson_really_inline bool is_root_null(const uint8_t *json, uint32_t max_len) const noexcept;
-  simdjson_really_inline simdjson_result<bool> parse_root_bool(const uint8_t *json, uint32_t max_len) const noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> parse_root_uint64(const uint8_t *json, uint32_t max_len) const noexcept;
-  simdjson_really_inline simdjson_result<int64_t> parse_root_int64(const uint8_t *json, uint32_t max_len) const noexcept;
-  simdjson_really_inline simdjson_result<double> parse_root_double(const uint8_t *json, uint32_t max_len) const noexcept;
 
   simdjson_really_inline const uint8_t *peek_scalar() const noexcept;
   simdjson_really_inline uint32_t peek_scalar_length() const noexcept;

--- a/tests/ondemand/ondemand_dom_api_tests.cpp
+++ b/tests/ondemand/ondemand_dom_api_tests.cpp
@@ -688,42 +688,112 @@ namespace dom_api_tests {
       }
       return true;
     }));
-    padded_string array_json = std::string("[") + std::string(json) + "]";
-    std::cout << "- JSON: " << array_json << endl;
-    SUBTEST( "simdjson_result<ondemand::value>", test_ondemand_doc(array_json, [&](auto doc_result) {
-      int count = 0;
-      for (simdjson_result<ondemand::value> val_result : doc_result) {
+
+    {
+      padded_string whitespace_json = std::string(json) + " ";
+      std::cout << "- JSON: " << whitespace_json << endl;
+      SUBTEST( "simdjson_result<document>", test_ondemand_doc(whitespace_json, [&](auto doc_result) {
         T actual;
-        ASSERT_SUCCESS( val_result.get(actual) );
-        ASSERT_EQUAL(expected, actual);
+        ASSERT_SUCCESS( doc_result.get(actual) );
+        ASSERT_EQUAL( expected, actual );
         // Test it twice (scalars can be retrieved more than once)
         if (test_twice) {
+          ASSERT_SUCCESS( doc_result.get(actual) );
+          ASSERT_EQUAL( expected, actual );
+        }
+        return true;
+      }));
+      SUBTEST( "document", test_ondemand_doc(whitespace_json, [&](auto doc_result) {
+        T actual;
+        ASSERT_SUCCESS( doc_result.get(actual) );
+        ASSERT_EQUAL( expected, actual );
+        // Test it twice (scalars can be retrieved more than once)
+        if (test_twice) {
+          ASSERT_SUCCESS( doc_result.get(actual) );
+          ASSERT_EQUAL( expected, actual );
+        }
+        return true;
+      }));
+    }
+
+    {
+      padded_string array_json = std::string("[") + std::string(json) + "]";
+      std::cout << "- JSON: " << array_json << endl;
+      SUBTEST( "simdjson_result<value>", test_ondemand_doc(array_json, [&](auto doc_result) {
+        int count = 0;
+        for (simdjson_result<ondemand::value> val_result : doc_result) {
+          T actual;
           ASSERT_SUCCESS( val_result.get(actual) );
           ASSERT_EQUAL(expected, actual);
+          // Test it twice (scalars can be retrieved more than once)
+          if (test_twice) {
+            ASSERT_SUCCESS( val_result.get(actual) );
+            ASSERT_EQUAL(expected, actual);
+          }
+          count++;
         }
-        count++;
-      }
-      ASSERT_EQUAL(count, 1);
-      return true;
-    }));
-    SUBTEST( "ondemand::value", test_ondemand_doc(array_json, [&](auto doc_result) {
-      int count = 0;
-      for (simdjson_result<ondemand::value> val_result : doc_result) {
-        ondemand::value val;
-        ASSERT_SUCCESS( val_result.get(val) );
-        T actual;
-        ASSERT_SUCCESS( val.get(actual) );
-        ASSERT_EQUAL(expected, actual);
-        // Test it twice (scalars can be retrieved more than once)
-        if (test_twice) {
+        ASSERT_EQUAL(count, 1);
+        return true;
+      }));
+      SUBTEST( "value", test_ondemand_doc(array_json, [&](auto doc_result) {
+        int count = 0;
+        for (simdjson_result<ondemand::value> val_result : doc_result) {
+          ondemand::value val;
+          ASSERT_SUCCESS( val_result.get(val) );
+          T actual;
           ASSERT_SUCCESS( val.get(actual) );
           ASSERT_EQUAL(expected, actual);
+          // Test it twice (scalars can be retrieved more than once)
+          if (test_twice) {
+            ASSERT_SUCCESS( val.get(actual) );
+            ASSERT_EQUAL(expected, actual);
+          }
+          count++;
         }
-        count++;
-      }
-      ASSERT_EQUAL(count, 1);
-      return true;
-    }));
+        ASSERT_EQUAL(count, 1);
+        return true;
+      }));
+    }
+
+    {
+      padded_string whitespace_array_json = std::string("[") + std::string(json) + " ]";
+      std::cout << "- JSON: " << whitespace_array_json << endl;
+      SUBTEST( "simdjson_result<value>", test_ondemand_doc(whitespace_array_json, [&](auto doc_result) {
+        int count = 0;
+        for (simdjson_result<ondemand::value> val_result : doc_result) {
+          T actual;
+          ASSERT_SUCCESS( val_result.get(actual) );
+          ASSERT_EQUAL(expected, actual);
+          // Test it twice (scalars can be retrieved more than once)
+          if (test_twice) {
+            ASSERT_SUCCESS( val_result.get(actual) );
+            ASSERT_EQUAL(expected, actual);
+          }
+          count++;
+        }
+        ASSERT_EQUAL(count, 1);
+        return true;
+      }));
+      SUBTEST( "value", test_ondemand_doc(whitespace_array_json, [&](auto doc_result) {
+        int count = 0;
+        for (simdjson_result<ondemand::value> val_result : doc_result) {
+          ondemand::value val;
+          ASSERT_SUCCESS( val_result.get(val) );
+          T actual;
+          ASSERT_SUCCESS( val.get(actual) );
+          ASSERT_EQUAL(expected, actual);
+          // Test it twice (scalars can be retrieved more than once)
+          if (test_twice) {
+            ASSERT_SUCCESS( val.get(actual) );
+            ASSERT_EQUAL(expected, actual);
+          }
+          count++;
+        }
+        ASSERT_EQUAL(count, 1);
+        return true;
+      }));
+    }
+
     TEST_SUCCEED();
   }
 

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -240,8 +240,8 @@ namespace error_tests {
     TEST_START();
     ONDEMAND_SUBTEST("missing comma", "[1 1]",  assert_iterate(doc, { int64_t(1) }, { TAPE_ERROR }));
     ONDEMAND_SUBTEST("extra comma  ", "[1,,1]", assert_iterate(doc, { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", "[,]",    assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", "[,,]",   assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", "[,]",    assert_iterate(doc,                 { NUMBER_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", "[,,]",   assert_iterate(doc,                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
     TEST_SUCCEED();
   }
   bool top_level_array_iterate_unclosed_error() {
@@ -250,7 +250,7 @@ namespace error_tests {
     ONDEMAND_SUBTEST("unclosed     ", "[1 ",    assert_iterate(doc, { int64_t(1) }, { TAPE_ERROR }));
     // TODO These pass the user values that may run past the end of the buffer if they aren't careful
     // In particular, if the padding is decorated with the wrong values, we could cause overrun!
-    ONDEMAND_SUBTEST("unclosed extra comma", "[,,", assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed extra comma", "[,,", assert_iterate(doc,                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
     ONDEMAND_SUBTEST("unclosed     ", "[1,",    assert_iterate(doc, { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
     ONDEMAND_SUBTEST("unclosed     ", "[1",     assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
     ONDEMAND_SUBTEST("unclosed     ", "[",      assert_iterate(doc,                 { NUMBER_ERROR, TAPE_ERROR }));
@@ -261,21 +261,21 @@ namespace error_tests {
     TEST_START();
     ONDEMAND_SUBTEST("missing comma", R"({ "a": [1 1] })",  assert_iterate(doc["a"], { int64_t(1) }, { TAPE_ERROR }));
     ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [1,,1] })", assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [1,,] })",  assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,] })",    assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,,] })",   assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [1,,] })",  assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,] })",    assert_iterate(doc["a"],                 { NUMBER_ERROR }));
+    ONDEMAND_SUBTEST("extra comma  ", R"({ "a": [,,] })",   assert_iterate(doc["a"],                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
     TEST_SUCCEED();
   }
   bool array_iterate_unclosed_error() {
     TEST_START();
-    ONDEMAND_SUBTEST("unclosed extra comma", R"({ "a": [,)", assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("unclosed extra comma", R"({ "a": [,,)", assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [1 )",     assert_iterate(doc["a"], { int64_t(1) }, { TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed extra comma", R"({ "a": [,)",  assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed extra comma", R"({ "a": [,,)", assert_iterate(doc["a"],                 { NUMBER_ERROR, NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [1 )",        assert_iterate(doc["a"], { int64_t(1) }, { TAPE_ERROR }));
     // TODO These pass the user values that may run past the end of the buffer if they aren't careful
     // In particular, if the padding is decorated with the wrong values, we could cause overrun!
-    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [1,)",     assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [1)",      assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
-    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [)",       assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [1,)",        assert_iterate(doc["a"], { int64_t(1) }, { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [1)",         assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
+    ONDEMAND_SUBTEST("unclosed     ", R"({ "a": [)",          assert_iterate(doc["a"],                 { NUMBER_ERROR, TAPE_ERROR }));
     TEST_SUCCEED();
   }
 


### PR DESCRIPTION
This PR makes it so you can keep a `value` around as long as you like (even after the document is parsed), and still convert it to a scalar (string, number, boolean, null) correctly and without error.

It also removes the distinction between `&&` and `&` when retrieving scalar values: when you first attempt to parse a value, the iterator is *always* advanced, even if it fails. Subsequent attempts (for example, trying other types) will reach back to read the value.

The biggest reason to do this, besides the apparent performance gain on existing benchmarks, is that it makes some constructs work that would be confusing otherwise. The principal one is one I wrote myself: `std::pair<double, double>(tweet["x"], tweet["y"])` works correctly with this patch. Another scenario this fixes:

```c++
for (auto tweet : doc["statuses"]) {
  simdjson::value name;
  if (tweet["user"]["verified"]) {
    name = tweet["user"]["name"];
  } else {
    name = tweet["user"]["screen_name"];
  }
  std::cout << "Name: " << name << std::endl;
}
```

Silly scenario for twitter, but I'm sure we've both seen records where the data you want is either in field X or Y depending on the value in field Z. There are other ways to write any of these, but as they do compile, it's definitely better that they *work*.

### Top Tweet Scenario

For an example scenario, consider finding the "top tweet"--the tweet with the highest retweet_count. Since you can't know which is the top tweet until you scan them all, you can't know which tweet you're going to need to parse into a result. Therefore, a purely forward-only API with no lazy value support will be forced to parse each candidate tweet just in case it turns out to be the top tweet.

```c++
// Get the screen name and text of the tweet with the most retweets
uint64_t max_retweets;
ondemand::value top_screen_name, top_text;
for (auto tweet : doc["statuses"]) {
  uint64_t retweets = tweet["retweet_count"];
  if (retweets > max_retweets) {
    top_text = tweet["text"];
    top_screen_name = tweet["user"]["screen_name"];
  }
}
std::cout << "Most retweeted tweet (with " << max_retweets << " tweets) was by user " << std::string_view(top_screen_name) << std::endl;
std::cout << std::string_view(top_text) << std::endl;
```

By delaying the (relatively expensive) parsing of text until the end, you can do just *one* screen name and text instead of having to extract every one.

#### Top Tweet Scenario Performance (Skylake Clang 10)

I implemented two versions of the above benchmark:

* `ondemand` saves the text and screen_name JSON scalar values without parsing. This means we repeat the *lookup* over and over, but not the parse.
* `ondemand_forwardonly` parses text and screen_name every time, to highlight the savings of this feature in particular.

ondemand_forwardonly is *faster*. I cannot tell you why. It is still absolutely true that parsing values later does less work, and I still want this checkin due to the fact that it makes some stuff work that didn't before ... but we should make sure to come back to this one day :)

```
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
top_tweet<simdjson_dom>/manual_time                       258876 ns       287022 ns         2704           3.261k           2.45534G               0        86.454k    949.692k              1.50383          3.88801k       3.69241G          2.88216M                    4.56388                     3.03484           3.88801k    3.43207k   631.515k       2.27192G/s   0.768861   86.4597k   955.407k         1.51288   3.86286k/s  3.6906G/s     2.88216M               4.56388                3.01668          1       3.86286k/s [BEST: throughput=  2.46 GB/s doc_throughput=  3888 docs/s instructions=     2882159 cycles=      949692 branch_miss=    3261 cache_miss=       0 cache_ref=     86454 items=         1 avg_time=    258875 ns]
top_tweet<simdjson_ondemand>/manual_time                  149617 ns       177518 ns         4672           1.513k           4.25079G               0        52.936k    548.711k              0.86888          6.73111k       3.69343G          1.91575M                    3.03358                     3.49137           6.73111k    1.62116k   631.515k       3.93101G/s  0.0432363   52.9805k   552.307k        0.874575   6.68375k/s 3.69148G/s     1.91575M               3.03358                3.46863          1       6.68375k/s [BEST: throughput=  4.25 GB/s doc_throughput=  6731 docs/s instructions=     1915751 cycles=      548711 branch_miss=    1513 cache_miss=       0 cache_ref=     52936 items=         1 avg_time=    149616 ns]
top_tweet<simdjson_ondemand_forward_only>/manual_time     160857 ns       188864 ns         4353           1.463k           3.97239G               0        53.851k    587.123k             0.929706          6.29026k       3.69315G          1.92366M                    3.04611                     3.27642           6.29026k    1.61333k   631.515k       3.65633G/s  0.0259591   53.8618k   593.784k        0.940253   6.21672k/s 3.69139G/s     1.92366M               3.04611                3.23967          1       6.21672k/s [BEST: throughput=  3.97 GB/s doc_throughput=  6290 docs/s instructions=     1923664 cycles=      587123 branch_miss=    1463 cache_miss=       0 cache_ref=     53851 items=         1 avg_time=    160856 ns]
top_tweet<yyjson>/manual_time                             625825 ns       655530 ns         1125          10.141k            1.7421G             618        69.202k     1.2998M              2.05823          2.75861k       3.58564G          2.82777M                    4.47776                     2.17554           2.75861k    7.78023k   631.515k       962.345M/s    1020.73   44.5412k   1.51008M         2.39121   1.59789k/s 2.41295G/s     2.82835M               4.47868                1.87298          1       1.59789k/s [BEST: throughput=  1.74 GB/s doc_throughput=  2758 docs/s instructions=     2827770 cycles=     1299801 branch_miss=   10141 cache_miss=     618 cache_ref=     69202 items=         1 avg_time=    625825 ns]
top_tweet<yyjson_insitu>/manual_time                      425042 ns       454211 ns         1647           7.133k           2.04327G             312        40.429k    1.13499M              1.79725           3.2355k       3.67226G          2.82775M                    4.47772                     2.49143            3.2355k    7.57587k   631.515k       1.38373G/s    48.4323   26.9132k   1.23679M         1.95844   2.35271k/s 2.90979G/s     2.82801M               4.47814                2.28658          1       2.35271k/s [BEST: throughput=  2.04 GB/s doc_throughput=  3235 docs/s instructions=     2827746 cycles=     1134990 branch_miss=    7133 cache_miss=     312 cache_ref=     40429 items=         1 avg_time=    425042 ns]
top_tweet<sajson>/manual_time                             582843 ns       611379 ns         1201          10.398k           1094.49M               0        41.191k    2.13017M              3.37311          1.73312k       3.69184G          5.74294M                    9.09391                       2.696           1.73312k    10.7316k   631.515k       1033.31M/s   0.843464   41.3345k   2.15073M         3.40566   1.71573k/s 3.69006G/s     5.74294M               9.09391                2.67023          1       1.71573k/s [BEST: throughput=  1.09 GB/s doc_throughput=  1733 docs/s instructions=     5742943 cycles=     2130168 branch_miss=   10398 cache_miss=       0 cache_ref=     41191 items=         1 avg_time=    582843 ns]
top_tweet<rapidjson>/manual_time                         2155200 ns      2184293 ns          325          32.404k           321.623M         14.557k        50.628k    7.24841M              11.4778           509.288       3.69153G          21.8021M                    34.5235                     3.00784            509.288    32.6587k   631.515k       279.445M/s    478.412   29.8018k   7.38989M         11.7018    463.994/s 3.42887G/s      21.803M                34.525                2.95039          1        463.994/s [BEST: throughput=  0.32 GB/s doc_throughput=   509 docs/s instructions=    21802077 cycles=     7248406 branch_miss=   32404 cache_miss=   14557 cache_ref=     50628 items=         1 avg_time=   2155199 ns]
top_tweet<rapidjson_insitu>/manual_time                  1513668 ns      1542722 ns          466          25.438k           450.833M              62        39.181k    5.17121M              8.18857           713.892       3.69168G          13.2241M                    20.9403                     2.55726            713.892    26.4094k   631.515k       397.881M/s    218.444   29.9593k   5.25642M         8.32351    660.647/s 3.47264G/s     13.2245M               20.9409                2.51587          1        660.647/s [BEST: throughput=  0.45 GB/s doc_throughput=   713 docs/s instructions=    13224096 cycles=     5171207 branch_miss=   25438 cache_miss=      62 cache_ref=     39181 items=         1 avg_time=   1513667 ns]
top_tweet<nlohmann_json>/manual_time                     8909969 ns      8940213 ns           79         196.661k           71.2889M              10       377.498k    32.6837M              51.7544           112.886       3.68952G          85.4176M                    135.258                     2.61346            112.886    200.142k   631.515k       67.5939M/s    13.8228   380.493k   32.8712M         52.0513    112.234/s 3.68926G/s     85.7546M               135.792                2.60881          1        112.234/s [BEST: throughput=  0.07 GB/s doc_throughput=   112 docs/s instructions=    85417566 cycles=    32683690 branch_miss=  196661 cache_miss=      10 cache_ref=    377498 items=         1 avg_time=   8909968 ns]
```

### Other Things It Solves

This also solves the issue I had originally with `make_pair<double, double>(obj["x"], obj["y"])`, correctly turning x and y into a double even though that doesn't happen until the iterator is sitting at "y".

This does *not* attempt a similar thing with arrays or objects. Those will require more design than this.

## Performance vs. master

A *key* part of this is that in-order parsing should not get even a little bit slower. We accomplish this with an if statement when we get the JSON text for the scalar we want to parse:

```c++
if (!is_at_start()) { return iter.peek(_start_index); } // don't advance the iterator if we're not using it
else { return iter.advance(); } // *do* advance the iterator if we're using the iterator
```

This way, when it's used in order, the iterator is properly advanced when the value is used. When it's used out of order, it just reaches back to find the value and doesn't worry about the iterator.

My belief is that this is optimized away for single-use values (such as `double x = obj["x"]`). This is because, when the `value_iterator` is created, its _start_index is set to `json_iterator->token.index`. Then the very next thing that's done is `if (_start_index == json_iterator->token.index) {` ... which the compiler can optimize away. Not only that, it knows the value of start_index is already stored in token.index (which should be a register already), so it doesn't need to allocate a register or memory to it--the _start_index *itself* should be optimized away.

### Skylake (Clang 10)

Performance numbers seem to bear this out, showing no downside, and a little bit of *upside* on partial_tweets and find_tweet:

PR:

```
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
partial_tweets<simdjson_ondemand>/manual_time             155736 ns       183895 ns         4496           1.426k           4.08586G               0        54.665k    570.869k             0.903967          6.46994k       3.69349G          1.94927M                    3.08666                     3.41457           646.994k    1.56714k   631.515k       3.77654G/s  0.0531584   54.8954k   574.893k         0.91034   6.42112k/s 3.69146G/s     1.94927M               3.08666                3.39067        100       642.112k/s [BEST: throughput=  4.09 GB/s doc_throughput=  6469 docs/s instructions=     1949274 cycles=      570869 branch_miss=    1426 cache_miss=       0 cache_ref=     54665 items=       100 avg_time=    155736 ns]
Creating a source file spanning 44921 KB 
large_random<simdjson_ondemand>/manual_time             66933147 ns     70347823 ns           10         908.667k           687.718M        5.77398M       7.90181M    246.763M              5.36455           14.9508        3.6893G          689.848M                    14.9971                     2.79559           14.9508M    909.785k   45.9988M       655.398M/s   5.77303M   7.89844M   246.922M         5.36801    14.9403/s 3.68908G/s     689.848M               14.9971                2.79379      1000k       14.9403M/s [BEST: throughput=  0.69 GB/s doc_throughput=    14 docs/s instructions=   689847657 cycles=   246762771 branch_miss=  908667 cache_miss= 5773977 cache_ref=   7901813 items=   1000000 avg_time=  66933147 ns]
large_random<simdjson_ondemand_unordered>/manual_time   66587053 ns     69998774 ns           11         915.819k           691.137M        5.75063M       7.89995M    245.541M              5.33798           15.0251       3.68928G          690.848M                    15.0188                     2.81358           15.0251M    915.218k   45.9988M       658.805M/s   5.76904M   7.90159M   245.646M         5.34027    15.0179/s 3.68909G/s     690.848M               15.0188                2.81237      1000k       15.0179M/s [BEST: throughput=  0.69 GB/s doc_throughput=    15 docs/s instructions=   690847915 cycles=   245540733 branch_miss=  915819 cache_miss= 5750632 cache_ref=   7899946 items=   1000000 avg_time=  66587053 ns]
Creating a source file spanning 134087 KB 
kostya<simdjson_ondemand>/manual_time                   60349654 ns     70747151 ns           12          459.96k           2.27674G        10.0868M       13.9045M    222.481M              1.62034           16.5816       3.68908G          660.474M                    4.81027                     2.96868           8.69353M    459.832k   137.305M       2.11891G/s   10.0962M   13.8133M   222.634M         1.62146    16.5701/s 3.68907G/s     660.474M               4.81027                2.96663   524.288k       8.68751M/s [BEST: throughput=  2.28 GB/s doc_throughput=    16 docs/s instructions=   660473985 cycles=   222480501 branch_miss=  459960 cache_miss=10086798 cache_ref=  13904489 items=    524288 avg_time=  60349654 ns]
distinct_user_id<simdjson_ondemand>/manual_time           149454 ns       178779 ns         4676           1.555k           4.28614G               0        52.782k    544.147k             0.861653          6.78707k       3.69316G          1.89752M                    3.00471                     3.48714           780.513k    1.80153k   631.515k       3.93529G/s  0.0530368   52.7491k   551.693k        0.873603   6.69103k/s 3.69139G/s     1.89752M               3.00471                3.43944        115       769.468k/s [BEST: throughput=  4.29 GB/s doc_throughput=  6787 docs/s instructions=     1897519 cycles=      544147 branch_miss=    1555 cache_miss=       0 cache_ref=     52782 items=       115 avg_time=    149453 ns]
find_tweet<simdjson_ondemand>/manual_time                 105333 ns       133367 ns         6626              629           6.02039G               0        30.093k    387.529k              0.61365          9.53325k       3.69441G          1.39043M                    2.20173                     3.58793           9.53325k     655.537   631.515k       5.58368G/s   9.96076m    30.186k   388.885k        0.615797   9.49372k/s 3.69197G/s     1.39043M               2.20173                3.57542          1       9.49372k/s [BEST: throughput=  6.02 GB/s doc_throughput=  9533 docs/s instructions=     1390428 cycles=      387529 branch_miss=     629 cache_miss=       0 cache_ref=     30093 items=         1 avg_time=    105332 ns]
```

master:

```
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations best_branch_miss best_bytes_per_sec best_cache_miss best_cache_ref best_cycles best_cycles_per_byte best_docs_per_sec best_frequency best_instructions best_instructions_per_byte best_instructions_per_cycle best_items_per_sec branch_miss      bytes bytes_per_second cache_miss  cache_ref     cycles cycles_per_byte docs_per_sec  frequency instructions instructions_per_byte instructions_per_cycle      items items_per_second
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
partial_tweets<simdjson_ondemand>/manual_time             160377 ns       188859 ns         4358           1.454k           3.97354G               0        58.441k    586.947k             0.929427          6.29208k       3.69312G          1.94802M                    3.08467                      3.3189           629.208k    1.59764k   631.515k       3.66725G/s  0.0160624   58.3613k   591.996k        0.937422    6.2353k/s 3.69127G/s     1.94802M               3.08467                3.29059        100        623.53k/s [BEST: throughput=  3.97 GB/s doc_throughput=  6292 docs/s instructions=     1948018 cycles=      586947 branch_miss=    1454 cache_miss=       0 cache_ref=     58441 items=       100 avg_time=    160377 ns]
Creating a source file spanning 44921 KB 
large_random<simdjson_ondemand>/manual_time             67294617 ns     70721688 ns           10         916.344k            683.85M        5.80264M       8.10347M    248.152M              5.39475           14.8667        3.6892G          684.848M                    14.8884                     2.75979           14.8667M    916.192k   45.9988M       651.878M/s   5.82182M   8.10406M   248.243M         5.39674      14.86/s  3.6889G/s     684.848M               14.8884                2.75878      1000k         14.86M/s [BEST: throughput=  0.68 GB/s doc_throughput=    14 docs/s instructions=   684847925 cycles=   248152119 branch_miss=  916344 cache_miss= 5802635 cache_ref=   8103475 items=   1000000 avg_time=  67294616 ns]
large_random<simdjson_ondemand_unordered>/manual_time   67134101 ns     70554604 ns           10         909.919k           685.565M        5.80221M       8.10405M    247.533M               5.3813            14.904       3.68923G          690.848M                    15.0188                     2.79093            14.904M    909.899k   45.9988M       653.436M/s   5.81723M   8.10429M   247.663M         5.38411    14.8956/s 3.68907G/s     690.848M               15.0188                2.78947      1000k       14.8956M/s [BEST: throughput=  0.69 GB/s doc_throughput=    14 docs/s instructions=   690847916 cycles=   247533396 branch_miss=  909919 cache_miss= 5802212 cache_ref=   8104047 items=   1000000 avg_time=  67134101 ns]
Creating a source file spanning 134087 KB 
kostya<simdjson_ondemand>/manual_time                   61202036 ns     71629566 ns           11         462.985k           2.24534G        10.0524M       14.0229M    225.594M              1.64302            16.353       3.68914G          658.901M                    4.79882                     2.92073           8.57366M    463.195k   137.305M        2.0894G/s    10.049M   13.9333M   225.707M         1.64384    16.3393/s  3.6879G/s     658.901M               4.79882                2.91928   524.288k       8.56651M/s [BEST: throughput=  2.25 GB/s doc_throughput=    16 docs/s instructions=   658901371 cycles=   225594486 branch_miss=  462985 cache_miss=10052444 cache_ref=  14022892 items=    524288 avg_time=  61202035 ns]
distinct_user_id<simdjson_ondemand>/manual_time           148788 ns       178374 ns         4704           1.562k           4.28114G               0        56.169k    544.955k             0.862933          6.77916k       3.69433G          1.89752M                    3.00471                     3.48197           779.603k    1.71676k   631.515k        3.9529G/s  0.0909864   55.8807k   549.209k        0.869669   6.72097k/s 3.69122G/s     1.89752M               3.00471                  3.455        115       772.912k/s [BEST: throughput=  4.28 GB/s doc_throughput=  6779 docs/s instructions=     1897519 cycles=      544955 branch_miss=    1562 cache_miss=       0 cache_ref=     56169 items=       115 avg_time=    148787 ns]
find_tweet<simdjson_ondemand>/manual_time                 108972 ns       137386 ns         6401              659           5.82256G               0        32.044k    400.709k              0.63452          9.21999k       3.69453G          1.39034M                     2.2016                      3.4697           9.21999k     697.896   631.515k        5.3972G/s   0.193564   32.1385k   402.283k        0.637012   9.17666k/s 3.69161G/s     1.39034M                2.2016                3.45613          1       9.17666k/s [BEST: throughput=  5.82 GB/s doc_throughput=  9219 docs/s instructions=     1390341 cycles=      400709 branch_miss=     659 cache_miss=       0 cache_ref=     32044 items=         1 avg_time=    108972 ns]
```

### Cleanup

This PR also cleans up the fallout: before this change, we needed separate versions of scalar parsers for && (where you can guarantee the value will only be read once) and & (where you keep the value and may read it multiple times). This was because in the & (read-many) case, we only want to advance the cursor *if* the value is the type the user asked for (so they can try a different type next). But in the && (read-once) case it's more efficient to advance the cursor immediately. Now, we advance the cursor immediately the first time it's read no matter what, and subsequent accesses will use _start_index. This makes out-of-order access stay the same speed, but makes it so we only need one version of all these functions.

There's a lot less code now, thanks to that :)

It also fixes a bug where we assume the padding starts with whitespace when the document consists of a single scalar value. I added tests for this (test_scalar_value now tests `<value>`, `<value> `, `[<value>]` and `[<value> ]`).