### PR TITLE
Make it so that dom::element instances can be passed *by value* from simdjson_result instances

### DIFF
--- a/include/simdjson/error-inl.h
+++ b/include/simdjson/error-inl.h
@@ -69,7 +69,7 @@ simdjson_really_inline error_code simdjson_result_base<T>::error() const noexcep
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline T& simdjson_result_base<T>::value() & noexcept(false) {
+simdjson_really_inline const T& simdjson_result_base<T>::value() const& noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return this->first;
 }
@@ -86,7 +86,7 @@ simdjson_really_inline T&& simdjson_result_base<T>::take_value() && noexcept(fal
 }
 
 template<typename T>
-simdjson_really_inline simdjson_result_base<T>::operator T&() & noexcept(false) {
+simdjson_really_inline simdjson_result_base<T>::operator const T&() const& noexcept(false) {
   return value();
 }
 
@@ -134,7 +134,7 @@ simdjson_really_inline error_code simdjson_result<T>::error() const noexcept {
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline T& simdjson_result<T>::value() & noexcept(false) {
+simdjson_really_inline const T& simdjson_result<T>::value() const& noexcept(false) {
   return internal::simdjson_result_base<T>::value();
 }
 
@@ -149,7 +149,7 @@ simdjson_really_inline T&& simdjson_result<T>::take_value() && noexcept(false) {
 }
 
 template<typename T>
-simdjson_really_inline simdjson_result<T>::operator T&() & noexcept(false) {
+simdjson_really_inline simdjson_result<T>::operator const T&() const& noexcept(false) {
   return value();
 }
 

--- a/include/simdjson/error-inl.h
+++ b/include/simdjson/error-inl.h
@@ -86,6 +86,11 @@ simdjson_really_inline T&& simdjson_result_base<T>::take_value() && noexcept(fal
 }
 
 template<typename T>
+simdjson_really_inline simdjson_result_base<T>::operator T&() & noexcept(false) {
+  return value();
+}
+
+template<typename T>
 simdjson_really_inline simdjson_result_base<T>::operator T&&() && noexcept(false) {
   return std::forward<simdjson_result_base<T>>(*this).take_value();
 }
@@ -141,6 +146,11 @@ simdjson_really_inline T&& simdjson_result<T>::value() && noexcept(false) {
 template<typename T>
 simdjson_really_inline T&& simdjson_result<T>::take_value() && noexcept(false) {
   return std::forward<internal::simdjson_result_base<T>>(*this).take_value();
+}
+
+template<typename T>
+simdjson_really_inline simdjson_result<T>::operator T&() & noexcept(false) {
+  return value();
 }
 
 template<typename T>

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -146,7 +146,7 @@ struct simdjson_result_base : public std::pair<T, error_code> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T& value() & noexcept(false);
+  simdjson_really_inline const T& value() const& noexcept(false);
 
   /**
    * Take the result value (move it).
@@ -174,7 +174,7 @@ struct simdjson_result_base : public std::pair<T, error_code> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline operator T&() & noexcept(false);
+  simdjson_really_inline operator const T&() const& noexcept(false);
 #endif // SIMDJSON_EXCEPTIONS
 }; // struct simdjson_result_base
 
@@ -231,7 +231,7 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T& value() & noexcept(false);
+  simdjson_really_inline const T& value() const& noexcept(false);
 
   /**
    * Take the result value (move it).
@@ -252,7 +252,7 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline operator T&() & noexcept(false);
+  simdjson_really_inline operator const T&() const& noexcept(false);
 
   /**
    * Cast to the value (will throw on error).

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -169,6 +169,12 @@ struct simdjson_result_base : public std::pair<T, error_code> {
    */
   simdjson_really_inline operator T&&() && noexcept(false);
 
+  /**
+   * Cast to the value (will throw on error).
+   *
+   * @throw simdjson_error if there was an error.
+   */
+  simdjson_really_inline operator T&() & noexcept(false);
 #endif // SIMDJSON_EXCEPTIONS
 }; // struct simdjson_result_base
 
@@ -240,6 +246,13 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
    * @throw simdjson_error if there was an error.
    */
   simdjson_really_inline T&& take_value() && noexcept(false);
+
+  /**
+   * Cast to the value (will throw on error).
+   *
+   * @throw simdjson_error if there was an error.
+   */
+  simdjson_really_inline operator T&() & noexcept(false);
 
   /**
    * Cast to the value (will throw on error).

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -27,7 +27,6 @@
 #endif
 #endif
 
-
 const size_t AMAZON_CELLPHONES_NDJSON_DOC_COUNT = 793;
 #define SIMDJSON_SHOW_DEFINE(x) printf("%s=%s\n", #x, STRINGIFY(x))
 

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -27,6 +27,7 @@
 #endif
 #endif
 
+
 const size_t AMAZON_CELLPHONES_NDJSON_DOC_COUNT = 793;
 #define SIMDJSON_SHOW_DEFINE(x) printf("%s=%s\n", #x, STRINGIFY(x))
 
@@ -795,6 +796,10 @@ namespace dom_api_tests {
     dom::parser parser;
     dom::object object;
     ASSERT_SUCCESS( parser.parse(json).get(object) );
+    // Next three lines are for https://github.com/simdjson/simdjson/issues/1341
+    auto node = object["a"];
+    auto mylambda = [](dom::element e) { return int64_t(e); };
+    ASSERT_EQUAL( mylambda(node), 1 );
     ASSERT_EQUAL( object["a"].get<uint64_t>().first, 1 );
     ASSERT_EQUAL( object["b"].get<uint64_t>().first, 2 );
     ASSERT_EQUAL( object["c/d"].get<uint64_t>().first, 3 );

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -796,11 +796,13 @@ namespace dom_api_tests {
     dom::parser parser;
     dom::object object;
     ASSERT_SUCCESS( parser.parse(json).get(object) );
+  #if SIMDJSON_EXCEPTIONS
     // Next three lines are for https://github.com/simdjson/simdjson/issues/1341
     auto node = object["a"];
     auto mylambda = [](dom::element e) { return int64_t(e); };
     ASSERT_EQUAL( mylambda(node), 1 );
     ASSERT_EQUAL( object["a"].get<uint64_t>().first, 1 );
+  #endif
     ASSERT_EQUAL( object["b"].get<uint64_t>().first, 2 );
     ASSERT_EQUAL( object["c/d"].get<uint64_t>().first, 3 );
     // Check all three again in backwards order, to ensure we can go backwards


### PR DESCRIPTION
Enables the following use case:

```C++
    string json(R"({ "a": 1, "b": 2, "c/d": 3})");
    dom::parser parser;
    dom::object object;
    parser.parse(json).get(object);
    // Next three lines are for https://github.com/simdjson/simdjson/issues/1341
    auto node = object["a"]; // here node is a simdjson_result<dom::element>
    auto mylambda = [](dom::element e) { return int64_t(e); };
    mylambda(node);
```

In this instance, `dom::element` might get copied (instead of moved).

Fixes issue https://github.com/simdjson/simdjson/issues/1341