### PR TITLE
Fixing issue 1332 (documentation)

### DIFF
--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -457,7 +457,21 @@ public:
   /** @private Use `parser.parse(...).error()` instead */
   error_code error{UNINITIALIZED};
 
-  /** @private Use `parser.parse(...).value()` instead */
+  /**
+   * @private Use `parser.parse(...).value()` instead
+   *
+   * In rare instances, a user might want to access the document
+   * directly. Indeed, after moving the parser instance, the
+   * parsed document and its element are invalidated. You can
+   * recover access like so:
+   *
+   *    auto parser = dom::parser{};
+   *    auto root = parser.parse(input);
+   *    auto parser2 = std::move(parser);
+   *    root = parser2.doc.root();
+   *
+   * Such usage should be limited to advanced users.
+   */
   document doc{};
 
   /** @private returns true if the document parsed was valid */

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -551,8 +551,7 @@ namespace parse_api_tests {
 #endif
 
   bool run() {
-    return parser_moving_parser_and_recovering_struct() &&
-           parser_moving_parser() &&
+    return parser_moving_parser() &&
            parser_parse() &&
            parser_parse_many() &&
 #ifdef SIMDJSON_ENABLE_DEPRECATED_API
@@ -566,6 +565,7 @@ namespace parse_api_tests {
            parser_load_many_deprecated() &&
 #endif
 #if SIMDJSON_EXCEPTIONS
+           parser_moving_parser_and_recovering_struct() &&
            parser_moving_parser_and_recovering() &
            parser_parse_exception() &&
            parser_parse_many_exception() &&

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -342,6 +342,7 @@ namespace parse_api_tests {
     }
     return true;
   }
+#if SIMDJSON_EXCEPTIONS
   // See https://github.com/simdjson/simdjson/issues/1332
   bool parser_moving_parser_and_recovering() {
     std::cout << "Running " << __func__ << std::endl;
@@ -351,8 +352,9 @@ namespace parse_api_tests {
     auto parser2 = std::move(parser);
     root = parser2.doc.root();
     std::cout << simdjson::to_string(root) << std::endl;
-    return simdjson::to_string(root) == "[1,2,3]";
+    return simdjson::to_string(root) == "[1,2,3]";// might throw
   }
+#endif
   bool parser_parse() {
     std::cout << "Running " << __func__ << std::endl;
     dom::parser parser;
@@ -523,8 +525,7 @@ namespace parse_api_tests {
 #endif
 
   bool run() {
-    return parser_moving_parser_and_recovering() &
-           parser_moving_parser() &&
+    return parser_moving_parser() &&
            parser_parse() &&
            parser_parse_many() &&
 #ifdef SIMDJSON_ENABLE_DEPRECATED_API
@@ -538,6 +539,7 @@ namespace parse_api_tests {
            parser_load_many_deprecated() &&
 #endif
 #if SIMDJSON_EXCEPTIONS
+           parser_moving_parser_and_recovering() &
            parser_parse_exception() &&
            parser_parse_many_exception() &&
            parser_load_exception() &&

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -342,6 +342,17 @@ namespace parse_api_tests {
     }
     return true;
   }
+  // See https://github.com/simdjson/simdjson/issues/1332
+  bool parser_moving_parser_and_recovering() {
+    std::cout << "Running " << __func__ << std::endl;
+    auto input = "[1, 2, 3]"_padded;
+    auto parser = dom::parser{};
+    auto root = parser.parse(input);
+    auto parser2 = std::move(parser);
+    root = parser2.doc.root();
+    std::cout << simdjson::to_string(root) << std::endl;
+    return simdjson::to_string(root) == "[1,2,3]";
+  }
   bool parser_parse() {
     std::cout << "Running " << __func__ << std::endl;
     dom::parser parser;
@@ -512,7 +523,8 @@ namespace parse_api_tests {
 #endif
 
   bool run() {
-    return parser_moving_parser() &&
+    return parser_moving_parser_and_recovering() &
+           parser_moving_parser() &&
            parser_parse() &&
            parser_parse_many() &&
 #ifdef SIMDJSON_ENABLE_DEPRECATED_API


### PR DESCRIPTION
In https://github.com/simdjson/simdjson/issues/1332 asked how to recover access to the document after moving the parser:

```C++
  simdjson::dom::parser parser;
  simdjson::dom::element elem = parser.parse("[1, 2, 3]"s);
  auto parser2 = std::move(parser);
  std::cout << elem; // bad!
```

It turns out that you can do this:

```C++
  simdjson::dom::parser parser;
  simdjson::dom::element elem = parser.parse("[1, 2, 3]"s);
  auto parser2 = std::move(parser);
  elem = parser2.doc.get_root();
  std::cout << elem; // good!
```

It is not directly documented for good reasons: accessing directly the document is potentially unsafe. However, you can make it safe if you track whether the last outcome of `parse` was a success. The `parser` itself does not record that fact. However, you can do it easily enough by embedding the parser into a data structure of your own. This PR adds an example.

Fixes https://github.com/simdjson/simdjson/issues/1332 (maybe)
