### PR TITLE
partly replacement for old-style-cast (*) to c++-casts *_cast<>()

### DIFF
--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -52,7 +52,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint6
   return *result < value1;
 #else
   return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+                                   reinterpret_cast<unsigned long long *>(result));
 #endif
 }
 

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -68,7 +68,7 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
       os << "string \"";
       std::memcpy(&string_length, string_buf.get() + payload, sizeof(uint32_t));
       os << internal::escape_json_string(std::string_view(
-        (const char *)(string_buf.get() + payload + sizeof(uint32_t)),
+        reinterpret_cast<const char *>(string_buf.get() + payload + sizeof(uint32_t)),
         string_length
       ));
       os << '"';

--- a/include/simdjson/fallback/numberparsing.h
+++ b/include/simdjson/fallback/numberparsing.h
@@ -20,7 +20,7 @@ static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const char *c
   return uint32_t((val & 0x0000FFFF0000FFFF) * 42949672960001 >> 32);
 }
 static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
-  return parse_eight_digits_unrolled((const char *)chars);
+  return parse_eight_digits_unrolled(reinterpret_cast<const char *>(chars));
 }
 
 } // unnamed namespace

--- a/include/simdjson/generic/jsoncharutils.h
+++ b/include/simdjson/generic/jsoncharutils.h
@@ -103,7 +103,7 @@ simdjson_really_inline value128 full_multiplication(uint64_t value1, uint64_t va
   answer.low = _umul128(value1, value2, &answer.high); // _umul128 not available on ARM64
 #endif // _M_ARM64
 #else // defined(SIMDJSON_REGULAR_VISUAL_STUDIO) || defined(SIMDJSON_IS_32BITS)
-  __uint128_t r = ((__uint128_t)value1) * value2;
+  __uint128_t r = (static_cast<__uint128_t>(value1)) * value2;
   answer.low = uint64_t(r);
   answer.high = uint64_t(r >> 64);
 #endif

--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -29,7 +29,7 @@ simdjson_really_inline double to_double(uint64_t mantissa, uint64_t real_exponen
     double d;
     mantissa &= ~(1ULL << 52);
     mantissa |= real_exponent << 52;
-    mantissa |= (((uint64_t)negative) << 63);
+    mantissa |= ((static_cast<uint64_t>(negative)) << 63);
     std::memcpy(&d, &mantissa, sizeof(d));
     return d;
 }
@@ -292,7 +292,7 @@ simdjson_really_inline bool compute_float_64(int64_t power, uint64_t i, bool neg
 // The string parsing itself always succeeds. We know that there is at least
 // one digit.
 static bool parse_float_fallback(const uint8_t *ptr, double *outDouble) {
-  *outDouble = simdjson::internal::from_chars((const char *)ptr);
+  *outDouble = simdjson::internal::from_chars(reinterpret_cast<const char *>(ptr));
   // We do not accept infinite values.
 
   // Detecting finite values in a portable manner is ridiculously hard, ideally

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -28,8 +28,8 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::it
   }
 
   // Run stage 1.
-  SIMDJSON_TRY( dom_parser->stage1((const uint8_t *)buf.data(), buf.size(), false) );
-  return document::start({ (const uint8_t *)buf.data(), this });
+  SIMDJSON_TRY( dom_parser->stage1(reinterpret_cast<const uint8_t *>(buf.data()), buf.size(), false) );
+  return document::start({ reinterpret_cast<const uint8_t *>(buf.data()), this });
 }
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string> &result) & noexcept {
@@ -46,8 +46,8 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<json_iterator> parse
   }
 
   // Run stage 1.
-  SIMDJSON_TRY( dom_parser->stage1((const uint8_t *)buf.data(), buf.size(), false) );
-  return json_iterator((const uint8_t *)buf.data(), this);
+  SIMDJSON_TRY( dom_parser->stage1(reinterpret_cast<const uint8_t *>(buf.data()), buf.size(), false) );
+  return json_iterator(reinterpret_cast<const uint8_t *>(buf.data()), this);
 }
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -4,11 +4,11 @@ namespace ondemand {
 
 simdjson_really_inline raw_json_string::raw_json_string(const uint8_t * _buf) noexcept : buf{_buf} {}
 
-simdjson_really_inline const char * raw_json_string::raw() const noexcept { return (const char *)buf; }
+simdjson_really_inline const char * raw_json_string::raw() const noexcept { return reinterpret_cast<const char *>(buf); }
 simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> raw_json_string::unescape(uint8_t *&dst) const noexcept {
   uint8_t *end = stringparsing::parse_string(buf, dst);
   if (!end) { return STRING_ERROR; }
-  std::string_view result((const char *)dst, end-dst);
+  std::string_view result(reinterpret_cast<const char *>(dst), end-dst);
   dst = end;
   return result;
 }

--- a/include/simdjson/haswell/bitmanipulation.h
+++ b/include/simdjson/haswell/bitmanipulation.h
@@ -50,7 +50,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
                        reinterpret_cast<unsigned __int64 *>(result));
 #else
   return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+                                   reinterpret_cast<unsigned long long *>(result));
 #endif
 }
 

--- a/include/simdjson/haswell/stringparsing.h
+++ b/include/simdjson/haswell/stringparsing.h
@@ -34,8 +34,8 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
   // store to dest unconditionally - we can overwrite the bits we don't like later
   v.store(dst);
   return {
-      (uint32_t)(v == '\\').to_bitmask(),     // bs_bits
-      (uint32_t)(v == '"').to_bitmask(), // quote_bits
+      static_cast<uint32_t>((v == '\\').to_bitmask()),     // bs_bits
+      static_cast<uint32_t>((v == '"').to_bitmask()), // quote_bits
   };
 }
 

--- a/include/simdjson/internal/jsonformatutils.h
+++ b/include/simdjson/internal/jsonformatutils.h
@@ -46,7 +46,7 @@ inline std::ostream& operator<<(std::ostream& out, const escape_json_string &une
       out << "\\\\";
       break;
     default:
-      if ((unsigned char)unescaped.str[i] <= 0x1F) {
+      if (static_cast<unsigned char>(unescaped.str[i]) <= 0x1F) {
         // TODO can this be done once at the beginning, or will it mess up << char?
         std::ios::fmtflags f(out.flags());
         out << "\\u" << std::hex << std::setw(4) << std::setfill('0') << int(unescaped.str[i]);

--- a/include/simdjson/padded_string-inl.h
+++ b/include/simdjson/padded_string-inl.h
@@ -134,7 +134,7 @@ inline simdjson_result<padded_string> padded_string::load(const std::string &fil
   }
 
   // Allocate the padded_string
-  size_t len = (size_t) llen;
+  size_t len = static_cast<size_t>(llen);
   padded_string s(len);
   if (s.data() == nullptr) {
     std::fclose(fp);

--- a/include/simdjson/ppc64/bitmanipulation.h
+++ b/include/simdjson/ppc64/bitmanipulation.h
@@ -59,7 +59,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
   return *result < value1;
 #else
   return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+                                   reinterpret_cast<unsigned long long *>(result));
 #endif
 }
 

--- a/include/simdjson/westmere/bitmanipulation.h
+++ b/include/simdjson/westmere/bitmanipulation.h
@@ -59,7 +59,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
                        reinterpret_cast<unsigned __int64 *>(result));
 #else
   return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+                                   reinterpret_cast<unsigned long long *>(result));
 #endif
 }
 

--- a/include/simdjson/westmere/simd.h
+++ b/include/simdjson/westmere/simd.h
@@ -27,9 +27,9 @@ namespace simd {
     simdjson_really_inline Child operator&(const Child other) const { return _mm_and_si128(*this, other); }
     simdjson_really_inline Child operator^(const Child other) const { return _mm_xor_si128(*this, other); }
     simdjson_really_inline Child bit_andnot(const Child other) const { return _mm_andnot_si128(other, *this); }
-    simdjson_really_inline Child& operator|=(const Child other) { auto this_cast = (Child*)this; *this_cast = *this_cast | other; return *this_cast; }
-    simdjson_really_inline Child& operator&=(const Child other) { auto this_cast = (Child*)this; *this_cast = *this_cast & other; return *this_cast; }
-    simdjson_really_inline Child& operator^=(const Child other) { auto this_cast = (Child*)this; *this_cast = *this_cast ^ other; return *this_cast; }
+    simdjson_really_inline Child& operator|=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast | other; return *this_cast; }
+    simdjson_really_inline Child& operator&=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast & other; return *this_cast; }
+    simdjson_really_inline Child& operator^=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
   };
 
   // Forward-declared so they can be used by splat and friends.
@@ -99,8 +99,8 @@ namespace simd {
     // Addition/subtraction are the same for signed and unsigned
     simdjson_really_inline simd8<T> operator+(const simd8<T> other) const { return _mm_add_epi8(*this, other); }
     simdjson_really_inline simd8<T> operator-(const simd8<T> other) const { return _mm_sub_epi8(*this, other); }
-    simdjson_really_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *(simd8<T>*)this; }
-    simdjson_really_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *(simd8<T>*)this; }
+    simdjson_really_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *static_cast<simd8<T>*>(this); }
+    simdjson_really_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *static_cast<simd8<T>*>(this); }
 
     // Perform a lookup assuming the value is between 0 and 16 (undefined behavior for out of range values)
     template<typename L>
@@ -141,9 +141,9 @@ namespace simd {
       // it fills in with the bytes from the second 8 bytes + some filling
       // at the end.
       __m128i compactmask =
-      _mm_loadu_si128((const __m128i *)(pshufb_combine_table + pop1 * 8));
+      _mm_loadu_si128(reinterpret_cast<const __m128i *>(pshufb_combine_table + pop1 * 8));
       __m128i answer = _mm_shuffle_epi8(pruned, compactmask);
-      _mm_storeu_si128(( __m128i *)(output), answer);
+      _mm_storeu_si128(reinterpret_cast<__m128i *>(output), answer);
     }
 
     template<typename L>

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -247,7 +247,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
 
 // credit: based on code from Google Fuchsia (Apache Licensed)
 simdjson_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
-  const uint8_t *data = (const uint8_t *)buf;
+  const uint8_t *data = reinterpret_cast<const uint8_t *>(buf);
   uint64_t pos = 0;
   uint32_t code_point = 0;
   while (pos < len) {

--- a/src/generic/stage1/buf_block_reader.h
+++ b/src/generic/stage1/buf_block_reader.h
@@ -30,7 +30,7 @@ private:
 
 // Routines to print masks and text for debugging bitmask operations
 simdjson_unused static char * format_input_text_64(const uint8_t *text) {
-  static char *buf = (char*)malloc(sizeof(simd8x64<uint8_t>) + 1);
+  static char *buf = reinterpret_cast<char*>(malloc(sizeof(simd8x64<uint8_t>) + 1));
   for (size_t i=0; i<sizeof(simd8x64<uint8_t>); i++) {
     buf[i] = int8_t(text[i]) < ' ' ? '_' : int8_t(text[i]);
   }
@@ -40,8 +40,8 @@ simdjson_unused static char * format_input_text_64(const uint8_t *text) {
 
 // Routines to print masks and text for debugging bitmask operations
 simdjson_unused static char * format_input_text(const simd8x64<uint8_t>& in) {
-  static char *buf = (char*)malloc(sizeof(simd8x64<uint8_t>) + 1);
-  in.store((uint8_t*)buf);
+  static char *buf = reinterpret_cast<char*>(malloc(sizeof(simd8x64<uint8_t>) + 1));
+  in.store(reinterpret_cast<uint8_t*>(buf));
   for (size_t i=0; i<sizeof(simd8x64<uint8_t>); i++) {
     if (buf[i] < ' ') { buf[i] = '_'; }
   }
@@ -50,7 +50,7 @@ simdjson_unused static char * format_input_text(const simd8x64<uint8_t>& in) {
 }
 
 simdjson_unused static char * format_mask(uint64_t mask) {
-  static char *buf = (char*)malloc(64 + 1);
+  static char *buf = reinterpret_cast<char*>(malloc(64 + 1));
   for (size_t i=0; i<64; i++) {
     buf[i] = (mask & (size_t(1) << i)) ? 'X' : ' ';
   }

--- a/src/generic/stage1/utf8_validator.h
+++ b/src/generic/stage1/utf8_validator.h
@@ -25,7 +25,7 @@ bool generic_validate_utf8(const uint8_t * input, size_t length) {
 }
 
 bool generic_validate_utf8(const char * input, size_t length) {
-    return generic_validate_utf8<utf8_checker>((const uint8_t *)input,length);
+    return generic_validate_utf8<utf8_checker>(reinterpret_cast<const uint8_t *>(input),length);
 }
 
 } // namespace stage1

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -51,7 +51,7 @@ namespace logger {
       printf("| %*s%s%-*s ", log_depth*2, "", title_prefix, LOG_EVENT_LEN - log_depth*2 - int(strlen(title_prefix)), title);
       auto current_index = structurals.at_beginning() ? nullptr : structurals.next_structural-1;
       auto next_index = structurals.next_structural;
-      auto current = current_index ? &structurals.buf[*current_index] : (const uint8_t*)"                                                       ";
+      auto current = current_index ? &structurals.buf[*current_index] : reinterpret_cast<const uint8_t*>("                                                       ");
       auto next = &structurals.buf[*next_index];
       {
         // Print the next N characters in the buffer.

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -147,7 +147,7 @@ SIMDJSON_DLLIMPORTEXPORT const internal::available_implementation_list available
 SIMDJSON_DLLIMPORTEXPORT internal::atomic_ptr<const implementation> active_implementation{&internal::detect_best_supported_implementation_on_first_use_singleton};
 
 simdjson_warn_unused error_code minify(const char *buf, size_t len, char *dst, size_t &dst_len) noexcept {
-  return active_implementation->minify((const uint8_t *)buf, len, (uint8_t *)dst, dst_len);
+  return active_implementation->minify(reinterpret_cast<const uint8_t *>(buf), len, reinterpret_cast<uint8_t *>(dst), dst_len);
 }
 simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) noexcept {
   return active_implementation->validate_utf8(buf, len);


### PR DESCRIPTION
No bug replacement
No performance change
All tests passed by "make test"

Only changes are old c-style casts to modern c++ casts to compile with 
CXXFLAGS = -Werror=old-style-cast -pedantic -Wpedantic -Wall -Wextra

Please suggest to change coding style to only use c++ casts
