### PR TITLE
replace __builtin_uaddll_overflow with __builtin_uaddl_overflow v2

### DIFF
--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -51,8 +51,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint6
   *result = value1 + value2;
   return *result < value1;
 #else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+  return __builtin_uaddl_overflow(value1, value2, result);
 #endif
 }
 

--- a/include/simdjson/haswell/bitmanipulation.h
+++ b/include/simdjson/haswell/bitmanipulation.h
@@ -49,8 +49,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
   return _addcarry_u64(0, value1, value2,
                        reinterpret_cast<unsigned __int64 *>(result));
 #else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+  return __builtin_uaddl_overflow(value1, value2, result);
 #endif
 }
 

--- a/include/simdjson/ppc64/bitmanipulation.h
+++ b/include/simdjson/ppc64/bitmanipulation.h
@@ -58,8 +58,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
   *result = value1 + value2;
   return *result < value1;
 #else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+  return __builtin_uaddl_overflow(value1, value2, result);
 #endif
 }
 

--- a/include/simdjson/westmere/bitmanipulation.h
+++ b/include/simdjson/westmere/bitmanipulation.h
@@ -58,8 +58,7 @@ simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
   return _addcarry_u64(0, value1, value2,
                        reinterpret_cast<unsigned __int64 *>(result));
 #else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   (unsigned long long *)result);
+  return __builtin_uaddl_overflow(value1, value2, result);
 #endif
 }
 


### PR DESCRIPTION
# We can handle this as a separate PR.
_Originally posted by @lemire in https://github.com/simdjson/simdjson/pull/1403#discussion_r563722967_

I think the correct functions here are  
__builtin_uaddl_overflow
and not
__builtin_uaddll_overflow

so all pointer casts go away and the correct types are safe also for future use by types bigger than 64 bit
__builtin_uaddll_overflow  possibly can cause buffer overflows by access addresses behind an 64bit integer.
