### PR TITLE
Fix the CMake generated install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/simdjson-config.cmake
       INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/simdjson"
       NO_SET_AND_CHECK_MACRO
       NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+install(FILES "${PROJECT_BINARY_DIR}/simdjson-config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/simdjson")
 
 #
 # Compile tools / tests / benchmarks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/simdjson-config.cmake
       INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/simdjson"
       NO_SET_AND_CHECK_MACRO
       NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+write_basic_package_version_file(
+      "${PROJECT_BINARY_DIR}/simdjson-config-version.cmake"
+      VERSION ${SIMDJSON_SEMANTIC_VERSION}
+      COMPATIBILITY SameMinorVersion)
 install(FILES "${PROJECT_BINARY_DIR}/simdjson-config.cmake"
+              "${PROJECT_BINARY_DIR}/simdjson-config-version.cmake"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/simdjson")
 
 #


### PR DESCRIPTION
A recent refactoring cleaned up the list of exported targets and introduced the use of the `CMakePackageConfigHelpers` utilities. Unfortunately it seems that the generated `simdjson-config.cmake` file was not added to the `install` target. This oversight trips up downstream users of the library that rely on the exported targets mechanism.

Specifically, the code `find_package(simdjson)` will fail. This can be worked around by adding
```
find_package(simdjson
  CONFIGS
    "simdjson-config.cmake"
    "simdjson-targets.cmake")
```
But figuring that out costs time, especially for users that are not familiar with CMake.

Additionally, the 3rd commit adds a `simdjson-config-version.cmake` file to allow a version check in `find_package`.

Additionally, the library's soversion was still at "7.0.0". I'm not sure if this was intentionally not bumped. If so, I will drop that commit.