### PR TITLE
Add safety checks for out of order array/object iteration+indexing

### DIFF
--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -35,6 +35,7 @@ enum error_code {
   INVALID_URI_FRAGMENT,     ///< Invalid URI fragment
   UNEXPECTED_ERROR,         ///< indicative of a bug in simdjson
   PARSER_IN_USE,            ///< parser is already in use.
+  OUT_OF_ORDER_ITERATION,   ///< tried to iterate an array or object out of order
   /** @private Number of error codes */
   NUM_ERROR_CODES
 };

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -55,11 +55,12 @@ simdjson_really_inline array array::started(value_iterator &iter) noexcept {
   return array(iter);
 }
 
-simdjson_really_inline array_iterator array::begin() noexcept {
-  return iter;
+simdjson_really_inline simdjson_result<array_iterator> array::begin() noexcept {
+  if (!iter.is_at_container_start()) { return OUT_OF_ORDER_ITERATION; }
+  return array_iterator(iter);
 }
-simdjson_really_inline array_iterator array::end() noexcept {
-  return {};
+simdjson_really_inline simdjson_result<array_iterator> array::end() noexcept {
+  return array_iterator();
 }
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -24,13 +24,13 @@ public:
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline array_iterator begin() noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> begin() noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline array_iterator end() noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> end() noexcept;
 
 protected:
   /**

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -52,6 +52,7 @@ simdjson_really_inline object::object(const value_iterator &_iter) noexcept
 }
 
 simdjson_really_inline object_iterator object::begin() noexcept {
+  // TODO make it a runtime error if this is violated
   // Expanded version of SIMDJSON_ASSUME( iter.at_field_start() || !iter.is_open() )
   SIMDJSON_ASSUME( (iter._json_iter->token.index == iter._start_position + 1) || (iter._json_iter->_depth < iter._depth) );
   return iter;

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -51,14 +51,12 @@ simdjson_really_inline object::object(const value_iterator &_iter) noexcept
 {
 }
 
-simdjson_really_inline object_iterator object::begin() noexcept {
-  // TODO make it a runtime error if this is violated
-  // Expanded version of SIMDJSON_ASSUME( iter.at_field_start() || !iter.is_open() )
-  SIMDJSON_ASSUME( (iter._json_iter->token.index == iter._start_position + 1) || (iter._json_iter->_depth < iter._depth) );
-  return iter;
+simdjson_really_inline simdjson_result<object_iterator> object::begin() noexcept {
+  if (!iter.is_at_container_start()) { return OUT_OF_ORDER_ITERATION; }
+  return object_iterator(iter);
 }
-simdjson_really_inline object_iterator object::end() noexcept {
-  return {};
+simdjson_really_inline simdjson_result<object_iterator> object::end() noexcept {
+  return object_iterator();
 }
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -16,8 +16,8 @@ public:
    */
   simdjson_really_inline object() noexcept = default;
 
-  simdjson_really_inline object_iterator begin() noexcept;
-  simdjson_really_inline object_iterator end() noexcept;
+  simdjson_really_inline simdjson_result<object_iterator> begin() noexcept;
+  simdjson_really_inline simdjson_result<object_iterator> end() noexcept;
 
   /**
    * Look up a field by name on an object (order-sensitive).

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -68,7 +68,13 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //        ^ (depth 0, index 2)
   //    ```
   //
-  if (!is_open()) { return false; }
+  if (!is_open()) {
+    // If we're past the end of the object, we're being iterated out of order.
+    // Note: this isn't perfect detection. It's possible the user is inside some other object; if so,
+    // this object iterator will blithely scan that object for fields.
+    if (_json_iter->depth() < depth() - 1) { return OUT_OF_ORDER_ITERATION; }
+    return false;
+  }
   if (at_first_field()) {
     has_value = true;
 

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -59,6 +59,10 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //      ^ (depth 2, index 1)
   //    ```
   //
+  if (at_first_field()) {
+    has_value = true;
+
+  //
   // 2. When a previous search did not yield a value or the object is empty:
   //
   //    ```
@@ -68,15 +72,12 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //        ^ (depth 0, index 2)
   //    ```
   //
-  if (!is_open()) {
+  } else if (!is_open()) {
     // If we're past the end of the object, we're being iterated out of order.
     // Note: this isn't perfect detection. It's possible the user is inside some other object; if so,
     // this object iterator will blithely scan that object for fields.
     if (_json_iter->depth() < depth() - 1) { return OUT_OF_ORDER_ITERATION; }
-    return false;
-  }
-  if (at_first_field()) {
-    has_value = true;
+    has_value = false;
 
   // 3. When a previous search found a field or an iterator yielded a value:
   //
@@ -146,6 +147,10 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //    ```
   //
   } else if (!is_open()) {
+    // If we're past the end of the object, we're being iterated out of order.
+    // Note: this isn't perfect detection. It's possible the user is inside some other object; if so,
+    // this object iterator will blithely scan that object for fields.
+    if (_json_iter->depth() < depth() - 1) { return OUT_OF_ORDER_ITERATION; }
     has_value = false;
 
   // 3. When a previous search found a field or an iterator yielded a value:

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -274,7 +274,7 @@ protected:
   simdjson_really_inline const uint8_t *peek_start() const noexcept;
   simdjson_really_inline uint32_t peek_start_length() const noexcept;
   simdjson_really_inline const uint8_t *advance_start(const char *type) const noexcept;
-  simdjson_really_inline const uint8_t *advance_container_start(const char *type) const noexcept;
+  simdjson_really_inline error_code advance_container_start(const char *type, const uint8_t *&json) const noexcept;
   simdjson_really_inline const uint8_t *advance_root_scalar(const char *type) const noexcept;
   simdjson_really_inline const uint8_t *advance_non_root_scalar(const char *type) const noexcept;
 

--- a/src/internal/error_tables.cpp
+++ b/src/internal/error_tables.cpp
@@ -28,7 +28,8 @@ namespace internal {
     { INVALID_JSON_POINTER, "Invalid JSON pointer syntax." },
     { INVALID_URI_FRAGMENT, "Invalid URI fragment syntax." },
     { UNEXPECTED_ERROR, "Unexpected error, consider reporting this problem as you may have found a bug in simdjson" },
-    { PARSER_IN_USE, "Cannot parse a new document while a document is still in use." }
+    { PARSER_IN_USE, "Cannot parse a new document while a document is still in use." },
+    { OUT_OF_ORDER_ITERATION, "Objects and arrays can only be iterated when they are first encountered." }
   }; // error_messages[]
 
 } // namespace internal


### PR DESCRIPTION
Because On Demand keeps a single cursor across multiple iterators, arrays and objects can only be iterated through when the cursor is in position at the array or object. If used incorrectly, the cursor will move to the wrong places.

This PR gives people runtime errors when iteration happens out of order, instead of weird, hard to diagnose errors. It creates a new error_code, OUT_OF_ORDER_ERROR, and yields it in these scenarios:

* Yields OUT_OF_ORDER_ERROR if you attempt to iterate (begin()) an array or object when the cursor is *anywhere* except the start of the array or object.
* Yields OUT_OF_ORDER_ERROR if you look up an object field when the cursor is outside the object (at a low depth).

The above checks can be done using information we already have, comparing the object / array index and depth to the cursor index and depth. Performance-wise, this is actually an improvement: it recovers about half the performance loss from the predecessor PR, #1414.

The only remaining safety issue I'm aware of is if you look up an object field when the cursor is outside the original object, but inside some other object or array at the same or higher depth. That will cost more to catch, I'm pretty sure--which is why it's not part of this PR.

## Examples

An example of code we'll catch:

```c++
auto json = R"( [
  { "x': 3, "y": 4 },
  { "x': 1, "y": 2 },
  { "x': 5, "y": 6 },
] )"_padded;
simdjson_result<ondemand::value> leftmost_point;
uint64_t leftmost_x = 100000;
auto doc = parser.iterate(json);
for (auto point : doc) {
  uint64_t x = point["x"];
  if (leftmost_x < x) {
    leftmost_x = x;
    // User intends to save the object to look up y later.
    leftmost_point = point;
  }
}
// OUT_OF_ORDER_ITERATION yielded here, because we're accessing the object when we're no longer in (or near) it:
std::cout << "x: " << leftmost_x << ", y: " << uint64_t(leftmost_point["y"]) << std::endl;
```

## Negative Example

This is an example that we still *won't* catch--even in a debug build:

```c++
auto json = R"( [
  { "x': 3, "y": 4 },
  { "x': 1, "y": 2 },
  { "x': 5, "y": 6 },
] )"_padded;
auto doc = parser.iterate(json);
simdjson_result<ondemand::value> leftmost_point;
bool first_value = true;
for (auto point : doc) {
  if (first_value) {
    leftmost_point = point;
    first_value = false;
    continue;
  }
  // The user is trying to compare the "x" from the previous point to the "x" in the current one. The code is reasonable, if inefficient.
  // ERROR: this will silently do the wrong thing: even though leftmost_point is a previous point, it will search inside the current object, yielding the same "x" both times.
  if (uint64_t(leftmost_point["x"]) < point["x"]) {
    leftmost_point = point;
  }
}
// ERROR: because of the above, this will print x: 3, y: 5 (the wrong answer).
std::cout << "x: " << uint64_t(leftmost_point["x"]) << ", y: " << uint64_t(leftmost_point["y"]) << std::endl;
```

(Note that I haven't run these--there are tests that check the former behavior, and no tests that check the latter (because they would fail :)