### PR TITLE
Why would you use a reference when looping?

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -202,7 +202,7 @@ dom::parser parser;
 
 // Parse and iterate through an array of objects
 for (dom::object obj : parser.parse(abstract_json)) {
-    for(const auto& key_value : obj) {
+    for(const auto key_value : obj) {
       cout << "key: " << key_value.key << " : ";
       dom::object innerobj = key_value.value;
       cout << "a: " << double(innerobj["a"]) << ", ";

--- a/doc/basics_doxygen.md
+++ b/doc/basics_doxygen.md
@@ -184,7 +184,7 @@ dom::parser parser;
 
 // Parse and iterate through an array of objects
 for (dom::object obj : parser.parse(abstract_json)) {
-    for(const auto& key_value : obj) {
+    for(const auto key_value : obj) {
       cout << "key: " << key_value.key << " : ";
       dom::object innerobj = key_value.value;
       cout << "a: " << double(innerobj["a"]) << ", ";

--- a/include/simdjson.h
+++ b/include/simdjson.h
@@ -23,7 +23,7 @@
         ] )"_padded;
 
       for (simdjson::dom::object obj : parser.parse(abstract_json)) {
-        for(const auto& key_value : obj) {
+        for(const auto key_value : obj) {
           cout << "key: " << key_value.key << " : ";
           simdjson::dom::object innerobj = key_value.value;
           cout << "a: " << double(innerobj["a"]) << ", ";

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -81,7 +81,7 @@ void basics_dom_3() {
 
   // Parse and iterate through an array of objects
   for (dom::object obj : parser.parse(abstract_json)) {
-    for(const auto& key_value : obj) {
+    for(const auto key_value : obj) {
       cout << "key: " << key_value.key << " : ";
       dom::object innerobj = key_value.value;
       cout << "a: " << double(innerobj["a"]) << ", ";


### PR DESCRIPTION
The examples currently fail under the latest Xcode (Apple clang version 12.0.0):

```
readme_examples.cpp:84:21: error: loop variable 'key_value' is always a copy because the range of type 'dom::object' does not return a reference [-Werror,-Wrange-loop-analysis]
     for(const auto& key_value : obj) {
                     ^
readme_examples.cpp:84:9: note: use non-reference type 'simdjson::dom::key_value_pair'
     for(const auto& key_value : obj) {
```

Hopefully, `simdjson::dom::key_value_pair` is a lightweight object?

Note that we do not appear to use this construction anywhere else, but in our examples.

