### PR TITLE
It appears that Qt uses macros for common terms like slots, signals and so forth.

### DIFF
--- a/include/simdjson/dom/array-inl.h
+++ b/include/simdjson/dom/array-inl.h
@@ -61,7 +61,7 @@ inline array::iterator array::end() const noexcept {
 inline size_t array::size() const noexcept {
   return tape.scope_count();
 }
-inline size_t array::slots() const noexcept {
+inline size_t array::number_of_slots() const noexcept {
   return tape.matching_brace_index() - tape.json_index;
 }
 inline simdjson_result<element> array::at_pointer(std::string_view json_pointer) const noexcept {

--- a/include/simdjson/dom/array.h
+++ b/include/simdjson/dom/array.h
@@ -95,7 +95,7 @@ public:
    * to figure out the total size of an array (including its children,
    * recursively) if you know its structure ahead of time.
    **/
-  inline size_t slots() const noexcept;
+  inline size_t number_of_slots() const noexcept;
   /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
    * https://tools.ietf.org/html/rfc6901 standard, interpreting the current node


### PR DESCRIPTION
So I propose to rename 'slots' to 'number_of_slots'. This is an API breaking change but I believe that the number of users is small.