### PR TITLE
This makes it possible to a have document instance (DOM) that is separate from the parser if you would like.

### DIFF
--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -26,7 +26,7 @@ inline size_t document::capacity() const noexcept {
 
 simdjson_warn_unused
 inline error_code document::allocate(size_t capacity) noexcept {
-  if (len == 0) {
+  if (capacity == 0) {
     string_buf.reset();
     tape.reset();
     allocated_capacity = 0;

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -38,7 +38,7 @@ inline error_code document::allocate(size_t capacity) noexcept {
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
   // generated, see issue https://github.com/lemire/simdjson/issues/345
-  size_t tape_capacity = SIMDJSON_ROUNDUP_N(len + 3, 64);
+  size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
   size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * capacity / 3 + SIMDJSON_PADDING, 64);

--- a/include/simdjson/dom/document.h
+++ b/include/simdjson/dom/document.h
@@ -63,9 +63,27 @@ public:
    * Should be at least byte_capacity.
    */
   std::unique_ptr<uint8_t[]> string_buf{};
+  /** @private Allocate memory to support
+   * input JSON documents of up to len bytes.
+   *
+   * When calling this function, you lose
+   * all the data.
+   *
+   * The memory allocation is strict: you
+   * can you use this function to increase
+   * or lower the amount of allocated memory.
+   * Passsing zero clears the memory.
+   */
+  error_code allocate(size_t len) noexcept;
+  /** @private Capacity in bytes, in terms
+   * of how many bytes of input JSON we can
+   * support.
+   */
+  size_t capacity() const noexcept;
+
 
 private:
-  inline error_code allocate(size_t len) noexcept;
+  size_t allocated_capacity{0};
   friend class parser;
 }; // class document
 

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -178,7 +178,7 @@ simdjson_really_inline bool document_stream::iterator::operator!=(const document
 
 inline void document_stream::start() noexcept {
   if (error) { return; }
-  error = parser->ensure_capacity_with_document(batch_size);
+  error = parser->ensure_capacity(batch_size);
   if (error) { return; }
   // Always run the first stage 1 parse immediately
   batch_start = 0;
@@ -193,7 +193,7 @@ inline void document_stream::start() noexcept {
 #ifdef SIMDJSON_THREADS_ENABLED
   if (use_thread && next_batch_start() < len) {
     // Kick off the first thread if needed
-    error = stage1_thread_parser.ensure_capacity_with_document(batch_size);
+    error = stage1_thread_parser.ensure_capacity(batch_size);
     if (error) { return; }
     worker->start_thread();
     start_stage1_thread();

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -199,8 +199,8 @@ inline void document_stream::start() noexcept {
     // Kick off the first thread if needed
     error = stage1_thread_parser.ensure_capacity(batch_size);
     if (error) { return; }
-    if(stage1_thread_parser->doc.capacity() < batch_size) {
-      error = stage1_thread_parser->doc.allocate(batch_size);
+    if(stage1_thread_parser.doc.capacity() < batch_size) {
+      error = stage1_thread_parser.doc.allocate(batch_size);
       if (error) { return; }
     }
     worker->start_thread();

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -180,7 +180,10 @@ inline void document_stream::start() noexcept {
   if (error) { return; }
   error = parser->ensure_capacity(batch_size);
   if (error) { return; }
-
+  if(parser->doc.capacity() < batch_size) {
+    error = parser->doc.allocate(batch_size);
+    if (error) { return; }
+  }
   // Always run the first stage 1 parse immediately
   batch_start = 0;
   error = run_stage1(*parser, batch_start);

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -199,6 +199,10 @@ inline void document_stream::start() noexcept {
     // Kick off the first thread if needed
     error = stage1_thread_parser.ensure_capacity(batch_size);
     if (error) { return; }
+    if(stage1_thread_parser->doc.capacity() < batch_size) {
+      error = stage1_thread_parser->doc.allocate(batch_size);
+      if (error) { return; }
+    }
     worker->start_thread();
     start_stage1_thread();
     if (error) { return; }

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -178,12 +178,8 @@ simdjson_really_inline bool document_stream::iterator::operator!=(const document
 
 inline void document_stream::start() noexcept {
   if (error) { return; }
-  error = parser->ensure_capacity(batch_size);
+  error = parser->ensure_capacity_with_document(batch_size);
   if (error) { return; }
-  if(parser->doc.capacity() < batch_size) {
-    error = parser->doc.allocate(batch_size);
-    if (error) { return; }
-  }
   // Always run the first stage 1 parse immediately
   batch_start = 0;
   error = run_stage1(*parser, batch_start);
@@ -197,12 +193,8 @@ inline void document_stream::start() noexcept {
 #ifdef SIMDJSON_THREADS_ENABLED
   if (use_thread && next_batch_start() < len) {
     // Kick off the first thread if needed
-    error = stage1_thread_parser.ensure_capacity(batch_size);
+    error = stage1_thread_parser.ensure_capacity_with_document(batch_size);
     if (error) { return; }
-    if(stage1_thread_parser.doc.capacity() < batch_size) {
-      error = stage1_thread_parser.doc.allocate(batch_size);
-      if (error) { return; }
-    }
     worker->start_thread();
     start_stage1_thread();
     if (error) { return; }

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -176,7 +176,7 @@ inline bool parser::allocate_capacity(size_t capacity, size_t max_depth) noexcep
 }
 #endif // SIMDJSON_DISABLE_DEPRECATED_API
 
-inline error_code parser::ensure_capacity_with_document(size_t desired_capacity) noexcept {
+inline error_code parser::ensure_capacity(size_t desired_capacity) noexcept {
   return ensure_capacity(doc, desired_capacity);
 }
 

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -186,7 +186,7 @@ inline error_code parser::ensure_capacity(document& target_document, size_t desi
   // 2. If we allow desired_capacity = 0 then it is possible to exit this function with implementation == nullptr.
   if(desired_capacity < MINIMAL_DOCUMENT_CAPACITY) { desired_capacity = MINIMAL_DOCUMENT_CAPACITY; }
   // If we don't have enough capacity, (try to) automatically bump it.
-  // If the document need allocation, do it too.
+  // If the document needs allocation, do it too.
   // Both in one if statement to minimize unlikely branching.
   //
   // Note: we must make sure that this function is called if capacity() == 0. We do so because we

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -182,12 +182,15 @@ inline error_code parser::ensure_capacity_with_document(size_t desired_capacity)
 
 
 inline error_code parser::ensure_capacity(document& target_document, size_t desired_capacity) noexcept {
-  // 1. It is wasteful to allocate a document and a parser for document spanning less than MINIMAL_DOCUMENT_CAPACITY bytes.
-  // 2. If we allow desired_capacity then it is possible to exit this function with implementation == nullptr.
+  // 1. It is wasteful to allocate a document and a parser for documents spanning less than MINIMAL_DOCUMENT_CAPACITY bytes.
+  // 2. If we allow desired_capacity = 0 then it is possible to exit this function with implementation == nullptr.
   if(desired_capacity < MINIMAL_DOCUMENT_CAPACITY) { desired_capacity = MINIMAL_DOCUMENT_CAPACITY; }
   // If we don't have enough capacity, (try to) automatically bump it.
   // If the document need allocation, do it too.
   // Both in one if statement to minimize unlikely branching.
+  //
+  // Note: we must make sure that this function is called if capacity() == 0. We do so because we
+  // ensure that desired_capacity > 0.
   if (simdjson_unlikely(capacity() < desired_capacity || target_document.capacity() < desired_capacity)) {
     if (desired_capacity > max_capacity()) {
       return error = CAPACITY;

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -204,7 +204,11 @@ inline error_code parser::ensure_capacity(document& target_document, size_t desi
 }
 
 simdjson_really_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
-  _max_capacity = max_capacity;
+  if(max_capacity < MINIMAL_DOCUMENT_CAPACITY) {
+    _max_capacity = max_capacity;
+  } else {
+    _max_capacity = MINIMAL_DOCUMENT_CAPACITY;
+  }
 }
 
 } // namespace dom

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -93,7 +93,6 @@ inline simdjson_result<element> parser::parse_into_document(document& provided_d
   error_code _error = ensure_capacity(provided_doc, len);
   if (_error) { return _error; }
   std::unique_ptr<uint8_t[]> tmp_buf;
-
   if (realloc_if_needed) {
     tmp_buf.reset(reinterpret_cast<uint8_t *>( internal::allocate_padded_buffer(len) ));
     if (tmp_buf.get() == nullptr) { return MEMALLOC; }
@@ -183,6 +182,9 @@ inline error_code parser::ensure_capacity_with_document(size_t desired_capacity)
 
 
 inline error_code parser::ensure_capacity(document& target_document, size_t desired_capacity) noexcept {
+  // 1. It is wasteful to allocate a document and a parser for document spanning less than MINIMAL_DOCUMENT_CAPACITY bytes.
+  // 2. If we allow desired_capacity then it is possible to exit this function with implementation == nullptr.
+  if(desired_capacity < MINIMAL_DOCUMENT_CAPACITY) { desired_capacity = MINIMAL_DOCUMENT_CAPACITY; }
   // If we don't have enough capacity, (try to) automatically bump it.
   // If the document need allocation, do it too.
   // Both in one if statement to minimize unlikely branching.

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -586,7 +586,7 @@ private:
    * and auto-allocate if not. This also allocates memory if needed in the
    * internal document.
    */
-  inline error_code ensure_capacity_with_document(size_t desired_capacity) noexcept;
+  inline error_code ensure_capacity(size_t desired_capacity) noexcept;
   /**
    * Ensure we have enough capacity to handle at least desired_capacity bytes,
    * and auto-allocate if not. This also allocates memory if needed in the

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -574,11 +574,16 @@ private:
 
   /**
    * Ensure we have enough capacity to handle at least desired_capacity bytes,
-   * and auto-allocate if not.
-   *
-   * Important: the document instance must be allocated separately.
+   * and auto-allocate if not. This also allocates memory if needed in the
+   * internal document.
    */
-  inline error_code ensure_capacity(size_t desired_capacity) noexcept;
+  inline error_code ensure_capacity_with_document(size_t desired_capacity) noexcept;
+  /**
+   * Ensure we have enough capacity to handle at least desired_capacity bytes,
+   * and auto-allocate if not. This also allocates memory if needed in the
+   * provided document.
+   */
+  inline error_code ensure_capacity(document& doc, size_t desired_capacity) noexcept;
 
   /** Read the file into loaded_bytes */
   inline simdjson_result<size_t> read_file(const std::string &path) noexcept;

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -32,6 +32,11 @@ static constexpr size_t DEFAULT_BATCH_SIZE = 1000000;
 static constexpr size_t MINIMAL_BATCH_SIZE = 32;
 
 /**
+ * It is wasteful to allocate memory for tiny documents (e.g., 4 bytes).
+ */
+static constexpr size_t MINIMAL_DOCUMENT_CAPACITY = 32;
+
+/**
  * A persistent document parser.
  *
  * The parser is designed to be reused, holding the internal buffers necessary to do parsing,

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -494,6 +494,10 @@ public:
    * The parser may reallocate internal buffers as needed up to this amount as documents are passed
    * to it.
    *
+   * Note: To avoid limiting the memory to an absurd value, such as zero or two bytes,
+   * iff you try to set max_capacity to a value lower than MINIMAL_DOCUMENT_CAPACITY,
+   * then the maximal capacity is set to MINIMAL_DOCUMENT_CAPACITY.
+   *
    * This call will not allocate or deallocate, even if capacity is currently above max_capacity.
    *
    * @param max_capacity The new maximum capacity, in bytes.

--- a/tests/readme_examples_noexceptions.cpp
+++ b/tests/readme_examples_noexceptions.cpp
@@ -76,7 +76,7 @@ void basics_error_3() {
   for (dom::element elem : array) {
       dom::object obj;
       if ((error = elem.get(obj))) { cerr << error << endl; exit(1); }
-      for (auto & key_value : obj) {
+      for (auto key_value : obj) {
           cout << "key: " << key_value.key << " : ";
           dom::object innerobj;
           if ((error = key_value.value.get(innerobj))) { cerr << error << endl; exit(1); }


### PR DESCRIPTION
In the DOM API, we tied the parser to the document leading to issue https://github.com/simdjson/simdjson/issues/1332 where people who want to use the DOM for storage have to also keep the parser. This separates the two effectively. You can now provide your own document instance, and while there will still be a parser's document instance, it may never be used (and allocated) if you don't want it. 


You can now do the following...

```C++

    auto input = "[1, 2, 3]"_padded;
    dom::document doc;
    {
      dom::parser parser;
      element doc_root = parser.parse_into_document(doc, input);
      if(simdjson::to_string(doc_root) != "[1,2,3]") { return false; }
      // parser will go out of scope here.
    }
    if(simdjson::to_string(doc.root()) != "[1,2,3]") { return false; }
    dom::parser parser; // new parser
    element doc_root1 = parser.parse_into_document(doc, input);
    if(simdjson::to_string(doc_root1) != "[1,2,3]") { return false; }
    //... doc_root1 is a pointer inside doc
    element doc_root2 = parser.parse_into_document(doc, input);
    //... doc_root2 is a pointer inside doc
    if(simdjson::to_string(doc_root2) != "[1,2,3]") { return false; }

    // Here let us take moving the document:
    dom::document docm = std::move(doc);
    element doc_root3 = docm.root();
    if(simdjson::to_string(doc_root3) != "[1,2,3]") { return false; }
    return true;
  }
```

Ping @mmatrosov 

Fixes https://github.com/simdjson/simdjson/issues/1332 (hopefully)

Fixes https://github.com/simdjson/simdjson/issues/679