### PR TITLE
Adding legacy Win32 / Visual Studio 2017 CI tests to GitHub Actions.

### DIFF
--- a/.github/workflows/vs15win32-ci.yml
+++ b/.github/workflows/vs15win32-ci.yml
@@ -1,0 +1,39 @@
+name: VS15Win32Legacy-CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
+    name: windows-vs15win32
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: dependencies/.cache
+        key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
+    - name: 'Run CMake with VS15 under Win32 (legacy)'
+      uses: lukka/run-cmake@v2
+      with:
+        cmakeListsOrSettingsJson: CMakeListsTxtAdvanced
+        cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
+        buildDirectory: "${{ github.workspace }}/../../_temp/windows"
+        cmakeBuildType: Release   
+        buildWithCMake: true
+        cmakeGenerator: VS15Win32 
+        cmakeAppendedArgs: -DSIMDJSON_COMPETITION=OFF
+        buildWithCMakeArgs: --config Release  
+        
+    - name: 'Run CTest'
+      run: ctest -C Release  -LE explicitonly  --output-on-failure 
+      working-directory: "${{ github.workspace }}/../../_temp/windows"
+  


### PR DESCRIPTION
Hunting for build issues with respect to https://github.com/simdjson/simdjson/issues/1437

Note that Win32 builds are not officially supported, we offer some fallback but users should not use Win32 with simdjson.