### PR TITLE
Fix bug reporting out of order iteration

### DIFF
--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -62,7 +62,7 @@ simdjson_really_inline simdjson_result<array_iterator> array::begin() noexcept {
   return array_iterator(iter);
 }
 simdjson_really_inline simdjson_result<array_iterator> array::end() noexcept {
-  return array_iterator();
+  return array_iterator(iter);
 }
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -57,7 +57,7 @@ simdjson_really_inline array array::started(value_iterator &iter) noexcept {
 
 simdjson_really_inline simdjson_result<array_iterator> array::begin() noexcept {
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
-  if (!iter.is_at_container_start()) { return OUT_OF_ORDER_ITERATION; }
+  if (!iter.is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   return array_iterator(iter);
 }

--- a/include/simdjson/generic/ondemand/array_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/array_iterator-inl.h
@@ -37,6 +37,7 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_
 ) noexcept
   : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>(value))
 {
+  first.iter.assert_is_valid();
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::simdjson_result(error_code error) noexcept
   : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>({}, error)
@@ -44,20 +45,21 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_
 }
 
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator*() noexcept {
-  if (this->error()) { this->second = SUCCESS; return this->error(); }
-  return *this->first;
+  if (error()) { return error(); }
+  return *first;
 }
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
-  if (this->error()) { return true; }
-  return this->first == other.first;
+  if (!first.iter.is_valid()) { return !error(); }
+  return first == other.first;
 }
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
-  if (this->error()) { return false; }
-  return this->first != other.first;
+  if (!first.iter.is_valid()) { return error(); }
+  return first != other.first;
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator++() noexcept {
-  if (this->error()) { return *this; }
-  ++(this->first);
+  // Clear the error if there is one, so we don't yield it twice
+  if (error()) { second = SUCCESS; return *this; }
+  ++(first);
   return *this;
 }
 

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -58,7 +58,7 @@ simdjson_really_inline simdjson_result<object_iterator> object::begin() noexcept
   return object_iterator(iter);
 }
 simdjson_really_inline simdjson_result<object_iterator> object::end() noexcept {
-  return object_iterator();
+  return object_iterator(iter);
 }
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -53,7 +53,7 @@ simdjson_really_inline object::object(const value_iterator &_iter) noexcept
 
 simdjson_really_inline simdjson_result<object_iterator> object::begin() noexcept {
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
-  if (!iter.is_at_container_start()) { return OUT_OF_ORDER_ITERATION; }
+  if (!iter.is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   return object_iterator(iter);
 }

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -97,6 +97,7 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object
 ) noexcept
   : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>(value))
 {
+  first.iter.assert_is_valid();
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::simdjson_result(error_code error) noexcept
   : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>({}, error)
@@ -104,22 +105,23 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object
 }
 
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator*() noexcept {
-  if (error()) { second = SUCCESS; return error(); }
+  if (error()) { return error(); }
   return *first;
 }
-// Assumes it's being compared with the end. true if depth < iter->depth.
+// If we're iterating and there is an error, return the error once.
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
-  if (error()) { return true; }
+  if (!first.iter.is_valid()) { return !error(); }
   return first == other.first;
 }
-// Assumes it's being compared with the end. true if depth >= iter->depth.
+// If we're iterating and there is an error, return the error once.
 simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
-  if (error()) { return false; }
+  if (!first.iter.is_valid()) { return error(); }
   return first != other.first;
 }
 // Checks for ']' and ','
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator++() noexcept {
-  if (error()) { return *this; }
+  // Clear the error if there is one, so we don't yield it twice
+  if (error()) { second = SUCCESS; return *this; }
   ++first;
   return *this;
 }

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -26,11 +26,6 @@ simdjson_really_inline bool object_iterator::operator!=(const object_iterator &)
   return iter.is_open();
 }
 
-// GCC 7 warns when the first line of this function is inlined away into oblivion due to the caller
-// relating depth and iterator depth, which is a desired effect. It does not happen if is_open is
-// marked non-inline.
-SIMDJSON_PUSH_DISABLE_WARNINGS
-SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
 simdjson_really_inline object_iterator &object_iterator::operator++() noexcept {
   // TODO this is a safety rail ... users should exit loops as soon as they receive an error.
   // Nonetheless, let's see if performance is OK with this if statement--the compiler may give it to us for free.
@@ -43,7 +38,6 @@ simdjson_really_inline object_iterator &object_iterator::operator++() noexcept {
   if ((error = iter.has_next_field().get(has_value) )) { return *this; };
   return *this;
 }
-SIMDJSON_POP_DISABLE_WARNINGS
 
 //
 // ### Live States

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -422,7 +422,6 @@ simdjson_really_inline void value_iterator::abandon() noexcept {
   _json_iter->abandon();
 }
 
-
 simdjson_warn_unused simdjson_really_inline depth_t value_iterator::depth() const noexcept {
   return _depth;
 }
@@ -539,6 +538,13 @@ simdjson_really_inline void value_iterator::assert_at_non_root_start() const noe
   SIMDJSON_ASSUME( _depth > 1 );
 }
 
+simdjson_really_inline void value_iterator::assert_is_valid() const noexcept {
+  SIMDJSON_ASSUME( _json_iter != nullptr );
+}
+
+simdjson_really_inline bool value_iterator::is_valid() const noexcept {
+  return _json_iter;
+}
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -401,9 +401,15 @@ simdjson_really_inline value_iterator value_iterator::child() const noexcept {
   return { _json_iter, depth()+1, _json_iter->token.position() };
 }
 
+// GCC 7 warns when the first line of this function is inlined away into oblivion due to the caller
+// relating depth and iterator depth, which is a desired effect. It does not happen if is_open is
+// marked non-inline.
+SIMDJSON_PUSH_DISABLE_WARNINGS
+SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
 simdjson_really_inline bool value_iterator::is_open() const noexcept {
   return _json_iter->depth() >= depth();
 }
+SIMDJSON_POP_DISABLE_WARNINGS
 
 simdjson_really_inline bool value_iterator::at_eof() const noexcept {
   return _json_iter->at_eof();

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -462,7 +462,7 @@ simdjson_really_inline error_code value_iterator::advance_container_start(const 
   // If we're not at the position anymore, we don't want to advance the cursor.
   if (!is_at_start()) {
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
-    if (!is_at_container_start()) { return OUT_OF_ORDER_ITERATION; }
+    if (!is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
     json = peek_start();
     return SUCCESS;
@@ -502,6 +502,10 @@ simdjson_really_inline bool value_iterator::is_at_start() const noexcept {
 }
 simdjson_really_inline bool value_iterator::is_at_container_start() const noexcept {
   return _json_iter->token.index == _start_position + 1;
+}
+simdjson_really_inline bool value_iterator::is_at_iterator_start() const noexcept {
+  auto delta = _json_iter->token.index - _start_position;
+  return delta == 1 || delta == 2;
 }
 
 simdjson_really_inline void value_iterator::assert_at_start() const noexcept {

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -510,6 +510,7 @@ simdjson_really_inline bool value_iterator::is_at_container_start() const noexce
   return _json_iter->token.index == _start_position + 1;
 }
 simdjson_really_inline bool value_iterator::is_at_iterator_start() const noexcept {
+  // We can legitimately be either at the first value ([1]), or after the array if it's empty ([]).
   auto delta = _json_iter->token.index - _start_position;
   return delta == 1 || delta == 2;
 }

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -263,6 +263,9 @@ public:
   simdjson_really_inline const json_iterator &json_iter() const noexcept;
   simdjson_really_inline json_iterator &json_iter() noexcept;
 
+  simdjson_really_inline void assert_is_valid() const noexcept;
+  simdjson_really_inline bool is_valid() const noexcept;
+
   /** @} */
 
 protected:

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -285,6 +285,7 @@ protected:
 
   simdjson_really_inline bool is_at_start() const noexcept;
   simdjson_really_inline bool is_at_container_start() const noexcept;
+  simdjson_really_inline bool is_at_iterator_start() const noexcept;
   simdjson_really_inline void assert_at_start() const noexcept;
   simdjson_really_inline void assert_at_container_start() const noexcept;
   simdjson_really_inline void assert_at_root() const noexcept;

--- a/tests/ondemand/ondemand_object_error_tests.cpp
+++ b/tests/ondemand/ondemand_object_error_tests.cpp
@@ -135,7 +135,7 @@ namespace object_error_tests {
       for (auto element : doc) {
         auto obj = element.get_object();
         for (auto field : obj) { ASSERT_SUCCESS(field); }
-        ASSERT_ERROR( obj.begin(), OUT_OF_ORDER_ITERATION );
+        ASSERT_ITERATE_ERROR( obj, OUT_OF_ORDER_ITERATION );
       }
       return true;
     }));
@@ -144,8 +144,27 @@ namespace object_error_tests {
         ondemand::object obj;
         ASSERT_SUCCESS( element.get(obj) );
         for (auto field : obj) { ASSERT_SUCCESS(field); }
-        ASSERT_ERROR( obj.begin(), OUT_OF_ORDER_ITERATION );
+        ASSERT_ITERATE_ERROR( obj, OUT_OF_ORDER_ITERATION );
       }
+      return true;
+    }));
+    TEST_SUCCEED();
+  }
+
+  bool out_of_order_top_level_object_iteration_error() {
+    TEST_START();
+    auto json = R"({ "x": 1, "y": 2 })"_padded;
+    SUBTEST("simdjson_result<object>", test_ondemand_doc(json, [&](auto doc) {
+      auto obj = doc.get_object();
+      for (auto field : obj) { ASSERT_SUCCESS(field); }
+      ASSERT_ITERATE_ERROR( obj, OUT_OF_ORDER_ITERATION );
+      return true;
+    }));
+    SUBTEST("object", test_ondemand_doc(json, [&](auto doc) {
+      ondemand::object obj;
+      ASSERT_SUCCESS( doc.get(obj) );
+      for (auto field : obj) { ASSERT_SUCCESS(field); }
+      ASSERT_ITERATE_ERROR( obj, OUT_OF_ORDER_ITERATION );
       return true;
     }));
     TEST_SUCCEED();
@@ -528,6 +547,7 @@ namespace object_error_tests {
            object_lookup_miss_next_error() &&
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
            out_of_order_object_iteration_error() &&
+           out_of_order_top_level_object_iteration_error() &&
            out_of_order_object_index_child_error() &&
            out_of_order_object_index_sibling_error() &&
            out_of_order_object_find_field_child_error() &&

--- a/tests/ondemand/ondemand_scalar_tests.cpp
+++ b/tests/ondemand/ondemand_scalar_tests.cpp
@@ -21,12 +21,14 @@ namespace scalar_tests {
       return true;
     }));
     SUBTEST( "document", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::document doc;
+      ASSERT_SUCCESS( std::move(doc_result).get(doc) );
       T actual;
-      ASSERT_SUCCESS( doc_result.get(actual) );
+      ASSERT_SUCCESS( doc.get(actual) );
       ASSERT_EQUAL( expected, actual );
       // Test it twice (scalars can be retrieved more than once)
       if (test_twice) {
-        ASSERT_SUCCESS( doc_result.get(actual) );
+        ASSERT_SUCCESS( doc.get(actual) );
         ASSERT_EQUAL( expected, actual );
       }
       return true;
@@ -47,12 +49,14 @@ namespace scalar_tests {
         return true;
       }));
       SUBTEST( "document", test_ondemand_doc(whitespace_json, [&](auto doc_result) {
+        ondemand::document doc;
+        ASSERT_SUCCESS( std::move(doc_result).get(doc) );
         T actual;
-        ASSERT_SUCCESS( doc_result.get(actual) );
+        ASSERT_SUCCESS( doc.get(actual) );
         ASSERT_EQUAL( expected, actual );
         // Test it twice (scalars can be retrieved more than once)
         if (test_twice) {
-          ASSERT_SUCCESS( doc_result.get(actual) );
+          ASSERT_SUCCESS( doc.get(actual) );
           ASSERT_EQUAL( expected, actual );
         }
         return true;
@@ -213,7 +217,9 @@ namespace scalar_tests {
   bool test_scalar_value_exception(const padded_string &json, const T &expected) {
     std::cout << "- JSON: " << json << endl;
     SUBTEST( "document", test_ondemand_doc(json, [&](auto doc_result) {
-      ASSERT_EQUAL( expected, T(doc_result) );
+      ondemand::document doc;
+      ASSERT_SUCCESS( std::move(doc_result).get(doc) );
+      ASSERT_EQUAL( expected, T(doc) );
       return true;
     }));
     padded_string array_json = std::string("[") + std::string(json) + "]";

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -88,7 +88,17 @@ simdjson_really_inline bool assert_true(bool value, const char *operation = "res
   }
   return true;
 }
-
+template<typename T>
+simdjson_really_inline bool assert_iterate_error(T &arr, simdjson::error_code expected, const char *operation = "result") {
+  int count = 0;
+  for (auto element : arr) {
+    count++;
+    if (!assert_error( element, expected, operation )) {
+      return false;
+    }
+  }
+  return assert_equal( count, 1, operation );
+}
 #define TEST_START()                    do { std::cout << "Running " << __func__ << " ..." << std::endl; } while(0);
 #define SUBTEST(NAME, TEST)             do { std::cout << "- Subtest " << (NAME) << " ..." << std::endl; if (!(TEST)) { return false; } } while (0);
 #define ASSERT_EQUAL(ACTUAL, EXPECTED)  do { if (!::assert_equal  ((ACTUAL), (EXPECTED), #ACTUAL)) { return false; } } while (0);
@@ -97,6 +107,7 @@ simdjson_really_inline bool assert_true(bool value, const char *operation = "res
 #define ASSERT_ERROR(ACTUAL, EXPECTED)  do { if (!::assert_error  ((ACTUAL), (EXPECTED), #ACTUAL)) { return false; } } while (0);
 #define ASSERT_TRUE(ACTUAL)             do { if (!::assert_true   ((ACTUAL),             #ACTUAL)) { return false; } } while (0);
 #define ASSERT(ACTUAL, MESSAGE)         do { if (!::assert_true   ((ACTUAL),           (MESSAGE))) { return false; } } while (0);
+#define ASSERT_ITERATE_ERROR(ACTUAL, EXPECTED)  do { if (!::assert_iterate_error((ACTUAL), (EXPECTED), #ACTUAL)) { return false; } } while (0);
 #define RUN_TEST(ACTUAL)                do { if (!(ACTUAL)) { return false; } } while (0);
 #define TEST_FAIL(MESSAGE)              do { std::cerr << "FAIL: " << (MESSAGE) << std::endl; return false; } while (0);
 #define TEST_SUCCEED()                  do { return true; } while (0);


### PR DESCRIPTION
Right now, loops aren't reporting the out of order iteration error when you actually descend into the loop. This masked a bug where we were reporting out of order iteration error for empty arrays! This fixes both bugs.

It has no impact on performance, as far as I can tell.

This PR is based against #1432, to avoid conflicts.