### PR TITLE
Guarding undefined templates with a static_assert.

### DIFF
--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -222,7 +222,11 @@ public:
    */
 
   template<typename T>
-  inline simdjson_result<T> get() const noexcept;
+  inline simdjson_result<T> get() const noexcept {
+    // Unless the simdjson library provides an inline implementation, calling this method should
+    // immediately fail.
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+  }
 
   /**
    * Get the value as the provided type (T).

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -198,14 +198,6 @@ public:
   simdjson_really_inline bool is() const noexcept;
 
   /**
-   * @private
-   * Deprecated as a public interface. These methods will be made private in a future
-   * release. Use get_double(), get_bool(), get_uint64(), get_int64(),
-   * get_object(), get_array() or get_string() instead.  We found in practice that
-   * the template would mislead users into writing get<X>() for types X that
-   * are not among the supported types (e.g., get<QString>(), get<std::string>(),
-   * get<short>()), and the resulting C++ compiler error is difficult to parse.
-   *
    * Get the value as the provided type (T).
    *
    * Supported types:
@@ -214,6 +206,9 @@ public:
    * - String: std::string_view, const char *
    * - Array: dom::array
    * - Object: dom::object
+   *
+   * You may use get_double(), get_bool(), get_uint64(), get_int64(),
+   * get_object(), get_array() or get_string() instead.
    *
    * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
    *

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -103,9 +103,9 @@ public:
    * @private
    * Deprecated as a public interface. These methods will be made private in a future
    * release. Use get_double(), get_bool(), get_uint64(), get_int64(),
-   * get_object(), get_array() or get_string() instead. We found in practice that
-   * the template would mislead users into writing get<X>() for types X that
-   * are not among the supported types (e.g., get<QString>(), get<std::string>(),
+   * get_object(), get_array(), get_raw_json_string(), or get_string() instead.
+   * We found in practice that the template would mislead users into writing get<X>()
+   * for types X that are not among the supported types (e.g., get<QString>(), get<std::string>(),
    * get<short>()), and the resulting C++ compiler error is difficult to parse.
    *
    * Get this value as the given type.

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -115,9 +115,17 @@ public:
    * @returns A value of the given type, parsed from the JSON.
    * @returns INCORRECT_TYPE If the JSON value is not the given type.
    */
-  template<typename T> simdjson_really_inline simdjson_result<T> get() & noexcept;
+  template<typename T> simdjson_really_inline simdjson_result<T> get() & noexcept {
+    // Unless the simdjson library provides an inline implementation, calling this method should
+    // immediately fail.
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+  }
   /** @overload template<typename T> simdjson_result<T> get() & noexcept */
-  template<typename T> simdjson_really_inline simdjson_result<T> get() && noexcept;
+  template<typename T> simdjson_really_inline simdjson_result<T> get() && noexcept {
+    // Unless the simdjson library provides an inline implementation, calling this method should
+    // immediately fail.
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+  }
 
   /**
    * Get this value as the given type.

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -100,17 +100,12 @@ public:
   simdjson_really_inline bool is_null() noexcept;
 
   /**
-   * @private
-   * Deprecated as a public interface. These methods will be made private in a future
-   * release. Use get_double(), get_bool(), get_uint64(), get_int64(),
-   * get_object(), get_array(), get_raw_json_string(), or get_string() instead.
-   * We found in practice that the template would mislead users into writing get<X>()
-   * for types X that are not among the supported types (e.g., get<QString>(), get<std::string>(),
-   * get<short>()), and the resulting C++ compiler error is difficult to parse.
-   *
    * Get this value as the given type.
    *
    * Supported types: object, array, raw_json_string, string_view, uint64_t, int64_t, double, bool
+   *
+   * You may use get_double(), get_bool(), get_uint64(), get_int64(),
+   * get_object(), get_array(), get_raw_json_string(), or get_string() instead.
    *
    * @returns A value of the given type, parsed from the JSON.
    * @returns INCORRECT_TYPE If the JSON value is not the given type.

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -23,6 +23,14 @@ public:
   simdjson_really_inline value() noexcept = default;
 
   /**
+   * @private
+   * Deprecated as a public interface. These methods will be made private in a future
+   * release. Use get_double(), get_bool(), get_uint64(), get_int64(),
+   * get_object(), get_array() or get_string() instead.  We found in practice that
+   * the template would mislead users into writing get<X>() for types X that
+   * are not among the supported types (e.g., get<QString>(), get<std::string>(),
+   * get<short>()), and the resulting C++ compiler error is difficult to parse.
+   *
    * Get this value as the given type.
    *
    * Supported types: object, array, raw_json_string, string_view, uint64_t, int64_t, double, bool
@@ -30,7 +38,11 @@ public:
    * @returns A value of the given type, parsed from the JSON.
    * @returns INCORRECT_TYPE If the JSON value is not the given type.
    */
-  template<typename T> simdjson_really_inline simdjson_result<T> get() noexcept;
+  template<typename T> simdjson_really_inline simdjson_result<T> get() noexcept {
+    // Unless the simdjson library provides an inline implementation, calling this method should
+    // immediately fail.
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+  }
 
   /**
    * Get this value as the given type.

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -26,9 +26,9 @@ public:
    * @private
    * Deprecated as a public interface. These methods will be made private in a future
    * release. Use get_double(), get_bool(), get_uint64(), get_int64(),
-   * get_object(), get_array() or get_string() instead.  We found in practice that
-   * the template would mislead users into writing get<X>() for types X that
-   * are not among the supported types (e.g., get<QString>(), get<std::string>(),
+   * get_object(), get_array(), get_raw_json_string(), or get_string() instead.
+   * We found in practice that the template would mislead users into writing get<X>()
+   * for types X that are not among the supported types (e.g., get<QString>(), get<std::string>(),
    * get<short>()), and the resulting C++ compiler error is difficult to parse.
    *
    * Get this value as the given type.

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -23,17 +23,12 @@ public:
   simdjson_really_inline value() noexcept = default;
 
   /**
-   * @private
-   * Deprecated as a public interface. These methods will be made private in a future
-   * release. Use get_double(), get_bool(), get_uint64(), get_int64(),
-   * get_object(), get_array(), get_raw_json_string(), or get_string() instead.
-   * We found in practice that the template would mislead users into writing get<X>()
-   * for types X that are not among the supported types (e.g., get<QString>(), get<std::string>(),
-   * get<short>()), and the resulting C++ compiler error is difficult to parse.
-   *
    * Get this value as the given type.
    *
    * Supported types: object, array, raw_json_string, string_view, uint64_t, int64_t, double, bool
+   *
+   * You may use get_double(), get_bool(), get_uint64(), get_int64(),
+   * get_object(), get_array(), get_raw_json_string(), or get_string() instead.
    *
    * @returns A value of the given type, parsed from the JSON.
    * @returns INCORRECT_TYPE If the JSON value is not the given type.


### PR DESCRIPTION
Lesson learned. When you use a template in a public API, people will expect the template to work with any type that they may provide. If you fail to provide a definition for their chosen type, the compiler should issue a warning, but more importantly, it will let it compile and the fatal error will occur at link time when no definition is found. This leads users to think that there is some problem with the build.

To put it differently, when using templates in C++ as part of a public API, you should expect users to try anything at all... and unless you are ok with mysterious failures, you want to validate somehow the type that they provide.

Instead, we want the code to fail immediately at compile time when using a template function that is undefined. You can achieve the result with a static_assert, as suggested by @rychale. This PR implements this solution. The error message is not going to be great, but it will contain an explanation and, most importantly, it will prevent the error from happening at link time.

This PR also fixes the comment in ondemand/document.h and extends the previously announced "public deprecation" in ondemand/value.h.

Fixes: https://github.com/simdjson/simdjson/issues/1448
