### PR TITLE
Throwing -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store at GNU GCC under x86/x64 systems.

### DIFF
--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -100,6 +100,12 @@ else(MSVC)
   target_compile_options(simdjson-internal-flags INTERFACE -Wsign-compare -Wshadow -Wwrite-strings -Wpointer-arith -Winit-self -Wconversion -Wno-sign-conversion)
 endif(MSVC)
 
+
+# workaround for GNU GCC poor AVX load/store code generation
+if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86(_64)?)$"))
+  target_compile_options(simdjson-internal-flags PRIVATE -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store)
+endif()
+
 #
 # Optional flags
 #

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -103,7 +103,7 @@ endif(MSVC)
 
 # workaround for GNU GCC poor AVX load/store code generation
 if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86(_64)?)$"))
-  target_compile_options(simdjson-internal-flags INTERFACE -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store)
+  target_compile_options(simdjson-flags INTERFACE -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store)
 endif()
 
 #

--- a/cmake/simdjson-flags.cmake
+++ b/cmake/simdjson-flags.cmake
@@ -103,7 +103,7 @@ endif(MSVC)
 
 # workaround for GNU GCC poor AVX load/store code generation
 if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_SYSTEM_PROCESSOR MATCHES "^(i.86|x86(_64)?)$"))
-  target_compile_options(simdjson-internal-flags PRIVATE -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store)
+  target_compile_options(simdjson-internal-flags INTERFACE -mno-avx256-split-unaligned-load -mno-avx256-split-unaligned-store)
 endif()
 
 #


### PR DESCRIPTION
It probably cannot harm performance but even so, the issue is less about performance than hygiene. It seems that GNU GCC tunes by default for Sandy Bridge processors... yet we don't use AVX under such old processors. The flags are chosen to target a specific problems whereas unaligned loads/stores under AVX are executed as two instructions by GNU GCC instead of one obvious instructions. Note that clang does not have this problem.

Fixes https://github.com/simdjson/simdjson/issues/1461
