### PR TITLE
Change new usages to std::allocator to accept custom memory allocator

### DIFF
--- a/doc/tape.md
+++ b/doc/tape.md
@@ -31,7 +31,7 @@ The following is a dump of the content of the tape, with the first number of eac
 ### The Tape
 | index | element (64 bit word)                                               |
 | ----- | ------------------------------------------------------------------- |
-| 0     | r	// pointing to 38 (right after last node)                         |
+| 0     | r	// pointing to 39 (right after last node)                         |
 | 1     | {	// pointing to next tape location 38 (first node after the scope) |
 | 2     | string "Image"                                                      |
 | 3     | {	// pointing to next tape location 37 (first node after the scope) |
@@ -115,7 +115,7 @@ We store string values using UTF-8 encoding with null termination on a separate 
 
 JSON arrays are represented using two 64-bit tape elements.
 
-- The first 64-bit tape element contains the value `('[' << 56) + x` where the payload `x` is 1 + the index of the second 64-bit tape element on the tape.
+- The first 64-bit tape element contains the value `('[' << 56) + (c << 32) + x` where the payload `x` is 1 + the index of the second 64-bit tape element on the tape  as a 32-bit integer and where `c` is the count of the number of elements (immediate children) in the array, satured to a 24-bit value (meaning that it cannot exceed 16777215 and if the real count exceeds 16777215, 16777215 is stored).  Note that the exact count of elements can always be computed by iterating (e.g., when it is 16777215 or higher).
 - The second 64-bit tape element contains the value `(']' << 56) + x` where the payload `x` contains the index of the first 64-bit tape element on the tape.
 
 All the content of the array is located between these two tape elements, including arrays and objects.
@@ -126,7 +126,7 @@ Performance consideration: We can skip the content of an array entirely by acces
 
 JSON objects are represented using two 64-bit tape elements.
 
-- The first 64-bit tape element contains the value `('{' << 56) + x` where the payload `x` is 1 + the index of the second 64-bit tape element on the tape.
+- The first 64-bit tape element contains the value `('{' << 56) + (c << 32) + x` where the payload `x` is 1 + the index of the second 64-bit tape element on the tape as a 32-bit integer and where `c` is the count of the number of key-value pairs (immediate children) in the array, satured to a 24-bit value (meaning that it cannot exceed 16777215 and if the real count exceeds 16777215, 16777215 is stored). Note that the exact count of key-value pairs can always be computed by iterating (e.g., when it is 16777215 or higher).
 - The second 64-bit tape element contains the value `('}' << 56) + x` where the payload `x` contains the index of the first 64-bit tape element on the tape.
 
 In-between these two tape elements, we alternate between key (which must be strings) and values. A value could be an object or an array.

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -42,7 +42,8 @@ inline error_code document::allocate(size_t capacity) noexcept {
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
   size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * capacity / 3 + SIMDJSON_PADDING, 64);
-  string_buf.reset( new (std::nothrow) uint8_t[string_capacity]);
+  std::allocator<uint8_t> uint8_allocator;
+  string_buf.reset( std::allocator_traits<std::allocator<uint8_t>>::allocate(uint8_allocator, string_capacity));
   tape.reset(new (std::nothrow) uint64_t[tape_capacity]);
   if(!(string_buf && tape)) {
     allocated_capacity = 0;

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -119,20 +119,23 @@ inline bool document::dump_raw_tape(std::ostream &os) const noexcept {
       os << "false\n";
       break;
     case '{': // we have an object
-      os << "{\t// pointing to next tape location " << payload
-         << " (first node after the scope) \n";
-      break;
-    case '}': // we end an object
-      os << "}\t// pointing to previous tape location " << payload
-         << " (start of the scope) \n";
+      os << "{\t// pointing to next tape location " << uint32_t(payload)
+         << " (first node after the scope), "
+         << " saturated count "
+         << ((payload >> 32) & internal::JSON_COUNT_MASK)<< "\n";
+      break;    case '}': // we end an object
+      os << "}\t// pointing to previous tape location " << uint32_t(payload)
+         << " (start of the scope)\n";
       break;
     case '[': // we start an array
-      os << "[\t// pointing to next tape location " << payload
-         << " (first node after the scope) \n";
+      os << "[\t// pointing to next tape location " << uint32_t(payload)
+         << " (first node after the scope), "
+         << " saturated count "
+         << ((payload >> 32) & internal::JSON_COUNT_MASK)<< "\n";
       break;
     case ']': // we end an array
-      os << "]\t// pointing to previous tape location " << payload
-         << " (start of the scope) \n";
+      os << "]\t// pointing to previous tape location " << uint32_t(payload)
+         << " (start of the scope)\n";
       break;
     case 'r': // we start and end with the root node
       // should we be hitting the root node?

--- a/include/simdjson/dom/document.h
+++ b/include/simdjson/dom/document.h
@@ -58,11 +58,19 @@ public:
   /** @private Structural values. */
   std::unique_ptr<uint64_t[]> tape{};
 
+  struct uint8_unique_ptr_deleter {
+    void operator()(uint8_t* p) {
+      std::allocator<uint8_t> uint8_allocator;
+      std::allocator_traits<std::allocator<uint8_t>>::destroy(uint8_allocator, p);
+    }
+  };
+
   /** @private String values.
    *
    * Should be at least byte_capacity.
    */
-  std::unique_ptr<uint8_t[]> string_buf{};
+  std::unique_ptr<uint8_t[], uint8_unique_ptr_deleter> string_buf{};
+
   /** @private Allocate memory to support
    * input JSON documents of up to len bytes.
    *

--- a/include/simdjson/dom/document.h
+++ b/include/simdjson/dom/document.h
@@ -9,7 +9,26 @@ namespace simdjson {
 namespace dom {
 
 class element;
+class deleter {
+public:
+  struct uint8_unique_ptr_deleter {
+    std::allocator<uint8_t> uint8_allocator = decltype(uint8_allocator)();
+    size_t allocated_count = 0;
+    void operator()(uint8_t* p) {
+      std::allocator_traits<decltype(uint8_allocator)>::destroy(uint8_allocator, p);
+      std::allocator_traits<decltype(uint8_allocator)>::deallocate(uint8_allocator, p, allocated_count);
+    }
+  };
 
+  struct uint64_unique_ptr_deleter {
+    std::allocator<uint64_t> uint64_allocator = decltype(uint64_allocator)();
+    size_t allocated_count = 0;
+    void operator()(uint64_t* p) {
+      std::allocator_traits<decltype(uint64_allocator)>::destroy(uint64_allocator, p);
+      std::allocator_traits<decltype(uint64_allocator)>::deallocate(uint64_allocator, p, allocated_count);
+    }
+  };
+};
 /**
  * A parsed JSON document.
  *
@@ -56,20 +75,13 @@ public:
   bool dump_raw_tape(std::ostream &os) const noexcept;
 
   /** @private Structural values. */
-  std::unique_ptr<uint64_t[]> tape{};
-
-  struct uint8_unique_ptr_deleter {
-    void operator()(uint8_t* p) {
-      std::allocator<uint8_t> uint8_allocator;
-      std::allocator_traits<std::allocator<uint8_t>>::destroy(uint8_allocator, p);
-    }
-  };
+  std::unique_ptr<uint64_t[], deleter::uint64_unique_ptr_deleter> tape{};
 
   /** @private String values.
    *
    * Should be at least byte_capacity.
    */
-  std::unique_ptr<uint8_t[], uint8_unique_ptr_deleter> string_buf{};
+  std::unique_ptr<uint8_t[], deleter::uint8_unique_ptr_deleter> string_buf{};
 
   /** @private Allocate memory to support
    * input JSON documents of up to len bytes.
@@ -94,6 +106,8 @@ private:
   size_t allocated_capacity{0};
   friend class parser;
 }; // class document
+
+
 
 } // namespace dom
 } // namespace simdjson


### PR DESCRIPTION
I've checked the performance using benchmark/perfdiff as well as benchmark/on_demand, and there seems to be no difference.

The main issue with this PR is that [std::allocator::allocate](https://en.cppreference.com/w/cpp/memory/allocator/allocate) throws bad_alloc when it fails to allocate instead of gracefully failing into a nullptr like new (std::nothrow) does. Per [this stack overflow post](https://stackoverflow.com/questions/6049563/with-fno-exceptions-what-happens-with-new-t), forcing a bad_alloc with -fno_exceptions would result in an abort() (also confirmed locally). 

Edit: Also wasn't sure to mess with malloc calls or not, so I chose not to.

Closes issue #1017