### PR TITLE
fixing issue 1480

### DIFF
--- a/doc/ondemand_design.md
+++ b/doc/ondemand_design.md
@@ -632,7 +632,10 @@ We iterate through object instances using `field` instances which represent key-
 is accessible by the `value()` method whereas the key is accessible by the `key()` method.
 The keys are treated differently than values are made available as as special type `raw_json_string`
 which is a lightweight type that is meant to be used on a temporary basis, amost solely for
-direct raw ASCII comparisons (`field.key() == "mykey"`). If you occasionally need to access and store the
+direct raw ASCII comparisons: `key().raw()` provides direct access to the unescaped string.
+You can compare `key()` with unescaped C strings (e.g., `key()=="test"`). Importantly,
+the C string must not contain the escape character (`\`).
+If you occasionally need to access and store the
 unescaped key values, you may use the `unescaped_key()` method. Once you have called `unescaped_key()` method,
 neither the `key()` nor the `unescaped_key()` methods should be called: the current field instance
 has no longer a key (that is by design). Like other strings, the resulting `std::string_view` generated

--- a/doc/ondemand_design.md
+++ b/doc/ondemand_design.md
@@ -633,9 +633,10 @@ is accessible by the `value()` method whereas the key is accessible by the `key(
 The keys are treated differently than values are made available as as special type `raw_json_string`
 which is a lightweight type that is meant to be used on a temporary basis, amost solely for
 direct raw ASCII comparisons: `key().raw()` provides direct access to the unescaped string.
-You can compare `key()` with unescaped C strings (e.g., `key()=="test"`). Importantly,
-the C string must not contain an unescaped quote character (`"`) which you can check with
-`raw_json_string::is_free_from_unescaped_quote("test")`.
+You can compare `key()` with unescaped C strings (e.g., `key()=="test"`). It is expected
+that the provided string is a valid JSON string. Importantly,
+the C string must not contain an unescaped quote character (`"`). For speed, the comparison is done byte-by-byte
+without handling the escaped caracters.
 If you occasionally need to access and store the
 unescaped key values, you may use the `unescaped_key()` method. Once you have called `unescaped_key()` method,
 neither the `key()` nor the `unescaped_key()` methods should be called: the current field instance

--- a/doc/ondemand_design.md
+++ b/doc/ondemand_design.md
@@ -634,7 +634,8 @@ The keys are treated differently than values are made available as as special ty
 which is a lightweight type that is meant to be used on a temporary basis, amost solely for
 direct raw ASCII comparisons: `key().raw()` provides direct access to the unescaped string.
 You can compare `key()` with unescaped C strings (e.g., `key()=="test"`). Importantly,
-the C string must not contain the escape character (`\`).
+the C string must not contain an unescaped quote character (`"`) which you can check with
+`raw_json_string::is_free_from_unescaped_quote("test")`.
 If you occasionally need to access and store the
 unescaped key values, you may use the `unescaped_key()` method. Once you have called `unescaped_key()` method,
 neither the `key()` nor the `unescaped_key()` methods should be called: the current field instance

--- a/include/simdjson/generic/ondemand/field.h
+++ b/include/simdjson/generic/ondemand/field.h
@@ -30,8 +30,8 @@ public:
    */
   simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> unescaped_key() noexcept;
   /**
-   * Get the key as a raw_json_string: this is fast and allows straight comparisons.
-   * We want this to be the default for most users.
+   * Get the key as a raw_json_string. Can be used for direct comparison with
+   * an unescaped C string: e.g., key() == "test".
    */
   simdjson_really_inline raw_json_string key() const noexcept;
   /**

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -32,6 +32,8 @@ public:
    * double y = obj.find_field("y");
    * double x = obj.find_field("x");
    * ```
+   * If you have multiple fields with a matching key ({"x": 1,  "x": 1}) be mindful
+   * that only one field is returned.
    *
    * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    * e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
@@ -58,6 +60,9 @@ public:
    *
    * Use find_field() if you are sure fields will be in order (or are willing to treat it as if the
    * field wasn't there when they aren't).
+   *
+   * If you have multiple fields with a matching key ({"x": 1,  "x": 1}) be mindful
+   * that only one field is returned.
    *
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -73,11 +73,14 @@ simdjson_really_inline bool raw_json_string::is_equal(std::string_view target) c
   bool escaping{false};
   for(;pos < target.size();pos++) {
     if(r[pos] != target[pos]) { return false; }
-    if((r[pos] == '"') && !escaping) {
+    // if target is a compile-time constant and it is free from
+    // quotes, then the next part could get optimized away through
+    // inlining.
+    if((target[pos] == '"') && !escaping) {
       // We have reached the end of the raw_json_string but
       // the target is not done.
       return false;
-    } else if(r[pos] == '\\') {
+    } else if(target[pos] == '\\') {
       escaping = !escaping;
     } else {
       escaping = false;
@@ -108,11 +111,14 @@ simdjson_really_inline bool raw_json_string::is_equal(const char* target) const 
   bool escaping{false};
   for(;target[pos];pos++) {
     if(r[pos] != target[pos]) { return false; }
-    if((r[pos] == '"') && !escaping) {
+    // if target is a compile-time constant and it is free from
+    // quotes, then the next part could get optimized away through
+    // inlining.
+    if((target[pos] == '"') && !escaping) {
       // We have reached the end of the raw_json_string but
       // the target is not done.
       return false;
-    } else if(r[pos] == '\\') {
+    } else if(target[pos] == '\\') {
       escaping = !escaping;
     } else {
       escaping = false;

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -13,6 +13,43 @@ simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> ra
   return result;
 }
 
+constexpr simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(std::string_view target) noexcept {
+  size_t pos{0};
+  // if the content has no escape character, just scan through it quickly!
+  for(;pos < target.size() && target[pos] != '\\';pos++) {}
+  // slow path may begin.
+  bool escaping{false};
+  for(;pos < target.size();pos++) {
+    if((target[pos] == '"') && !escaping) {
+      return false;
+    } else if(target[pos] == '\\') {
+      escaping = !escaping;
+    } else {
+      escaping = false;
+    }
+  }
+  return true;
+}
+
+constexpr simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(const char* target) noexcept {
+  size_t pos{0};
+  // if the content has no escape character, just scan through it quickly!
+  for(;target[pos] && target[pos] != '\\';pos++) {}
+  // slow path may begin.
+  bool escaping{false};
+  for(;target[pos];pos++) {
+    if((target[pos] == '"') && !escaping) {
+      return false;
+    } else if(target[pos] == '\\') {
+      escaping = !escaping;
+    } else {
+      escaping = false;
+    }
+  }
+  return true;
+}
+
+
 simdjson_really_inline bool raw_json_string::unsafe_is_equal(size_t length, std::string_view target) const noexcept {
   // If we are going to call memcmp, then we must know something about the length of the raw_json_string.
   return (length >= target.size()) && (raw()[target.size()] == '"') && !memcmp(raw(), target.data(), target.size());

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -13,7 +13,7 @@ simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> ra
   return result;
 }
 
-constexpr simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(std::string_view target) noexcept {
+simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(std::string_view target) noexcept {
   size_t pos{0};
   // if the content has no escape character, just scan through it quickly!
   for(;pos < target.size() && target[pos] != '\\';pos++) {}
@@ -31,7 +31,7 @@ constexpr simdjson_really_inline bool raw_json_string::is_free_from_unescaped_qu
   return true;
 }
 
-constexpr simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(const char* target) noexcept {
+simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(const char* target) noexcept {
   size_t pos{0};
   // if the content has no escape character, just scan through it quickly!
   for(;target[pos] && target[pos] != '\\';pos++) {}

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -58,6 +58,9 @@ simdjson_really_inline bool raw_json_string::unsafe_is_equal(size_t length, std:
 simdjson_really_inline bool raw_json_string::unsafe_is_equal(std::string_view target) const noexcept {
   // Assumptions: does not contain unescaped quote characters, and
   // the raw content is quote terminated within a valid JSON string.
+  if(target.size() <= SIMDJSON_PADDING) {
+    return (raw()[target.size()] == '"') && !memcmp(raw(), target.data(), target.size());
+  }
   const char * r{raw()};
   size_t pos{0};
   for(;pos < target.size();pos++) {
@@ -127,6 +130,23 @@ simdjson_really_inline bool raw_json_string::is_equal(const char* target) const 
   if(r[pos] != '"') { return false; }
   return true;
 }
+
+simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, std::string_view c) noexcept {
+  return a.unsafe_is_equal(c);
+}
+
+simdjson_unused simdjson_really_inline bool operator==(std::string_view c, const raw_json_string &a) noexcept {
+  return a == c;
+}
+
+simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, std::string_view c) noexcept {
+  return !(a == c);
+}
+
+simdjson_unused simdjson_really_inline bool operator!=(std::string_view c, const raw_json_string &a) noexcept {
+  return !(a == c);
+}
+
 
 simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, const char *c) noexcept {
   return a.unsafe_is_equal(c);

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -1,4 +1,5 @@
 namespace simdjson {
+
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
@@ -147,22 +148,6 @@ simdjson_unused simdjson_really_inline bool operator!=(std::string_view c, const
   return !(a == c);
 }
 
-
-simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, const char *c) noexcept {
-  return a.unsafe_is_equal(c);
-}
-
-simdjson_unused simdjson_really_inline bool operator==(const char *c, const raw_json_string &a) noexcept {
-  return a == c;
-}
-
-simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, const char *c) noexcept {
-  return !(a == c);
-}
-
-simdjson_unused simdjson_really_inline bool operator!=(const char *c, const raw_json_string &a) noexcept {
-  return !(a == c);
-}
 
 simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> raw_json_string::unescape(json_iterator &iter) const noexcept {
   return unescape(iter.string_buf_loc());

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -16,7 +16,7 @@ class json_iterator;
  * JSON file.)
  *
  * This class is deliberately simplistic and has little functionality. You can
- * compare two raw_json_string instances, or compare a raw_json_string with a string_view, but
+ * compare a raw_json_string instance with an unescaped C string, but
  * that is pretty much all you can do.
  *
  * They originate typically from field instance which in turn represent key-value pairs from
@@ -49,7 +49,25 @@ public:
    */
   simdjson_really_inline const char * raw() const noexcept;
 
+  /**
+   * This compares the current instance to the std::string_view target: returns true if
+   * they are byte-by-byte equal (no escaping is done).
+   * If length is smaller than target.size(), this will return false.
+   */
+  simdjson_really_inline bool unsafe_is_equal(size_t length, std::string_view target) const noexcept;
+
+  /**
+   * This compares the current instance to the C string target: returns true if
+   * they are byte-by-byte equal (no escaping is done).
+   * If length is smaller than target.size(), this will return false.
+   * The provided C string should be null terminated and it should not end with
+   * the escape character (\): the caller is responsible for reaching.
+   */
+  simdjson_really_inline bool unsafe_is_equal(const char* target) const noexcept;
+
 private:
+
+
   /**
    * This will set the inner pointer to zero, effectively making
    * this instance unusable.
@@ -92,12 +110,9 @@ private:
   friend struct simdjson_result<raw_json_string>;
 };
 
-simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, std::string_view b) noexcept;
-simdjson_unused simdjson_really_inline bool operator==(std::string_view a, const raw_json_string &b) noexcept;
-simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, std::string_view b) noexcept;
-simdjson_unused simdjson_really_inline bool operator!=(std::string_view a, const raw_json_string &b) noexcept;
-
 simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &, const raw_json_string &) noexcept;
+simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, const char *c) noexcept;
+simdjson_unused simdjson_really_inline bool operator==(const char *c, const raw_json_string &a) noexcept;
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -53,8 +53,24 @@ public:
    * This compares the current instance to the std::string_view target: returns true if
    * they are byte-by-byte equal (no escaping is done).
    * If length is smaller than target.size(), this will return false.
+   * The std::string_view instance may contain any characters. However, the caller
+   * is responsible for setting length so that length bytes may be read in the
+   * raw_json_string.
+   *
+   * Performance: the comparison may be done using memcmp which may be efficient
+   * for long strings.
    */
   simdjson_really_inline bool unsafe_is_equal(size_t length, std::string_view target) const noexcept;
+
+  /**
+   * This compares the current instance to the std::string_view target: returns true if
+   * they are byte-by-byte equal (no escaping is done).
+   * The std::string_view instance should be unescaped, it should not contain quote characters.
+   *
+   * Performance: the comparison is done byte-by-byte which might be inefficient for
+   * long strings.
+   */
+  simdjson_really_inline bool unsafe_is_equal(std::string_view target) const noexcept;
 
   /**
    * This compares the current instance to the C string target: returns true if
@@ -111,8 +127,15 @@ private:
 };
 
 simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &, const raw_json_string &) noexcept;
+
+/**
+ * Comparisons between raw_json_string and C string are potentially unsafe: the user is responsible
+ * for providing a null terminated string with unescaped content, without quote.
+ */
 simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, const char *c) noexcept;
 simdjson_unused simdjson_really_inline bool operator==(const char *c, const raw_json_string &a) noexcept;
+simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, const char *c) noexcept;
+simdjson_unused simdjson_really_inline bool operator!=(const char *c, const raw_json_string &a) noexcept;
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -51,8 +51,11 @@ public:
 
   /**
    * This compares the current instance to the std::string_view target: returns true if
-   * they are byte-by-byte equal (no escaping is done).
+   * they are byte-by-byte equal (no escaping is done) on target.size() characters,
+   * and if the raw_json_string instance has a quote character at byte index target.size().
+   * We never read more than length + 1 bytes in the raw_json_string instance.
    * If length is smaller than target.size(), this will return false.
+   *
    * The std::string_view instance may contain any characters. However, the caller
    * is responsible for setting length so that length bytes may be read in the
    * raw_json_string.
@@ -65,7 +68,7 @@ public:
   /**
    * This compares the current instance to the std::string_view target: returns true if
    * they are byte-by-byte equal (no escaping is done).
-   * The std::string_view instance should be unescaped, it should not contain quote characters.
+   * The std::string_view instance should not contain unescaped quote characters.
    *
    * Performance: the comparison is done byte-by-byte which might be inefficient for
    * long strings.
@@ -75,9 +78,8 @@ public:
   /**
    * This compares the current instance to the C string target: returns true if
    * they are byte-by-byte equal (no escaping is done).
-   * If length is smaller than target.size(), this will return false.
-   * The provided C string should be null terminated and it should not end with
-   * the escape character (\): the caller is responsible for reaching.
+   * The provided C string should not contain an unescape quote character:
+   * the caller is responsible for this check.
    */
   simdjson_really_inline bool unsafe_is_equal(const char* target) const noexcept;
 
@@ -130,7 +132,7 @@ simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &, 
 
 /**
  * Comparisons between raw_json_string and C string are potentially unsafe: the user is responsible
- * for providing a null terminated string with unescaped content, without quote.
+ * for providing a null terminated string with no unescaped quote.
  */
 simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, const char *c) noexcept;
 simdjson_unused simdjson_really_inline bool operator==(const char *c, const raw_json_string &a) noexcept;

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -165,12 +165,21 @@ simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &, 
 
 /**
  * Comparisons between raw_json_string and C string are potentially unsafe: the user is responsible
- * for providing a null terminated string with no unescaped quote.
+ * for providing a null terminated string with no unescaped quote. Note that unescaped quotes cannot be present in valid JSON strings.
  */
 simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, const char *c) noexcept;
 simdjson_unused simdjson_really_inline bool operator==(const char *c, const raw_json_string &a) noexcept;
 simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, const char *c) noexcept;
 simdjson_unused simdjson_really_inline bool operator!=(const char *c, const raw_json_string &a) noexcept;
+/**
+ * Comparisons between raw_json_string and std::string_view instances are potentially unsafe: the user is responsible
+ * for providing a string with no unescaped quote. Note that unescaped quotes cannot be present in valid JSON strings.
+ */
+simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, std::string_view c) noexcept;
+simdjson_unused simdjson_really_inline bool operator==(std::string_view c, const raw_json_string &a) noexcept;
+simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, std::string_view c) noexcept;
+simdjson_unused simdjson_really_inline bool operator!=(std::string_view c, const raw_json_string &a) noexcept;
+
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -113,8 +113,8 @@ public:
    * compile-time, we might expect the computation to happen at compile time with
    * many compilers (not all!).
    */
-  static constexpr simdjson_really_inline bool is_free_from_unescaped_quote(std::string_view target) noexcept;
-  static constexpr simdjson_really_inline bool is_free_from_unescaped_quote(const char* target) noexcept;
+  static simdjson_really_inline bool is_free_from_unescaped_quote(std::string_view target) noexcept;
+  static simdjson_really_inline bool is_free_from_unescaped_quote(const char* target) noexcept;
 
 private:
 

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -83,6 +83,17 @@ public:
    */
   simdjson_really_inline bool unsafe_is_equal(const char* target) const noexcept;
 
+  /**
+   * This compares the current instance to the std::string_view target: returns true if
+   * they are byte-by-byte equal (no escaping is done).
+   */
+  simdjson_really_inline bool is_equal(std::string_view target) const noexcept;
+
+  /**
+   * This compares the current instance to the C string target: returns true if
+   * they are byte-by-byte equal (no escaping is done).
+   */
+  simdjson_really_inline bool is_equal(const char* target) const noexcept;
 private:
 
 

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -68,18 +68,31 @@ public:
   /**
    * This compares the current instance to the std::string_view target: returns true if
    * they are byte-by-byte equal (no escaping is done).
-   * The std::string_view instance should not contain unescaped quote characters.
+   * The std::string_view instance should not contain unescaped quote characters:
+   * the caller is responsible for this check. See is_free_from_unescaped_quote.
    *
    * Performance: the comparison is done byte-by-byte which might be inefficient for
    * long strings.
+   *
+   * If target is a compile-time constant, and your compiler likes you,
+   * you should be able to do the following without performance penatly...
+   *
+   *   static_assert(raw_json_string::is_free_from_unescaped_quote(target), "");
+   *   s.unsafe_is_equal(target);
    */
   simdjson_really_inline bool unsafe_is_equal(std::string_view target) const noexcept;
 
   /**
    * This compares the current instance to the C string target: returns true if
    * they are byte-by-byte equal (no escaping is done).
-   * The provided C string should not contain an unescape quote character:
-   * the caller is responsible for this check.
+   * The provided C string should not contain an unescaped quote character:
+   * the caller is responsible for this check. See is_free_from_unescaped_quote.
+   *
+   * If target is a compile-time constant, and your compiler likes you,
+   * you should be able to do the following without performance penatly...
+   *
+   *   static_assert(raw_json_string::is_free_from_unescaped_quote(target), "");
+   *   s.unsafe_is_equal(target);
    */
   simdjson_really_inline bool unsafe_is_equal(const char* target) const noexcept;
 
@@ -94,6 +107,15 @@ public:
    * they are byte-by-byte equal (no escaping is done).
    */
   simdjson_really_inline bool is_equal(const char* target) const noexcept;
+
+  /**
+   * Returns true if target is free from unescaped quote. If target is known at
+   * compile-time, we might expect the computation to happen at compile time with
+   * many compilers (not all!).
+   */
+  static constexpr simdjson_really_inline bool is_free_from_unescaped_quote(std::string_view target) noexcept;
+  static constexpr simdjson_really_inline bool is_free_from_unescaped_quote(const char* target) noexcept;
+
 private:
 
 

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -164,14 +164,6 @@ private:
 simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &, const raw_json_string &) noexcept;
 
 /**
- * Comparisons between raw_json_string and C string are potentially unsafe: the user is responsible
- * for providing a null terminated string with no unescaped quote. Note that unescaped quotes cannot be present in valid JSON strings.
- */
-simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, const char *c) noexcept;
-simdjson_unused simdjson_really_inline bool operator==(const char *c, const raw_json_string &a) noexcept;
-simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, const char *c) noexcept;
-simdjson_unused simdjson_really_inline bool operator!=(const char *c, const raw_json_string &a) noexcept;
-/**
  * Comparisons between raw_json_string and std::string_view instances are potentially unsafe: the user is responsible
  * for providing a string with no unescaped quote. Note that unescaped quotes cannot be present in valid JSON strings.
  */

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -222,7 +222,9 @@ public:
    * double y = obj.find_field("y");
    * double x = obj.find_field("x");
    * ```
-   *
+   * If you have multiple fields with a matching key ({"x": 1,  "x": 1}) be mindful
+   * that only one field is returned.
+
    * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    * e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
    *
@@ -245,6 +247,9 @@ public:
    * It is the default, however, because it would be highly surprising (and hard to debug) if the
    * default behavior failed to look up a field just because it was in the wrong order--and many
    * APIs assume this. Therefore, you must be explicit if you want to treat objects as out of order.
+   *
+   * If you have multiple fields with a matching key ({"x": 1,  "x": 1}) be mindful
+   * that only one field is returned.
    *
    * Use find_field() if you are sure fields will be in order (or are willing to treat it as if the
    * field wasn't there when they aren't).

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -56,7 +56,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_raw(const std::string_view key) noexcept {
   error_code error;
   bool has_value;
-
   //
   // Initially, the object can be in one of a few different places:
   //
@@ -143,7 +142,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_unordered_raw(const std::string_view key) noexcept {
   error_code error;
   bool has_value;
-
   //
   // Initially, the object can be in one of a few different places:
   //

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -113,11 +113,12 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   while (has_value) {
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
+    size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
     if ((error = field_key().get(actual_key) )) { abandon(); return error; };
-    if ((error = field_value() )) { abandon(); return error; }
 
+    if ((error = field_value() )) { abandon(); return error; }
     // If it matches, stop and return
-    if (actual_key == key) {
+    if (actual_key.unsafe_is_equal(max_key_length, key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
     }
@@ -215,11 +216,13 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
+    size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
+
     if ((error = field_key().get(actual_key) )) { abandon(); return error; };
     if ((error = field_value() )) { abandon(); return error; }
 
     // If it matches, stop and return
-    if (actual_key == key) {
+    if (actual_key.unsafe_is_equal(max_key_length, key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
     }
@@ -243,11 +246,13 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
+    size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
+
     error = field_key().get(actual_key); SIMDJSON_ASSUME(!error);
     error = field_value(); SIMDJSON_ASSUME(!error);
 
     // If it matches, stop and return
-    if (actual_key == key) {
+    if (actual_key.unsafe_is_equal(max_key_length, key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
     }

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -122,7 +122,9 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // key content (including escaped quotes).
     //if (actual_key.unsafe_is_equal(max_key_length, key)) {
     // Instead we do the following which may trigger buffer overruns if the
-    // user provides an adversarial key.
+    // user provides an adversarial key (containing a well placed unescaped quote
+    // character and being longer than the number of bytes remaining in the JSON
+    // input).
     if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
@@ -231,7 +233,9 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // key content (including escaped quotes).
     // if (actual_key.unsafe_is_equal(max_key_length, key)) {
     // Instead we do the following which may trigger buffer overruns if the
-    // user provides an adversarial key.
+    // user provides an adversarial key (containing a well placed unescaped quote
+    // character and being longer than the number of bytes remaining in the JSON
+    // input).
     if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
@@ -266,7 +270,9 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // key content (including escaped quotes).
     // if (actual_key.unsafe_is_equal(max_key_length, key)) {
     // Instead we do the following which may trigger buffer overruns if the
-    // user provides an adversarial key.
+    // user provides an adversarial key (containing a well placed unescaped quote
+    // character and being longer than the number of bytes remaining in the JSON
+    // input).
     if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
       return true;

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -113,12 +113,17 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   while (has_value) {
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
-    size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
+    // size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
     if ((error = field_key().get(actual_key) )) { abandon(); return error; };
 
     if ((error = field_value() )) { abandon(); return error; }
     // If it matches, stop and return
-    if (actual_key.unsafe_is_equal(max_key_length, key)) {
+    // We could do it this way if we wanted to allow arbitrary
+    // key content (including escaped quotes).
+    //if (actual_key.unsafe_is_equal(max_key_length, key)) {
+    // Instead we do the following which may trigger buffer overruns if the
+    // user provides an adversarial key.
+    if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
     }
@@ -216,13 +221,18 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
-    size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
+    // size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
 
     if ((error = field_key().get(actual_key) )) { abandon(); return error; };
     if ((error = field_value() )) { abandon(); return error; }
 
     // If it matches, stop and return
-    if (actual_key.unsafe_is_equal(max_key_length, key)) {
+    // We could do it this way if we wanted to allow arbitrary
+    // key content (including escaped quotes).
+    // if (actual_key.unsafe_is_equal(max_key_length, key)) {
+    // Instead we do the following which may trigger buffer overruns if the
+    // user provides an adversarial key.
+    if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
     }
@@ -246,13 +256,18 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
     // Get the key and colon, stopping at the value.
     raw_json_string actual_key;
-    size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
+    // size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
 
     error = field_key().get(actual_key); SIMDJSON_ASSUME(!error);
     error = field_value(); SIMDJSON_ASSUME(!error);
 
     // If it matches, stop and return
-    if (actual_key.unsafe_is_equal(max_key_length, key)) {
+    // We could do it this way if we wanted to allow arbitrary
+    // key content (including escaped quotes).
+    // if (actual_key.unsafe_is_equal(max_key_length, key)) {
+    // Instead we do the following which may trigger buffer overruns if the
+    // user provides an adversarial key.
+    if (actual_key.unsafe_is_equal(key)) {
       logger::log_event(*this, "match", key, -2);
       return true;
     }

--- a/tests/ondemand/ondemand_compilation_tests.cpp
+++ b/tests/ondemand/ondemand_compilation_tests.cpp
@@ -25,7 +25,6 @@ void compilation_test_1() {
     }
 }
 
-
 // Do not run this, it is only meant to compile
  void compilation_test_2() {
   const padded_string bogus = ""_padded;

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -564,6 +564,16 @@ namespace object_tests {
       ASSERT_EQUAL( counter_version_major, 1 );
       return true;
     }));
+    SUBTEST("ondemand::issue_1480::big-key", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::object object;
+      ASSERT_SUCCESS( doc_result.get(object) );
+      std::vector<char> large_buf(512,' ');
+      std::string_view lb{large_buf.data(), large_buf.size()};
+      ASSERT_ERROR( object.find_field(lb), NO_SUCH_FIELD );
+      return true;
+    }));
+
+#if SIMDJSON_EXCEPTIONS
     SUBTEST("ondemand::issue_1480::object-iteration-string-view", test_ondemand_doc(json, [&](auto doc_result) {
       ondemand::object object;
       ASSERT_SUCCESS( doc_result.get(object) );
@@ -584,16 +594,6 @@ namespace object_tests {
       ASSERT_EQUAL( counter_version_major, 1 );
       return true;
     }));
-    SUBTEST("ondemand::issue_1480::big-key", test_ondemand_doc(json, [&](auto doc_result) {
-      ondemand::object object;
-      ASSERT_SUCCESS( doc_result.get(object) );
-      std::vector<char> large_buf(512,' ');
-      std::string_view lb{large_buf.data(), large_buf.size()};
-      ASSERT_ERROR( object.find_field(lb), NO_SUCH_FIELD );
-      return true;
-    }));
-
-#if SIMDJSON_EXCEPTIONS
     SUBTEST("ondemand::issue_1480::original", test_ondemand_doc(json, [&](auto doc_result) {
       size_t counter{0};
       for (auto field : doc_result.get_object()) {

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -550,6 +550,16 @@ namespace object_tests {
       ASSERT_EQUAL( object.find_field_unordered("version").get_string().value_unsafe(),  "0.13.2");
       return true;
     }));
+    SUBTEST("ondemand::issue_1480::big-key", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::object object;
+      ASSERT_SUCCESS( doc_result.get(object) );
+      std::vector<char> large_buf(512,' ');
+      std::string_view lb{large_buf.data(), large_buf.size()};
+      ASSERT_ERROR( object.find_field(lb), NO_SUCH_FIELD );
+      return true;
+    }));
+
+#if SIMDJSON_EXCEPTIONS
     SUBTEST("ondemand::issue_1480::object-iteration", test_ondemand_doc(json, [&](auto doc_result) {
       ondemand::object object;
       ASSERT_SUCCESS( doc_result.get(object) );
@@ -564,16 +574,6 @@ namespace object_tests {
       ASSERT_EQUAL( counter_version_major, 1 );
       return true;
     }));
-    SUBTEST("ondemand::issue_1480::big-key", test_ondemand_doc(json, [&](auto doc_result) {
-      ondemand::object object;
-      ASSERT_SUCCESS( doc_result.get(object) );
-      std::vector<char> large_buf(512,' ');
-      std::string_view lb{large_buf.data(), large_buf.size()};
-      ASSERT_ERROR( object.find_field(lb), NO_SUCH_FIELD );
-      return true;
-    }));
-
-#if SIMDJSON_EXCEPTIONS
     SUBTEST("ondemand::issue_1480::object-iteration-string-view", test_ondemand_doc(json, [&](auto doc_result) {
       ondemand::object object;
       ASSERT_SUCCESS( doc_result.get(object) );


### PR DESCRIPTION
The raw_json_string is unsafe in some ways and this PR makes it better. One key design constraint is that raw_json_string is unaware of this length. It has no idea. You have do everything manually. This exposes you to buffer overruns and to incorrect comparisons.

Two problems could happen:

A. The comparator  just did byte-by-byte (memcmp) comparison without checking for the final quote. So the keys "ab" and "ac" would both match "a". That's pretty bad.
B. Just as bad, you could pass "ababaababababababababababa...aaa" (make it very long) as a potential key against the json document `{"a":1}` and it would just happily compare, reading inside the JSON input for as long as you want (buffer overflow!!!).


So there are two types of algorithm you could use:

1. Find some bound on how far off you can read within the document without a buffer overrun: if you know where you are in the JSON input and you know how long the JSON document, then you have one such upperbound. But you can also call a `peek_length()` method right before accessing the key and it should give you a sensible upper bound on the string. Note that you must do this on your own because the raw_json_string does not track its length.
2. Or else, you rely on the fact that the user is not going to give you as a possible key something evil like `baba"fdfdsfddsfsd...fdsfd` since a key "baba" would then suffer from a buffer overrun.
 
For the public API, we offer raw_json_string and it does not know its length, so only option 2 is viable, unless you change raw_json_string so that it becomes more like a string_view... and can track an upper bound on its length.



We relied on C++ magic to do the comparison between a C string and raw_json_string. I think that what would happen is that the C string would be automatically converted to string_view (which, presumably, involves finding its length with strlen though that can done at compile time). I checked and it seems that at least GNU GCC is able to basically do it for free (no std::string_view instance needs to be created) when the C string is a compile-time constant (if not, then you get a call to strlen + the comparison which is inefficient). For now, I removed the std::string_view API within raw_json_string and put just a C string API since this is what it is designed for. As far as the public API goes, it serves us well enough.


I have a reason for removing the overload to string_view and it has to do with the fact that there are two ways to skin this cat. Internally, we now have two `unsafe_is_equal` comparators. One with strategy 1 and one with strategy 2. Currently the PR relies on strategy 2. My main justification is that it is the less intrusive change to the current codebase.

Expected effects of this PR:

a. For our internal functions, instead of doing a straight memcmp, we do a loop and we check the final quote. I do not think it is should affect the performance. You would expect  memcmp to mostly do well on longer strings or on strings that have a predictible length... which is not our case.
b. For the public API (`my.key() == "a"`) , then it is much the same. We check the final quote which is a bit of extra work and we do not do the memcmp.
c. The code made assumptions that the user-provided input was not adversarial and this is still true with this PR. The only added safety is that we are protected against inputs that are longer than the remaining bytes in the JSON document, but only if the user provides a non-escaped JSON key. If the user inserts a quote, we are in trouble.  We can "easily" flip the problem around and produce slightly safe code with strategy 1. However, it is more likely, I feel, to come at a computational cost so we should proceed with some care.


Fixes https://github.com/simdjson/simdjson/issues/1480