### PR TITLE
Provides a more correct simdjson::ondemand implementation message.

### DIFF
--- a/benchmark/json_benchmark/run_json_benchmark.h
+++ b/benchmark/json_benchmark/run_json_benchmark.h
@@ -11,7 +11,8 @@ void maybe_display_implementation() {
   if(!displayed_implementation) {
     displayed_implementation = true;
     std::cout << "simdjson::dom implementation:      " << simdjson::active_implementation->name() << std::endl;
-    std::cout << "simdjson::ondemand implementation: " << simdjson::builtin_implementation()->name() << std::endl;
+    std::cout << "simdjson::ondemand implementation (stage 1): " << simdjson::active_implementation->name() << std::endl;
+    std::cout << "simdjson::ondemand implementation (stage 2): " << simdjson::builtin_implementation()->name() << std::endl;
   }
 }
 


### PR DESCRIPTION
@jkeiser has enabled runtime dispatch for stage 1 under OnDemand, so we need to print out both the stage 1 and stage 2 kernel names.


