### PR TITLE
Increase build timeout for circle-ci sanitize job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,9 @@ commands:
   cmake_build:
     steps:
       - cmake_build_cache
-      - run: cmake --build build
+      - run:
+          command: cmake --build build
+          no_output_timeout: 60m
 
   cmake_test:
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -182,7 +182,10 @@ script:
   - mkdir build
   - cd build
   - cmake $CMAKE_FLAGS ..
-  - cmake --build . -- -j2
+  - if [[ "${SANITIZE}" == "on" ]]; then
+      export TRAVIS_WAIT=travis_wait
+    fi
+  - $TRAVIS_WAIT cmake --build . -- -j2
   - SIMDJSON_FORCE_IMPLEMENTATION=ppc64 ctest $CTEST_FLAGS -L per_implementation
   - SIMDJSON_FORCE_IMPLEMENTATION=fallback ctest $CTEST_FLAGS -L per_implementation
   - ctest $CTEST_FLAGS -LE "acceptance|per_implementation"


### PR DESCRIPTION
This is an attempt to get rid of the spurious errors we keep getting for gcc sanitize in circle ci.