### PR TITLE
guarded number parsing (to be merged into Remove padding access from iteration #1511)

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -19,6 +19,8 @@ char *to_chars(char *first, const char *last, double value);
  * Defined in src/from_chars
  */
 double from_chars(const char *first) noexcept;
+double from_chars(const char *first, const char* end) noexcept;
+
 }
 
 #ifndef SIMDJSON_EXCEPTIONS


### PR DESCRIPTION
I propose merging this new code into jkeiser/no-padding.

What I did was just to copy/paste the number parsing routines and add a "final pointer" indicating the end point of memory safety.

I deliberately did not get clever. It is obvious that you could avoid copy/paste and streamline the implementation but this should be done as a secondary step. By doing it this way, I know that I am not affecting the existing functions.


This is not "hooked up" (actually used).

Note that the atom parsing functions are already available in safe mode.
