### PR TITLE
Fix bug in find_field_unordered when the key being queried is missing (issue 1521)

### DIFF
--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -142,6 +142,9 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_unordered_raw(const std::string_view key) noexcept {
   error_code error;
   bool has_value;
+  // We want to be able to loop back to where we were.
+  token_position search_start = _json_iter->position();
+
   //
   // Initially, the object can be in one of a few different places:
   //
@@ -213,7 +216,6 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
   // First, we scan from that point to the end.
   // If we don't find a match, we loop back around, and scan from the beginning to that point.
-  token_position search_start = _json_iter->position();
 
   // Next, we find a match starting from the current position.
   while (has_value) {
@@ -250,9 +252,11 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   // (We have already run through the object before, so we've already validated its structure. We
   // don't check errors in this bit.)
   _json_iter->reenter_child(_start_position + 1, _depth);
+  // If we started at the beginning of the object, we are done.
+  if(_json_iter->position() == search_start) { return false; }
 
   has_value = started_object();
-  while (_json_iter->position() < search_start) {
+  while (true) {
     SIMDJSON_ASSUME(has_value); // we should reach search_start before ever reaching the end of the object
     SIMDJSON_ASSUME( _json_iter->_depth == _depth ); // We must be at the start of a field
 
@@ -279,7 +283,11 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     // No match: skip the value and see if , or } is next
     logger::log_event(*this, "no match", key, -2);
     SIMDJSON_TRY( skip_child() );
-    error = has_next_field().get(has_value); SIMDJSON_ASSUME(!error);
+    if(_json_iter->position() < search_start) {
+      error = has_next_field().get(has_value); SIMDJSON_ASSUME(!error);
+    } else {
+      break;
+    }
   }
 
   // If the loop ended, we're out of fields to look at.

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -6,6 +6,28 @@ using namespace simdjson;
 namespace object_tests {
   using namespace std;
   using simdjson::ondemand::json_type;
+
+
+  bool missing_keys() {
+    TEST_START();
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string docdata =  R"([{"a":"a"},{}])"_padded;
+    simdjson::ondemand::document doc;
+    auto error = parser.iterate(docdata).get(doc);
+    if(error != simdjson::SUCCESS) { return false; }
+    simdjson::ondemand::array a;
+    error = doc.get_array().get(a);
+    if(error != simdjson::SUCCESS) { return false; }
+    for(auto elem : a) {
+      error = elem.find_field_unordered("keynotfound").error();
+      if(error != simdjson::NO_SUCH_FIELD) {
+        std::cout << error << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+
 #if SIMDJSON_EXCEPTIONS
 
   // used in issue_1521
@@ -964,6 +986,7 @@ namespace object_tests {
 
   bool run() {
     return
+           missing_keys() &&
 #if SIMDJSON_EXCEPTIONS
            fixed_broken_issue_1521() &&
            issue_1521() &&

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -35,6 +35,21 @@ namespace object_tests {
     TEST_SUCCEED();
   }
 
+  bool fixed_broken_issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    // We omit the ',"nodes":[]'
+    padded_string json = R"({"type":"root","nodes":[{"type":"child"},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      broken_descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+
   // used in issue_1521
   // difficult to use as a lambda because it is recursive.
   void descend(ondemand::object node) {
@@ -950,8 +965,9 @@ namespace object_tests {
   bool run() {
     return
 #if SIMDJSON_EXCEPTIONS
-           broken_issue_1521() &&
+           fixed_broken_issue_1521() &&
            issue_1521() &&
+           broken_issue_1521() &&
 #endif
            iterate_object() &&
            iterate_empty_object() &&

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -29,8 +29,6 @@ namespace object_tests {
       std::cout << "The document is valid JSON: " << json << std::endl;
       TEST_FAIL(e.error());
     }
-    simdjson::ondemand::object root_object;
-    if(file_tree.get(root_object)) { descend(root_object); }
     TEST_SUCCEED();
   }
 

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -6,6 +6,8 @@ using namespace simdjson;
 namespace object_tests {
   using namespace std;
   using simdjson::ondemand::json_type;
+#if SIMDJSON_EXCEPTIONS
+
   // used in issue_1521
   // difficult to use as a lambda because it is recursive.
   void broken_descend(ondemand::object node) {
@@ -60,7 +62,7 @@ namespace object_tests {
     TEST_SUCCEED();
   }
 
-
+#endif
   bool iterate_object() {
     TEST_START();
     auto json = R"({ "a": 1, "b": 2, "c": 3 })"_padded;
@@ -947,8 +949,10 @@ namespace object_tests {
 
   bool run() {
     return
+#if SIMDJSON_EXCEPTIONS
            broken_issue_1521() &&
            issue_1521() &&
+#endif
            iterate_object() &&
            iterate_empty_object() &&
            object_index() &&

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -8,10 +8,38 @@ namespace object_tests {
   using simdjson::ondemand::json_type;
   // used in issue_1521
   // difficult to use as a lambda because it is recursive.
-  void descend(ondemand::object node) {
+  void broken_descend(ondemand::object node) {
     if(auto type = node.find_field_unordered("type"); type.error() == SUCCESS && type == "child") {
-      if(node.find_field_unordered("name").error() == simdjson::SUCCESS) {
-          std::cout << std::string_view(node["name"]) << std::endl;
+      auto n = node.find_field_unordered("name");
+      if(n.error() == simdjson::SUCCESS) {
+          std::cout << std::string_view(n) << std::endl;
+      }
+    } else {
+     for (ondemand::object child_node : node["nodes"]) { broken_descend(child_node); }
+    }
+  }
+
+  bool broken_issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    padded_string json = R"({"type":"root","nodes":[{"type":"child","nodes":[]},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      broken_descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+
+  // used in issue_1521
+  // difficult to use as a lambda because it is recursive.
+  void descend(ondemand::object node) {
+    auto n = node.find_field_unordered("name");
+    if(auto type = node.find_field_unordered("type"); type.error() == SUCCESS && type == "child") {
+      if(n.error() == simdjson::SUCCESS) {
+          std::cout << std::string_view(n) << std::endl;
       }
     } else {
      for (ondemand::object child_node : node["nodes"]) { descend(child_node); }
@@ -919,6 +947,7 @@ namespace object_tests {
 
   bool run() {
     return
+           broken_issue_1521() &&
            issue_1521() &&
            iterate_object() &&
            iterate_empty_object() &&


### PR DESCRIPTION
In some cases, when using the on demand front-end, when seeking a missing key in unordered mode in an object (i.e., `find_field_unordered` or `operator[]`), the JSON iterator would be left in a bad state. That is, whereas the JSON iterator would be initially pointing at the `,`, it would leave the function pointing at the next structural element (`"`) and this would  mess up the rest of the logic of the code.

You can verify the bug with the following examples which throws a TAPE_ERROR. The input JSON is fine. It does not throw if you search and replace the `find_field_unordered` with  `find_field`. It throws with the second call to `find_field_unordered` (with `"name"`). The `node.find_field_unordered("type")` can be replaced with `node.find_field("type")` without changing the outcome.

```C++
  void descend(ondemand::object node) {
    if(auto type = node.find_field_unordered("type"); type.error() == SUCCESS && type == "child") {
      if(node.find_field_unordered("name").error() == simdjson::SUCCESS) {
          std::cout << std::string_view(node["name"]) << std::endl;
      }
    } else {
     for (ondemand::object child_node : node["nodes"]) { descend(child_node); }
    }
  }

  bool issue_1521() {
    ondemand::parser parser;
    padded_string json = R"({"type":"root","nodes":[{"type":"child","nodes":[]},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
    ondemand::document file_tree = parser.iterate(json);
     descend(file_tree);
   }
```


Fixes: https://github.com/simdjson/simdjson/issues/1521