### PR TITLE
Preparing a patch release (0.9.2) for issue 1521 [NOT FOR MERGER]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ project(simdjson
 
 set(PROJECT_VERSION_MAJOR 0)
 set(PROJECT_VERSION_MINOR 9)
-set(PROJECT_VERSION_PATCH 1)
-set(SIMDJSON_SEMANTIC_VERSION "0.9.1" CACHE STRING "simdjson semantic version")
+set(PROJECT_VERSION_PATCH 2)
+set(SIMDJSON_SEMANTIC_VERSION "0.9.2" CACHE STRING "simdjson semantic version")
 set(SIMDJSON_LIB_VERSION "8.0.0" CACHE STRING "simdjson library version")
 set(SIMDJSON_LIB_SOVERSION "8" CACHE STRING "simdjson library soversion")
 set(SIMDJSON_GITHUB_REPOSITORY https://github.com/simdjson/simdjson)

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = simdjson
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = "0.9.1"
+PROJECT_NUMBER         = "0.9.2"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -144,7 +144,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   bool has_value;
   // We want to be able to loop back to where we were.
   token_position search_start = _json_iter->position();
-  
+
   //
   // Initially, the object can be in one of a few different places:
   //

--- a/include/simdjson/simdjson_version.h
+++ b/include/simdjson/simdjson_version.h
@@ -4,7 +4,7 @@
 #define SIMDJSON_SIMDJSON_VERSION_H
 
 /** The version of simdjson being used (major.minor.revision) */
-#define SIMDJSON_VERSION 0.9.1
+#define SIMDJSON_VERSION 0.9.2
 
 namespace simdjson {
 enum {
@@ -19,7 +19,7 @@ enum {
   /**
    * The revision (major.minor.REVISION) of simdjson being used.
    */
-  SIMDJSON_VERSION_REVISION = 1
+  SIMDJSON_VERSION_REVISION = 2
 };
 } // namespace simdjson
 

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2021-03-18 11:30:40 -0400. Do not edit! */
+/* auto-generated on 2021-03-18 11:31:38 -0400. Do not edit! */
 /* begin file src/simdjson.cpp */
 #include "simdjson.h"
 

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -22093,7 +22093,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   bool has_value;
   // We want to be able to loop back to where we were.
   token_position search_start = _json_iter->position();
-  
+
   //
   // Initially, the object can be in one of a few different places:
   //


### PR DESCRIPTION
This is not for merging into master, this a pre-release PR to run CI and to get feedback from @jkeiser.

The short story is that in some cases, when using the on demand front-end, when seeking a missing key in unordered mode in an object (i.e., `find_field_unordered` or `operator[]`), the JSON iterator would be left in a bad state. That is, whereas the JSON iterator would be initially pointing at the `,`, it would leave the function pointing at the next structural element (`"`) and this would  mess up the rest of the logic of the code.

This is rather bad and so we should patch 0.9.x. This would create version 0.9.2.

https://github.com/simdjson/simdjson/issues/1521
