### PR TITLE
Reduction of the missing-key bug.

### DIFF
--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -6,6 +6,30 @@ using namespace simdjson;
 namespace object_tests {
   using namespace std;
   using simdjson::ondemand::json_type;
+  // In this test, no non-trivial object in an array have a missing key
+  bool no_missing_keys() {
+    TEST_START();
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string docdata =  R"([{"a":"a"},{}])"_padded;
+    simdjson::ondemand::document doc;
+    auto error = parser.iterate(docdata).get(doc);
+    if(error != simdjson::SUCCESS) { return false; }
+    simdjson::ondemand::array a;
+    error = doc.get_array().get(a);
+    if(error != simdjson::SUCCESS) { return false; }
+    size_t counter{0};
+    for(auto elem : a) {
+      error = elem.find_field_unordered("a").error();
+      if(counter == 0) {
+        ASSERT_EQUAL( error, simdjson::SUCCESS);
+      } else {
+        ASSERT_EQUAL( error, simdjson::NO_SUCH_FIELD);
+      }
+      counter++;
+    }
+    return true;
+  }
+
 
   bool missing_keys() {
     TEST_START();
@@ -26,6 +50,77 @@ namespace object_tests {
     }
     return true;
   }
+
+#if SIMDJSON_EXCEPTIONS
+  // used in issue_1521
+  // difficult to use as a lambda because it is recursive.
+  void broken_descend(ondemand::object node) {
+    if(auto type = node.find_field_unordered("type"); type.error() == SUCCESS && type == "child") {
+      auto n = node.find_field_unordered("name");
+      if(n.error() == simdjson::SUCCESS) {
+          std::cout << std::string_view(n) << std::endl;
+      }
+    } else {
+     for (ondemand::object child_node : node["nodes"]) { broken_descend(child_node); }
+    }
+  }
+
+  bool broken_issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    padded_string json = R"({"type":"root","nodes":[{"type":"child","nodes":[]},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      broken_descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+
+  bool fixed_broken_issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    // We omit the ',"nodes":[]'
+    padded_string json = R"({"type":"root","nodes":[{"type":"child"},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      broken_descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+
+  // used in issue_1521
+  // difficult to use as a lambda because it is recursive.
+  void descend(ondemand::object node) {
+    auto n = node.find_field_unordered("name");
+    if(auto type = node.find_field_unordered("type"); type.error() == SUCCESS && type == "child") {
+      if(n.error() == simdjson::SUCCESS) {
+          std::cout << std::string_view(n) << std::endl;
+      }
+    } else {
+     for (ondemand::object child_node : node["nodes"]) { descend(child_node); }
+    }
+  }
+
+  bool issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    padded_string json = R"({"type":"root","nodes":[{"type":"child","nodes":[]},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+#endif
 
   bool iterate_object() {
     TEST_START();
@@ -913,7 +1008,13 @@ namespace object_tests {
 
   bool run() {
     return
+           no_missing_keys() &&
            missing_keys() &&
+#if SIMDJSON_EXCEPTIONS
+           fixed_broken_issue_1521() &&
+           issue_1521() &&
+           broken_issue_1521() &&
+#endif
            iterate_object() &&
            iterate_empty_object() &&
            object_index() &&

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -7,6 +7,26 @@ namespace object_tests {
   using namespace std;
   using simdjson::ondemand::json_type;
 
+  bool missing_keys() {
+    TEST_START();
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string docdata =  R"([{"a":"a"},{}])"_padded;
+    simdjson::ondemand::document doc;
+    auto error = parser.iterate(docdata).get(doc);
+    if(error != simdjson::SUCCESS) { return false; }
+    simdjson::ondemand::array a;
+    error = doc.get_array().get(a);
+    if(error != simdjson::SUCCESS) { return false; }
+    for(auto elem : a) {
+      error = elem.find_field_unordered("keynotfound").error();
+      if(error != simdjson::NO_SUCH_FIELD) {
+        std::cout << error << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+
   bool iterate_object() {
     TEST_START();
     auto json = R"({ "a": 1, "b": 2, "c": 3 })"_padded;
@@ -893,6 +913,7 @@ namespace object_tests {
 
   bool run() {
     return
+           missing_keys() &&
            iterate_object() &&
            iterate_empty_object() &&
            object_index() &&


### PR DESCRIPTION
This is a reduction of bug https://github.com/simdjson/simdjson/issues/1521

Take the following JSON:

```JSON
[{"a":"a"},{}]
```

The following should return true....

```C++
   auto error = parser.iterate(docdata).get(doc);
    if(error != simdjson::SUCCESS) { return false; }
    simdjson::ondemand::array a;
    error = doc.get_array().get(a);
    if(error != simdjson::SUCCESS) { return false; }
    for(auto elem : a) {
      error = elem.find_field_unordered("keynotfound").error();
      if(error != simdjson::NO_SUCH_FIELD) {
        std::cout << error << std::endl;
        return false;
      }
    }
    return true;
```

It does not. It exits with a TAPE_ERROR.

Here is the log of the issue...


```
| Event                | Buffer                         | Next       | Depth | Detail |
|----------------------|--------------------------------|------------|-------|--------|
|   +document          | [{"a":"a"},{}]                 | [{"a":"a"} |     1 |  |
|   +array             | [{"a":"a"},{}]                 | {"a":"a"}, |     1 |  |
|   +array             | [{"a":"a"},{}]                 | {"a":"a"}, |     1 |  |
|     +object          | {"a":"a"},{}]                  | "a":"a"},{ |     2 |  |
|     +object          | {"a":"a"},{}]                  | "a":"a"},{ |     2 |  |
|       no match       | "a":"a"},{}]                   | :"a"},{}]  |     3 | keynotfound |
|       skip           | "a"},{}]                       | },{}]      |     3 |  |
|     -object          | },{}]                          | ,{}]       |     2 |  |
|     +object          | {"a":"a"},{}]                  | "a":"a"},{ |     2 |  |
|     skip             | "a":"a"},{}]                   | :"a"},{}]  |     2 |  |
|   ERROR: Missing comma between array elements | :"a"},{}]                      | "a"},{}]   |     1 |  |
The JSON document has an improper structure: missing or superfluous commas, braces, missing keys, etc.
FAILED.
```

To understand what is going on ... Consider this JSON: `[{"a":"a"},{}]`. Suppose that I am in this state at end of or within find_field_unordered_raw.
```
|     final            | {"a":"a"},{}]                  | "a":"a"},{ |     2 |  |
```

That state does not look insane. You are pointing at the object and it is at a depth 2. Ok. Good. And then you call `skip_child` at depth 2 aiming for depth 1. So far so good. What it does currently is advance the pointer by one, accessing the quote in "a". Then it goes to a code section with the following comment "For the first scalar, we will have incremented the depth already". It reduces the depth by one and then exit. The depth was clearly not incremented... the function itself just advanced the pointer. This leaves you at this stage...

`|   has_next_element   | "a":"a"},{}]                   | :"a"},{}]  |     1 |  |`

And then you are dead.

There are other issues.
