### PR TITLE
My third attempt at fixing issue 1521 (not being merged due to performance concerns)

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -252,11 +252,19 @@ namespace std {
 #endif
 
 #if SIMDJSON_CPLUSPLUS17
+// if we have C++, then fallthrough is a default attribute
 # define simdjson_fallthrough [[fallthrough]]
-#elif __has_attribute(__fallthrough__)
+// check if we have __attribute__ support
+#elif defined(__has_attribute)
+// check if we have the __fallthrough__ attribute
+#if __has_attribute(__fallthrough__)
+// we are good to go:
 # define simdjson_fallthrough                    __attribute__((__fallthrough__))
-#else
-# define simdjson_fallthrough                    do {} while (0)  /* fallthrough */
+#endif
+#endif
+// on some systems, we simply do not have support for fallthrough, so use a default:
+#ifndef simdjson_fallthrough
+# define simdjson_fallthrough do {} while (0)  /* fallthrough */
 #endif
 
 #endif // SIMDJSON_COMMON_DEFS_H

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -252,11 +252,11 @@ namespace std {
 #endif
 
 #if SIMDJSON_CPLUSPLUS17
-# define simdjson_fallthrough [[fallthrough]];
+# define simdjson_fallthrough [[fallthrough]]
 #elif __has_attribute(__fallthrough__)
 # define simdjson_fallthrough                    __attribute__((__fallthrough__))
 #else
-# define simdjson_fallthrough                    do {} while (0);  /* fallthrough */
+# define simdjson_fallthrough                    do {} while (0)  /* fallthrough */
 #endif
 
 #endif // SIMDJSON_COMMON_DEFS_H

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -251,4 +251,12 @@ namespace std {
 #endif
 #endif
 
+#if SIMDJSON_CPLUSPLUS17
+# define simdjson_fallthrough [[fallthrough]];
+#elif __has_attribute(__fallthrough__)
+# define simdjson_fallthrough                    __attribute__((__fallthrough__))
+#else
+# define simdjson_fallthrough                    do {} while (0);  /* fallthrough */
+#endif
+
 #endif // SIMDJSON_COMMON_DEFS_H

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -67,7 +67,7 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
         advance(); // eat up the ':'
         break; // important!!!
       }
-      simdjson_fallthrough
+      simdjson_fallthrough;
     // Anything else must be a scalar value
     default:
       // For the first scalar, we will have incremented depth already, so we decrement it here.

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -60,10 +60,15 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
       break;
     // Anything else must be a scalar value
     default:
-      // For the first scalar, we will have incremented depth already, so we decrement it here.
-      logger::log_value(*this, "skip");
-      _depth--;
-      if (depth() <= parent_depth) { return SUCCESS; }
+      if(*peek() == ':') {
+        // we are at a key!!!
+        logger::log_value(*this, "key");
+      } else {
+        // For the first scalar, we will have incremented depth already, so we decrement it here.
+        logger::log_value(*this, "skip");
+        _depth--;
+        if (depth() <= parent_depth) { return SUCCESS; }
+      }
       break;
   }
 

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -67,21 +67,7 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
         advance(); // eat up the ':'
         break; // important!!!
       }
-      // Because maniacs want to do crazy pedantic static analysis, we get the following
-      // error if we stop there...
-      // error: this statement may fall through [-Werror=implicit-fallthrough=]
-      //
-      // So we have to patch it up with the following ugly bit:
-#if SIMDJSON_CPLUSPLUS17
-      [[fallthrough]];
-#else
-      // copy-pase of default:
-      logger::log_value(*this, "skip");
-      _depth--;
-      if (depth() <= parent_depth) { return SUCCESS; }
-      break;
-      // End of ugly bit.
-#endif
+      simdjson_fallthrough
     // Anything else must be a scalar value
     default:
       // For the first scalar, we will have incremented depth already, so we decrement it here.

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -62,11 +62,26 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
       if(*peek() == ':') {
         // we are at a key!!! This is
         // only possible if someone searched
-        // for a key and the  key was not found.
+        // for a key and the key was not found.
         logger::log_value(*this, "key");
         advance(); // eat up the ':'
         break; // important!!!
       }
+      // Because maniacs want to do crazy pedantic static analysis, we get the following
+      // error if we stop there...
+      // error: this statement may fall through [-Werror=implicit-fallthrough=]
+      //
+      // So we have to patch it up with the following ugly bit:
+#if SIMDJSON_CPLUSPLUS17
+      [[fallthrough]];
+#else
+      // copy-pase of default:
+      logger::log_value(*this, "skip");
+      _depth--;
+      if (depth() <= parent_depth) { return SUCCESS; }
+      break;
+      // End of ugly bit.
+#endif
     // Anything else must be a scalar value
     default:
       // For the first scalar, we will have incremented depth already, so we decrement it here.

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -58,17 +58,21 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
       _depth--;
       if (depth() <= parent_depth) { return SUCCESS; }
       break;
+    case '"':
+      if(*peek() == ':') {
+        // we are at a key!!! This is
+        // only possible if someone searched
+        // for a key and the  key was not found.
+        logger::log_value(*this, "key");
+        advance(); // eat up the ':'
+        break; // important!!!
+      }
     // Anything else must be a scalar value
     default:
-      if(*peek() == ':') {
-        // we are at a key!!!
-        logger::log_value(*this, "key");
-      } else {
-        // For the first scalar, we will have incremented depth already, so we decrement it here.
-        logger::log_value(*this, "skip");
-        _depth--;
-        if (depth() <= parent_depth) { return SUCCESS; }
-      }
+      // For the first scalar, we will have incremented depth already, so we decrement it here.
+      logger::log_value(*this, "skip");
+      _depth--;
+      if (depth() <= parent_depth) { return SUCCESS; }
       break;
   }
 

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -6,6 +6,30 @@ using namespace simdjson;
 namespace object_tests {
   using namespace std;
   using simdjson::ondemand::json_type;
+  // In this test, no non-trivial object in an array have a missing key
+  bool no_missing_keys() {
+    TEST_START();
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string docdata =  R"([{"a":"a"},{}])"_padded;
+    simdjson::ondemand::document doc;
+    auto error = parser.iterate(docdata).get(doc);
+    if(error != simdjson::SUCCESS) { return false; }
+    simdjson::ondemand::array a;
+    error = doc.get_array().get(a);
+    if(error != simdjson::SUCCESS) { return false; }
+    size_t counter{0};
+    for(auto elem : a) {
+      error = elem.find_field_unordered("a").error();
+      if(counter == 0) {
+        ASSERT_EQUAL( error, simdjson::SUCCESS);
+      } else {
+        ASSERT_EQUAL( error, simdjson::NO_SUCH_FIELD);
+      }
+      counter++;
+    }
+    return true;
+  }
+
 
   bool missing_keys() {
     TEST_START();
@@ -26,6 +50,77 @@ namespace object_tests {
     }
     return true;
   }
+
+#if SIMDJSON_EXCEPTIONS
+  // used in issue_1521
+  // difficult to use as a lambda because it is recursive.
+  void broken_descend(ondemand::object node) {
+    if(auto type = node.find_field_unordered("type"); type.error() == SUCCESS && type == "child") {
+      auto n = node.find_field_unordered("name");
+      if(n.error() == simdjson::SUCCESS) {
+          std::cout << std::string_view(n) << std::endl;
+      }
+    } else {
+     for (ondemand::object child_node : node["nodes"]) { broken_descend(child_node); }
+    }
+  }
+
+  bool broken_issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    padded_string json = R"({"type":"root","nodes":[{"type":"child","nodes":[]},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      broken_descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+
+  bool fixed_broken_issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    // We omit the ',"nodes":[]'
+    padded_string json = R"({"type":"root","nodes":[{"type":"child"},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      broken_descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+
+  // used in issue_1521
+  // difficult to use as a lambda because it is recursive.
+  void descend(ondemand::object node) {
+    auto n = node.find_field_unordered("name");
+    if(auto type = node.find_field_unordered("type"); type.error() == SUCCESS && type == "child") {
+      if(n.error() == simdjson::SUCCESS) {
+          std::cout << std::string_view(n) << std::endl;
+      }
+    } else {
+     for (ondemand::object child_node : node["nodes"]) { descend(child_node); }
+    }
+  }
+
+  bool issue_1521() {
+    TEST_START();
+    ondemand::parser parser;
+    padded_string json = R"({"type":"root","nodes":[{"type":"child","nodes":[]},{"type":"child","name":"child-name","nodes":[]}]})"_padded;
+    ondemand::document file_tree = parser.iterate(json);
+    try {
+      descend(file_tree);
+    } catch(simdjson::simdjson_error& e) {
+      std::cout << "The document is valid JSON: " << json << std::endl;
+      TEST_FAIL(e.error());
+    }
+    TEST_SUCCEED();
+  }
+#endif
 
   bool iterate_object() {
     TEST_START();
@@ -913,7 +1008,13 @@ namespace object_tests {
 
   bool run() {
     return
+           no_missing_keys() &&
            missing_keys() &&
+#if SIMDJSON_EXCEPTIONS
+           fixed_broken_issue_1521() &&
+           issue_1521() &&
+           broken_issue_1521() &&
+#endif
            iterate_object() &&
            iterate_empty_object() &&
            object_index() &&

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -7,6 +7,26 @@ namespace object_tests {
   using namespace std;
   using simdjson::ondemand::json_type;
 
+  bool missing_keys() {
+    TEST_START();
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string docdata =  R"([{"a":"a"},{}])"_padded;
+    simdjson::ondemand::document doc;
+    auto error = parser.iterate(docdata).get(doc);
+    if(error != simdjson::SUCCESS) { return false; }
+    simdjson::ondemand::array a;
+    error = doc.get_array().get(a);
+    if(error != simdjson::SUCCESS) { return false; }
+    for(auto elem : a) {
+      error = elem.find_field_unordered("keynotfound").error();
+      if(error != simdjson::NO_SUCH_FIELD) {
+        std::cout << error << std::endl;
+        return false;
+      }
+    }
+    return true;
+  }
+
   bool iterate_object() {
     TEST_START();
     auto json = R"({ "a": 1, "b": 2, "c": 3 })"_padded;
@@ -893,6 +913,7 @@ namespace object_tests {
 
   bool run() {
     return
+           missing_keys() &&
            iterate_object() &&
            iterate_empty_object() &&
            object_index() &&


### PR DESCRIPTION
The core issue seems to be with skip_child. The skip_child function makes some assumption regarding the state you are in. In particular, it seems that you cannot be right before a key so that the first step of skip_child is to bring you to a key. That's never a problem when the key you are searching for is found. When the key you are searching found is not found, then it is possible that you may end up just before a key.

By convention, keys are at the level of the object, so the code in the main branch and in the 0.9.x is wrong in such cases because skip_child will encounter a key, it will decrement the depth and conclude that it is back in the parent. This is bad.

This is not the nicest fix in the world and it may have small negative impact on performance but I am preoccupied by patching 0.9.x as soon as possible.

A better solution might be to ensure that when a key is not found, we are never right before a key. I had implemented that (it is not hard), but it is more invasive. This patch here is very small.

Fixes  https://github.com/simdjson/simdjson/issues/1521
