### PR TITLE
Document stream: truncate final unfinished document and give access to the number of truncated bytes.

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -331,7 +331,7 @@ struct benchmarker {
 
     // Stage 1 (find structurals)
     collector.start();
-    error = parser.implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.size(), false);
+    error = parser.implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.size(), stage1_mode::regular);
     event_count stage1_count = collector.end();
     stage1 << stage1_count;
     if (error) {

--- a/benchmark/statisticalmodel.cpp
+++ b/benchmark/statisticalmodel.cpp
@@ -183,7 +183,7 @@ int main(int argc, char *argv[]) {
   for (uint32_t i = 0; i < iterations; i++) {
     unified.start();
     // The default template is simdjson::architecture::NATIVE.
-    bool isok = (parser.implementation->stage1((const uint8_t *)p.data(), p.size(), false) == simdjson::SUCCESS);
+    bool isok = (parser.implementation->stage1((const uint8_t *)p.data(), p.size(), simdjson::stage1_mode::regular) == simdjson::SUCCESS);
     unified.end(results);
 
     cy1 += results[0];

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -207,5 +207,11 @@ Incomplete streams
 
 Some users may need to work with truncated streams while tracking their location in the stream.
 The same code, with the `current_index()` will work. These users need to be aware that the last
-document parsed may be in error if it is truncated. These users are responsible for handling the
-last truncated document.
+document parsed may be in error if it is truncated.
+
+If the input ends with an unclosed string, the unclosed string is virtually removed. Its content
+is not checked.
+
+You can query `i.current_index()` after looping through the documents to see where
+the parsing ended: it should point just beyond the last document. If there was an unclosed string,
+the processing terminates before the unclosed string.

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -168,6 +168,7 @@ Tracking your position
 Some users would like to know where the document they parsed is in the input array of bytes.
 It is possible to do so by accessing directly the iterator and calling its `current_index()`
 method which reports the location (in bytes) of the current document in the input stream.
+You may also call the `source()` method to get a `std::string_view` instance on the document.
 
 Let us illustrate the idea with code:
 
@@ -182,6 +183,11 @@ Let us illustrate the idea with code:
         auto doc = *i;
         if(!doc.error()) {
           std::cout << "got full document at " << i.current_index() << std::endl;
+          std::cout << i.source() << std::endl;
+          count++;
+        } else {
+          std::cout << "got broken document at " << i.current_index() << std::endl;
+          return false;
         }
     }
     size_t index = i.current_index();
@@ -195,8 +201,11 @@ Let us illustrate the idea with code:
 This code will print:
 ```
 got full document at 0
+[1,2,3]
 got full document at 9
+{"1":1,"2":3,"4":4}
 got full document at 29
+[1,2,3]
 ```
 
 The last call to `i.current_index()` return the byte index 38, which is just beyond
@@ -207,11 +216,5 @@ Incomplete streams
 
 Some users may need to work with truncated streams while tracking their location in the stream.
 The same code, with the `current_index()` will work. These users need to be aware that the last
-document parsed may be in error if it is truncated.
-
-If the input ends with an unclosed string, the unclosed string is virtually removed. Its content
-is not checked.
-
-You can query `i.current_index()` after looping through the documents to see where
-the parsing ended: it should point just beyond the last document. If there was an unclosed string,
-the processing terminates before the unclosed string.
+document parsed may be in error if it is truncated. They may use the `source()` method to
+determine which content was parsed.

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -217,4 +217,5 @@ Incomplete streams
 Some users may need to work with truncated streams while tracking their location in the stream.
 The same code, with the `current_index()` will work. These users need to be aware that the last
 document parsed may be in error if it is truncated. They may use the `source()` method to
-determine which content was parsed.
+determine which content was parsed. In some instances, a truncated final document may be detected
+as a document in error.

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -206,12 +206,6 @@ Incomplete streams
 -----------
 
 Some users may need to work with truncated streams while tracking their location in the stream.
-The same code, with the `current_index()` will work. However, the last block (by default 1MB)
-terminates with an unclosed string, then no JSON document within this last block will validate.
-In particular, it means that if your input string is `[1,2,3]  {"1":1,"2":3,"4":4} [1,2` then
-no JSON document will be successfully parsed. The error `simdjson::UNCLOSED_STRING` will be
-given (even with the first JSON document). It is then your responsability to terminate the input
-maybe by appending the missing data at the end of the truncated string, or by copying the truncated
-data before the continuing input.
-
-
+The same code, with the `current_index()` will work. These users need to be aware that the last
+document parsed may be in error if it is truncated. These users are responsible for handling the
+last truncated document.

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -213,8 +213,15 @@ simdjson_really_inline size_t document_stream::iterator::current_index() const n
 }
 
 simdjson_really_inline std::string_view document_stream::iterator::source() const noexcept {
-  size_t next_doc_index = stream->batch_start + stream->parser->implementation->structural_indexes[stream->parser->implementation->next_structural_index];
-  return std::string_view(reinterpret_cast<const char*>(stream->buf) + current_index(), next_doc_index - current_index() - 1);
+  const char* start = reinterpret_cast<const char*>(stream->buf) + current_index();
+  bool object_or_array = ((*start == '[') || (*start == '{'));
+  if(object_or_array) {
+    size_t next_doc_index = stream->batch_start + stream->parser->implementation->structural_indexes[stream->parser->implementation->next_structural_index - 1];
+    return std::string_view(start, next_doc_index - current_index() + 1);
+  } else {
+    size_t next_doc_index = stream->batch_start + stream->parser->implementation->structural_indexes[stream->parser->implementation->next_structural_index];
+    return std::string_view(reinterpret_cast<const char*>(stream->buf) + current_index(), next_doc_index - current_index() - 1);
+  }
 }
 
 

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -251,12 +251,11 @@ inline size_t document_stream::next_batch_start() const noexcept {
 }
 
 inline error_code document_stream::run_stage1(dom::parser &p, size_t _batch_start) noexcept {
-  // If this is the final batch, pass partial = false
   size_t remaining = len - _batch_start;
   if (remaining <= batch_size) {
-    return p.implementation->stage1(&buf[_batch_start], remaining, false);
+    return p.implementation->stage1(&buf[_batch_start], remaining, stage1_mode::streaming_final);
   } else {
-    return p.implementation->stage1(&buf[_batch_start], batch_size, true);
+    return p.implementation->stage1(&buf[_batch_start], batch_size, stage1_mode::streaming_partial);
   }
 }
 

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -252,6 +252,13 @@ inline void document_stream::next() noexcept {
     error = parser->implementation->stage2_next(parser->doc);
   }
 }
+inline size_t document_stream::size_in_bytes() const noexcept {
+  return len;
+}
+
+inline size_t document_stream::truncated_bytes() const noexcept {
+  return parser->implementation->structural_indexes[parser->implementation->n_structural_indexes] - parser->implementation->structural_indexes[parser->implementation->n_structural_indexes + 1];
+}
 
 inline size_t document_stream::next_batch_start() const noexcept {
   return batch_start + parser->implementation->structural_indexes[parser->implementation->n_structural_indexes];

--- a/include/simdjson/dom/document_stream.h
+++ b/include/simdjson/dom/document_stream.h
@@ -245,7 +245,6 @@ private:
   error_code error;
   size_t batch_start{0};
   size_t doc_index{};
-
 #ifdef SIMDJSON_THREADS_ENABLED
   /** Indicates whether we use threads. Note that this needs to be a constant during the execution of the parsing. */
   bool use_thread;

--- a/include/simdjson/dom/document_stream.h
+++ b/include/simdjson/dom/document_stream.h
@@ -87,7 +87,29 @@ public:
   simdjson_really_inline document_stream &operator=(document_stream &&other) noexcept = default;
 
   simdjson_really_inline ~document_stream() noexcept;
-
+  /**
+   * Returns the input size in bytes.
+   */
+  inline size_t size_in_bytes() const noexcept;
+  /**
+   * After iterating through the stream, this method
+   * returns the number of bytes that were not parsed at the end
+   * of the stream. If truncated_bytes() differs from zero,
+   * then the input was truncated maybe because incomplete JSON
+   * documents were found at the end of the stream. You
+   * may need to process the bytes in the interval [size_in_bytes()-truncated_bytes(), size_in_bytes()).
+   *
+   * You should only call truncated_bytes() after streaming through all
+   * documents, like so:
+   *
+   *   document_stream stream = parser.parse_many(json,window);
+   *   for(auto doc : stream) {
+   *      // do something with doc
+   *   }
+   *   size_t truncated = stream.truncated_bytes();
+   *
+   */
+  inline size_t truncated_bytes() const noexcept;
   /**
    * An iterator through a forward-only stream of documents.
    */

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -32,7 +32,7 @@ public:
   dom_parser_implementation &operator=(const dom_parser_implementation &) = delete;
 
   simdjson_warn_unused error_code parse(const uint8_t *buf, size_t len, dom::document &doc) noexcept final;
-  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, bool partial) noexcept final;
+  simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, stage1_mode partial) noexcept final;
   simdjson_warn_unused error_code stage2(dom::document &doc) noexcept final;
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -32,7 +32,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::it
   }
 
   // Run stage 1.
-  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), false) );
+  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), stage1_mode::regular) );
   return document::start({ reinterpret_cast<const uint8_t *>(json.data()), this });
 }
 
@@ -75,7 +75,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<json_iterator> parse
   }
 
   // Run stage 1.
-  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), false) );
+  SIMDJSON_TRY( implementation->stage1(reinterpret_cast<const uint8_t *>(json.data()), json.length(), stage1_mode::regular) );
   return json_iterator(reinterpret_cast<const uint8_t *>(json.data()), this);
 }
 

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -25,7 +25,10 @@ enum class stage1_mode { regular, streaming_partial, streaming_final};
  * Returns true if mode == streaming_partial or mode == streaming_final
  */
 inline bool is_streaming(stage1_mode mode) {
-  return (mode == stage1_mode::streaming_partial || mode == stage1_mode::streaming_final);
+  // performance note: it is probably faster to check that mode is different
+  // from regular than checking that it is either streaming_partial or streaming_final.
+  return (mode != stage1_mode::regular);
+  // return (mode == stage1_mode::streaming_partial || mode == stage1_mode::streaming_final);
 }
 
 

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -11,7 +11,26 @@ namespace dom {
 class document;
 } // namespace dom
 
+/**
+* This enum is used with the dom_parser_implementation::stage1 function.
+* 1) The regular mode expects a fully formed JSON document.
+* 2) The streaming_partial mode expects a possibly truncated
+* input within a stream on JSON documents.
+* 3) The stream_final mode allows us to truncate final
+* unterminated strings. It is useful in conjunction with streaming_partial.
+*/
+enum class stage1_mode { regular, streaming_partial, streaming_final};
+
+/**
+ * Returns true if mode == streaming_partial or mode == streaming_final
+ */
+inline bool is_streaming(stage1_mode mode) {
+  return (mode == stage1_mode::streaming_partial || mode == stage1_mode::streaming_final);
+}
+
+
 namespace internal {
+
 
 /**
  * An implementation of simdjson's DOM parser for a particular CPU architecture.
@@ -51,7 +70,7 @@ public:
    * @param streaming Whether this is being called by parser::parse_many.
    * @return The error code, or SUCCESS if there was no error.
    */
-  simdjson_warn_unused virtual error_code stage1(const uint8_t *buf, size_t len, bool streaming) noexcept = 0;
+  simdjson_warn_unused virtual error_code stage1(const uint8_t *buf, size_t len, stage1_mode streaming) noexcept = 0;
 
   /**
    * @private For internal implementation use

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -152,7 +152,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -133,7 +133,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return arm64::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return arm64::stage1::json_structural_indexer::index<64>(buf, len, *this, streaming);

--- a/src/generic/stage1/find_next_document_index.h
+++ b/src/generic/stage1/find_next_document_index.h
@@ -29,6 +29,7 @@ namespace {
   */
 simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
   // TODO don't count separately, just figure out depth
+  if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;
   auto obj_cnt = 0;
   for (auto i = parser.n_structural_indexes - 1; i > 0; i--) {

--- a/src/generic/stage1/find_next_document_index.h
+++ b/src/generic/stage1/find_next_document_index.h
@@ -13,8 +13,8 @@ namespace {
   *
   * Simply put, we iterate over the structural characters, starting from
   * the end. We consider that we found the end of a JSON document when the
-  * first element of the pair is NOT one of these characters: '{' '[' ';' ','
-  * and when the second element is NOT one of these characters: '}' '}' ';' ','.
+  * first element of the pair is NOT one of these characters: '{' '[' ':' ','
+  * and when the second element is NOT one of these characters: '}' ']' ':' ','.
   *
   * This simple comparison works most of the time, but it does not cover cases
   * where the batch's structural indexes contain a perfect amount of documents.
@@ -28,7 +28,7 @@ namespace {
   * batch.
   */
 simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
-  // TODO don't count separately, just figure out depth
+  // Variant: do not count separately, just figure out depth
   if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;
   auto obj_cnt = 0;
@@ -65,6 +65,25 @@ simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementati
     }
     // Last document is incomplete; mark the document at i + 1 as the next one
     return i;
+  }
+  // If we made it to the end, we want to finish counting to see if we have a full document.
+  switch (parser.buf[parser.structural_indexes[0]]) {
+    case '}':
+      obj_cnt--;
+      break;
+    case ']':
+      arr_cnt--;
+      break;
+    case '{':
+      obj_cnt++;
+      break;
+    case '[':
+      arr_cnt++;
+      break;
+  }
+  if (!arr_cnt && !obj_cnt) {
+    // We have a complete document.
+    return parser.n_structural_indexes;
   }
   return 0;
 }

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -74,14 +74,14 @@ public:
    *   you are processing substrings, you may want to call on a function like trimmed_length_safe_utf8.
    */
   template<size_t STEP_SIZE>
-  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept;
+  static error_code index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept;
 
 private:
   simdjson_really_inline json_structural_indexer(uint32_t *structural_indexes);
   template<size_t STEP_SIZE>
   simdjson_really_inline void step(const uint8_t *block, buf_block_reader<STEP_SIZE> &reader) noexcept;
   simdjson_really_inline void next(const simd::simd8x64<uint8_t>& in, const json_block& block, size_t idx);
-  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial);
+  simdjson_really_inline error_code finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial);
 
   json_scanner scanner{};
   utf8_checker checker{};
@@ -131,9 +131,9 @@ simdjson_really_inline size_t trim_partial_utf8(const uint8_t *buf, size_t len) 
 // workout.
 //
 template<size_t STEP_SIZE>
-error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, bool partial) noexcept {
+error_code json_structural_indexer::index(const uint8_t *buf, size_t len, dom_parser_implementation &parser, stage1_mode partial) noexcept {
   if (simdjson_unlikely(len > parser.capacity())) { return CAPACITY; }
-  if (partial) { len = trim_partial_utf8(buf, len); }
+  if (is_streaming(partial)) { len = trim_partial_utf8(buf, len); }
 
   buf_block_reader<STEP_SIZE> reader(buf, len);
   json_structural_indexer indexer(parser.structural_indexes.get());
@@ -178,14 +178,14 @@ simdjson_really_inline void json_structural_indexer::next(const simd::simd8x64<u
   unescaped_chars_error |= block.non_quote_inside_string(unescaped);
 }
 
-simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, bool partial) {
+simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_implementation &parser, size_t idx, size_t len, stage1_mode partial) {
   // Write out the final iteration's structurals
   indexer.write(uint32_t(idx-64), prev_structurals);
 
   error_code error = scanner.finish();
   // We deliberately break down the next expression so that it is
   // human readable.
-  const bool should_we_exit =  partial ?
+  const bool should_we_exit = is_streaming(partial) ?
     ((error != SUCCESS) && (error != UNCLOSED_STRING)) // when partial we tolerate UNCLOSED_STRING
     : (error != SUCCESS); // if partial is false, we must have SUCCESS
   const bool have_unclosed_string = (error == UNCLOSED_STRING);
@@ -194,7 +194,6 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (unescaped_chars_error) {
     return UNESCAPED_CHARS;
   }
-
   parser.n_structural_indexes = uint32_t(indexer.tail - parser.structural_indexes.get());
   /***
    * This is related to https://github.com/simdjson/simdjson/issues/906
@@ -221,7 +220,7 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
   if (simdjson_unlikely(parser.structural_indexes[parser.n_structural_indexes - 1] > len)) {
     return UNEXPECTED_ERROR;
   }
-  if (partial) {
+  if (partial == stage1_mode::streaming_partial) {
     // If we have an unclosed string, then the last structural
     // will be the quote and we want to make sure to omit it.
     if(have_unclosed_string) {
@@ -234,6 +233,16 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
       return CAPACITY; // If the buffer is partial but the document is incomplete, it's too big to parse.
     }
     parser.n_structural_indexes = new_structural_indexes;
+  } else if (partial == stage1_mode::streaming_final) {
+     if(have_unclosed_string) {
+      parser.n_structural_indexes--;
+      if (simdjson_unlikely(parser.n_structural_indexes == 0u)) {
+        // We tolerate an unclosed string at the very end of the stream. Indeed, users
+        // often load their data in bulk without being careful and they want us to ignore
+        // the trailing garbage.
+        return EMPTY;
+      }
+     }
   }
   checker.check_eof();
   return checker.errors();

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -214,7 +214,7 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
    * This is illustrated with the test array_iterate_unclosed_error() on the following input:
    * R"({ "a": [,,)"
    **/
-  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
+  parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len); // used later in partial == stage1_mode::streaming_final
   parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 2] = 0;
   parser.next_structural_index = 0;
@@ -252,6 +252,11 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
     // document_stream instances allow people to know the JSON documents they are
     // parsing (see the iterator.source() method).
     parser.n_structural_indexes = find_next_document_index(parser);
+    // We store the initial n_structural_indexes so that the client can see
+    // whether we used truncation. If initial_n_structural_indexes == parser.n_structural_indexes,
+    // then this will query parser.structural_indexes[parser.n_structural_indexes] which is len,
+    // otherwise, it will copy some prior index.
+    parser.structural_indexes[parser.n_structural_indexes + 1] = parser.structural_indexes[parser.n_structural_indexes];
     // This next line is critical, do not change it unless you understand what you are
     // doing.
     parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -211,7 +211,8 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
    * starts with [, it should end with ]. If we enforce that rule, then we would get
    * ][[ which is invalid.
    *
-   *
+   * This is illustrated with the test array_iterate_unclosed_error() on the following input:
+   * R"({ "a": [,,)"
    **/
   parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
   parser.structural_indexes[parser.n_structural_indexes + 1] = uint32_t(len);

--- a/src/generic/stage1/json_structural_indexer.h
+++ b/src/generic/stage1/json_structural_indexer.h
@@ -234,15 +234,19 @@ simdjson_really_inline error_code json_structural_indexer::finish(dom_parser_imp
     }
     parser.n_structural_indexes = new_structural_indexes;
   } else if (partial == stage1_mode::streaming_final) {
-     if(have_unclosed_string) {
+    if(have_unclosed_string) {
       parser.n_structural_indexes--;
+      parser.n_structural_indexes = find_next_document_index(parser);
+      // This next line is critical, do not change it unless you understand what you are
+      // doing.
+      parser.structural_indexes[parser.n_structural_indexes] = uint32_t(len);
       if (simdjson_unlikely(parser.n_structural_indexes == 0u)) {
         // We tolerate an unclosed string at the very end of the stream. Indeed, users
         // often load their data in bulk without being careful and they want us to ignore
         // the trailing garbage.
         return EMPTY;
       }
-     }
+    }
   }
   checker.check_eof();
   return checker.errors();

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -134,7 +134,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return haswell::stage1::json_minifier::minify<128>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return haswell::stage1::json_structural_indexer::index<128>(_buf, _len, *this, streaming);
@@ -153,7 +153,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }

--- a/src/ppc64/dom_parser_implementation.cpp
+++ b/src/ppc64/dom_parser_implementation.cpp
@@ -123,7 +123,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }

--- a/src/ppc64/dom_parser_implementation.cpp
+++ b/src/ppc64/dom_parser_implementation.cpp
@@ -104,7 +104,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return ppc64::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return ppc64::stage1::json_structural_indexer::index<64>(buf, len, *this, streaming);

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -133,7 +133,7 @@ simdjson_warn_unused error_code implementation::minify(const uint8_t *buf, size_
   return westmere::stage1::json_minifier::minify<64>(buf, len, dst, dst_len);
 }
 
-simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, bool streaming) noexcept {
+simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t *_buf, size_t _len, stage1_mode streaming) noexcept {
   this->buf = _buf;
   this->len = _len;
   return westmere::stage1::json_structural_indexer::index<64>(_buf, _len, *this, streaming);
@@ -152,7 +152,7 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
 }
 
 simdjson_warn_unused error_code dom_parser_implementation::parse(const uint8_t *_buf, size_t _len, dom::document &_doc) noexcept {
-  auto error = stage1(_buf, _len, false);
+  auto error = stage1(_buf, _len, stage1_mode::regular);
   if (error) { return error; }
   return stage2(_doc);
 }

--- a/tests/basictests.cpp
+++ b/tests/basictests.cpp
@@ -2149,7 +2149,7 @@ int main(int argc, char *argv[]) {
   }
   // We want to know what we are testing.
   std::cout << "Running tests against this implementation: " << simdjson::active_implementation->name();
-  std::cout << "(" << simdjson::active_implementation->description() << ")" << std::endl;
+  std::cout << " (" << simdjson::active_implementation->description() << ")" << std::endl;
   std::cout << "------------------------------------------------------------" << std::endl;
 
   std::cout << "Running basic tests." << std::endl;

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -319,7 +319,12 @@ namespace document_stream_tests {
       count++;
       previous_i = i;
     }
-    return count == 1;
+    // We should have three documents including a broken one
+    if(count != 3) {
+      std::cout << "finished with count = " << count << std::endl;
+      return false;
+    }
+    return true;
   }
 
   bool single_document() {
@@ -458,17 +463,22 @@ namespace document_stream_tests {
     ASSERT_SUCCESS( parser.parse_many(json,json.size()).get(stream) );
     // Rest is ineffective because stage 1 fails.
     auto i = stream.begin();
+    size_t counter{0};
     for(; i != stream.end(); ++i) {
         auto doc = *i;
         if(!doc.error()) {
           std::cout << "got full document at " << i.current_index() << std::endl;
-          return false;
+          if(counter > 1) { return false; }
         } else {
           std::cout << doc.error() << std::endl;
-          return (doc.error() == simdjson::UNCLOSED_STRING);
         }
+        counter++;
     }
-    return false;
+    if(counter != 2) {
+      std::cerr << "You should have parsed two documents. I found " << counter << "." << std::endl;
+      return false;
+    }
+    return true;
   }
   bool small_window() {
     std::cout << "Running " << __func__ << std::endl;

--- a/tests/document_stream_tests.cpp
+++ b/tests/document_stream_tests.cpp
@@ -461,7 +461,6 @@ namespace document_stream_tests {
     simdjson::dom::document_stream stream;
     // We use a window of json.size() though any large value would do.
     ASSERT_SUCCESS( parser.parse_many(json,json.size()).get(stream) );
-    // Rest is ineffective because stage 1 fails.
     auto i = stream.begin();
     size_t counter{0};
     for(; i != stream.end(); ++i) {
@@ -473,6 +472,11 @@ namespace document_stream_tests {
           std::cout << doc.error() << std::endl;
         }
         counter++;
+    }
+    std::cout << "final index is " << i.current_index() << std::endl;
+    if(i.current_index() != 29) {
+      std::cerr << "bad final index" << std::endl;
+      return false;
     }
     if(counter != 2) {
       std::cerr << "You should have parsed two documents. I found " << counter << "." << std::endl;

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -222,7 +222,7 @@ int main(int argc, char *argv[]) {
   }
   // We want to know what we are testing.
   std::cout << "Running tests against this implementation: " << simdjson::active_implementation->name();
-  std::cout << "(" << simdjson::active_implementation->description() << ")" << std::endl;
+  std::cout << " (" << simdjson::active_implementation->description() << ")" << std::endl;
   std::cout << "------------------------------------------------------------" << std::endl;
 
   std::cout << "Running document tests." << std::endl;

--- a/tests/parse_many_test.cpp
+++ b/tests/parse_many_test.cpp
@@ -30,10 +30,6 @@ bool contains(const char *pre, const char *str) {
     return (strstr(str, pre) != nullptr);
 }
 
- 
- 
- 
- 
 bool is_skip_listed(const char *name) {
   std::vector<const char*> white_list = {"fail36.json", "fail62.json", "fail63.json", "fail64.json"};
   for(const char* x : white_list) {
@@ -87,9 +83,7 @@ bool validate(const char *dirname) {
     for (int i = 0; i < c; i++) {
         const char *name = entry_list[i]->d_name;
         if (has_extension(name, extension1) || has_extension(name, extension2) || has_extension(name, extension3)) {
-            if(is_skip_listed(name)) {
-                continue;
-            } 
+            if(is_skip_listed(name)) { continue; }
 
             /*  Finding the file path  */
             printf("validating: file %s ", name);
@@ -111,7 +105,7 @@ bool validate(const char *dirname) {
                   error = doc.error();
                 }
             }
-            std::cout << "error status:  "<<error<<std::endl; 
+            std::cout << "error status:  " << error << std::endl;
             /* Check if the file is supposed to pass or not.  Print the results */
             if (contains("EXCLUDE", name)) {
                 // skipping

--- a/tests/readme_examples.cpp
+++ b/tests/readme_examples.cpp
@@ -52,7 +52,17 @@ void basics_dom_1() {
   }
 }
 
-
+void parse_many_truncated() {
+    auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} {"key":"intentionally unclosed string  )"_padded;
+    simdjson::dom::parser parser;
+    simdjson::dom::document_stream stream;
+    auto error = parser.parse_many(json,json.size()).get(stream);
+    if(error) { std::cerr << error << std::endl; return; }
+    for(auto doc : stream) {
+       std::cout << doc << std::endl;
+    }
+    std::cout << stream.truncated_bytes() << " bytes "<< std::endl; // returns 39 bytes
+}
 
 void basics_dom_2() {
   auto cars_json = R"( [


### PR DESCRIPTION
Currently, when using parse_many, if there is an unclosed final string, then a whole block (e.g., 1 MB) of stage 1 processing is wasted since stage 1 ends in error. Thus we must instruct users not to provide ndjson inputs with unclosed final string...

This PR would tolerate a final unclosed string. What it does is to exclude the unclosed string (it is virtually removed) as well as other "trailing garbage".

The downside of this approach is that a final unclosed string gets ignored, so it is possible to have garbage as part of your stream and be unaware if the garbage is part of an unclosed string. Users are expected to call the `truncated_bytes()` to see whether truncation occurs. If so, they have to handle these leftover bytes somehow.

It is mostly a quality-of-life issue.