### PR TITLE
Alternative to PR 1545 : do not reverse bits under ARM

### DIFF
--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -4,6 +4,8 @@
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace {
+// ARM does not have a single trailing zero instruction.
+#define SIMDJSON_PREFER_LEADING_ZEROS 1
 
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
@@ -46,27 +48,6 @@ simdjson_really_inline int count_ones(uint64_t input_num) {
    return vaddv_u8(vcnt_u8(vcreate_u8(input_num)));
 }
 
-
-#if defined(__GNUC__) // catches clang and gcc
-/**
- * ARM has a fast 64-bit "bit reversal function" that is handy. However,
- * it is not generally available as an intrinsic function under Visual
- * Studio (though this might be changing). Even under clang/gcc, we
- * apparently need to invoke inline assembly.
- */
-/*
- * We use SIMDJSON_PREFER_REVERSE_BITS as a hint that algorithms that
- * work well with bit reversal may use it.
- */
-#define SIMDJSON_PREFER_REVERSE_BITS 1
-
-/* reverse the bits */
-simdjson_really_inline uint64_t reverse_bits(uint64_t input_num) {
-    uint64_t rev_bits;
-    __asm("rbit %0, %1" : "=r"(rev_bits) : "r"(input_num));
-    return rev_bits;
-}
-#endif
 
 simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO

--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -46,6 +46,28 @@ simdjson_really_inline int count_ones(uint64_t input_num) {
    return vaddv_u8(vcnt_u8(vcreate_u8(input_num)));
 }
 
+
+#if defined(__GNUC__) // catches clang and gcc
+/**
+ * ARM has a fast 64-bit "bit reversal function" that is handy. However,
+ * it is not generally available as an intrinsic function under Visual
+ * Studio (though this might be changing). Even under clang/gcc, we
+ * apparently need to invoke inline assembly.
+ */
+/*
+ * We use SIMDJSON_PREFER_REVERSE_BITS as a hint that algorithms that
+ * work well with bit reversal may use it.
+ */
+#define SIMDJSON_PREFER_REVERSE_BITS 1
+
+/* reverse the bits */
+simdjson_really_inline uint64_t reverse_bits(uint64_t input_num) {
+    uint64_t rev_bits;
+    __asm("rbit %0, %1" : "=r"(rev_bits) : "r"(input_num));
+    return rev_bits;
+}
+#endif
+
 simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   *result = value1 + value2;


### PR DESCRIPTION
ARM does not have a trailing zero instruction. To emulate it, it tends to reverse the bit order and then call the leading zero instruction. [In PR 1545](https://github.com/simdjson/simdjson/pull/1545), we reverse bits in a word once before extracting bit indexes.

This proves beneficial. Here is another approach that avoids bit reversal entirely....

```C++
    uint64_t lowest = 0;
    int cnt = static_cast<int>(count_ones(bits));
    int i = 0;
    // Do the first 8 all together
    for (; i<8; i++) {
      // we make a 'copy' of lowest, but it should not be compiled as a copy
      uint64_t tmp = lowest;
      // the next two line can execute at the same time
      lowest = (lowest - bits);
      bits = (bits - tmp);
      // then we finish updating 'lowest', in a second cycle
      lowest &= bits;
      // We are now reading to loop back again since lowest and bits have both
      // been updated (in 2 cycles).
      uint32_t lz = static_cast<uint32_t>(leading_zeroes(lowest));
      this->tail[i] = idx + 63 - lz;
    }
```

The hot loop compiles to the following...

```asm
.L19:
  sub x0, x2, x3
  sub x3, x3, x2
  and x2, x0, x3
  clz x0, x2
  sub w0, w6, w0
  str w0, [x5, x4, lsl 2]
  add x4, x4, 1
  cmp x4, 16
  bne .L19
```

This is the same number of instructions as our main branch but in theory, on the basis of data dependency, it could run the whole sequence in two cycles. 

PR 1545 saves one instruction...

```asm
.L11:
  clz x0, x3
  add w5, w2, w0
  str w5, [x6, x4, lsl 2]
  add x4, x4, 1
  lsr x0, x7, x0
  eor x3, x3, x0
  cmp x4, 16
  bne .L11
```

but it requires at least 3 cycles to complete based on data dependency.

My experimental results indicate that PR 1545 is favorable. That is, saving instructions is better than reducing data dependency.

|   |  before |  PR 1545 | this PR |
|---|---|---|---|
|  twitter | 5.6936 GB/s  |   5.8474 GB/s |  5.6787 GB/s |
| canada  | 5.2355 GB/s   |  5.4106 GB/s  | 5.2651 GB/s |
| apache_builds  |    6.1337 GB/s |  6.3507 GB/s  | 6.1961 GB/s |
| github_events  |  6.5684 GB/s |   6.7383 GB/s |  6.5407 GB/s|

Godbolt: https://godbolt.org/z/GPcb3aGfz