### PR TITLE
adjust GitHub links to current repository URL

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -5,12 +5,12 @@ FROM gcc:8.3
 # # Build latest
 # ENV latest_release=v0.2.1
 # WORKDIR /usr/src/$latest_release/
-# RUN git clone --depth 1 https://github.com/lemire/simdjson/ -b $latest_release .
+# RUN git clone --depth 1 https://github.com/simdjson/simdjson/ -b $latest_release .
 # RUN make parse
 
 # # Build master
 # WORKDIR /usr/src/master/
-# RUN git clone --depth 1 https://github.com/lemire/simdjson/ .
+# RUN git clone --depth 1 https://github.com/simdjson/simdjson/ .
 # RUN make parse
 
 # Build the current source

--- a/include/simdjson.h
+++ b/include/simdjson.h
@@ -4,7 +4,7 @@
 /**
  * @mainpage
  *
- * Check the [README.md](https://github.com/lemire/simdjson/blob/master/README.md#simdjson--parsing-gigabytes-of-json-per-second).
+ * Check the [README.md](https://github.com/simdjson/simdjson/blob/master/README.md#simdjson--parsing-gigabytes-of-json-per-second).
  *
  * Sample code. See https://github.com/simdjson/simdjson/blob/master/doc/basics.md for more examples.
 

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -38,7 +38,7 @@ constexpr size_t SIMDJSON_MAXSIZE_BYTES = 0xFFFFFFFF;
  * the input buf should be readable up to buf + SIMDJSON_PADDING
  * this is a stopgap; there should be a better description of the
  * main loop and its behavior that abstracts over this
- * See https://github.com/lemire/simdjson/issues/174
+ * See https://github.com/simdjson/simdjson/issues/174
  */
 constexpr size_t SIMDJSON_PADDING = 32;
 

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -37,7 +37,7 @@ inline error_code document::allocate(size_t capacity) noexcept {
   // need a capacity of at least capacity + 1, but it is also possible to do
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
-  // generated, see issue https://github.com/lemire/simdjson/issues/345
+  // generated, see issue https://github.com/simdjson/simdjson/issues/345
   size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer

--- a/jsonexamples/small/jsoniter_scala/README.md
+++ b/jsonexamples/small/jsoniter_scala/README.md
@@ -1,7 +1,7 @@
 Files from https://github.com/plokhotnyuk/jsoniter-scala/tree/master/jsoniter-scala-benchmark/src/main/resources/com/github/plokhotnyuk/jsoniter_scala/benchmark
 
 See issue:
-https://github.com/lemire/simdjson/issues/70
+https://github.com/simdjson/simdjson/issues/70
 
 The files che-*.geo.json are number-parsing stress tests.
 

--- a/tests/document_tests.cpp
+++ b/tests/document_tests.cpp
@@ -36,7 +36,7 @@ namespace document_tests {
     return true;
   }
 
-  // adversarial example that once triggred overruns, see https://github.com/lemire/simdjson/issues/345
+  // adversarial example that once triggered overruns, see https://github.com/simdjson/simdjson/issues/345
   bool bad_example() {
     std::cout << __func__ << std::endl;
     simdjson::padded_string badjson = "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"_padded;


### PR DESCRIPTION
Switch links (mostly in comments) from old repository URL <https://github.com/lemire/simdjson/> to the current URL <https://github.com/simdjson/simdjson/>.
