### PR TITLE
Return err when encountering memory allocation failures

### DIFF
--- a/src/arm64/implementation.cpp
+++ b/src/arm64/implementation.cpp
@@ -10,8 +10,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 

--- a/src/fallback/implementation.cpp
+++ b/src/fallback/implementation.cpp
@@ -10,8 +10,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 

--- a/src/haswell/implementation.cpp
+++ b/src/haswell/implementation.cpp
@@ -10,8 +10,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 

--- a/src/ppc64/implementation.cpp
+++ b/src/ppc64/implementation.cpp
@@ -10,8 +10,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 

--- a/src/westmere/implementation.cpp
+++ b/src/westmere/implementation.cpp
@@ -10,8 +10,10 @@ simdjson_warn_unused error_code implementation::create_dom_parser_implementation
 ) const noexcept {
   dst.reset( new (std::nothrow) dom_parser_implementation() );
   if (!dst) { return MEMALLOC; }
-  dst->set_capacity(capacity);
-  dst->set_max_depth(max_depth);
+  if (auto err = dst->set_capacity(capacity))
+    return err;
+  if (auto err = dst->set_max_depth(max_depth))
+    return err;
   return SUCCESS;
 }
 


### PR DESCRIPTION
Or else we can hit nullptr segfault in various places such as

https://github.com/simdjson/simdjson/blob/master/src/generic/stage2/tape_builder.h#L193

This issue is found in ClickHouse when using JSON functions in memory intensive environment