### PR TITLE
By default, we should not do the DOM checkperf…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ commands:
     steps:
       - cmake_build_cache
       - run: |
-          cmake --build  build --target checkperf &&
+          cmake -DSIMDJSON_ENABLE_DOM_CHECKPERF=ON --build  build --target checkperf &&
           cd build && 
           ctest --output-on-failure -R checkperf
 

--- a/.github/workflows/msys2-clang.yml
+++ b/.github/workflows/msys2-clang.yml
@@ -20,16 +20,16 @@ jobs:
       matrix:
         include:
           - msystem: "MINGW64"
-            install: mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-clang
+            install: mingw-w64-x86_64-libxml2 mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-clang
             type: Release
           - msystem: "MINGW32"
-            install: mingw-w64-i686-cmake mingw-w64-i686-ninja mingw-w64-i686-clang
+            install: mingw-w64-i686-libxml2 mingw-w64-i686-cmake mingw-w64-i686-ninja mingw-w64-i686-clang
             type: Release
           - msystem: "MINGW64"
-            install: mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-clang
+            install: mingw-w64-x86_64-libxml2 mingw-w64-x86_64-cmake mingw-w64-x86_64-ninja mingw-w64-x86_64-clang
             type: Debug
           - msystem: "MINGW32"
-            install: mingw-w64-i686-cmake mingw-w64-i686-ninja mingw-w64-i686-clang
+            install: mingw-w64-i686-libxml2 mingw-w64-i686-cmake mingw-w64-i686-ninja mingw-w64-i686-clang
             type: Debug
     env:
       CMAKE_GENERATOR: Ninja

--- a/.github/workflows/ubuntu18-checkperf.yml
+++ b/.github/workflows/ubuntu18-checkperf.yml
@@ -24,6 +24,6 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake  -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
+          cmake  -DSIMDJSON_ENABLE_DOM_CHECKPERF=ON -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
           cmake --build . --target checkperf  &&
           ctest --output-on-failure -R checkperf  ubuntu18-checkperf.yml

--- a/.github/workflows/ubuntu20-checkperf.yml
+++ b/.github/workflows/ubuntu20-checkperf.yml
@@ -24,6 +24,6 @@ jobs:
         run: |
           mkdir build &&
           cd build &&
-          cmake  -DCMAKE_CXX_FLAGS="-Werror=old-style-cast -pedantic -Wpedantic" -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
+          cmake  -DSIMDJSON_ENABLE_DOM_CHECKPERF=ON -DCMAKE_CXX_FLAGS="-Werror=old-style-cast -pedantic -Wpedantic" -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
           cmake --build . --target checkperf  &&
           ctest --output-on-failure -R checkperf

--- a/benchmark/dom/checkperf.cmake
+++ b/benchmark/dom/checkperf.cmake
@@ -5,9 +5,12 @@
 # checkperf-repo: initialize and sync reference repository (first time only)
 # TEST checkperf: runs the actual checkperf test
 
+option(SIMDJSON_ENABLE_DOM_CHECKPERF "Enable DOM performance comparison with main branch" OFF)
+
+
 # Clone the repository if it's not there
 find_package(Git QUIET)
-if (Git_FOUND AND (GIT_VERSION_STRING VERSION_GREATER  "2.1.4") AND (NOT CMAKE_GENERATOR MATCHES Ninja) AND (NOT MSVC) ) # We use "-C" which requires a recent git
+if (SIMDJSON_ENABLE_DOM_CHECKPERF AND Git_FOUND AND (GIT_VERSION_STRING VERSION_GREATER  "2.1.4") AND (NOT CMAKE_GENERATOR MATCHES Ninja) AND (NOT MSVC) ) # We use "-C" which requires a recent git
   message(STATUS "Git is available and it is recent. We are enabling checkperf targets.")
   # sync_git_repository(myrepo ...) creates two targets:
   # myrepo - if the repo does not exist, creates and syncs it against the origin branch


### PR DESCRIPTION
These targets assume that main branch remains compatible, an assumption that will break over time.

Also, we are much less focused on DOM performance at this point.