### PR TITLE
Add RapidJSON and nlohmann_json SAX to kostya benchmark

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -46,7 +46,9 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "kostya/yyjson.h"
 #include "kostya/sajson.h"
 #include "kostya/rapidjson.h"
+#include "kostya/rapidjson_sax.h"
 #include "kostya/nlohmann_json.h"
+#include "kostya/nlohmann_json_sax.h"
 
 #include "distinct_user_id/simdjson_dom.h"
 #include "distinct_user_id/simdjson_ondemand.h"

--- a/benchmark/kostya/nlohmann_json_sax.h
+++ b/benchmark/kostya/nlohmann_json_sax.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_NLOHMANN_JSON
+
+#include "kostya.h"
+
+namespace kostya {
+
+using json = nlohmann::json;
+
+struct nlohmann_json_sax {
+    static constexpr diff_flags DiffFlags = diff_flags::NONE;
+    
+    struct Handler : json::json_sax_t
+    {
+        size_t k{0};
+        double buffer[3];
+        std::vector<point>* result;
+        
+        Handler(std::vector<point> &r) { result=&r; }
+
+        bool key(string_t& val) override { 
+            switch(val[0]) {
+                case 'x':
+                    k = 0;
+                    break;
+                case 'y':
+                    k = 1;
+                    break;
+                case 'z':
+                    k = 2;
+                    break;  
+            }
+            return true; 
+        }   
+        bool number_unsigned(number_unsigned_t val) override { 
+            buffer[k] = val;
+            if (k==2) {
+                (*result).emplace_back(json_benchmark::point{buffer[0],buffer[1],buffer[2]});
+                k = 0;
+            }
+            return true; 
+            }        
+        bool number_float(number_float_t val, const string_t& s) override { 
+            buffer[k] = val;
+            if (k==2) {
+                (*result).emplace_back(json_benchmark::point{buffer[0],buffer[1],buffer[2]});
+                k = 0;
+            }
+            return true;  
+        }  
+        // Irrelevant events
+        bool null() override { return true; }
+        bool boolean(bool val) override { return true; }      
+        bool number_integer(number_integer_t val) override { return true; }    
+        bool string(string_t& val) override { return true; }        
+        bool start_object(std::size_t elements) override { return true; }        
+        bool end_object() override { return true; }        
+        bool start_array(std::size_t elements) override { return true; }        
+        bool end_array() override { return true; }       
+        bool binary(json::binary_t& val) override { return true; }        
+        bool parse_error(std::size_t position, const std::string& last_token, const json::exception& ex) override { return false; }
+    }; // Handler
+
+    bool run(simdjson::padded_string &json, std::vector<point> &result) {
+        Handler handler(result);
+        json::sax_parse(json.data(), &handler);
+        
+        return true;
+    }
+}; // nlohmann_json_sax
+BENCHMARK_TEMPLATE(kostya, nlohmann_json_sax)->UseManualTime();
+} // namespace kostya
+
+#endif // SIMDJSON_COMPETITION_NLOHMANN_JSON

--- a/benchmark/kostya/rapidjson_sax.h
+++ b/benchmark/kostya/rapidjson_sax.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_RAPIDJSON
+
+#include "kostya.h"
+
+namespace kostya {
+
+using namespace rapidjson;
+
+struct rapidjson_sax {
+    static constexpr diff_flags DiffFlags = diff_flags::NONE;
+
+    struct Handler {
+        size_t k{0};
+        double buffer[3];
+        std::vector<point>* result;
+        
+        Handler(std::vector<point> &r) { result=&r; }
+
+        bool Key(const char* key, SizeType length, bool copy) { 
+            switch(key[0]) {
+            case 'x':
+                k = 0;
+                break;
+            case 'y':
+                k = 1;
+                break;
+            case 'z':
+                k = 2;
+                break;  
+            }
+            return true; 
+        }
+        bool Double(double d) { 
+            buffer[k] = d;
+            if (k==2) {
+                (*result).emplace_back(json_benchmark::point{buffer[0],buffer[1],buffer[2]});
+                k = 0;
+            }
+            return true; 
+        }
+        bool Uint(unsigned i) {     // Need this event because coordinate value can be equal to 1
+            return Double(i);
+        }
+        // Irrelevant events
+        bool Null() { return true; }
+        bool Bool(bool b) { return true; }
+        bool Int(int i) { return true; }
+        bool Int64(int64_t i) { return true; }
+        bool Uint64(uint64_t i) { return true; }
+        bool RawNumber(const char* str, SizeType length, bool copy) { return true; }
+        bool String(const char* str, SizeType length, bool copy) { return true; }
+        bool StartObject() { return true; }
+        bool EndObject(SizeType memberCount) { return true; }
+        bool StartArray() { return true; }
+        bool EndArray(SizeType elementCount) { return true; }
+    }; // handler
+    
+    bool run(simdjson::padded_string &json, std::vector<point> &result) {
+        Reader reader;
+        Handler handler(result);
+        StringStream ss(json.data());
+        reader.Parse(ss,handler);
+
+        return true;
+    }
+
+}; // rapid_jason_sax
+BENCHMARK_TEMPLATE(kostya, rapidjson_sax)->UseManualTime();
+} // namespace kostyacd
+
+#endif // SIMDJSON_COMPETITION_RAPIDJSON


### PR DESCRIPTION
This adds RapidJSON and nlohmann_json SAX API for kostya benchmark. Using SAX is much faster than using their regular counterparts:
<table>
<center><b> Comparison SAX vs. non-SAX (gcc) </b></center>
<tr><td>

|Benchmark|throughput|
|-----|-----|
|kostya<rapidjson>/manual_time|0.57GB/s|
|kostya<rapidjson_lossless>/manual_time|0.53GB/s|
|kostya<rapidjson_insitu>/manual_time|0.63GB/s|
|kostya<rapidjson_sax>/manual_time|0.63GB/s|
|<b>---------------</b>|<b>---------------</b>|
|kostya<nlohmann_json>/manual_time|0.08GB/s|
|kostya<nlohmann_json_sax>/manual_time|0.17GB/s|

</td></tr>
</table>

For reference simdjson_ondemand has a throughput of 2.29GB/s.