### PR TITLE
Add RapidJSON and nlohmann_json SAX to distinct_user_id benchmark

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -55,6 +55,7 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "distinct_user_id/rapidjson.h"
 #include "distinct_user_id/rapidjson_sax.h"
 #include "distinct_user_id/nlohmann_json.h"
+#include "distinct_user_id/nlohmann_json_sax.h"
 
 #include "find_tweet/simdjson_dom.h"
 #include "find_tweet/simdjson_ondemand.h"

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -53,6 +53,7 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "distinct_user_id/yyjson.h"
 #include "distinct_user_id/sajson.h"
 #include "distinct_user_id/rapidjson.h"
+#include "distinct_user_id/rapidjson_sax.h"
 #include "distinct_user_id/nlohmann_json.h"
 
 #include "find_tweet/simdjson_dom.h"

--- a/benchmark/distinct_user_id/nlohmann_json_sax.h
+++ b/benchmark/distinct_user_id/nlohmann_json_sax.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_NLOHMANN_JSON
+
+#include "distinct_user_id.h"
+#include <string.h>
+namespace distinct_user_id {
+
+using json = nlohmann::json;
+
+struct nlohmann_json_sax {
+    struct Handler : json::json_sax_t
+    {
+        std::vector<uint64_t>* result;
+        bool user = false;
+        bool user_id = false;
+        Handler(std::vector<uint64_t> &r) { result=&r; }
+
+        bool key(string_t& val) override {
+            if (val.compare("user") == 0) { user = true; }
+            else if (user && val.compare("id") == 0) { user_id = true; }
+            return true;
+        }
+        bool number_unsigned(number_unsigned_t val) override {
+            if (user_id) {
+                (*result).emplace_back(val);
+                user = false;
+                user_id = false;
+            }
+            return true;
+            }
+
+        // Irrelevant events
+        bool null() override { return true; }
+        bool boolean(bool val) override { return true; }
+        bool number_float(number_float_t val, const string_t& s) override { return true; }
+        bool number_integer(number_integer_t val) override { return true; }
+        bool string(string_t& val) override { return true; }
+        bool start_object(std::size_t elements) override { return true; }
+        bool end_object() override { return true; }
+        bool start_array(std::size_t elements) override { return true; }
+        bool end_array() override { return true; }
+        bool binary(json::binary_t& val) override { return true; }
+        bool parse_error(std::size_t position, const std::string& last_token, const json::exception& ex) override { return false; }
+    }; // Handler
+
+    bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
+        Handler handler(result);
+        json::sax_parse(json.data(), &handler);
+
+        return true;
+    }
+}; // nlohmann_json_sax
+BENCHMARK_TEMPLATE(distinct_user_id, nlohmann_json_sax)->UseManualTime();
+} // namespace distinct_user_id
+
+#endif // SIMDJSON_COMPETITION_NLOHMANN_JSON

--- a/benchmark/distinct_user_id/nlohmann_json_sax.h
+++ b/benchmark/distinct_user_id/nlohmann_json_sax.h
@@ -17,9 +17,11 @@ struct nlohmann_json_sax {
         Handler(std::vector<uint64_t> &r) : result(r) { }
 
         bool key(string_t& val) override {
-            // Assume that valid user/id pairs are only in user objects
-            if (val.compare("user") == 0) { user = true; }
-            else if (user && val.compare("id") == 0) { user_id = true; }
+            // Assume that valid user/id pairs appear only once in main array of user objects
+            if (user) { // If already found user object, find id key
+                if (val.compare("id") == 0) { user_id = true; }
+            }
+            else if (val.compare("user") == 0) { user = true; } // Otherwise, find user object
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {
@@ -29,8 +31,7 @@ struct nlohmann_json_sax {
                 user_id = false;
             }
             return true;
-            }
-
+        }
         // Irrelevant events
         bool null() override { return true; }
         bool boolean(bool val) override { return true; }

--- a/benchmark/distinct_user_id/nlohmann_json_sax.h
+++ b/benchmark/distinct_user_id/nlohmann_json_sax.h
@@ -11,19 +11,20 @@ using json = nlohmann::json;
 struct nlohmann_json_sax {
     struct Handler : json::json_sax_t
     {
-        std::vector<uint64_t>* result;
+        std::vector<uint64_t>& result;
         bool user = false;
         bool user_id = false;
-        Handler(std::vector<uint64_t> &r) { result=&r; }
+        Handler(std::vector<uint64_t> &r) : result(r) { }
 
         bool key(string_t& val) override {
+            // Assume that valid user/id pairs are only in user objects
             if (val.compare("user") == 0) { user = true; }
             else if (user && val.compare("id") == 0) { user_id = true; }
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {
             if (user_id) {
-                (*result).emplace_back(val);
+                result.emplace_back(val);
                 user = false;
                 user_id = false;
             }

--- a/benchmark/distinct_user_id/rapidjson_sax.h
+++ b/benchmark/distinct_user_id/rapidjson_sax.h
@@ -16,16 +16,12 @@ struct rapidjson_sax {
         Handler(std::vector<uint64_t> &r) { result=&r; }
 
         bool Key(const char* key, SizeType length, bool copy) {
-            if (strcmp(key,"user") == 0) {  // Checking if entering user object
-                user = true;
-            }
-            if (user && strcmp(key,"id") == 0) { // Checking if in an user object and accessing id field
-                user_id = true;
-            }
+            if (strcmp(key,"user") == 0) { user = true; } // Checking if entering user object
+            else if (user && strcmp(key,"id") == 0) { user_id = true; } // Checking if in an user object and accessing id field
             return true;
         }
         bool Uint(unsigned i) {
-            if (user_id) {  // Getting id if previous key was a user id
+            if (user_id) {  // Getting id if previous key was "id" for a user
                 (*result).emplace_back(i);
                 user_id=false;
                 user = false;
@@ -58,6 +54,6 @@ struct rapidjson_sax {
 
 }; // rapid_jason_sax
 BENCHMARK_TEMPLATE(distinct_user_id, rapidjson_sax)->UseManualTime();
-} // namespace kostyacd
+} // namespace distinct_user_id
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/distinct_user_id/rapidjson_sax.h
+++ b/benchmark/distinct_user_id/rapidjson_sax.h
@@ -16,12 +16,14 @@ struct rapidjson_sax {
         Handler(std::vector<uint64_t> &r) : result(r) { }
 
         bool Key(const char* key, SizeType length, bool copy) {
-            // Assume that valid user/id pairs are only in user objects
-            if (strcmp(key,"user") == 0) { user = true; } // Checking if entering user object
-            else if (user && strcmp(key,"id") == 0) { user_id = true; } // Checking if in a user object and accessing id field
+            // Assume that valid user/id pairs appear only once in main array of user objects
+            if (user) { // If already found user object, find id key
+                if (strcmp(key,"id") == 0) { user_id = true; }
+            }
+            else if (strcmp(key,"user") == 0) { user = true; } // Otherwise, find user object
             return true;
         }
-        bool Uint(unsigned i) {
+        bool Uint(unsigned i) {     // id values are treated as Uint (not Uint64) by the reader
             if (user_id) {  // Getting id if previous key was "id" for a user
                 result.emplace_back(i);
                 user_id = false;
@@ -48,7 +50,7 @@ struct rapidjson_sax {
         Reader reader;
         Handler handler(result);
         InsituStringStream ss(json.data());
-        reader.Parse<kParseInsituFlag | kParseValidateEncodingFlag | kParseFullPrecisionFlag>(ss,handler);
+        reader.Parse<kParseInsituFlag | kParseValidateEncodingFlag | kParseFullPrecisionFlag>(ss,handler);;
 
         return true;
     }

--- a/benchmark/distinct_user_id/rapidjson_sax.h
+++ b/benchmark/distinct_user_id/rapidjson_sax.h
@@ -10,20 +10,21 @@ using namespace rapidjson;
 
 struct rapidjson_sax {
     struct Handler {
-        std::vector<uint64_t>* result;
+        std::vector<uint64_t>& result;
         bool user = false;
-        bool user_id =false;
-        Handler(std::vector<uint64_t> &r) { result=&r; }
+        bool user_id = false;
+        Handler(std::vector<uint64_t> &r) : result(r) { }
 
         bool Key(const char* key, SizeType length, bool copy) {
+            // Assume that valid user/id pairs are only in user objects
             if (strcmp(key,"user") == 0) { user = true; } // Checking if entering user object
-            else if (user && strcmp(key,"id") == 0) { user_id = true; } // Checking if in an user object and accessing id field
+            else if (user && strcmp(key,"id") == 0) { user_id = true; } // Checking if in a user object and accessing id field
             return true;
         }
         bool Uint(unsigned i) {
             if (user_id) {  // Getting id if previous key was "id" for a user
-                (*result).emplace_back(i);
-                user_id=false;
+                result.emplace_back(i);
+                user_id = false;
                 user = false;
             }
             return true;

--- a/benchmark/distinct_user_id/rapidjson_sax.h
+++ b/benchmark/distinct_user_id/rapidjson_sax.h
@@ -18,9 +18,9 @@ struct rapidjson_sax {
         bool Key(const char* key, SizeType length, bool copy) {
             // Assume that valid user/id pairs appear only once in main array of user objects
             if (user) { // If already found user object, find id key
-                if (strcmp(key,"id") == 0) { user_id = true; }
+                if ((length == 2) && memcmp(key,"id",2) == 0) { user_id = true; }
             }
-            else if (strcmp(key,"user") == 0) { user = true; } // Otherwise, find user object
+            else if ((length == 4) && memcmp(key,"user",4) == 0) { user = true; } // Otherwise, find user object
             return true;
         }
         bool Uint(unsigned i) {     // id values are treated as Uint (not Uint64) by the reader
@@ -50,8 +50,7 @@ struct rapidjson_sax {
         Reader reader;
         Handler handler(result);
         InsituStringStream ss(json.data());
-        reader.Parse<kParseInsituFlag | kParseValidateEncodingFlag | kParseFullPrecisionFlag>(ss,handler);;
-
+        reader.Parse<kParseInsituFlag | kParseValidateEncodingFlag | kParseFullPrecisionFlag>(ss,handler);
         return true;
     }
 

--- a/benchmark/distinct_user_id/rapidjson_sax.h
+++ b/benchmark/distinct_user_id/rapidjson_sax.h
@@ -46,8 +46,8 @@ struct rapidjson_sax {
     bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
         Reader reader;
         Handler handler(result);
-        StringStream ss(json.data());
-        reader.Parse(ss,handler);
+        InsituStringStream ss(json.data());
+        reader.Parse<kParseInsituFlag | kParseValidateEncodingFlag | kParseFullPrecisionFlag>(ss,handler);
 
         return true;
     }

--- a/benchmark/distinct_user_id/rapidjson_sax.h
+++ b/benchmark/distinct_user_id/rapidjson_sax.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_RAPIDJSON
+
+#include "distinct_user_id.h"
+#include <string.h>
+namespace distinct_user_id {
+
+using namespace rapidjson;
+
+struct rapidjson_sax {
+    struct Handler {
+        std::vector<uint64_t>* result;
+        bool user = false;
+        bool user_id =false;
+        Handler(std::vector<uint64_t> &r) { result=&r; }
+
+        bool Key(const char* key, SizeType length, bool copy) {
+            if (strcmp(key,"user") == 0) {  // Checking if entering user object
+                user = true;
+            }
+            if (user && strcmp(key,"id") == 0) { // Checking if in an user object and accessing id field
+                user_id = true;
+            }
+            return true;
+        }
+        bool Uint(unsigned i) {
+            if (user_id) {  // Getting id if previous key was a user id
+                (*result).emplace_back(i);
+                user_id=false;
+                user = false;
+            }
+            return true;
+        }
+        // Irrelevant events
+        bool Null() { return true; }
+        bool Bool(bool b) { return true; }
+        bool Double(double d) { return true; }
+        bool Int(int i) { return true; }
+        bool Int64(int64_t i) { return true; }
+        bool Uint64(uint64_t i) { return true; }
+        bool RawNumber(const char* str, SizeType length, bool copy) { return true; }
+        bool String(const char* str, SizeType length, bool copy) { return true; }
+        bool StartObject() { return true; }
+        bool EndObject(SizeType memberCount) { return true; }
+        bool StartArray() { return true; }
+        bool EndArray(SizeType elementCount) { return true; }
+    }; // handler
+
+    bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
+        Reader reader;
+        Handler handler(result);
+        StringStream ss(json.data());
+        reader.Parse(ss,handler);
+
+        return true;
+    }
+
+}; // rapid_jason_sax
+BENCHMARK_TEMPLATE(distinct_user_id, rapidjson_sax)->UseManualTime();
+} // namespace kostyacd
+
+#endif // SIMDJSON_COMPETITION_RAPIDJSON


### PR DESCRIPTION
This adds RapidJSON SAX and nlohmann_json SAX for distinct_user_id benchmark. Results:

<table>
<center><b> Comparison SAX vs. non-SAX (gcc) </b></center>
<tr><td>

|Benchmark|throughput|
|-----|-----|
|distinct_user_id<rapidjson>/manual_time |0.41GB/s|
|distinct_user_id<rapidjson_insitu>/manual_time|0.77GB/s|
|distinct_user_id<rapidjson_sax>/manual_time|0.43GB/s|
|<b>---------------</b>|<b>---------------</b>|
|distinct_user_id<nlohmann_json>/manual_time|0.08GB/s|
|distinct_user_id<nlohmann_json_sax>/manual_time|0.16GB/s|
|<b>---------------</b>|<b>---------------</b>|
|distinct_user_id<simdjson_ondemand>/manual_time|3.51GB/s|
</td></tr>
</table>

For nlohmann_json, performance is doubled. However, for RapidJSON, SAX is slightly better than base RapidJSON, but is quite under rapidjson_insitu. This might indicate that there is a better way to implement the SAX API for RapidJSON. Propositions are welcomed.

Relates to #1401