### PR TITLE
Adds a warning message when SIMDJSON_DEVELOPER_MODE is OFF.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ include(cmake/handle-deprecations.cmake)
 
 if(SIMDJSON_DEVELOPER_MODE)
   include(cmake/developer-options.cmake)
+else()
+  message(STATUS "Building only the library. Advanced users may want to turn SIMDJSON_DEVELOPER_MODE to ON, e.g., via -D SIMDJSON_DEVELOPER_MODE=ON.")
 endif()
 
 # ---- simdjson library ----


### PR DESCRIPTION
It is a good idea to only build the library by default, but it can be hard for people who want to run the tests to figure out  how to do it. This PR adds a warning message with instructions.