### PR TITLE
This adds /permissive- to recent visual studio builds

### DIFF
--- a/cmake/developer-options.cmake
+++ b/cmake/developer-options.cmake
@@ -120,7 +120,7 @@ We recommend Visual Studio 2019 or better on a 64-bit system.")
     # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4714?view=vs-2019
     target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl /w34714)
     if(MSVC_VERSION GREATER 1910)
-      target_compile_options(simdjson-internal-flags INTERFACE /permissive-")
+      target_compile_options(simdjson-internal-flags INTERFACE /permissive-)
     endif()
   endif()
   if(SIMDJSON_VISUAL_STUDIO_BUILD_WITH_DEBUG_INFO_FOR_PROFILING)

--- a/cmake/developer-options.cmake
+++ b/cmake/developer-options.cmake
@@ -119,6 +119,9 @@ We recommend Visual Studio 2019 or better on a 64-bit system.")
     # are unsupported.
     # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4714?view=vs-2019
     target_compile_options(simdjson-internal-flags INTERFACE /WX /W3 /sdl /w34714)
+    if(MSVC_VERSION GREATER 1910)
+      target_compile_options(simdjson-internal-flags INTERFACE /permissive-")
+    endif()
   endif()
   if(SIMDJSON_VISUAL_STUDIO_BUILD_WITH_DEBUG_INFO_FOR_PROFILING)
     add_link_options(/DEBUG)

--- a/windows/getopt.h
+++ b/windows/getopt.h
@@ -112,13 +112,8 @@ char    *optarg;		/* argument associated with option */
 extern char __declspec(dllimport) *__progname;
 #endif
 
-// D. Lemire (April 2020): adding __clang__
-// D. Lemire (June 2020): adding __MINGW32__ and __MINGW64__
-#if defined(__CYGWIN__) || defined(__clang__) || defined(__MINGW32__) || defined(__MINGW64__)
+// next line modified D. Lemire (last modified on June 1st 2021)
 static char EMSG[] = "";
-#else
-#define	EMSG		""
-#endif
 
 static int getopt_internal(int, char * const *, const char *,
 			   const struct option *, int *, int);


### PR DESCRIPTION
By default CMake does not set /permissive- but it is the default for new projects with Visual Studio 2019.