### PR TITLE
Add RapidJSON and nlohmann_json SAX to partial_tweets benchmark

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -31,6 +31,7 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "partial_tweets/yyjson.h"
 #include "partial_tweets/sajson.h"
 #include "partial_tweets/rapidjson.h"
+#include "partial_tweets/rapidjson_sax.h"
 #include "partial_tweets/nlohmann_json.h"
 
 #include "large_random/simdjson_dom.h"

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -33,6 +33,7 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "partial_tweets/rapidjson.h"
 #include "partial_tweets/rapidjson_sax.h"
 #include "partial_tweets/nlohmann_json.h"
+#include "partial_tweets/nlohmann_json_sax.h"
 
 #include "large_random/simdjson_dom.h"
 #include "large_random/simdjson_ondemand.h"

--- a/benchmark/partial_tweets/nlohmann_json_sax.h
+++ b/benchmark/partial_tweets/nlohmann_json_sax.h
@@ -58,46 +58,46 @@ struct nlohmann_json_sax {
                 if (val.compare("retweeted_status") == 0) { inretweet = true; }   // Check if entering retweet
                 else if (val.compare("metadata") == 0) { values = 0; }  // Reset
                 // Check if key has been found and if key matches a valid key
-                else if (!(values &(found_date)) && (val.compare("created_at") == 0)) { values |= (key_date); }
+                else if (!(values & found_date) && (val.compare("created_at") == 0)) { values |= (key_date); }
                 // Must also check if not in a user object
-                else if (!(values &(found_id)) && !userobject_id && (val.compare("id") == 0)) { values |= (key_id); }
-                else if (!(values &(found_text)) && (val.compare("text") == 0)) { values |= (key_text); }
-                else if (!(values &(found_reply)) && (val.compare("in_reply_to_status_id") == 0)) { values |= (key_reply); }
+                else if (!(values & found_id) && !userobject_id && (val.compare("id") == 0)) { values |= (key_id); }
+                else if (!(values & found_text) && (val.compare("text") == 0)) { values |= (key_text); }
+                else if (!(values & found_reply) && (val.compare("in_reply_to_status_id") == 0)) { values |= (key_reply); }
                 // Check if entering user object
                 else if ((val.compare("user") == 0)) { userobject_id = userobject_screen_name = true; }
                 // Must also check if in a user object
-                else if (!(values &(found_userid)) && userobject_id && (val.compare("id") == 0)) { values |= (key_userid); }
+                else if (!(values & found_userid) && userobject_id && (val.compare("id") == 0)) { values |= (key_userid); }
                 // Must also check if in a user object
-                else if (!(values &(found_screenname)) && userobject_screen_name && (val.compare("screen_name") == 0)) { values |= (key_screenname); }
-                else if (!(values &(found_rt)) && (val.compare("retweet_count") == 0)) { values |= (key_rt); }
-                else if (!(values &(found_fav)) && (val.compare("favorite_count") == 0)) { values |= (key_fav); }
+                else if (!(values & found_screenname) && userobject_screen_name && (val.compare("screen_name") == 0)) { values |= (key_screenname); }
+                else if (!(values & found_rt) && (val.compare("retweet_count") == 0)) { values |= (key_rt); }
+                else if (!(values & found_fav) && (val.compare("favorite_count") == 0)) { values |= (key_fav); }
             }
             else if (val.compare("retweeted") == 0) { inretweet = false; }  // Check if end of retweet
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {
-            if ((values &(key_id)) && !(values &(found_id))) {    // id
+            if (values & key_id && !(values & found_id)) {    // id
                 id = val;
                 values &= ~(key_id);
                 values |= (found_id);
             }
-            else if (!(values &(found_reply)) && (values &(key_reply))) {   // in_reply_status_id
+            else if (values & key_reply && !(values & found_reply)) {   // in_reply_status_id
                 reply_status = val;
                 values &= ~(key_reply);
                 values |= (found_reply);
             }
-            else if (!(values &(found_userid)) && (values &(key_userid))) {    // user.id
+            else if (values & key_userid && !(values & found_userid)) {    // user.id
                 user_id = val;
                 userobject_id = false;
                 values &= ~(key_userid);
                 values |= (found_userid);
             }
-            else if (!(values &(found_rt)) && (values &(key_rt))) {   // retweet_count
+            else if (values & key_rt && !(values & found_rt)) {   // retweet_count
                 rt = val;
                 values &= ~(key_rt);
                 values |= (found_rt);
             }
-            else if ((values &(key_fav)) && !(values &(found_fav))) {   // favorite_count
+            else if (values & key_fav && !(values & found_fav)) {   // favorite_count
                 fav = val;
                 values &= ~(key_fav);
                 values |= (found_fav);
@@ -108,17 +108,17 @@ struct nlohmann_json_sax {
             return true;
         }
         bool string(string_t& val) override {
-            if (!(values &(found_date)) && (values &(key_date))) {   //  created_at
+            if (values & key_date && !(values & found_date)) {   //  created_at
                 date = val;
                 values &= ~(key_date);
                 values |= (found_date);
             }
-            else if (!(values &(found_text)) && (values &(key_text))) {   // text
+            else if (values & key_text && !(values & found_text)) {   // text
                 text = val;
                 values &= ~(key_text);
                 values |= (found_text);
             }
-            else if (!(values &(found_screenname)) && (values &(key_screenname))) {    // user.screen_name
+            else if (values & key_screenname && !(values & found_screenname)) {    // user.screen_name
                 screen_name = val;
                 userobject_screen_name = false;
                 values &= ~(key_screenname);
@@ -127,7 +127,7 @@ struct nlohmann_json_sax {
             return true;
         }
         bool null() override {
-            if (!(values &(found_reply)) && (values &(key_reply))) {    // in_reply_status (null case)
+            if (values & key_reply && !(values & found_reply)) {    // in_reply_status (null case)
                 reply_status = 0;
                 values &= ~(key_reply);
                 values |= (found_reply);

--- a/benchmark/partial_tweets/nlohmann_json_sax.h
+++ b/benchmark/partial_tweets/nlohmann_json_sax.h
@@ -1,0 +1,143 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_NLOHMANN_JSON
+
+#include "partial_tweets.h"
+
+namespace partial_tweets {
+
+using json = nlohmann::json;
+
+struct nlohmann_json_sax {
+    using StringType=std::string;
+
+    struct Handler : json::json_sax_t
+    {
+        // 8 keys to parse for each tweet (in order of appearance): "created_at", "id", "text", "in_reply_status_id", "id"(user),
+        // "screen_name"(user), "retweet_count" and "favorite_count".
+        // Assume that the first valid key encountered will be the correct key to parse.
+        // Assume that each tweet/retweet start with a key "metadata" and has a key "retweeted" towards the end
+        // The previous assumption will be used to check for the beginning of a new tweet and the end of a retweet
+        bool keys[8] = { false };   // Stores if previous parsed key was a valid key (in same order as above)
+        bool found[8] = { false }; // Stores if ith key has already been found once
+        bool userobject_id = false; // If in a user object (to find user.id)
+        bool userobject_screen_name = false;    // If in a user object (to find user.screen_name)
+        bool inretweet = false; // If in a retweet (all keys irrelevant in retweet object)
+        // Fields to store partial tweet info
+        uint64_t user_id;
+        uint64_t id;
+        uint64_t rt;
+        uint64_t fav;
+        uint64_t reply_status;
+        string_t screen_name;
+        string_t date;
+        string_t text;
+        std::vector<tweet<std::string>>& result;
+
+        Handler(std::vector<tweet<std::string>> &r) : result(r) { }
+
+        bool key(string_t& val) override {
+            if (!inretweet) {   // If not in a retweet object, find relevant keys
+                if (val.compare("retweeted_status") == 0) { inretweet = true; }   // Check if entering retweet
+                else if (val.compare("metadata") == 0) {    // Reset at beginning of tweet
+                    found[0] = found[1] = found[2] = found[3] = found[4] = found[5] = found[6] = found[7] = found[8] = false;
+                    keys[0] = keys[1] = keys[2] = keys[3] = keys[4] = keys[5] = keys[6] = keys[7] = keys[8] = false;
+                }
+                // Check if key has been found and if key matches a valid key
+                else if (!found[0] && (val.compare("created_at") == 0)) { keys[0] = true; }
+                // Must also check if not in a user object
+                else if (!found[1] && !userobject_id && (val.compare("id") == 0)) { keys[1] = true; }
+                else if (!found[2] && (val.compare("text") == 0)) { keys[2] = true; }
+                else if (!found[3] && (val.compare("in_reply_to_status_id") == 0)) { keys[3] = true; }
+                // Check if entering user object
+                else if (!found[4] && (val.compare("user") == 0)) { userobject_id = userobject_screen_name = true; }
+                // Must also check if in a user object
+                else if (!found[5] && userobject_id && (val.compare("id") == 0)) { keys[4] = true; }
+                // Must also check if in a user object
+                else if (!found[6] && userobject_screen_name && (val.compare("screen_name") == 0)) { keys[5] = true; }
+                else if (!found[7] && (val.compare("retweet_count") == 0)) { keys[6] = true; }
+                else if (!found[8] && (val.compare("favorite_count") == 0)) { keys[7] = true; }
+            }
+            else if (val.compare("retweeted") == 0) { inretweet = false; }  // Check if end of retweet
+            return true;
+        }
+        bool number_unsigned(number_unsigned_t val) override {
+           if (!found[4] && keys[4]) {    // user.id
+                user_id = val;
+                userobject_id = keys[4] = false;
+                found[4] = true;
+            }
+            else if (!found[6] && keys[6]) {   // retweet_count
+                rt = val;
+                keys[6] = false;
+                found[6] = true;
+            }
+            else if (!found[7] && keys[7]) {   // favorite_count
+                fav = val;
+                keys[7] = false;
+                found[7] = true;
+                // Assume that this is last key required, so add the partial_tweet to result
+                result.emplace_back(partial_tweets::tweet<std::string>{
+                date,id,text,reply_status,{user_id,screen_name},rt,fav});
+            }
+            else if (!found[1] && keys[1]) {    // id
+                id = val;
+                keys[1] = false;
+                found[1] = true;
+            }
+            else if (!found[3] && keys[3]) {   // in_reply_status_id
+                reply_status = val;
+                found[3] = true;
+                keys[3] = false;
+            }
+            return true;
+        }
+        bool string(string_t& val) override {
+            if (!found[5] && keys[5]) {    // user.screen_name
+                screen_name = val;
+                userobject_screen_name = keys[5] = false;
+                found[5] = true;
+            }
+            else if (!found[0] && keys[0]) {   //  created_at
+                date = val;
+                keys[0] = false;
+                found[0] = true;
+            }
+            else if (!found[2] && keys[2]) {   // text
+                text = val;
+                keys[2] = false;
+                found[2] = true;
+            }
+            return true;
+        }
+        bool null() override {
+            if (!found[3] && keys[3]) {    // in_reply_status (null case)
+                reply_status = 0;
+                found[3] = true;
+                keys[3] = false;
+            }
+            return true;
+        }
+        // Irrelevant events
+        bool boolean(bool val) override { return true; }
+        bool number_float(number_float_t val, const string_t& s) override { return true; }
+        bool number_integer(number_integer_t val) override { return true; }
+        bool start_object(std::size_t elements) override { return true; }
+        bool end_object() override { return true; }
+        bool start_array(std::size_t elements) override { return true; }
+        bool end_array() override { return true; }
+        bool binary(json::binary_t& val) override { return true; }
+        bool parse_error(std::size_t position, const std::string& last_token, const json::exception& ex) override { return false; }
+    }; // Handler
+
+    bool run(simdjson::padded_string &json, std::vector<tweet<std::string>> &result) {
+        Handler handler(result);
+        json::sax_parse(json.data(), &handler);
+
+        return true;
+    }
+}; // nlohmann_json_sax
+BENCHMARK_TEMPLATE(partial_tweets, nlohmann_json_sax)->UseManualTime();
+} // namespace partial_tweets
+
+#endif // SIMDJSON_COMPETITION_NLOHMANN_JSON

--- a/benchmark/partial_tweets/nlohmann_json_sax.h
+++ b/benchmark/partial_tweets/nlohmann_json_sax.h
@@ -18,8 +18,25 @@ struct nlohmann_json_sax {
         // Assume that the first valid key encountered will be the correct key to parse.
         // Assume that each tweet/retweet start with a key "metadata" and has a key "retweeted" towards the end
         // The previous assumption will be used to check for the beginning of a new tweet and the end of a retweet
-        bool keys[8] = { false };   // Stores if previous parsed key was a valid key (in same order as above)
-        bool found[8] = { false }; // Stores if ith key has already been found once
+        enum state {    // Bitset to store state of search
+            key_date = (1<<0),
+            key_id = (1<<1),
+            key_text = (1<<2),
+            key_reply = (1<<3),
+            key_userid = (1<<4),
+            key_screenname = (1<<5),
+            key_rt = (1<<6),
+            key_fav = (1<<7),
+            found_date = (1<<8),
+            found_id = (1<<9),
+            found_text = (1<<10),
+            found_reply = (1<<11),
+            found_userid = (1<<12),
+            found_screenname = (1<<13),
+            found_rt = (1<<14),
+            found_fav = (1<<15)
+        };
+        int values = state::key_date;
         bool userobject_id = false; // If in a user object (to find user.id)
         bool userobject_screen_name = false;    // If in a user object (to find user.screen_name)
         bool inretweet = false; // If in a retweet (all keys irrelevant in retweet object)
@@ -39,82 +56,81 @@ struct nlohmann_json_sax {
         bool key(string_t& val) override {
             if (!inretweet) {   // If not in a retweet object, find relevant keys
                 if (val.compare("retweeted_status") == 0) { inretweet = true; }   // Check if entering retweet
-                else if (val.compare("metadata") == 0) {    // Reset at beginning of tweet
-                    found[0] = found[1] = found[2] = found[3] = found[4] = found[5] = found[6] = found[7] = found[8] = false;
-                    keys[0] = keys[1] = keys[2] = keys[3] = keys[4] = keys[5] = keys[6] = keys[7] = keys[8] = false;
-                }
+                else if (val.compare("metadata") == 0) { values = 0; }  // Reset
                 // Check if key has been found and if key matches a valid key
-                else if (!found[0] && (val.compare("created_at") == 0)) { keys[0] = true; }
+                else if (!(values &(found_date)) && (val.compare("created_at") == 0)) { values |= (key_date); }
                 // Must also check if not in a user object
-                else if (!found[1] && !userobject_id && (val.compare("id") == 0)) { keys[1] = true; }
-                else if (!found[2] && (val.compare("text") == 0)) { keys[2] = true; }
-                else if (!found[3] && (val.compare("in_reply_to_status_id") == 0)) { keys[3] = true; }
+                else if (!(values &(found_id)) && !userobject_id && (val.compare("id") == 0)) { values |= (key_id); }
+                else if (!(values &(found_text)) && (val.compare("text") == 0)) { values |= (key_text); }
+                else if (!(values &(found_reply)) && (val.compare("in_reply_to_status_id") == 0)) { values |= (key_reply); }
                 // Check if entering user object
-                else if (!found[4] && (val.compare("user") == 0)) { userobject_id = userobject_screen_name = true; }
+                else if ((val.compare("user") == 0)) { userobject_id = userobject_screen_name = true; }
                 // Must also check if in a user object
-                else if (!found[5] && userobject_id && (val.compare("id") == 0)) { keys[4] = true; }
+                else if (!(values &(found_userid)) && userobject_id && (val.compare("id") == 0)) { values |= (key_userid); }
                 // Must also check if in a user object
-                else if (!found[6] && userobject_screen_name && (val.compare("screen_name") == 0)) { keys[5] = true; }
-                else if (!found[7] && (val.compare("retweet_count") == 0)) { keys[6] = true; }
-                else if (!found[8] && (val.compare("favorite_count") == 0)) { keys[7] = true; }
+                else if (!(values &(found_screenname)) && userobject_screen_name && (val.compare("screen_name") == 0)) { values |= (key_screenname); }
+                else if (!(values &(found_rt)) && (val.compare("retweet_count") == 0)) { values |= (key_rt); }
+                else if (!(values &(found_fav)) && (val.compare("favorite_count") == 0)) { values |= (key_fav); }
             }
             else if (val.compare("retweeted") == 0) { inretweet = false; }  // Check if end of retweet
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {
-           if (!found[4] && keys[4]) {    // user.id
+            if ((values &(key_id)) && !(values &(found_id))) {    // id
+                id = val;
+                values &= ~(key_id);
+                values |= (found_id);
+            }
+            else if (!(values &(found_reply)) && (values &(key_reply))) {   // in_reply_status_id
+                reply_status = val;
+                values &= ~(key_reply);
+                values |= (found_reply);
+            }
+            else if (!(values &(found_userid)) && (values &(key_userid))) {    // user.id
                 user_id = val;
-                userobject_id = keys[4] = false;
-                found[4] = true;
+                userobject_id = false;
+                values &= ~(key_userid);
+                values |= (found_userid);
             }
-            else if (!found[6] && keys[6]) {   // retweet_count
+            else if (!(values &(found_rt)) && (values &(key_rt))) {   // retweet_count
                 rt = val;
-                keys[6] = false;
-                found[6] = true;
+                values &= ~(key_rt);
+                values |= (found_rt);
             }
-            else if (!found[7] && keys[7]) {   // favorite_count
+            else if ((values &(key_fav)) && !(values &(found_fav))) {   // favorite_count
                 fav = val;
-                keys[7] = false;
-                found[7] = true;
+                values &= ~(key_fav);
+                values |= (found_fav);
                 // Assume that this is last key required, so add the partial_tweet to result
                 result.emplace_back(partial_tweets::tweet<std::string>{
                 date,id,text,reply_status,{user_id,screen_name},rt,fav});
             }
-            else if (!found[1] && keys[1]) {    // id
-                id = val;
-                keys[1] = false;
-                found[1] = true;
-            }
-            else if (!found[3] && keys[3]) {   // in_reply_status_id
-                reply_status = val;
-                found[3] = true;
-                keys[3] = false;
-            }
             return true;
         }
         bool string(string_t& val) override {
-            if (!found[5] && keys[5]) {    // user.screen_name
-                screen_name = val;
-                userobject_screen_name = keys[5] = false;
-                found[5] = true;
-            }
-            else if (!found[0] && keys[0]) {   //  created_at
+            if (!(values &(found_date)) && (values &(key_date))) {   //  created_at
                 date = val;
-                keys[0] = false;
-                found[0] = true;
+                values &= ~(key_date);
+                values |= (found_date);
             }
-            else if (!found[2] && keys[2]) {   // text
+            else if (!(values &(found_text)) && (values &(key_text))) {   // text
                 text = val;
-                keys[2] = false;
-                found[2] = true;
+                values &= ~(key_text);
+                values |= (found_text);
+            }
+            else if (!(values &(found_screenname)) && (values &(key_screenname))) {    // user.screen_name
+                screen_name = val;
+                userobject_screen_name = false;
+                values &= ~(key_screenname);
+                values |= (found_screenname);
             }
             return true;
         }
         bool null() override {
-            if (!found[3] && keys[3]) {    // in_reply_status (null case)
+            if (!(values &(found_reply)) && (values &(key_reply))) {    // in_reply_status (null case)
                 reply_status = 0;
-                found[3] = true;
-                keys[3] = false;
+                values &= ~(key_reply);
+                values |= (found_reply);
             }
             return true;
         }

--- a/benchmark/partial_tweets/rapidjson_sax.h
+++ b/benchmark/partial_tweets/rapidjson_sax.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_RAPIDJSON
+
+#include "partial_tweets.h"
+#include <string.h>
+#include <fstream>
+
+namespace partial_tweets {
+
+using namespace rapidjson;
+
+struct rapidjson_sax {
+    using StringType=std::string_view;
+
+    struct Handler {
+        bool keys[9] = { false };
+        bool values[9] = { false };
+        uint64_t user_id = 0;
+        uint64_t id = 0;
+        uint64_t rt = 0;
+        uint64_t fav = 0;
+        uint64_t reply_status = 0;
+        bool inretweet = false;
+        char* name;
+        char* date;
+        char* text;
+        std::vector<tweet<std::string_view>>& result;
+
+        Handler(std::vector<tweet<std::string_view>> &r) : result(r) { }
+
+        bool Key(const char* key, SizeType length, bool copy) {
+            if (!inretweet) {
+                if (strcmp(key,"retweeted_status") == 0) { inretweet = true; }
+                else if (strcmp(key,"metadata") == 0) {
+                    values[0] = values[1] = values[2] = values[3] = values[4] = values[5] = values[6] = values[7] = values[8] = false;
+                    keys[0] = keys[1] = keys[2] = keys[3] = keys[4] = keys[5] = keys[6] = keys[7] = keys[8] = false;
+                }
+                else if (strcmp(key,"user") == 0) { keys[0] = true; }
+                else if (keys[0] && strcmp(key,"id") == 0) { keys[1] = true; }
+                else if (keys[0] && strcmp(key,"screen_name") == 0) { keys[2] = true; }
+                else if (strcmp(key,"created_at") == 0) { keys[3] = true; }
+                else if (strcmp(key,"id") == 0) { keys[4] = true; }
+                else if (strcmp(key,"text") == 0) { keys[5] = true; }
+                else if (strcmp(key,"in_reply_to_status_id") == 0) { keys[6] = true; }
+                else if (strcmp(key,"retweet_count") == 0) { keys[7] = true; }
+                else if (strcmp(key,"favorite_count") == 0) { keys[8] = true; }
+            }
+
+            // Assume that a tweet/retweet always finishes with a unique key "retweeted"
+            else if (strcmp(key,"retweeted") == 0) { inretweet = false; }
+            return true;
+        }
+        bool Uint(unsigned i) {
+            if (!values[1] && keys[1]) {
+                user_id = i;
+                //std::cout << user_id << std::endl;
+                keys[1] = false;
+                values[1] = true;
+            }
+            else if (!values[7] && keys[7]) {
+                rt = i;
+                //std::cout << rt << std::endl;
+                keys[7] = false;
+                values[7] = true;
+            }
+            else if (!values[8] && keys[8]) {
+                fav = i;
+                //std::cout << fav << std::endl;
+                keys[8] = false;
+                values[8] = true;
+
+                // Reset
+                result.emplace_back(partial_tweets::tweet<std::string_view>{
+                date,id,text,reply_status,{user_id,name},rt,fav});
+                //std::cout << date << ' ' << id << std::endl << text << std::endl << reply_status << ' ' << user_id << ' ' << name << std::endl;
+                //std::cout << rt << ' ' << fav << std::endl;
+            }
+            return true;
+        }
+        bool Uint64(uint64_t i) {
+            if (!values[4] && keys[4]) {
+                id = i;
+                //std::cout << i << std::endl;
+                keys[4] = false;
+                values[4] = true;
+            }
+            else if (!values[6] && keys[6]) {
+                reply_status = i;
+                //std::cout << i << std::endl;
+                values[6] = true;
+                keys[6] = false;
+            }
+            return true;
+        }
+        bool String(const char* str, SizeType length, bool copy) {
+            if (!values[2] && keys[2]) {
+                name = strdup(str);
+                //std::cout << name << std::endl;
+                keys[0] = keys[2] = false;
+                values[2] = true;
+            }
+            else if (!values[3] && keys[3]) {
+                date = strdup(str);
+                //std::cout << date << std::endl;
+                keys[3] = false;
+                values[3] = true;
+            }
+            else if (!values[5] && keys[5]) {
+                //text = str;
+                text = strdup(str);
+                //std::cout << text << std::endl;
+                keys[5] = false;
+                values[5] = true;
+            }
+            return true;
+        }
+        bool Null() {
+            if (!values[6] && keys[6]) {
+                reply_status = 0;
+                //std::cout << reply_status << std::endl;
+                values[6] = true;
+                keys[6] = false;
+            }
+            return true;
+        }
+        // Irrelevant events
+        bool Bool(bool b) { return true; }
+        bool Double(double d) { return true; }
+        bool Int(int i) { return true; }
+        bool Int64(int64_t i) { return true; }
+        bool RawNumber(const char* str, SizeType length, bool copy) { return true; }
+        bool StartObject() { return true; }
+        bool EndObject(SizeType memberCount) { return true; }
+        bool StartArray() { return true; }
+        bool EndArray(SizeType elementCount) { return true; }
+    }; // handler
+
+    bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
+        Reader reader;
+        Handler handler(result);
+        StringStream ss(json.data());
+        reader.Parse(ss,handler);
+        return true;
+    }
+
+}; // rapid_jason_sax
+BENCHMARK_TEMPLATE(partial_tweets, rapidjson_sax)->UseManualTime();
+} // namespace partial_tweets
+
+#endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/partial_tweets/rapidjson_sax.h
+++ b/benchmark/partial_tweets/rapidjson_sax.h
@@ -19,8 +19,25 @@ struct rapidjson_sax {
     // Assume that each tweet/retweet start with a key "metadata" and has a key "retweeted" towards the end
     // The previous assumption will be used to check for the beginning of a new tweet and the end of a retweet
     struct Handler {
-        bool keys[8] = { false };   // Stores if previous parsed key was a valid key (in same order as above)
-        bool found[8] = { false }; // Stores if ith key has already been found once
+        enum state {    // Bitset to store state of search
+            key_date = (1<<0),
+            key_id = (1<<1),
+            key_text = (1<<2),
+            key_reply = (1<<3),
+            key_userid = (1<<4),
+            key_screenname = (1<<5),
+            key_rt = (1<<6),
+            key_fav = (1<<7),
+            found_date = (1<<8),
+            found_id = (1<<9),
+            found_text = (1<<10),
+            found_reply = (1<<11),
+            found_userid = (1<<12),
+            found_screenname = (1<<13),
+            found_rt = (1<<14),
+            found_fav = (1<<15)
+        };
+        int values = state::key_date;
         bool userobject_id = false; // If in a user object (to find user.id)
         bool userobject_screen_name = false;    // If in a user object (to find user.screen_name)
         bool inretweet = false; // If in a retweet (all keys irrelevant in retweet object)
@@ -40,43 +57,41 @@ struct rapidjson_sax {
         bool Key(const char* key, SizeType length, bool copy) {
             if (!inretweet) {   // If not in a retweet object, find relevant keys
                 if ((length == 16) && (memcmp(key,"retweeted_status",16) == 0)) { inretweet = true; }   // Check if entering retweet
-                else if ((length == 8) && (memcmp(key,"metadata",8) == 0)) {    // Reset at beginning of tweet
-                    found[0] = found[1] = found[2] = found[3] = found[4] = found[5] = found[6] = found[7] = found[8] = false;
-                    keys[0] = keys[1] = keys[2] = keys[3] = keys[4] = keys[5] = keys[6] = keys[7] = keys[8] = false;
-                }
+                else if ((length == 8) && (memcmp(key,"metadata",8) == 0)) { values = 0; }  // Reset
                 // Check if key has been found and if key matches a valid key
-                else if (!found[0] && (length == 10) && (memcmp(key,"created_at",10) == 0)) { keys[0] = true; }
+                else if (!(values &(found_date)) && (length == 10) && (memcmp(key,"created_at",10) == 0)) { values |= (key_date); }
                 // Must also check if not in a user object
-                else if (!found[1] && !userobject_id && (length == 2) && (memcmp(key,"id",2) == 0)) { keys[1] = true; }
-                else if (!found[2] && (length == 4) && (memcmp(key,"text",4) == 0)) { keys[2] = true; }
-                else if (!found[3] && (length == 21) && (memcmp(key,"in_reply_to_status_id",21) == 0)) { keys[3] = true; }
+                else if (!(values &(found_id)) && !userobject_id && (length == 2) && (memcmp(key,"id",2) == 0)) { values |= (key_id); }
+                else if (!(values &(found_text)) && (length == 4) && (memcmp(key,"text",4) == 0)) { values |= (key_text); }
+                else if (!(values &(found_reply)) && (length == 21) && (memcmp(key,"in_reply_to_status_id",21) == 0)) { values |= (key_reply); }
                 // Check if entering user object
-                else if (!found[4] && (length == 4) && (memcmp(key,"user",4) == 0)) { userobject_id = userobject_screen_name = true; }
+                else if ((length == 4) && (memcmp(key,"user",4) == 0)) { userobject_id = userobject_screen_name = true; }
                 // Must also check if in a user object
-                else if (!found[5] && userobject_id && (length == 2) && (memcmp(key,"id",2) == 0)) { keys[4] = true; }
+                else if (!(values &(found_userid)) && userobject_id && (length == 2) && (memcmp(key,"id",2) == 0)) { values |= (key_userid); }
                 // Must also check if in a user object
-                else if (!found[6] && userobject_screen_name && (length == 11) && (memcmp(key,"screen_name",11) == 0)) { keys[5] = true; }
-                else if (!found[7] && (length == 13) && (memcmp(key,"retweet_count",13) == 0)) { keys[6] = true; }
-                else if (!found[8] && (length == 14) && (memcmp(key,"favorite_count",14) == 0)) { keys[7] = true; }
+                else if (!(values &(found_screenname)) && userobject_screen_name && (length == 11) && (memcmp(key,"screen_name",11) == 0)) { values |= (key_screenname); }
+                else if (!(values &(found_rt)) && (length == 13) && (memcmp(key,"retweet_count",13) == 0)) { values |= (key_rt); }
+                else if (!(values &(found_fav)) && (length == 14) && (memcmp(key,"favorite_count",14) == 0)) { values |= (key_fav); }
             }
             else if ((length == 9) && (memcmp(key,"retweeted",9) == 0)) { inretweet = false; }  // Check if end of retweet
             return true;
         }
         bool Uint(unsigned i) {
-            if (!found[4] && keys[4]) {    // user.id
+            if ((values &(key_userid)) && !(values &(found_userid))) {    // user.id
                 user_id = i;
-                userobject_id = keys[4] = false;
-                found[4] = true;
+                userobject_id = false;
+                values &= ~(key_userid);
+                values |= (found_userid);
             }
-            else if (!found[6] && keys[6]) {   // retweet_count
+            else if ((values &(key_rt)) && !(values &(found_rt))) {   // retweet_count
                 rt = i;
-                keys[6] = false;
-                found[6] = true;
+                values &= ~(key_rt);
+                values |= (found_rt);
             }
-            else if (!found[7] && keys[7]) {   // favorite_count
+            else if ((values &(key_fav)) && !(values &(found_fav))) {   // favorite_count
                 fav = i;
-                keys[7] = false;
-                found[7] = true;
+                values &= ~(key_fav);
+                values |= (found_fav);
                 // Assume that this is last key required, so add the partial_tweet to result
                 result.emplace_back(partial_tweets::tweet<std::string_view>{
                 date,id,text,reply_status,{user_id,screen_name},rt,fav});
@@ -84,41 +99,42 @@ struct rapidjson_sax {
             return true;
         }
         bool Uint64(uint64_t i) {
-            if (!found[1] && keys[1]) {    // id
+            if ((values &(key_id)) && !(values &(found_id))) {    // id
                 id = i;
-                keys[1] = false;
-                found[1] = true;
+                values &= ~(key_id);
+                values |= (found_id);
             }
-            else if (!found[3] && keys[3]) {   // in_reply_status_id
+            else if ((values &(key_reply)) && !(values &(found_reply))) {   // in_reply_status_id
                 reply_status = i;
-                found[3] = true;
-                keys[3] = false;
+                values &= ~(key_reply);
+                values |= (found_reply);
             }
             return true;
         }
         bool String(const char* str, SizeType length, bool copy) {
-            if (!found[5] && keys[5]) {    // user.screen_name
-                screen_name = strdup(str);
-                userobject_screen_name = keys[5] = false;
-                found[5] = true;
-            }
-            else if (!found[0] && keys[0]) {   //  created_at
+            if ((values &(key_date)) & !(values &(found_date))) {   //  created_at
                 date = strdup(str);
-                keys[0] = false;
-                found[0] = true;
+                values &= ~(key_date);
+                values |= (found_date);
             }
-            else if (!found[2] && keys[2]) {   // text
+            else if ((values &(key_text)) && !(values &(found_text))) {   // text
                 text = strdup(str);
-                keys[2] = false;
-                found[2] = true;
+                values &= ~(key_text);
+                values |= (found_text);
+            }
+            else if ((values &(key_screenname)) && !(values &(found_screenname))) {    // user.screen_name
+                screen_name = strdup(str);
+                userobject_screen_name = false;
+                values &= ~(key_screenname);
+                values |= (found_screenname);
             }
             return true;
         }
         bool Null() {
-            if (!found[3] && keys[3]) {    // in_reply_status (null case)
+            if ((values &(key_reply)) && !(values &(found_reply))) {    // in_reply_status (null case)
                 reply_status = 0;
-                found[3] = true;
-                keys[3] = false;
+                values &= ~(key_reply);
+                values |= (found_reply);
             }
             return true;
         }

--- a/benchmark/partial_tweets/rapidjson_sax.h
+++ b/benchmark/partial_tweets/rapidjson_sax.h
@@ -113,17 +113,17 @@ struct rapidjson_sax {
         }
         bool String(const char* str, SizeType length, bool copy) {
             if (values & key_date && !(values & found_date)) {   //  created_at
-                date = str;
+                date = {str,length};
                 values &= ~(key_date);
                 values |= (found_date);
             }
             else if (values & key_text && !(values & found_text)) {   // text
-                text = str;
+                text = {str,length};
                 values &= ~(key_text);
                 values |= (found_text);
             }
             else if (values & key_screenname && !(values & found_screenname)) {    // user.screen_name
-                screen_name = str;
+                screen_name = {str,length};
                 userobject_screen_name = false;
                 values &= ~(key_screenname);
                 values |= (found_screenname);


### PR DESCRIPTION
This adds RapidJSON and nlohmann_json SAX to the partial_tweets benchmark. Performance results:

<table>
<center><b> Comparison SAX vs. non-SAX (gcc) </b></center>
<tr><td>

|Benchmark|throughput|
|-----|-----|
|partial_tweets<rapidjson>/manual_time |0.42GB/s|
|partial_tweets<rapidjson_insitu>/manual_time|0.76GB/s|
|partial_tweets<rapidjson_sax>/manual_time|0.65GB/s|
|<b>---------------</b>|<b>---------------</b>|
|partial_tweets<nlohmann_json>/manual_time|0.08GB/s|
|partial_tweets<nlohmann_json_sax>/manual_time|0.14GB/s|
|<b>---------------</b>|<b>---------------</b>|
|partial_tweets<simdjson_ondemand>/manual_time|3.04GB/s|
</td></tr>
</table>

rapidjson_sax is still behind rapidjson_insitu, so there might be some optimisations or a better approach than the one I used, but for now, this is the best working version I could get. Suggestions are welcome.

NOTE: for some reasons, the performance of rapidjson_sax went down between commit eacf2d2 and commit d56ab71 even though rapidjson_sax was not modified. Performance went from 0.73 GB/s to 0.65 GB/s.