### PR TITLE
Add RapidJSON and nlohmann_json SAX to find_tweet benchmark

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -66,6 +66,7 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "find_tweet/rapidjson.h"
 #include "find_tweet/rapidjson_sax.h"
 #include "find_tweet/nlohmann_json.h"
+#include "find_tweet/nlohmann_json_sax.h"
 
 #include "top_tweet/simdjson_dom.h"
 #include "top_tweet/simdjson_ondemand.h"

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -64,6 +64,7 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "find_tweet/yyjson.h"
 #include "find_tweet/sajson.h"
 #include "find_tweet/rapidjson.h"
+#include "find_tweet/rapidjson_sax.h"
 #include "find_tweet/nlohmann_json.h"
 
 #include "top_tweet/simdjson_dom.h"

--- a/benchmark/find_tweet/nlohmann_json_sax.h
+++ b/benchmark/find_tweet/nlohmann_json_sax.h
@@ -14,6 +14,7 @@ struct nlohmann_json_sax {
     struct Handler : json::json_sax_t
     {
         bool text_key = false;
+        bool id_key = false;
         bool found_id = false;
         uint64_t find_id;
         std::string &result;
@@ -25,10 +26,11 @@ struct nlohmann_json_sax {
             if (found_id) { // If have found id, find text key
                 if (val.compare("text") == 0) { text_key = true; }
             }
+            else if (val.compare("id") == 0) { id_key = true; } // Otherwise, find id key
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {
-            if (val == find_id) {  // Looking for find_id
+            if (id_key && (val == find_id)) {  // If id key, check if id value matches find_id
                 found_id = true;
             }
             return true;

--- a/benchmark/find_tweet/nlohmann_json_sax.h
+++ b/benchmark/find_tweet/nlohmann_json_sax.h
@@ -2,33 +2,41 @@
 
 #ifdef SIMDJSON_COMPETITION_NLOHMANN_JSON
 
-#include "distinct_user_id.h"
+#include "find_tweet.h"
 
-namespace distinct_user_id {
+namespace find_tweet {
 
 using json = nlohmann::json;
 
 struct nlohmann_json_sax {
+    using StringType=std::string;
+
     struct Handler : json::json_sax_t
     {
-        std::vector<uint64_t>& result;
-        bool user = false;
-        bool user_id = false;
-        Handler(std::vector<uint64_t> &r) : result(r) { }
+        bool text_key = false;
+        bool found_id = false;
+        uint64_t find_id;
+        std::string &result;
 
+        Handler(std::string &r,uint64_t id): result(r), find_id(id) { }
+
+        // We assume id is found before text
         bool key(string_t& val) override {
-            // Assume that valid user/id pairs appear only once in main array of user objects
-            if (user) { // If already found user object, find id key
-                if (val.compare("id") == 0) { user_id = true; }
+            if (found_id) { // If have found id, find text key
+                if (val.compare("text") == 0) { text_key = true; }
             }
-            else if (val.compare("user") == 0) { user = true; } // Otherwise, find user object
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {
-            if (user_id) {
-                result.emplace_back(val);
-                user = false;
-                user_id = false;
+            if (val == find_id) {  // Looking for find_id
+                found_id = true;
+            }
+            return true;
+        }
+        bool string(string_t& val) override {
+            if (text_key) {
+                result = val;
+                return false;   // End parsing
             }
             return true;
         }
@@ -37,7 +45,6 @@ struct nlohmann_json_sax {
         bool boolean(bool val) override { return true; }
         bool number_float(number_float_t val, const string_t& s) override { return true; }
         bool number_integer(number_integer_t val) override { return true; }
-        bool string(string_t& val) override { return true; }
         bool start_object(std::size_t elements) override { return true; }
         bool end_object() override { return true; }
         bool start_array(std::size_t elements) override { return true; }
@@ -46,14 +53,14 @@ struct nlohmann_json_sax {
         bool parse_error(std::size_t position, const std::string& last_token, const json::exception& ex) override { return false; }
     }; // Handler
 
-    bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
-        Handler handler(result);
+    bool run(simdjson::padded_string &json, uint64_t find_id, std::string &result) {
+        Handler handler(result,find_id);
         json::sax_parse(json.data(), &handler);
 
         return true;
     }
 }; // nlohmann_json_sax
-BENCHMARK_TEMPLATE(distinct_user_id, nlohmann_json_sax)->UseManualTime();
-} // namespace distinct_user_id
+BENCHMARK_TEMPLATE(find_tweet, nlohmann_json_sax)->UseManualTime();
+} // namespace find_tweet
 
 #endif // SIMDJSON_COMPETITION_NLOHMANN_JSON

--- a/benchmark/find_tweet/rapidjson.h
+++ b/benchmark/find_tweet/rapidjson.h
@@ -47,6 +47,6 @@ struct rapidjson_insitu : rapidjson_base {
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson_insitu)->UseManualTime();
 
-} // namespace partial_tweets
+} // namespace find_tweet
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/find_tweet/rapidjson_sax.h
+++ b/benchmark/find_tweet/rapidjson_sax.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#ifdef SIMDJSON_COMPETITION_RAPIDJSON
+
+#include "find_tweet.h"
+#include <string.h>
+
+namespace find_tweet {
+
+using namespace rapidjson;
+
+struct rapidjson_sax {
+  using StringType=std::string_view;
+
+struct Handler {
+        bool text_key = false;
+        bool found_id = false;
+        uint64_t find_id;
+        std::string_view &result;
+
+        Handler(std::string_view &r,uint64_t id): result(r), find_id(id) { }
+
+        bool Key(const char* key, SizeType length, bool copy) {
+            if (found_id) { // If have found id, find text key
+                if ((length == 4) && (memcmp(key,"text",4) == 0)) { text_key = true; }
+            }
+            return true;
+        }
+        bool Uint64(uint64_t i) {
+            if (i == find_id) {  // Looking for find_id
+                found_id = true;
+            }
+            return true;
+        }
+        bool String(const char* str, SizeType length, bool copy) {
+            if (found_id && text_key) {
+                result = {str,length};
+                return false;   // End parsing
+            }
+            return true;
+        }
+        // Irrelevant events
+        bool Null() { return true; }
+        bool Bool(bool b) { return true; }
+        bool Double(double d) { return true; }
+        bool Int(int i) { return true; }
+        bool Int64(int64_t i) { return true; }
+        bool Uint(unsigned i) { return true; }
+        bool RawNumber(const char* str, SizeType length, bool copy) { return true; }
+        bool StartObject() { return true; }
+        bool EndObject(SizeType memberCount) { return true; }
+        bool StartArray() { return true; }
+        bool EndArray(SizeType elementCount) { return true; }
+    }; // handler
+
+  bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
+        Reader reader;
+        Handler handler(result,find_id);
+        InsituStringStream ss(json.data());
+        reader.Parse<kParseInsituFlag | kParseValidateEncodingFlag | kParseFullPrecisionFlag>(ss,handler);
+        return true;
+    }
+}; // rapidjson_sax
+BENCHMARK_TEMPLATE(find_tweet, rapidjson_sax)->UseManualTime();
+} // namespace find_tweet
+
+#endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/find_tweet/rapidjson_sax.h
+++ b/benchmark/find_tweet/rapidjson_sax.h
@@ -10,7 +10,7 @@ namespace find_tweet {
 using namespace rapidjson;
 
 struct rapidjson_sax {
-  using StringType=std::string_view;
+using StringType=std::string_view;
 
 struct Handler {
         bool text_key = false;
@@ -20,6 +20,7 @@ struct Handler {
 
         Handler(std::string_view &r,uint64_t id): result(r), find_id(id) { }
 
+        // We assume id is found before text
         bool Key(const char* key, SizeType length, bool copy) {
             if (found_id) { // If have found id, find text key
                 if ((length == 4) && (memcmp(key,"text",4) == 0)) { text_key = true; }
@@ -33,7 +34,7 @@ struct Handler {
             return true;
         }
         bool String(const char* str, SizeType length, bool copy) {
-            if (found_id && text_key) {
+            if (text_key) {
                 result = {str,length};
                 return false;   // End parsing
             }

--- a/benchmark/find_tweet/rapidjson_sax.h
+++ b/benchmark/find_tweet/rapidjson_sax.h
@@ -14,6 +14,7 @@ using StringType=std::string_view;
 
 struct Handler {
         bool text_key = false;
+        bool id_key = false;
         bool found_id = false;
         uint64_t find_id;
         std::string_view &result;
@@ -25,10 +26,11 @@ struct Handler {
             if (found_id) { // If have found id, find text key
                 if ((length == 4) && (memcmp(key,"text",4) == 0)) { text_key = true; }
             }
+            else if ((length == 2) && (memcmp(key,"id",2) == 0)) { id_key = true; } // Otherwise, find id key
             return true;
         }
         bool Uint64(uint64_t i) {
-            if (i == find_id) {  // Looking for find_id
+            if (id_key && (i == find_id)) {  // If id key, check if id value matches find_id
                 found_id = true;
             }
             return true;


### PR DESCRIPTION
This adds RapidJSON and nlohmman_json SAX to find_tweet benchmark. Performance results:

<table>
<center><b> Comparison SAX vs. non-SAX (gcc) </b></center>
<tr><td>

|Benchmark|throughput|
|-----|-----|
|find_tweet<rapidjson>/manual_time |0.40GB/s|
|find_tweet<rapidjson_insitu>/manual_time|0.59GB/s|
|find_tweet<rapidjson_sax>/manual_time|4.68GB/s|
|<b>---------------</b>|<b>---------------</b>|
|find_tweet<nlohmann_json>/manual_time|0.08GB/s|
|find_tweet<nlohmann_json_sax>/manual_time|1.31GB/s|
|<b>---------------</b>|<b>---------------</b>|
|find_tweet<simdjson_ondemand>/manual_time|4.72GB/s|
</td></tr>
</table>

Very significant increase between SAX and their dom couterparts. rapidjson_sax is very close to simdjson_ondemand for this benchmark, but simdjson_ondemand still holds the edge.
Relates to #1401 
