### PR TITLE
Don't #include "simdjson.cpp" in tests

### DIFF
--- a/tests/dom/CMakeLists.txt
+++ b/tests/dom/CMakeLists.txt
@@ -1,26 +1,4 @@
 
-#
-# These tests explicitly do #include "simdjson.cpp" so they can override stuff
-#
-if(NOT SIMDJSON_LEGACY_VISUAL_STUDIO AND NOT SIMDJSON_WINDOWS_DLL)
-  add_cpp_test(numberparsingcheck LABELS acceptance per_implementation)
-  simdjson_apply_props(numberparsingcheck)
-  target_link_libraries(numberparsingcheck PRIVATE simdjson-windows-headers)
-  target_compile_definitions(numberparsingcheck PRIVATE NOMINMAX)
-  target_include_directories(
-      numberparsingcheck
-      PRIVATE "${PROJECT_SOURCE_DIR}/src"
-  )
-  add_cpp_test(stringparsingcheck LABELS acceptance per_implementation)
-  simdjson_apply_props(numberparsingcheck)
-  target_link_libraries(stringparsingcheck PRIVATE simdjson-windows-headers)
-  target_compile_definitions(stringparsingcheck PRIVATE NOMINMAX)
-  target_include_directories(
-      stringparsingcheck
-      PRIVATE "${PROJECT_SOURCE_DIR}/src"
-  )
-endif()
-
 link_libraries(simdjson)
 include_directories(..)
 
@@ -35,8 +13,10 @@ add_cpp_test(extracting_values_example  LABELS dom acceptance per_implementation
 add_cpp_test(integer_tests              LABELS dom acceptance per_implementation)
 add_cpp_test(jsoncheck                  LABELS dom acceptance per_implementation)
 add_cpp_test(minefieldcheck             LABELS dom acceptance per_implementation)
+add_cpp_test(numberparsingcheck         LABELS dom acceptance per_implementation) # https://tools.ietf.org/html/rfc6901
 add_cpp_test(parse_many_test            LABELS dom acceptance per_implementation)
 add_cpp_test(pointercheck               LABELS dom acceptance per_implementation) # https://tools.ietf.org/html/rfc6901
+add_cpp_test(stringparsingcheck         LABELS dom acceptance per_implementation) # https://tools.ietf.org/html/rfc6901
 add_cpp_test(trivially_copyable_test    LABELS dom acceptance per_implementation)
 
 

--- a/tests/dom/numberparsingcheck.cpp
+++ b/tests/dom/numberparsingcheck.cpp
@@ -167,7 +167,6 @@ void found_float(double result, const uint8_t *buf) {
 #endif
 
 #include "simdjson.h"
-#include "simdjson.cpp"
 
 /**
  * Does the file filename ends with the given extension.

--- a/tests/dom/stringparsingcheck.cpp
+++ b/tests/dom/stringparsingcheck.cpp
@@ -293,7 +293,6 @@ void found_string(const uint8_t *buf, const uint8_t *parsed_begin,
 }
 
 #include "simdjson.h"
-#include "simdjson.cpp"
 
 /**
  * Does the file filename ends with the given extension.


### PR DESCRIPTION
This makes numberparsingcheck and stringparsingcheck use simdjson.cpp / simdjson.h. Because number / string parsing are now inline functions in the headers, our callbacks will be called just fine without having to include simdjson.cpp.

Fixes #1604.