### PR TITLE
Add JSON pointer benchmark for distinct_user_id

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -55,7 +55,9 @@ SIMDJSON_POP_DISABLE_WARNINGS
 #include "kostya/nlohmann_json_sax.h"
 
 #include "distinct_user_id/simdjson_dom.h"
+#include "distinct_user_id/simdjson_dom_json_pointer.h"
 #include "distinct_user_id/simdjson_ondemand.h"
+#include "distinct_user_id/simdjson_ondemand_json_pointer.h"
 #include "distinct_user_id/yyjson.h"
 #include "distinct_user_id/sajson.h"
 #include "distinct_user_id/rapidjson.h"

--- a/benchmark/distinct_user_id/simdjson_dom_json_pointer.h
+++ b/benchmark/distinct_user_id/simdjson_dom_json_pointer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "distinct_user_id.h"
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+
+struct simdjson_dom_json_pointer {
+  dom::parser parser{};
+
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
+    // Walk the document, parsing as we go
+    auto doc = parser.parse(json);
+    for (dom::object tweet : doc["statuses"]) {
+      // We believe that all statuses have a matching
+      // user, and we are willing to throw when they do not.
+      result.push_back(tweet.at_pointer("/user/id"));
+      // Not all tweets have a "retweeted_status", but when they do
+      // we want to go and find the user within.
+      auto retweet_id = tweet.at_pointer("/retweeted_status/user/id");
+      if (retweet_id.error() != NO_SUCH_FIELD) {
+        result.push_back(retweet_id);
+      }
+    }
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(distinct_user_id, simdjson_dom_json_pointer)->UseManualTime();
+
+} // namespace distinct_user_id
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/distinct_user_id/simdjson_ondemand_json_pointer.h
+++ b/benchmark/distinct_user_id/simdjson_ondemand_json_pointer.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#if SIMDJSON_EXCEPTIONS
+
+#include "distinct_user_id.h"
+
+namespace distinct_user_id {
+
+using namespace simdjson;
+
+struct simdjson_ondemand_json_pointer {
+  ondemand::parser parser{};
+
+  bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
+    // Walk the document, parsing as we go
+    auto doc = parser.iterate(json);
+    for (ondemand::object tweet : doc.find_field("statuses")) {
+      // We believe that all statuses have a matching
+      // user, and we are willing to throw when they do not.
+      result.push_back(tweet.at_pointer("/user/id"));
+      // Not all tweets have a "retweeted_status", but when they do
+      // we want to go and find the user within.
+      auto retweet_id = tweet.at_pointer("/retweeted_status/user/id");
+      if (retweet_id.error() != NO_SUCH_FIELD) {
+        result.push_back(retweet_id);
+      }
+    }
+
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(distinct_user_id, simdjson_ondemand_json_pointer)->UseManualTime();
+
+} // namespace distinct_user_id
+
+#endif // SIMDJSON_EXCEPTIONS


### PR DESCRIPTION
This adds two JSON pointer benchmark (DOM and On Demand) for the distinct_user_id benchmark.

Performance:
<table>
<center><b> Comparison SAX vs. non-SAX (gcc) </b></center>
<tr><td>

|Benchmark|throughput|
|-----|-----|
|distinct_user_id<simdjson_dom>/manual_time |2.41GB/s|
|distinct_user_id<simdjson_dom_json_pointer>/manual_time|2.34GB/s|
|distinct_user_id<simdjson_ondemand>/manual_time|3.49GB/s|
|distinct_user_id<simdjson_ondemand_json_pointer>/manual_time|3.02GB/s|

</table>

DOM is not that much affected by the usage of JSON pointer (-2.9%) while On Demand is significantly slower (-15%). Comparing both JSON pointers approach, we see that On Demand JSON pointer is much faster than DOM JSON pointer.

Remark: I used a relative path by iterating over each tweet in the json file instead of always using an absolute path. Is this fair?


Fixes https://github.com/simdjson/simdjson/issues/1617