### PR TITLE
Add automatic rewind for at_pointer

### DIFF
--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -54,7 +54,7 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("/0/foo/a/1") == 20
    *
-   * Note that at_pointer() does not automatically rewind between each call (call rewind() to reset).
+   * Note that at_pointer() automatically calls rewind between each call.
    * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching.
    * @return The value associated with the given JSON pointer, or:
    *         - NO_SUCH_FIELD if a field does not exist in an object

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -135,6 +135,7 @@ simdjson_really_inline simdjson_result<std::string_view> document::raw_json_toke
 }
 
 simdjson_really_inline simdjson_result<value> document::at_pointer(std::string_view json_pointer) noexcept {
+  rewind(); // Rewind the document each time at_pointer is called
   if (json_pointer.empty()) {
     return this->resume_value();
   }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -335,7 +335,7 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("//a/1") == 20
    *
-   * Note that at_pointer() does not automatically rewind between each call (call rewind() to reset).
+   * Note that at_pointer() automatically calls rewind between each call.
    * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching
    *
    * @return The value associated with the given JSON pointer, or:

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -91,7 +91,7 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("//a/1") == 20
    *
-   * Note that at_pointer() does not automatically rewind between each call (call rewind() to reset).
+   * Note that at_pointer() automatically calls rewind between each call.
    * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching.
    *
    * @return The value associated with the given JSON pointer, or:

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -330,7 +330,7 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("//a/1") == 20
    *
-   * Note that at_pointer() does not automatically rewind between each call (call rewind() to reset).
+   * Note that at_pointer() automatically calls rewind between each call.
    * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching
    *
    * @return The value associated with the given JSON pointer, or:

--- a/tests/ondemand/ondemand_json_pointer_tests.cpp
+++ b/tests/ondemand/ondemand_json_pointer_tests.cpp
@@ -117,7 +117,6 @@ namespace json_pointer_tests {
             std::string json_pointer = "/" + std::to_string(i) + "/tire_pressure/1";
             ASSERT_SUCCESS(cars.at_pointer(json_pointer).get(x));
             measured.push_back(x);
-            cars.rewind();
         }
 
         std::vector<double> expected = {39.9, 31, 30};


### PR DESCRIPTION
`at_pointer` now automatically rewinds each call (as per #1622). The rewind is done at the beginning of the call, before any parsing is done. This is something we would want to mention in the documentation. Furthermore, it will also be important to mention to the user that `rewind` invalidates certain values (objects/arrays), and so it is important to store/consume them independently between each call of `at_pointer` which rewinds automatically now. This PR just implements the automatic rewind feature, the documentation issue will be fixed by #1618.

Fixes #1622