### PR TITLE
Add .vscode workspace settings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 * text=auto
 
 # we don't want json files to be modified for this project
-*.json binary 
+*.json binary diff=astextplain
 
 
 # Common settings that generally should always be used with your language specific settings

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,10 @@ objs
 # Generated docs
 /doc/api
 *.orig
+
+# VSCode workspace files
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,17 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+	// List of extensions which should be recommended for users of this workspace.
+	"recommendations": [
+		// Syntax
+		"ms-vscode.cpptools",
+		"ms-vscode.cmake-tools",
+		"ms-python.python",
+		"twxs.cmake"
+	],
+	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+	"unwantedRecommendations": [
+
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.rulers": [
+        {"column": 95 },
+        {"column": 120 }
+    ],
+    "files.trimTrailingWhitespace": true
+}

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -1,0 +1,5 @@
+FROM gcc:10
+RUN echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+RUN apt-get update -qq
+RUN apt-get -t buster-backports install -y cmake
+


### PR DESCRIPTION
This adds some workspace level settings for .vscode. As best I can tell, workspace-level settings.json is considered something you check in to the project, while user-level settings are for, well, the user :)

The main reason I did this is I want it to auto-trim whitespaces at the end of the line when saving. It's driving me crazy having to patch up my PRs :)

This also adds a few recommended extensions for the project (which VS Code can show the user if they bring it up).