### PR TITLE
Partial documentation regarding relative JSON pointers.

### DIFF
--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -130,7 +130,7 @@ inline simdjson_result<value> array::at_pointer(std::string_view json_pointer) n
 }
 
 simdjson_really_inline simdjson_result<value> array::at(size_t index) noexcept {
-  size_t i=0;
+  size_t i = 0;
   for (auto value : *this) {
     if (i == index) { return value; }
     i++;

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -54,8 +54,17 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("/0/foo/a/1") == 20
    *
-   * Note that at_pointer() automatically calls rewind between each call.
+   * Note that at_pointer() called on the document automatically calls the document's rewind 
+   * method between each call. It invalidates all previously accessed arrays, objects and values
+   * that have not been consumed.
+   * 
+   * You may only call at_pointer on an array after it has been created, but before it has
+   * been first accessed. When calling at_pointer on an array, the pointer is advanced to 
+   * the location indicated by the JSON pointer (in case of success). It is no longer possible
+   * to call at_pointer on the same array.
+   *
    * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching.
+   *
    * @return The value associated with the given JSON pointer, or:
    *         - NO_SUCH_FIELD if a field does not exist in an object
    *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -54,12 +54,13 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("/0/foo/a/1") == 20
    *
-   * Note that at_pointer() called on the document automatically calls the document's rewind 
+   * Note that at_pointer() called on the document automatically calls the document's rewind
    * method between each call. It invalidates all previously accessed arrays, objects and values
-   * that have not been consumed.
-   * 
+   * that have not been consumed. Yet it is not the case when calling at_pointer on an array
+   * instance: there is no rewind and no invalidation.
+   *
    * You may only call at_pointer on an array after it has been created, but before it has
-   * been first accessed. When calling at_pointer on an array, the pointer is advanced to 
+   * been first accessed. When calling at_pointer on an array, the pointer is advanced to
    * the location indicated by the JSON pointer (in case of success). It is no longer possible
    * to call at_pointer on the same array.
    *

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -91,11 +91,11 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("//a/1") == 20
    *
-   * Note that at_pointer() called on the document automatically calls the document's rewind 
+   * Note that at_pointer() called on the document automatically calls the document's rewind
    * method between each call. It invalidates all previously accessed arrays, objects and values
    * that have not been consumed. Yet it is not the case when calling at_pointer on an object
    * instance: there is no rewind and no invalidation.
-   * 
+   *
    * You may call at_pointer more than once on an object, but each time the pointer is advanced
    * to be within the value matched by the key indicated by the JSON pointer query. Thus any preceeding
    * key (as well as the current key) can no longer be used with following JSON pointer calls.

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -91,7 +91,15 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("//a/1") == 20
    *
-   * Note that at_pointer() automatically calls rewind between each call.
+   * Note that at_pointer() called on the document automatically calls the document's rewind 
+   * method between each call. It invalidates all previously accessed arrays, objects and values
+   * that have not been consumed. Yet it is not the case when calling at_pointer on an object
+   * instance: there is no rewind and no invalidation.
+   * 
+   * You may call at_pointer more than once on an object, but each time the pointer is advanced
+   * to be within the value matched by the key indicated by the JSON pointer query. Thus any preceeding
+   * key (as well as the current key) can no longer be used with following JSON pointer calls.
+   *
    * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching.
    *
    * @return The value associated with the given JSON pointer, or:

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -330,7 +330,24 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("//a/1") == 20
    *
-   * Note that at_pointer() automatically calls rewind between each call.
+   * Note that at_pointer() called on the document automatically calls the document's rewind 
+   * method between each call. It invalidates all previously accessed arrays, objects and values
+   * that have not been consumed.
+   *
+   * Calling at_pointer() on non-document instances (e.g., arrays and objects) is not
+   * standardized (by RFC 6901). We provide some experimental support for JSON pointers
+   * on non-document instances.  Yet it is not the case when calling at_pointer on an array
+   * or an object instance: there is no rewind and no invalidation.
+   * 
+   * You may only call at_pointer on an array after it has been created, but before it has
+   * been first accessed. When calling at_pointer on an array, the pointer is advanced to 
+   * the location indicated by the JSON pointer (in case of success). It is no longer possible
+   * to call at_pointer on the same array.
+   * 
+   * You may call at_pointer more than once on an object, but each time the pointer is advanced
+   * to be within the value matched by the key indicated by the JSON pointer query. Thus any preceeding
+   * key (as well as the current key) can no longer be used with following JSON pointer calls.
+   *
    * Also note that at_pointer() relies on find_field() which implies that we do not unescape keys when matching
    *
    * @return The value associated with the given JSON pointer, or:

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -330,7 +330,7 @@ public:
    *   auto doc = parser.iterate(json);
    *   doc.at_pointer("//a/1") == 20
    *
-   * Note that at_pointer() called on the document automatically calls the document's rewind 
+   * Note that at_pointer() called on the document automatically calls the document's rewind
    * method between each call. It invalidates all previously accessed arrays, objects and values
    * that have not been consumed.
    *
@@ -338,12 +338,12 @@ public:
    * standardized (by RFC 6901). We provide some experimental support for JSON pointers
    * on non-document instances.  Yet it is not the case when calling at_pointer on an array
    * or an object instance: there is no rewind and no invalidation.
-   * 
+   *
    * You may only call at_pointer on an array after it has been created, but before it has
-   * been first accessed. When calling at_pointer on an array, the pointer is advanced to 
+   * been first accessed. When calling at_pointer on an array, the pointer is advanced to
    * the location indicated by the JSON pointer (in case of success). It is no longer possible
    * to call at_pointer on the same array.
-   * 
+   *
    * You may call at_pointer more than once on an object, but each time the pointer is advanced
    * to be within the value matched by the key indicated by the JSON pointer query. Thus any preceeding
    * key (as well as the current key) can no longer be used with following JSON pointer calls.


### PR DESCRIPTION
In https://github.com/simdjson/simdjson/pull/1618, @NicolasJiaxin documents the general usage of JSON pointers on top of On Demand. For document instances, we rewind/invalidate between each query at the beginning of each JSON pointer query. To recap, we rewind and reset the string buffer. The expectation is that people consume the result of a JSON pointer by, for example, copying the data into their own data structures.

However, somewhat discreetly, we also allow JSON pointer queries on arrays and object types. They are not formally supported by the standard. In such cases, we do not rewind. Rewinding at the component level would be problematic because the general JSON pointer implementation calls the component's JSON pointer implementation.

Currently, the behavior is as follows:

1. For arrays, we can only use `at_pointer` on a fresh, newly opened array. This means that you can only do `at_pointer` once... following queries should fail or give otherwise invalid results. There is a rather fundamental reason for this: we have no indexing. You may know that you are inside the array, but we don't track the index we are at. We could 'rewind' the arrays but that would allow people to consume the same string values multiple times which we don't want to allow. Furthermore, we don't want people to use `at_pointer` as an index (getting the value 0, 1, ...) as this could lead to performance anti-pattern. So, to sum it up, we allow one `at_pointer`. You can move to one index and maybe within the associated value, and that is all.
2. For objects, you can issue multiple `at_pointer` queries. Each time, you move (forward only) to a new key. Because we can only move forward, it works nicely and there is no other care needed.


The current plan is to remain discreet regarding this functionality. It will appear in our API documentation, but we will not document it further for the time being.

Fixes https://github.com/simdjson/simdjson/issues/1627
