### PR TITLE
Making it possible to copy a value_iterator instance, and later reset it to that prior value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,16 @@
         {"column": 95 },
         {"column": 120 }
     ],
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "files.associations": {
+        "__bit_reference": "cpp",
+        "algorithm": "cpp",
+        "bitset": "cpp",
+        "chrono": "cpp",
+        "map": "cpp",
+        "set": "cpp",
+        "unordered_map": "cpp",
+        "unordered_set": "cpp",
+        "*.ipp": "cpp"
+    }
 }

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -73,16 +73,7 @@ simdjson_really_inline simdjson_result<array_iterator> array::end() noexcept {
 }
 
 simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcept {
-  // If the array is empty (i.e., we already scanned past it), then we use a
-  // fast path and return 0.
-  if(!iter.is_open()) { return 0; }
-  // The count_elements method should always be called before you have begun
-  // iterating through the array.
-  // To open a new array you need to be at a `[`.
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
-  // array::begin() makes the same check.
-  if(!iter.is_at_container_start()) { return OUT_OF_ORDER_ITERATION; }
-#endif
+  auto start_state = iter.make_deep_copy();
   size_t count{0};
   // Important: we do not consume any of the values.
   for(simdjson_unused auto v : *this) { count++; }
@@ -90,8 +81,7 @@ simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcep
   if(iter.error()) { return iter.error(); }
   // We need to move back at the start because we expect users to iterate through
   // the array after counting the number of elements.
-  // enter_at_container_start is safe here because we know that we do not have an empty array.
-  iter.enter_at_container_start(); // sets the depth to indicate that we are inside the container and accesses the first element
+  iter.deep_reset(start_state);
   return count;
 }
 

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -2,6 +2,29 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
+
+struct frozen_value_iterator {
+  json_iterator _json_iter_value{};
+  depth_t _depth{};
+  token_position _start_position{};
+  frozen_value_iterator(const json_iterator & i, depth_t d, token_position t) :
+    _json_iter_value{i}, _depth(d), _start_position(t) {}
+};
+
+// no need to make as simdjson_really_inline since this should
+// never be called 'often'.
+inline void value_iterator::deep_reset(const frozen_value_iterator &o) noexcept {
+  *(_json_iter) = o._json_iter_value; // hard copy
+  _depth = o._depth;
+  _start_position = o._start_position;
+}
+
+// no need to make as simdjson_really_inline since this should
+// never be called 'often'.
+inline frozen_value_iterator value_iterator::make_deep_copy() const noexcept {
+  return frozen_value_iterator(*(_json_iter), _depth, _start_position);
+}
+
 simdjson_really_inline value_iterator::value_iterator(json_iterator *json_iter, depth_t depth, token_position start_index) noexcept
   : _json_iter{json_iter},
     _depth{depth},

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -9,6 +9,13 @@ class value;
 class raw_json_string;
 class parser;
 
+
+/**
+ * A frozen_value_iterator can capture the state of value_iterator.
+ * @private This is not intended for external use.
+ */
+struct frozen_value_iterator;
+
 /**
  * Iterates through a single JSON value at a particular depth.
  *
@@ -281,6 +288,20 @@ public:
 
   /** @} */
 protected:
+  /**
+   * Reset the value of this value_iterator so that it matches
+   * the value of the frozen_value_iterator. Note that this will
+   * modify the json_iterator (which typically belongs to the document),
+   * so that it affects more than just this value_iterator instance.
+   */
+  inline void deep_reset(const frozen_value_iterator &o) noexcept;
+
+  /**
+   * Save the state of the value_iterator (including the full state of
+   * the json_iterator) and returns it as a frozen_value_iterator instance.
+   */
+  inline frozen_value_iterator make_deep_copy() const noexcept;
+
   /* updates the index so that at_start() is true and syncs the depth. */
    simdjson_really_inline void move_at_start() noexcept;
   /**


### PR DESCRIPTION
Doing so greatly simplifies the count_elements method.

I am being careful because it is evident that @jkeiser really does not want use to copy value_iterator instances but I find that acting on them is too damn hard. See for example the mysterious issue https://github.com/simdjson/simdjson/pull/1634

Very often I find myself just wanting to "reset" the value_iterator. Without a proper copy, it requires a deep understanding of too many parts.