### PR TITLE
Get fuzzing working again

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -429,28 +429,26 @@ steps:
     - cmake $CMAKE_FLAGS ..
     - cmake --build . $BUILD_FLAGS
     - ctest $CTEST_FLAGS
-##############################
-# With bintray gone, it is clear how we should fuzz.
-#---
-#kind: pipeline
-#name: arm64-fuzz
-#platform: { os: linux, arch: arm64 }
-#steps:
-#- name: Build and run fuzzers shortly
-#  image: ubuntu:20.04
-#  environment:
-#    CC: clang
-#    CXX: clang++
-#    DEBIAN_FRONTEND: noninteractive
-#    ASAN_OPTIONS: detect_leaks=0
-#  commands:
-#    - apt-get -qq update
-#    - apt-get install -q -y clang cmake git wget zip ninja-build
-#    - wget --quiet https://dl.bintray.com/pauldreik/simdjson-fuzz-corpus/corpus/corpus.tar
-#    - tar xf corpus.tar && rm corpus.tar
-#    - fuzz/build_like_ossfuzz.sh
-#    - mkdir -p common_out
-#    - for fuzzer in build/fuzz/fuzz_* ; do echo $fuzzer;$fuzzer common_out out/* -max_total_time=40; done
+---
+kind: pipeline
+name: arm64-fuzz
+platform: { os: linux, arch: arm64 }
+steps:
+- name: Build and run fuzzers shortly
+  image: ubuntu:20.04
+  environment:
+    CC: clang
+    CXX: clang++
+    DEBIAN_FRONTEND: noninteractive
+    ASAN_OPTIONS: detect_leaks=0
+  commands:
+    - apt-get -qq update
+    - apt-get install -q -y clang cmake git wget zip ninja-build
+    - wget -O corpus.tar.gz https://readonly:readonly@www.pauldreik.se/fuzzdata/index.php?project=simdjson
+    - tar xf corpus.tar.gz && rm corpus.tar.gz
+    - fuzz/build_like_ossfuzz.sh
+    - mkdir -p common_out
+    - for fuzzer in build/fuzz/fuzz_* ; do echo $fuzzer;$fuzzer common_out out/* -max_total_time=40; done
 ---
 kind: pipeline
 name: stylecheck

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -129,6 +129,11 @@ jobs:
         name: corpus
         path: corpus.tar
 
+    - name: Store the corpus externally
+      run: |
+        gzip --keep corpus.tar
+        curl -F"filedata=@corpus.tar.gz" https://simdjson:${{ secrets.fuzzdatapassword }}@www.pauldreik.se/fuzzdata/index.php
+
     # This takes a subset of the minimized corpus and run it through valgrind. It is slow,
     # therefore take a "random" subset. The random selection is accomplished by sorting on filenames,
     # which are hashes of the content.

--- a/.github/workflows/power-fuzz.yml
+++ b/.github/workflows/power-fuzz.yml
@@ -16,16 +16,6 @@ jobs:
     name: Build on ubuntu-20.04 ppc64le
     steps:
       - uses: actions/checkout@v2.1.0
-      - uses: actions/cache@v2
-        id: cache-corpus
-        with:
-          path: out/
-          key: corpus-${{ github.run_id }}
-          restore-keys: corpus-
-       - name: show statistics for the cached corpus
-         run: |
-           echo number of files in github action corpus cache:
-           find out -type f |wc -l
       - uses: uraimo/run-on-arch-action@v2.0.5
         name: Run commands
         id: runcmd

--- a/.github/workflows/power-fuzz.yml
+++ b/.github/workflows/power-fuzz.yml
@@ -56,6 +56,8 @@ jobs:
             cd ..
             builddir=build
             cmake --build $builddir
+            wget -O corpus.tar.gz https://readonly:readonly@www.pauldreik.se/fuzzdata/index.php?project=simdjson
+            tar xf corpus.tar.gz
             fuzzernames=$(cmake --build $builddir --target print_all_fuzzernames |tail -n1)
             for fuzzer in $fuzzernames ; do
                exe=$builddir/fuzz/$fuzzer

--- a/fuzz/Fuzzing.md
+++ b/fuzz/Fuzzing.md
@@ -45,6 +45,9 @@ The corpus will grow over time and easy to find bugs will be detected already du
 ## Fuzzing as a CI job - arm64
 There is also a job running the fuzzers on arm64 (see .drone.yml) to make sure also the arm specific parts are fuzzed. This does not update the corpus, it just reuses what the x64 job finds.
 
+## Fuzzing as a CI job - power
+There is a fuzzing job similar to the arm64 one. It takes the corpus from the x64 fuzzer as a starting point and fuzzes it for a short while. See the "short fuzz on the power arch" github action job.
+
 ## Fuzzing on oss-fuzz
 The simdjson library is continuously fuzzed on [oss-fuzz](https://github.com/google/oss-fuzz). In case a bug is found, the offending input is minimized and tested for reproducibility. A report with the details is automatically filed, and the contact persons at simdjson are notified via email. An issue is opened at the oss-fuzz bugtracker with restricted view access. When the bug is fixed, the issue is automatically closed.
 
@@ -64,7 +67,7 @@ As little code as possible is kept at oss-fuzz since it is inconvenient to chang
 
 ## Corpus
 
-The simdjson library does not benefit from a corpus as much as other projects, because the library is very fast and explores the input space very well. With that said, it is still beneficial to have one. The CI job stores the corpus on bintray between runs, and is available at [bintray](https://dl.bintray.com/pauldreik/simdjson-fuzz-corpus/corpus/corpus.tar).
+The simdjson library does not benefit from a corpus as much as other projects, because the library is very fast and explores the input space very well. With that said, it is still beneficial to have one. The CI job stores the corpus on a remote server between runs, and is available at [www.pauldreik.se](https://readonly:readonly@www.pauldreik.se/fuzzdata/index.php?project=simdjson).
 
 One can also grab the corpus as an artifact from the github actions job. Pick a run, then go to artifacts and download.
 


### PR DESCRIPTION
This stores the the corpus on my server. The main github action fuzzer uploads the corpus repeatedly. The other fuzz jobs take the corpus from the server.

The arm64 fuzzer job was disabled, it is now enabled again.

The power fuzzer job was not running because of an .yml syntax error. It is now working.
