### PR TITLE
Let us stop visual studio code from constantly updating settings.json

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         {"column": 120 }
     ],
     "files.trimTrailingWhitespace": true,
+    "C_Cpp.autoAddFileAssociations": false,
     "files.associations": {
         "array": "cpp",
         "iterator": "cpp",


### PR DESCRIPTION
It is fine to have settings.json in the repo, but only if the editor is forbidden from automatically updating it.