### PR TITLE
This solves a minor issue with our legacy benchmark tools.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,6 +76,7 @@
         "unordered_map": "cpp",
         "utility": "cpp",
         "vector": "cpp",
-        "*.ipp": "cpp"
+        "*.ipp": "cpp",
+        "*.tcc": "cpp"
     }
 }

--- a/benchmark/linux/linux-perf-events.h
+++ b/benchmark/linux/linux-perf-events.h
@@ -29,7 +29,7 @@ template <int TYPE = PERF_TYPE_HARDWARE> class LinuxEvents {
   size_t num_events{};
   std::vector<uint64_t> temp_result_vec{};
   std::vector<uint64_t> result{};
-  std::vector<int> fdææs{};
+  std::vector<int> fds{};
   bool quiet;
 
 public:

--- a/benchmark/linux/linux-perf-events.h
+++ b/benchmark/linux/linux-perf-events.h
@@ -29,6 +29,7 @@ template <int TYPE = PERF_TYPE_HARDWARE> class LinuxEvents {
   size_t num_events{};
   std::vector<uint64_t> temp_result_vec{};
   std::vector<uint64_t> result{};
+  std::vector<int> fds;
   bool quiet;
 
 public:
@@ -52,10 +53,11 @@ public:
     uint32_t i = 0;
     for (auto config : config_vec) {
       attribs.config = config;
-      fd = static_cast<int>(syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags));
+      int fd = static_cast<int>(syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags));
       if (fd == -1) {
         report_error("perf_event_open");
       }
+      fds.push_back(fd);
       ioctl(fd, PERF_EVENT_IOC_ID, &result[i++]);
       if (group == -1) {
         group = fd;
@@ -65,7 +67,11 @@ public:
     temp_result_vec.resize(num_events * 2 + 1);
   }
 
-  ~LinuxEvents() { if (fd != -1) { close(fd); } }
+  ~LinuxEvents() {
+   for (auto fd : fds) {
+      if (fd != -1) { close(fd); }
+    }
+  }
 
   inline void start() {
     if (fd != -1) {

--- a/benchmark/linux/linux-perf-events.h
+++ b/benchmark/linux/linux-perf-events.h
@@ -29,7 +29,7 @@ template <int TYPE = PERF_TYPE_HARDWARE> class LinuxEvents {
   size_t num_events{};
   std::vector<uint64_t> temp_result_vec{};
   std::vector<uint64_t> result{};
-  std::vector<int> fds;
+  std::vector<int> fdææs{};
   bool quiet;
 
 public:
@@ -53,10 +53,11 @@ public:
     uint32_t i = 0;
     for (auto config : config_vec) {
       attribs.config = config;
-      int fd = static_cast<int>(syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags));
-      if (fd == -1) {
+      int _fd = static_cast<int>(syscall(__NR_perf_event_open, &attribs, pid, cpu, group, flags));
+      if (_fd == -1) {
         report_error("perf_event_open");
       }
+      fd = _fd; // fd tracks the last _fd value.
       fds.push_back(fd);
       ioctl(fd, PERF_EVENT_IOC_ID, &result[i++]);
       if (group == -1) {
@@ -68,8 +69,8 @@ public:
   }
 
   ~LinuxEvents() {
-   for (auto fd : fds) {
-      if (fd != -1) { close(fd); }
+   for (auto tfd : fds) {
+      if (tfd != -1) { close(tfd); }
     }
   }
 


### PR DESCRIPTION
Some symbolic files would never be closed. It never causes any problem but, in theory, it could exhaust the number of files that can be open at once... especially if the process was long lived.

(This is nitpicking.)