### PR TITLE
verify and fix issue 1668

### DIFF
--- a/benchmark/amazon_cellphones/simdjson_ondemand.h
+++ b/benchmark/amazon_cellphones/simdjson_ondemand.h
@@ -18,7 +18,7 @@ struct simdjson_ondemand {
     ondemand::document_stream::iterator i = stream.begin();
     ++i;  // Skip first line
     for (;i != stream.end(); ++i) {
-      auto & doc = *i;
+      auto doc = *i;
       size_t index{0};
       StringType copy;
       double rating;

--- a/benchmark/large_amazon_cellphones/simdjson_ondemand.h
+++ b/benchmark/large_amazon_cellphones/simdjson_ondemand.h
@@ -18,7 +18,7 @@ struct simdjson_ondemand {
     ondemand::document_stream::iterator i = stream.begin();
     ++i;  // Skip first line
     for (;i != stream.end(); ++i) {
-      auto & doc = *i;
+      auto doc = *i;
       size_t index{0};
       StringType copy;
       double rating;

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -990,22 +990,21 @@ format. If your JSON documents all contain arrays or objects, we even support di
 concatenation without whitespace. The concatenated file has no size restrictions (including larger
 than 4GB), though each individual document must be no larger than 4 GB.
 
-Here is a simple example:
+Here is an example:
 
 ```c++
 auto json = R"({ "foo": 1 } { "foo": 2 } { "foo": 3 } )"_padded;
 ondemand::parser parser;
 ondemand::document_stream docs = parser.iterate_many(json);
-for (auto & doc : docs) {
+for (auto doc : docs) {
   std::cout << doc["foo"] << std::endl;
 }
 // Prints 1 2 3
 ```
 
-It is important to note that the iteration returns a `document` reference, and hence why the `&` is needed.
 
 Unlike `parser.iterate`, `parser.iterate_many` may parse "on demand" (lazily). That is, no parsing may have been done before you enter the loop
-`for (auto & doc : docs) {` and you should expect the parser to only ever fully parse one JSON document at a time.
+`for (auto doc : docs) {` and you should expect the parser to only ever fully parse one JSON document at a time.
 
 As with `parser.iterate`, when calling  `parser.iterate_many(string)`, no copy is made of the provided string input. The provided memory buffer may be accessed each time a JSON document is parsed.  Calling `parser.iterate_many(string)` on a  temporary string buffer (e.g., `docs = parser.parse_many("[1,2,3]"_padded)`) is unsafe (and will not compile) because the  `document_stream` instance needs access to the buffer to return the JSON documents.
 

--- a/doc/iterate_many.md
+++ b/doc/iterate_many.md
@@ -175,7 +175,7 @@ Let us illustrate the idea with code:
     auto i = stream.begin();
 	 size_t count{0};
     for(; i != stream.end(); ++i) {
-        auto & doc = *i;
+        auto doc = *i;
         if(!i.error()) {
           std::cout << "got full document at " << i.current_index() << std::endl;
           std::cout << i.source() << std::endl;

--- a/include/simdjson/generic/implementation_simdjson_result_base-inl.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base-inl.h
@@ -49,8 +49,15 @@ simdjson_really_inline implementation_simdjson_result_base<T>::operator T&&() &&
   return std::forward<implementation_simdjson_result_base<T>>(*this).take_value();
 }
 
+#endif // SIMDJSON_EXCEPTIONS
+
 template<typename T>
 simdjson_really_inline const T& implementation_simdjson_result_base<T>::value_unsafe() const& noexcept {
+  return this->first;
+}
+
+template<typename T>
+simdjson_really_inline T& implementation_simdjson_result_base<T>::value_unsafe() & noexcept {
   return this->first;
 }
 
@@ -58,8 +65,6 @@ template<typename T>
 simdjson_really_inline T&& implementation_simdjson_result_base<T>::value_unsafe() && noexcept {
   return std::forward<T>(this->first);
 }
-
-#endif // SIMDJSON_EXCEPTIONS
 
 template<typename T>
 simdjson_really_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(T &&value, error_code error) noexcept

--- a/include/simdjson/generic/implementation_simdjson_result_base.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base.h
@@ -97,19 +97,24 @@ struct implementation_simdjson_result_base {
    */
   simdjson_really_inline operator T&&() && noexcept(false);
 
+
+#endif // SIMDJSON_EXCEPTIONS
+
   /**
    * Get the result value. This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
   simdjson_really_inline const T& value_unsafe() const& noexcept;
-
+  /**
+   * Get the result value. This function is safe if and only
+   * the error() method returns a value that evaluates to false.
+   */
+  simdjson_really_inline T& value_unsafe() & noexcept;
   /**
    * Take the result value (move it). This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
   simdjson_really_inline T&& value_unsafe() && noexcept;
-
-#endif // SIMDJSON_EXCEPTIONS
 
   T first{};
   error_code second{UNINITIALIZED};

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -376,4 +376,189 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
   return first.at_pointer(json_pointer);
 }
 
+
+} // namespace simdjson
+
+
+namespace simdjson {
+namespace SIMDJSON_IMPLEMENTATION {
+namespace ondemand {
+
+simdjson_really_inline document_reference::document_reference() noexcept : doc{nullptr} {}
+simdjson_really_inline document_reference::document_reference(document &d) noexcept : doc(&d) {}
+simdjson_really_inline void document_reference::rewind() noexcept { doc->rewind(); }
+simdjson_really_inline simdjson_result<array> document_reference::get_array() & noexcept { return doc->get_array(); }
+simdjson_really_inline simdjson_result<object> document_reference::get_object() & noexcept { return doc->get_object(); }
+simdjson_really_inline simdjson_result<uint64_t> document_reference::get_uint64() noexcept { return doc->get_uint64(); }
+simdjson_really_inline simdjson_result<int64_t> document_reference::get_int64() noexcept { return doc->get_int64(); }
+simdjson_really_inline simdjson_result<double> document_reference::get_double() noexcept { return doc->get_double(); }
+simdjson_really_inline simdjson_result<std::string_view> document_reference::get_string() noexcept { return doc->get_string(); }
+simdjson_really_inline simdjson_result<raw_json_string> document_reference::get_raw_json_string() noexcept { return doc->get_raw_json_string(); }
+simdjson_really_inline simdjson_result<bool> document_reference::get_bool() noexcept { return doc->get_bool(); }
+simdjson_really_inline bool document_reference::is_null() noexcept { return doc->is_null(); }
+
+#if SIMDJSON_EXCEPTIONS
+simdjson_really_inline document_reference::operator array() & noexcept(false) { return array(*doc); }
+simdjson_really_inline document_reference::operator object() & noexcept(false) { return object(*doc); }
+simdjson_really_inline document_reference::operator uint64_t() noexcept(false) { return uint64_t(*doc); }
+simdjson_really_inline document_reference::operator int64_t() noexcept(false) { return int64_t(*doc); }
+simdjson_really_inline document_reference::operator double() noexcept(false) { return double(*doc); }
+simdjson_really_inline document_reference::operator std::string_view() noexcept(false) { return std::string_view(*doc); }
+simdjson_really_inline document_reference::operator raw_json_string() noexcept(false) { return raw_json_string(*doc); }
+simdjson_really_inline document_reference::operator bool() noexcept(false) { return bool(*doc); }
+#endif
+simdjson_really_inline simdjson_result<size_t> document_reference::count_elements() & noexcept { return doc->count_elements(); }
+simdjson_really_inline simdjson_result<array_iterator> document_reference::begin() & noexcept { return doc->begin(); }
+simdjson_really_inline simdjson_result<array_iterator> document_reference::end() & noexcept { return doc->end(); }
+simdjson_really_inline simdjson_result<value> document_reference::find_field(std::string_view key) & noexcept { return doc->find_field(key); }
+simdjson_really_inline simdjson_result<value> document_reference::find_field(const char *key) & noexcept { return doc->find_field(key); }
+simdjson_really_inline simdjson_result<value> document_reference::operator[](std::string_view key) & noexcept { return (*doc)[key]; }
+simdjson_really_inline simdjson_result<value> document_reference::operator[](const char *key) & noexcept { return (*doc)[key]; }
+simdjson_really_inline simdjson_result<value> document_reference::find_field_unordered(std::string_view key) & noexcept { return doc->find_field_unordered(key); }
+simdjson_really_inline simdjson_result<value> document_reference::find_field_unordered(const char *key) & noexcept { return doc->find_field_unordered(key); }
+
+simdjson_really_inline simdjson_result<json_type> document_reference::type() noexcept { return doc->type(); }
+simdjson_really_inline simdjson_result<std::string_view> document_reference::raw_json_token() noexcept { return doc->raw_json_token(); }
+simdjson_really_inline simdjson_result<value> document_reference::at_pointer(std::string_view json_pointer) noexcept { return doc->at_pointer(json_pointer); }
+simdjson_really_inline simdjson_result<std::string_view> document_reference::raw_json() noexcept { return doc->raw_json();}
+simdjson_really_inline document_reference::operator document&() const noexcept { return *doc; }
+
+} // namespace ondemand
+} // namespace SIMDJSON_IMPLEMENTATION
+} // namespace simdjson
+
+
+
+namespace simdjson {
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_reference value, error_code error)
+  noexcept : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>(value), error) {}
+
+
+simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::count_elements() & noexcept {
+  if (error()) { return error(); }
+  return first.count_elements();
+}
+simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::rewind() noexcept {
+  if (error()) { return error(); }
+  first.rewind();
+  return SUCCESS;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::begin() & noexcept {
+  if (error()) { return error(); }
+  return first.begin();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::end() & noexcept {
+  return {};
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(std::string_view key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field_unordered(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(const char *key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field_unordered(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator[](std::string_view key) & noexcept {
+  if (error()) { return error(); }
+  return first[key];
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator[](const char *key) & noexcept {
+  if (error()) { return error(); }
+  return first[key];
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field(std::string_view key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field(const char *key) & noexcept {
+  if (error()) { return error(); }
+  return first.find_field(key);
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_array() & noexcept {
+  if (error()) { return error(); }
+  return first.get_array();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_object() & noexcept {
+  if (error()) { return error(); }
+  return first.get_object();
+}
+simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_uint64() noexcept {
+  if (error()) { return error(); }
+  return first.get_uint64();
+}
+simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_int64() noexcept {
+  if (error()) { return error(); }
+  return first.get_int64();
+}
+simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_double() noexcept {
+  if (error()) { return error(); }
+  return first.get_double();
+}
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_string() noexcept {
+  if (error()) { return error(); }
+  return first.get_string();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_raw_json_string() noexcept {
+  if (error()) { return error(); }
+  return first.get_raw_json_string();
+}
+simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_bool() noexcept {
+  if (error()) { return error(); }
+  return first.get_bool();
+}
+simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_null() noexcept {
+  if (error()) { return error(); }
+  return first.is_null();
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::type() noexcept {
+  if (error()) { return error(); }
+  return first.type();
+}
+
+#if SIMDJSON_EXCEPTIONS
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator uint64_t() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator int64_t() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator double() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator std::string_view() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator bool() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
+#endif
+
+simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::raw_json_token() noexcept {
+  if (error()) { return error(); }
+  return first.raw_json_token();
+}
+
+simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::at_pointer(std::string_view json_pointer) noexcept {
+  if (error()) { return error(); }
+  return first.at_pointer(json_pointer);
+}
+
+
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -13,7 +13,7 @@ class array_iterator;
 class document_stream;
 
 /**
- * A JSON document iteration.
+ * A JSON document. It holds a json_iterator instance.
  *
  * Used by tokens to get text, and string buffer location.
  *
@@ -389,6 +389,54 @@ protected:
   friend class document_stream;
 };
 
+
+/**
+ * A document_reference is a thin wrapper around a document reference instance.
+ */
+class document_reference {
+public:
+  simdjson_really_inline document_reference() noexcept;
+  simdjson_really_inline document_reference(document &d) noexcept;
+  simdjson_really_inline document_reference(const document_reference &other) noexcept = default;
+  simdjson_really_inline void rewind() noexcept;
+  simdjson_really_inline simdjson_result<array> get_array() & noexcept;
+  simdjson_really_inline simdjson_result<object> get_object() & noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
+  simdjson_really_inline operator document&() const noexcept;
+
+#if SIMDJSON_EXCEPTIONS
+  simdjson_really_inline operator array() & noexcept(false);
+  simdjson_really_inline operator object() & noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator raw_json_string() noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
+#endif
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
+  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field(const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<value> find_field_unordered(const char *key) & noexcept;
+
+  simdjson_really_inline simdjson_result<json_type> type() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+  simdjson_really_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+private:
+  document *doc{nullptr};
+};
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
@@ -446,5 +494,58 @@ public:
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
+
+
+} // namespace simdjson
+
+
+
+namespace simdjson {
+
+template<>
+struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document_reference> {
+public:
+  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_reference value, error_code error) noexcept;
+  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_really_inline error_code rewind() noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
+  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_really_inline bool is_null() noexcept;
+
+#if SIMDJSON_EXCEPTIONS
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
+  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_really_inline operator double() noexcept(false);
+  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_really_inline operator bool() noexcept(false);
+#endif
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) & noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> type() noexcept;
+
+  /** @copydoc simdjson_really_inline std::string_view document_reference::raw_json_token() const noexcept */
+  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+
+  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+};
+
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/document_stream-inl.h
+++ b/include/simdjson/generic/ondemand/document_stream-inl.h
@@ -137,8 +137,9 @@ simdjson_really_inline document_stream::iterator::iterator(document_stream* _str
   : stream{_stream}, finished{is_end} {
 }
 
-simdjson_really_inline ondemand::document& document_stream::iterator::operator*() noexcept {
-  return stream->doc;
+simdjson_really_inline simdjson_result<ondemand::document_reference> document_stream::iterator::operator*() noexcept {
+  //if(stream->error) { return stream->error; }
+  return simdjson_result<ondemand::document_reference>(stream->doc, stream->error);
 }
 
 simdjson_really_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {

--- a/include/simdjson/generic/ondemand/document_stream.h
+++ b/include/simdjson/generic/ondemand/document_stream.h
@@ -130,7 +130,7 @@ public:
     /**
      * Get the current document (or error).
      */
-    simdjson_really_inline ondemand::document& operator*() noexcept;
+    simdjson_really_inline simdjson_result<ondemand::document_reference> operator*() noexcept;
     /**
      * Advance to the next document (prefix).
      */

--- a/include/simdjson/generic/ondemand/serialization-inl.h
+++ b/include/simdjson/generic/ondemand/serialization-inl.h
@@ -20,6 +20,13 @@ inline simdjson_result<std::string_view> to_json_string(SIMDJSON_IMPLEMENTATION:
   return trim(v);
 }
 
+inline simdjson_result<std::string_view> to_json_string(SIMDJSON_IMPLEMENTATION::ondemand::document_reference& x) noexcept {
+  std::string_view v;
+  auto error = x.raw_json().get(v);
+  if(error) {return error; }
+  return trim(v);
+}
+
 inline simdjson_result<std::string_view> to_json_string(SIMDJSON_IMPLEMENTATION::ondemand::value& x) noexcept {
   /**
    * If we somehow receive a value that has already been consumed,
@@ -66,28 +73,30 @@ inline simdjson_result<std::string_view> to_json_string(SIMDJSON_IMPLEMENTATION:
   return trim(v);
 }
 
-#if SIMDJSON_EXCEPTIONS
-
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> x) {
   if (x.error()) { return x.error(); }
-  return to_json_string(x.value());
+  return to_json_string(x.value_unsafe());
+}
+
+inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference> x) {
+  if (x.error()) { return x.error(); }
+  return to_json_string(x.value_unsafe());
 }
 
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> x) {
   if (x.error()) { return x.error(); }
-  return to_json_string(x.value());
+  return to_json_string(x.value_unsafe());
 }
 
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> x) {
   if (x.error()) { return x.error(); }
-  return to_json_string(x.value());
+  return to_json_string(x.value_unsafe());
 }
 
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> x) {
   if (x.error()) { return x.error(); }
-  return to_json_string(x.value());
+  return to_json_string(x.value_unsafe());
 }
-#endif
 } // namespace simdjson
 
 
@@ -153,7 +162,20 @@ inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_IMPLEMENTA
     throw simdjson::simdjson_error(error);
   }
 }
-inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document> x) {
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document_reference& value)  {
+  std::string_view v;
+  auto error = simdjson::to_json_string(value).get(v);
+  if(error == simdjson::SUCCESS) {
+    return (out << v);
+  } else {
+    throw simdjson::simdjson_error(error);
+  }
+}
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document>&& x) {
+  if (x.error()) { throw simdjson::simdjson_error(x.error()); }
+  return (out << x.value());
+}
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document_reference>&& x) {
   if (x.error()) { throw simdjson::simdjson_error(x.error()); }
   return (out << x.value());
 }

--- a/include/simdjson/generic/ondemand/serialization.h
+++ b/include/simdjson/generic/ondemand/serialization.h
@@ -23,12 +23,10 @@ inline simdjson_result<std::string_view> to_json_string(SIMDJSON_IMPLEMENTATION:
  * contains JSON text that is suitable to be parsed as JSON again.
  */
 inline simdjson_result<std::string_view> to_json_string(SIMDJSON_IMPLEMENTATION::ondemand::array& x) noexcept;
-#if SIMDJSON_EXCEPTIONS
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> x);
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> x);
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> x);
 inline simdjson_result<std::string_view> to_json_string(simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> x);
-#endif
 } // namespace simdjson
 
 
@@ -63,7 +61,11 @@ inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<sim
  */
 inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document& value);
 #if SIMDJSON_EXCEPTIONS
-inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document> x);
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document>&& x);
+#endif
+inline std::ostream& operator<<(std::ostream& out, simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document_reference& value);
+#if SIMDJSON_EXCEPTIONS
+inline std::ostream& operator<<(std::ostream& out, simdjson::simdjson_result<simdjson::SIMDJSON_IMPLEMENTATION::ondemand::document_reference>&& x);
 #endif
 /**
  * Print JSON to an output stream.

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -349,6 +349,27 @@ namespace document_stream_tests {
     }
 
 
+    bool issue1668() {
+        TEST_START();
+        auto json = R"([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100])"_padded;
+
+        ondemand::parser odparser;
+        ondemand::document_stream odstream;
+        auto oderror = odparser.iterate_many(json.data(), json.length(), 50).get(odstream);
+
+        if (oderror) { std::cerr << "ondemand iterate_many error: " << oderror << std::endl; return false; }
+
+        for (auto &doc: odstream) {
+            ondemand::value val;
+            auto err = doc.at_pointer("/40").get(val);
+            if (err) {
+                std::cout << "ondemand: error accessing jsonpointer: " << err << std::endl;
+            } else {
+                std::cout << "ondemand: " << val << std::endl;
+            }
+        }
+        TEST_SUCCEED();
+    }
     bool document_stream_utf8_test() {
         TEST_START();
         fflush(NULL);
@@ -424,6 +445,7 @@ namespace document_stream_tests {
 
     bool run() {
         return
+            issue1668() &&
             simple_document_iteration() &&
             simple_document_iteration_multiple_batches() &&
             simple_document_iteration_with_parsing() &&

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -397,41 +397,41 @@ namespace document_stream_tests {
     }
 
     bool stress_data_race() {
-    TEST_START();
-    // Correct JSON.
-    auto input = R"([1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] )"_padded;;
-    ondemand::parser parser;
-    ondemand::document_stream stream;
-    ASSERT_SUCCESS(parser.iterate_many(input, 32).get(stream));
-    for(auto i = stream.begin(); i != stream.end(); ++i) {
-      ASSERT_SUCCESS(i.error());
-    }
-    TEST_SUCCEED();
-  }
-
-  bool stress_data_race_with_error() {
-    TEST_START();
-    #if SIMDJSON_THREAD_ENABLED
-    std::cout << "ENABLED" << std::endl;
-    #endif
-    // Intentionally broken
-    auto input = R"([1,23] [1,23] [1,23] [1,23 [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] )"_padded;
-    ondemand::parser parser;
-    ondemand::document_stream stream;
-    ASSERT_SUCCESS(parser.iterate_many(input, 32).get(stream));
-    size_t count{0};
-    for(auto i = stream.begin(); i != stream.end(); ++i) {
-        auto error = i.error();
-        if(count <= 3) {
-            ASSERT_SUCCESS(error);
-        } else {
-            ASSERT_ERROR(error,TAPE_ERROR);
-            break;
+        TEST_START();
+        // Correct JSON.
+        auto input = R"([1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] )"_padded;;
+        ondemand::parser parser;
+        ondemand::document_stream stream;
+        ASSERT_SUCCESS(parser.iterate_many(input, 32).get(stream));
+        for(auto i = stream.begin(); i != stream.end(); ++i) {
+            ASSERT_SUCCESS(i.error());
         }
-        count++;
+        TEST_SUCCEED();
     }
-    TEST_SUCCEED();
-  }
+
+    bool stress_data_race_with_error() {
+        TEST_START();
+        #if SIMDJSON_THREAD_ENABLED
+        std::cout << "ENABLED" << std::endl;
+        #endif
+        // Intentionally broken
+        auto input = R"([1,23] [1,23] [1,23] [1,23 [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] [1,23] )"_padded;
+        ondemand::parser parser;
+        ondemand::document_stream stream;
+        ASSERT_SUCCESS(parser.iterate_many(input, 32).get(stream));
+        size_t count{0};
+        for(auto i = stream.begin(); i != stream.end(); ++i) {
+            auto error = i.error();
+            if(count <= 3) {
+                ASSERT_SUCCESS(error);
+            } else {
+                ASSERT_ERROR(error,TAPE_ERROR);
+                break;
+            }
+            count++;
+        }
+        TEST_SUCCEED();
+    }
 
     bool run() {
         return

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -5,12 +5,6 @@ using namespace simdjson;
 
 namespace document_stream_tests {
 
-    std::string my_string(ondemand::document& doc) {
-        std::stringstream ss;
-        ss << doc;
-        return ss.str();
-    }
-
     bool simple_document_iteration() {
         TEST_START();
         auto json = R"([1,[1,2]] {"a":1,"b":2} {"o":{"1":1,"2":2}} [1,2,3])"_padded;
@@ -19,9 +13,11 @@ namespace document_stream_tests {
         ASSERT_SUCCESS(parser.iterate_many(json).get(stream));
         std::string_view expected[4] = {"[1,[1,2]]", "{\"a\":1,\"b\":2}", "{\"o\":{\"1\":1,\"2\":2}}", "[1,2,3]"};
         size_t counter{0};
-        for(auto & doc : stream) {
+        for(auto doc : stream) {
             ASSERT_TRUE(counter < 4);
-            ASSERT_EQUAL(my_string(doc), expected[counter++]);
+            std::string_view view;
+            ASSERT_SUCCESS(to_json_string(doc).get(view));
+            ASSERT_EQUAL(view, expected[counter++]);
         }
         ASSERT_EQUAL(counter, 4);
         TEST_SUCCEED();
@@ -60,7 +56,8 @@ namespace document_stream_tests {
         ++i;
 
         ASSERT_EQUAL(i.source(),expected[counter++]);
-        ASSERT_SUCCESS( (*i).find_field("a").get(x) );
+        simdjson_result<ondemand::document_reference> xxx = *i;
+        ASSERT_SUCCESS( xxx.find_field("a").get(x) );
         ASSERT_EQUAL(x,1);
         ++i;
 
@@ -289,7 +286,7 @@ namespace document_stream_tests {
         ondemand::document_stream stream;
         ASSERT_SUCCESS(parser.iterate_many(json).get(stream));
         size_t count{0};
-        for (auto & doc : stream) {
+        for (auto doc : stream) {
             (void)doc;
             count++;
         }
@@ -304,7 +301,7 @@ namespace document_stream_tests {
         ondemand::document_stream stream;
         ASSERT_SUCCESS(parser.iterate_many(json).get(stream));
         size_t count{0};
-        for (auto & doc : stream) {
+        for (auto doc : stream) {
             (void)doc;
             count++;
         }
@@ -336,7 +333,7 @@ namespace document_stream_tests {
             ondemand::document_stream stream;
             size_t count{0};
             ASSERT_SUCCESS( parser.iterate_many(str, batch_size).get(stream) );
-            for (auto & doc : stream) {
+            for (auto doc : stream) {
                 int64_t keyid;
                 ASSERT_SUCCESS( doc["id"].get(keyid) );
                 ASSERT_EQUAL( keyid, int64_t(count) );
@@ -355,21 +352,14 @@ namespace document_stream_tests {
 
         ondemand::parser odparser;
         ondemand::document_stream odstream;
-        auto oderror = odparser.iterate_many(json.data(), json.length(), 50).get(odstream);
-
-        if (oderror) { std::cerr << "ondemand iterate_many error: " << oderror << std::endl; return false; }
-
-        for (auto &doc: odstream) {
+        ASSERT_SUCCESS( odparser.iterate_many(json.data(), json.length(), 50).get(odstream) );
+        for (auto doc: odstream) {
             ondemand::value val;
-            auto err = doc.at_pointer("/40").get(val);
-            if (err) {
-                std::cout << "ondemand: error accessing jsonpointer: " << err << std::endl;
-            } else {
-                std::cout << "ondemand: " << val << std::endl;
-            }
+            ASSERT_ERROR(doc.at_pointer("/40").get(val), CAPACITY);
         }
         TEST_SUCCEED();
     }
+
     bool document_stream_utf8_test() {
         TEST_START();
         fflush(NULL);
@@ -394,7 +384,7 @@ namespace document_stream_tests {
             ondemand::document_stream stream;
             size_t count{0};
             ASSERT_SUCCESS( parser.iterate_many(str, batch_size).get(stream) );
-            for (auto & doc : stream) {
+            for (auto doc : stream) {
                 int64_t keyid;
                 ASSERT_SUCCESS( doc["id"].get(keyid) );
                 ASSERT_EQUAL( keyid, int64_t(count) );

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -360,6 +360,28 @@ namespace document_stream_tests {
         TEST_SUCCEED();
     }
 
+    bool issue1668_long() {
+        TEST_START();
+        auto json = R"([1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100])"_padded;
+
+        ondemand::parser odparser;
+        ondemand::document_stream odstream;
+        size_t counter{0};
+        ASSERT_SUCCESS( odparser.iterate_many(json.data(), json.length(), 50).get(odstream) );
+        for (auto doc: odstream) {
+            if(counter < 6) {
+                int64_t val;
+                ASSERT_SUCCESS(doc.at_pointer("/4").get(val));
+                ASSERT_EQUAL(val, 5);
+            } else {
+                ondemand::value val;
+                ASSERT_ERROR(doc.at_pointer("/4").get(val), CAPACITY);
+            }
+            counter++;
+        }
+        TEST_SUCCEED();
+    }
+
     bool document_stream_utf8_test() {
         TEST_START();
         fflush(NULL);
@@ -436,6 +458,7 @@ namespace document_stream_tests {
     bool run() {
         return
             issue1668() &&
+            issue1668_long() &&
             simple_document_iteration() &&
             simple_document_iteration_multiple_batches() &&
             simple_document_iteration_with_parsing() &&

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -407,7 +407,29 @@ bool ndjson_basics_example() {
   }
   TEST_SUCCEED();
 }
-
+bool stream_capacity_example() {
+  auto json = R"([1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5] [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100])"_padded;
+  ondemand::parser parser;
+  ondemand::document_stream stream;
+  size_t counter{0};
+  auto error = parser.iterate_many(json, 50).get(stream);
+  if( error ) { /* handle the error */ }
+  for (auto doc: stream) {
+    if(counter < 6) {
+      int64_t val;
+      error = doc.at_pointer("/4").get(val);
+      if( error ) { /* handle the error */ }
+      std::cout << "5 = " << val << std::endl;
+    } else {
+      ondemand::value val;
+      error = doc.at_pointer("/4").get(val);
+      // error == simdjson::CAPACITY
+      if(error) { std::cerr << error << std::endl;  break; }
+    }
+    counter++;
+  }
+  return true;
+}
 int main() {
   if (
     true
@@ -434,6 +456,7 @@ int main() {
     && iterate_many_example()
     && iterate_many_truncated_example()
     && ndjson_basics_example()
+    && stream_capacity_example()
   ) {
     return 0;
   } else {

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -360,7 +360,7 @@ bool iterate_many_example() {
   size_t expected_indexes[3] = {0,9,29};
   std::string_view expected_doc[3] = {"[1,2,3]", R"({"1":1,"2":3,"4":4})", "[1,2,3]"};
   for(; i != stream.end(); ++i) {
-      auto & doc = *i;
+      auto doc = *i;
       ASSERT_SUCCESS(doc.type());
       ASSERT_SUCCESS(i.error());
       ASSERT_EQUAL(i.current_index(),expected_indexes[count]);
@@ -400,7 +400,7 @@ bool ndjson_basics_example() {
   ASSERT_SUCCESS( parser.iterate_many(json).get(docs) );
   size_t count{0};
   int64_t expected[3] = {1,2,3};
-  for (auto & doc : docs) {
+  for (auto doc : docs) {
     int64_t actual;
     ASSERT_SUCCESS( doc["foo"].get(actual) );
     ASSERT_EQUAL( actual,expected[count++] );


### PR DESCRIPTION
@erichutchins identified a bug with our unreleased On Demand stream support. In case of error, you could get a null pointer access and a crash.

The problem is not that our code did not catch the error. It did. However, it would never pass it to the user. So the user would just happily continue after the error, and get a crash.

This commit updates the previous behavior of the On Demand stream support by returning a value type (`document_reference`) instead of a reference to a document. This allows us to bridge with the usually simdjson
error system, with its `simdjson_result` types. We had discussed such a design but it felt complex at the time. It is still a mess... since it requires a lot of copying and pasting... but I think it is a net win for the usability.

It makes error handing more robust and the following test passes:



```C++
    bool issue1668() {
        TEST_START();
        auto json = R"([1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100])"_padded;

        ondemand::parser odparser;
        ondemand::document_stream odstream;
        ASSERT_SUCCESS( odparser.iterate_many(json.data(), json.length(), 50).get(odstream) );
        for (auto doc: odstream) {
            ondemand::value val;
            ASSERT_ERROR(doc.at_pointer("/40").get(val), CAPACITY);
        }
        TEST_SUCCEED();
    }

```

Fixes https://github.com/simdjson/simdjson/issues/1668
