### PR TITLE
Fixing noexcept on operator << with simdjson_result.

### DIFF
--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -287,7 +287,7 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-inline std::ostream& operator<<(std::ostream& out, simdjson_result<T> value) noexcept { return out << value.value(); }
+inline std::ostream& operator<<(std::ostream& out, simdjson_result<T> value) { return out << value.value(); }
 #endif // SIMDJSON_EXCEPTIONS
 
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -30,13 +30,14 @@ namespace error_tests {
     auto json = "{\"haha\":{\"df2\":3.5, \"df3\": \"fd\"}}"_padded;
     ondemand::document doc;
     ASSERT_SUCCESS( parser.iterate(json).get(doc) );
-    ondemand::raw_json_string rawjson;
     try {
-      doc.get_raw_json_string().get(rawjson);
+      ondemand::raw_json_string rawjson = doc.get_raw_json_string();
+      (void)rawjson;
+      TEST_FAIL("Should have thrown an exception!")
     } catch(simdjson_error& e) {
       ASSERT_ERROR(e.error(), INCORRECT_TYPE);
+      TEST_SUCCEED();
     }
-    TEST_SUCCEED();
   }
 #endif
   bool parser_max_capacity() {

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -13,7 +13,32 @@ namespace error_tests {
     ASSERT_ERROR( parser.iterate(json), EMPTY );
     TEST_SUCCEED();
   }
-
+  bool raw_json_string_error() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "{\"haha\":{\"df2\":3.5, \"df3\": \"fd\"}}"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    ondemand::raw_json_string rawjson;
+    ASSERT_ERROR( doc.get_raw_json_string().get(rawjson), INCORRECT_TYPE );
+    TEST_SUCCEED();
+  }
+#if SIMDJSON_EXCEPTIONS
+  bool raw_json_string_except() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "{\"haha\":{\"df2\":3.5, \"df3\": \"fd\"}}"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    ondemand::raw_json_string rawjson;
+    try {
+      doc.get_raw_json_string().get(rawjson);
+    } catch(simdjson_error& e) {
+      ASSERT_ERROR(e.error(), INCORRECT_TYPE);
+    }
+    TEST_SUCCEED();
+  }
+#endif
   bool parser_max_capacity() {
     TEST_START();
     ondemand::parser parser(1); // max_capacity set to 1 byte
@@ -203,6 +228,10 @@ namespace error_tests {
 
   bool run() {
     return
+#if SIMDJSON_EXCEPTIONS
+           raw_json_string_except() &&
+#endif
+           raw_json_string_error() &&
            empty_document_error() &&
            parser_max_capacity() &&
            get_fail_then_succeed_bool() &&

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -39,6 +39,22 @@ namespace error_tests {
       TEST_SUCCEED();
     }
   }
+  bool raw_json_string_except_with_io() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "{\"haha\":{\"df2\":3.5, \"df3\": \"fd\"}}"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    try {
+      auto rawjson = doc.get_raw_json_string();
+      std::cout << rawjson;
+      TEST_FAIL("Should have thrown an exception!")
+    } catch(simdjson_error& e) {
+      ASSERT_ERROR(e.error(), INCORRECT_TYPE);
+      TEST_SUCCEED();
+    }
+  }
+
 #endif
   bool parser_max_capacity() {
     TEST_START();
@@ -231,6 +247,7 @@ namespace error_tests {
     return
 #if SIMDJSON_EXCEPTIONS
            raw_json_string_except() &&
+           raw_json_string_except_with_io() &&
 #endif
            raw_json_string_error() &&
            empty_document_error() &&


### PR DESCRIPTION
These tests illustrate two proper ways to handle error in simdjson: you either catch the exception or you handle error codes. It also fixes a related bug that we uncovered: there is one extra `noexcept` in the operator `<<`. A related test was added.