### PR TITLE
[WIP] Provide current location in JSON input

### DIFF
--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -20,8 +20,8 @@ inline std::string document::to_debug_string() noexcept {
   return iter.to_string();
 }
 
-inline const char * current_location() noexcept {
-  
+inline const char * document::current_location() noexcept {
+  return iter.current_location();
 }
 
 simdjson_really_inline value_iterator document::resume_value_iterator() noexcept {

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -20,6 +20,10 @@ inline std::string document::to_debug_string() noexcept {
   return iter.to_string();
 }
 
+inline const char * current_location() noexcept {
+  
+}
+
 simdjson_really_inline value_iterator document::resume_value_iterator() noexcept {
   return value_iterator(&iter, 1, iter.root_position());
 }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -352,7 +352,7 @@ public:
   inline std::string to_debug_string() noexcept;
 
   /**
-   * Returns the location in the document if in bounds.
+   * Returns the current location in the document if in bounds.
    */
   inline const char * current_location() noexcept;
 

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -352,6 +352,11 @@ public:
   inline std::string to_debug_string() noexcept;
 
   /**
+   * Returns the location in the document if in bounds.
+   */
+  inline const char * current_location() noexcept;
+
+  /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
    * https://tools.ietf.org/html/rfc6901 standard.
    *

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -191,6 +191,14 @@ inline std::string json_iterator::to_string() const noexcept {
           + std::string(" ]");
 }
 
+inline const char * json_iterator::current_location() noexcept {
+  auto cur_struct_index = token.position() - parser->implementation->structural_indexes.get();
+  if (cur_struct_index > parser->implementation->n_structural_indexes) {
+    return nullptr;
+  }
+  return reinterpret_cast<const char *>(token.peek());
+}
+
 simdjson_really_inline bool json_iterator::is_alive() const noexcept {
   return parser;
 }

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -237,6 +237,12 @@ public:
 #endif
   /* Useful for debugging and logging purposes. */
   inline std::string to_string() const noexcept;
+  
+  /**
+   * Returns the current location in the document if in bounds.
+   */
+  inline const char * current_location() noexcept;
+
   /**
    * Updates this json iterator so that it is back at the beginning of the document,
    * as if it had just been created.

--- a/tests/ondemand/CMakeLists.txt
+++ b/tests/ondemand/CMakeLists.txt
@@ -9,6 +9,7 @@ add_cpp_test(ondemand_array_error_tests      LABELS ondemand acceptance per_impl
 add_cpp_test(ondemand_compilation_tests      LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_document_stream_tests  LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_error_tests            LABELS ondemand acceptance per_implementation)
+add_cpp_test(ondemand_error_location_tests   LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_json_pointer_tests     LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_key_string_tests       LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_misc_tests             LABELS ondemand acceptance per_implementation)

--- a/tests/ondemand/ondemand_error_location_tests.cpp
+++ b/tests/ondemand/ondemand_error_location_tests.cpp
@@ -5,13 +5,28 @@ using namespace simdjson;
 
 namespace error_location_tests {
 
-    bool testing() {
+    bool simple_example() {
         TEST_START();
+        auto json = R"( [1,2,3] )"_padded;
+        ondemand::parser parser;
+        ondemand::document doc;
+        ASSERT_SUCCESS(parser.iterate(json).get(doc));
+        std::vector<char> expected = {'1','2','3'};
+        std::vector<int64_t> expected_values = {1,2,3};
+        size_t count{0};
+        for (auto value : doc) {
+            int64_t i;
+            // Must call current_location first because get_int64() will consume values
+            ASSERT_EQUAL(*doc.current_location(),expected[count]);
+            ASSERT_SUCCESS(value.get_int64().get(i));
+            ASSERT_EQUAL(i,expected_values[count]);
+            count++;
+        }
         TEST_SUCCEED();
     }
 
     bool run() {
-        return  testing() &&
+        return  simple_example() &&
                 true;
     }
 

--- a/tests/ondemand/ondemand_error_location_tests.cpp
+++ b/tests/ondemand/ondemand_error_location_tests.cpp
@@ -1,0 +1,22 @@
+#include "simdjson.h"
+#include "test_ondemand.h"
+
+using namespace simdjson;
+
+namespace error_location_tests {
+
+    bool testing() {
+        TEST_START();
+        TEST_SUCCEED();
+    }
+
+    bool run() {
+        return  testing() &&
+                true;
+    }
+
+} // namespace error_location_tests
+
+int main(int argc, char *argv[]) {
+  return test_main(argc, argv, error_location_tests::run);
+}


### PR DESCRIPTION
Fixes #1685 
This provides the `current_location()` method which is called on document instances. It returns a `simdjson_result<const char *>` instance to the current location in the JSON input.  It also checks if the location is within bounds (before last structural index). If out of bounds, it returns an `INDEX_OUT_OF_BOUNDS` error which is probably not the correct error to return. I was unsure if there was a more appropriate error to return or if I should add an error specific for this.