### PR TITLE
This exposes 'reset' for object and array instances.

### DIFF
--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -102,17 +102,10 @@ simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcep
 }
 
 simdjson_really_inline simdjson_result<bool> array::is_empty() & noexcept {
-  // If we enter this loop, then we are not empty.
-  for(simdjson_unused auto v : *this) {
-    iter.reset_array();
-    return false;
-  }
-  // We want to report errors.
-  if(iter.error()) { return iter.error(); }
-  // We need to move back at the start because we expect users to iterate through
-  // the array after counting the number of elements.
-  iter.reset_array();
-  return true;
+  bool is_not_empty;
+  auto error = iter.reset_array().get(is_not_empty);
+  if(error) { return error; }
+  return !is_not_empty;
 }
 
 inline simdjson_result<bool> array::rewind() & noexcept {

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -89,7 +89,7 @@ simdjson_really_inline simdjson_result<std::string_view> array::raw_json() noexc
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 
-simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcept {
+inline simdjson_result<size_t> array::count_elements() & noexcept {
   size_t count{0};
   // Important: we do not consume any of the values.
   for(simdjson_unused auto v : *this) { count++; }
@@ -99,6 +99,10 @@ simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcep
   // the array after counting the number of elements.
   iter.reset_array();
   return count;
+}
+
+inline simdjson_result<bool> array::rewind() & noexcept {
+  return iter.reset_array();
 }
 
 inline simdjson_result<value> array::at_pointer(std::string_view json_pointer) noexcept {

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -89,7 +89,7 @@ simdjson_really_inline simdjson_result<std::string_view> array::raw_json() noexc
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 
-inline simdjson_result<size_t> array::count_elements() & noexcept {
+simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcept {
   size_t count{0};
   // Important: we do not consume any of the values.
   for(simdjson_unused auto v : *this) { count++; }

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -101,6 +101,20 @@ simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcep
   return count;
 }
 
+simdjson_really_inline simdjson_result<bool> array::is_empty() & noexcept {
+  // If we enter this loop, then we are not empty.
+  for(simdjson_unused auto v : *this) {
+    iter.reset_array();
+    return false;
+  }
+  // We want to report errors.
+  if(iter.error()) { return iter.error(); }
+  // We need to move back at the start because we expect users to iterate through
+  // the array after counting the number of elements.
+  iter.reset_array();
+  return true;
+}
+
 inline simdjson_result<bool> array::rewind() & noexcept {
   return iter.reset_array();
 }
@@ -182,6 +196,10 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_
 simdjson_really_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::count_elements() & noexcept {
   if (error()) { return error(); }
   return first.count_elements();
+}
+simdjson_really_inline  simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::is_empty() & noexcept {
+  if (error()) { return error(); }
+  return first.is_empty();
 }
 simdjson_really_inline  simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::at(size_t index) noexcept {
   if (error()) { return error(); }

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -108,7 +108,7 @@ simdjson_really_inline simdjson_result<bool> array::is_empty() & noexcept {
   return !is_not_empty;
 }
 
-inline simdjson_result<bool> array::rewind() & noexcept {
+inline simdjson_result<bool> array::reset() & noexcept {
   return iter.reset_array();
 }
 

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -42,7 +42,7 @@ public:
    * there is a missing comma), then an error is returned and it is no longer
    * safe to continue.
    */
-  inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
 
   /**
    * Reset the iterator so that we are pointing back at the

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -42,8 +42,18 @@ public:
    * there is a missing comma), then an error is returned and it is no longer
    * safe to continue.
    */
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  inline simdjson_result<size_t> count_elements() & noexcept;
 
+  /**
+   * Reset the iterator so that we are pointing back at the
+   * beginning of the array. You should still consume values only once even if you
+   * can iterate through the array more than once. If you unescape a string within
+   * the array more than once, you have unsafe code. Note that rewinding an array
+   * means that you may need to reparse it anew: it is not a free operation.
+   *
+   * @returns true if the array contains some elements (not empty)
+   */
+  inline simdjson_result<bool> rewind() & noexcept;
   /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
    * https://tools.ietf.org/html/rfc6901 standard, interpreting the current node
@@ -159,7 +169,8 @@ public:
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  inline simdjson_result<size_t> count_elements() & noexcept;
+  inline simdjson_result<bool> rewind() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -41,15 +41,15 @@ public:
    * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
    * there is a missing comma), then an error is returned and it is no longer
    * safe to continue.
+   *
+   * To check that an array is empty, it is more performant to use
+   * the is_empty() method.
    */
   simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
   /**
    * This method scans the beginning of the array and checks whether the
    * array is empty.
-   * The is_empty method should always be called before you have begun
-   * iterating through the array: it is expected that you are pointing at
-   * the beginning of the array.
-   * The runtime complexity is constant. After
+   * The runtime complexity is constant time. After
    * calling this function, if successful, the array is 'rewinded' at its
    * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
    * there is a missing comma), then an error is returned and it is no longer

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -66,7 +66,7 @@ public:
    *
    * @returns true if the array contains some elements (not empty)
    */
-  inline simdjson_result<bool> rewind() & noexcept;
+  inline simdjson_result<bool> reset() & noexcept;
   /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
    * https://tools.ietf.org/html/rfc6901 standard, interpreting the current node
@@ -184,7 +184,7 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;
   inline simdjson_result<size_t> count_elements() & noexcept;
   inline simdjson_result<bool> is_empty() & noexcept;
-  inline simdjson_result<bool> rewind() & noexcept;
+  inline simdjson_result<bool> reset() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -47,9 +47,10 @@ public:
   /**
    * Reset the iterator so that we are pointing back at the
    * beginning of the array. You should still consume values only once even if you
-   * can iterate through the array more than once. If you unescape a string within
-   * the array more than once, you have unsafe code. Note that rewinding an array
-   * means that you may need to reparse it anew: it is not a free operation.
+   * can iterate through the array more than once. If you unescape a string
+   * within the array more than once, you have unsafe code. Note that rewinding
+   * an array means that you may need to reparse it anew: it is not a free
+   * operation.
    *
    * @returns true if the array contains some elements (not empty)
    */

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -43,7 +43,19 @@ public:
    * safe to continue.
    */
   simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
-
+  /**
+   * This method scans the beginning of the array and checks whether the
+   * array is empty.
+   * The is_empty method should always be called before you have begun
+   * iterating through the array: it is expected that you are pointing at
+   * the beginning of the array.
+   * The runtime complexity is constant. After
+   * calling this function, if successful, the array is 'rewinded' at its
+   * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
+   * there is a missing comma), then an error is returned and it is no longer
+   * safe to continue.
+   */
+  simdjson_really_inline simdjson_result<bool> is_empty() & noexcept;
   /**
    * Reset the iterator so that we are pointing back at the
    * beginning of the array. You should still consume values only once even if you
@@ -171,6 +183,7 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;
   inline simdjson_result<size_t> count_elements() & noexcept;
+  inline simdjson_result<bool> is_empty() & noexcept;
   inline simdjson_result<bool> rewind() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -38,20 +38,9 @@ simdjson_really_inline simdjson_result<value> document::get_value() noexcept {
   // gets called.
   iter.assert_at_document_depth();
   switch (*iter.peek()) {
-    case '[': {
-      array result;
-      SIMDJSON_TRY( get_array().get(result) );
-      iter._depth = 1 ; /* undoing the potential increment so we go back at the doc depth.*/
-      iter.assert_at_document_depth();
-      return value(result.iter);
-    }
-    case '{': {
-      object result;
-      SIMDJSON_TRY( get_object().get(result) );
-      iter._depth = 1 ; /* undoing the potential increment so we go back at the doc depth.*/
-      iter.assert_at_document_depth();
-      return value(result.iter);
-    }
+    case '[':
+    case '{':
+      return value(get_root_value_iterator());
     default:
       // Unfortunately, scalar documents are a special case in simdjson and they cannot
       // be safely converted to value instances.

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -147,7 +147,7 @@ simdjson_really_inline simdjson_result<bool> object::is_empty() & noexcept {
   return !is_not_empty;
 }
 
-simdjson_really_inline simdjson_result<bool> object::rewind() & noexcept {
+simdjson_really_inline simdjson_result<bool> object::reset() & noexcept {
   return iter.reset_object();
 }
 
@@ -200,9 +200,9 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
   return first.at_pointer(json_pointer);
 }
 
-inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::rewind() noexcept {
+inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::reset() noexcept {
   if (error()) { return error(); }
-  return first.rewind();
+  return first.reset();
 }
 
 inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::is_empty() noexcept {

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -140,6 +140,13 @@ inline simdjson_result<value> object::at_pointer(std::string_view json_pointer) 
 }
 
 
+simdjson_really_inline simdjson_result<bool> object::is_empty() & noexcept {
+  bool is_not_empty;
+  auto error = iter.reset_object().get(is_not_empty);
+  if(error) { return error; }
+  return !is_not_empty;
+}
+
 simdjson_really_inline simdjson_result<bool> object::rewind() & noexcept {
   return iter.reset_object();
 }
@@ -196,6 +203,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
 inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::rewind() noexcept {
   if (error()) { return error(); }
   return first.rewind();
+}
+
+inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::is_empty() noexcept {
+  if (error()) { return error(); }
+  return first.is_empty();
 }
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -139,6 +139,11 @@ inline simdjson_result<value> object::at_pointer(std::string_view json_pointer) 
   return child;
 }
 
+
+simdjson_really_inline simdjson_result<bool> object::rewind() & noexcept {
+  return iter.reset_object();
+}
+
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
@@ -186,6 +191,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::at_pointer(std::string_view json_pointer) noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
+}
+
+inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::rewind() noexcept {
+  if (error()) { return error(); }
+  return first.rewind();
 }
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -111,6 +111,16 @@ public:
   inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
 
   /**
+   * Reset the iterator so that we are pointing back at the
+   * beginning of the object. You should still consume values only once even if you
+   * can iterate through the object more than once. If you unescape a string within
+   * the object more than once, you have unsafe code. Note that rewinding an object
+   * means that you may need to reparse it anew: it is not a free operation.
+   *
+   * @returns true if the object contains some elements (not empty)
+   */
+  inline simdjson_result<bool> rewind() & noexcept;
+  /**
    * Consumes the object and returns a string_view instance corresponding to the
    * object as represented in JSON. It points inside the original byte array containg
    * the JSON document.
@@ -159,6 +169,7 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+  inline simdjson_result<bool> rewind() noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -121,6 +121,16 @@ public:
    */
   inline simdjson_result<bool> rewind() & noexcept;
   /**
+   * This method scans the beginning of the object and checks whether the
+   * object is empty.
+   * The runtime complexity is constant time. After
+   * calling this function, if successful, the object is 'rewinded' at its
+   * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
+   * there is a missing comma), then an error is returned and it is no longer
+   * safe to continue.
+   */
+  inline simdjson_result<bool> is_empty() & noexcept;
+  /**
    * Consumes the object and returns a string_view instance corresponding to the
    * object as represented in JSON. It points inside the original byte array containg
    * the JSON document.
@@ -170,6 +180,8 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
   inline simdjson_result<bool> rewind() noexcept;
+  inline simdjson_result<bool> is_empty() noexcept;
+
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -119,7 +119,7 @@ public:
    *
    * @returns true if the object contains some elements (not empty)
    */
-  inline simdjson_result<bool> rewind() & noexcept;
+  inline simdjson_result<bool> reset() & noexcept;
   /**
    * This method scans the beginning of the object and checks whether the
    * object is empty.
@@ -179,7 +179,7 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
-  inline simdjson_result<bool> rewind() noexcept;
+  inline simdjson_result<bool> reset() noexcept;
   inline simdjson_result<bool> is_empty() noexcept;
 
 };

--- a/tests/ondemand/ondemand_array_tests.cpp
+++ b/tests/ondemand/ondemand_array_tests.cpp
@@ -359,6 +359,23 @@ namespace array_tests {
     }));
     TEST_SUCCEED();
   }
+  bool empty_rewind() {
+    TEST_START();
+    const auto json = R"( [] )"_padded;
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    ondemand::array arr;
+    ASSERT_SUCCESS(doc.get_array().get(arr));
+    for(simdjson_unused auto i : arr) {
+      TEST_FAIL("should be empty?");
+    }
+    arr.rewind();
+    for(simdjson_unused auto i : arr) {
+      TEST_FAIL("should be empty?");
+    }
+    TEST_SUCCEED();
+  }
 
   bool iterate_array() {
     TEST_START();
@@ -678,6 +695,7 @@ namespace array_tests {
 
   bool run() {
     return
+           empty_rewind() &&
            iterate_empty_array_count() &&
            iterate_sub_array_count() &&
            iterate_complex_array_count() &&

--- a/tests/ondemand/ondemand_array_tests.cpp
+++ b/tests/ondemand/ondemand_array_tests.cpp
@@ -318,7 +318,7 @@ namespace array_tests {
       ASSERT_EQUAL(i*sizeof(uint64_t), sizeof(expected_value));
       std::vector<int64_t> container(i); // container of size 'i'.
 
-      array.rewind();
+      array.reset();
       i = 0;
       for (auto value : array) {
         int64_t actual;
@@ -370,7 +370,7 @@ namespace array_tests {
     for(simdjson_unused auto i : arr) {
       TEST_FAIL("should be empty?");
     }
-    arr.rewind();
+    arr.reset();
     for(simdjson_unused auto i : arr) {
       TEST_FAIL("should be empty?");
     }
@@ -687,7 +687,7 @@ namespace array_tests {
       for (auto value : array) { (void) value; i++; }
       ASSERT_EQUAL(i, 0);
 
-      array.rewind();
+      array.reset();
       i = 0;
       for (auto value : array) { (void) value; i++; }
       ASSERT_EQUAL(i, 0);

--- a/tests/ondemand/ondemand_array_tests.cpp
+++ b/tests/ondemand/ondemand_array_tests.cpp
@@ -308,7 +308,30 @@ namespace array_tests {
       }
       return true;
     }));
+    SUBTEST("ondemand::array-rewind", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::array array;
+      ASSERT_RESULT( doc_result.type(), json_type::array );
+      ASSERT_SUCCESS( doc_result.get(array) );
 
+      size_t i = 0;
+      for (auto value : array) { (void)value; i++; }
+      ASSERT_EQUAL(i*sizeof(uint64_t), sizeof(expected_value));
+      std::vector<int64_t> container(i); // container of size 'i'.
+
+      array.rewind();
+      i = 0;
+      for (auto value : array) {
+        int64_t actual;
+        ASSERT_SUCCESS( value.get(actual) );
+        container[i] = actual;
+        i++;
+      }
+      ASSERT_EQUAL(i * sizeof(int64_t), sizeof(expected_value));
+      for(size_t j = 0; j < sizeof(expected_value)/sizeof(int64_t); j++) {
+        ASSERT_EQUAL(container[j], expected_value[j]);
+      }
+      return true;
+    }));
     SUBTEST("simdjson_result<ondemand::array>", test_ondemand_doc(json, [&](auto doc_result) {
       simdjson_result<ondemand::array> array = doc_result.get_array();
       ASSERT_RESULT( doc_result.type(), json_type::array );
@@ -591,8 +614,24 @@ namespace array_tests {
       ASSERT_EQUAL(i, 0);
       return true;
     }));
+    SUBTEST("ondemand::array-rewind", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::array array;
+      ASSERT_RESULT( doc_result.type(), json_type::array );
+      ASSERT_SUCCESS( doc_result.get(array) );
+
+      size_t i = 0;
+      for (auto value : array) { (void) value; i++; }
+      ASSERT_EQUAL(i, 0);
+
+      array.rewind();
+      i = 0;
+      for (auto value : array) { (void) value; i++; }
+      ASSERT_EQUAL(i, 0);
+      return true;
+    }));
     TEST_SUCCEED();
   }
+
 #if SIMDJSON_EXCEPTIONS
 
   bool iterate_array_exception() {

--- a/tests/ondemand/ondemand_array_tests.cpp
+++ b/tests/ondemand/ondemand_array_tests.cpp
@@ -385,6 +385,15 @@ namespace array_tests {
     ASSERT_TRUE(is_empty);
     return true;
   }
+  bool value_to_array(simdjson::ondemand::value val) {
+    ondemand::json_type t;
+    ASSERT_SUCCESS(val.type().get(t));
+    ASSERT_EQUAL(t, ondemand::json_type::array);
+    simdjson::ondemand::array arr;
+    ASSERT_SUCCESS(val.get_array().get(arr));
+    if(count_empty(arr) != true) { return false; }
+    return true;
+  }
   bool empty_rewind_convoluted() {
     TEST_START();
     const auto json = R"( [] )"_padded;
@@ -393,15 +402,16 @@ namespace array_tests {
     ASSERT_SUCCESS(parser.iterate(json).get(doc));
     ondemand::value val;
     ASSERT_SUCCESS(doc.get_value().get(val));
-    ondemand::json_type t;
-    ASSERT_SUCCESS(val.type().get(t));
-    ASSERT_EQUAL(t, ondemand::json_type::array);
-    simdjson::ondemand::array arr;
-    ASSERT_SUCCESS(val.get_array().get(arr));
-    if(count_empty(arr) != true) { return false; }
+    if(!value_to_array(val)) { return false; }
     TEST_SUCCEED();
   }
 #if SIMDJSON_EXCEPTIONS
+  bool value_to_array_except(simdjson::ondemand::value val) {
+    ondemand::json_type t = val.type();
+    ASSERT_EQUAL(t, ondemand::json_type::array);
+    if(count_empty(simdjson::ondemand::array(val)) != true) { return false; }
+    return true;
+  }
   bool empty_rewind_convoluted_with_exceptions() {
     TEST_START();
     const auto json = R"( [] )"_padded;
@@ -410,10 +420,7 @@ namespace array_tests {
     ASSERT_SUCCESS(parser.iterate(json).get(doc));
     ondemand::value val;
     ASSERT_SUCCESS(doc.get_value().get(val));
-    ondemand::json_type t;
-    ASSERT_SUCCESS(val.type().get(t));
-    ASSERT_EQUAL(t, ondemand::json_type::array);
-    if(count_empty(simdjson::ondemand::array(val)) != true) { return false; }
+    if(value_to_array_except(val) != true) { return false; }
     TEST_SUCCEED();
   }
 #endif

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -249,7 +249,7 @@ namespace object_tests {
         i++;
       }
       ASSERT_EQUAL( i*sizeof(uint64_t), sizeof(expected_value) );
-      object.rewind();
+      object.reset();
       i = 0;
       for (auto field : object) {
         ASSERT_SUCCESS( field.error() );
@@ -623,7 +623,7 @@ namespace object_tests {
         i++;
       }
       ASSERT_EQUAL( i, 0 );
-      object.rewind();
+      object.reset();
       i = 0;
       for (auto field : object) {
         (void)field;
@@ -642,7 +642,7 @@ namespace object_tests {
         i++;
       }
       ASSERT_EQUAL( i, 0 );
-      object.rewind();
+      object.reset();
       i = 0;
       for (auto field : object) {
         (void)field;

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -237,6 +237,29 @@ namespace object_tests {
       ASSERT_EQUAL( i*sizeof(uint64_t), sizeof(expected_value) );
       return true;
     }));
+    SUBTEST("ondemand::object-rewind", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::object object;
+      ASSERT_RESULT( doc_result.type(), json_type::object );
+      ASSERT_SUCCESS( doc_result.get(object) );
+      size_t i = 0;
+      for (auto field : object) {
+        ASSERT_SUCCESS( field.error() );
+        ASSERT_EQUAL( field.key().value_unsafe(), expected_key[i]);
+        ASSERT_EQUAL( field.value().get_uint64().value_unsafe(), expected_value[i] );
+        i++;
+      }
+      ASSERT_EQUAL( i*sizeof(uint64_t), sizeof(expected_value) );
+      object.rewind();
+      i = 0;
+      for (auto field : object) {
+        ASSERT_SUCCESS( field.error() );
+        ASSERT_EQUAL( field.key().value_unsafe(), expected_key[i]);
+        ASSERT_EQUAL( field.value().get_uint64().value_unsafe(), expected_value[i] );
+        i++;
+      }
+      ASSERT_EQUAL( i*sizeof(uint64_t), sizeof(expected_value) );
+      return true;
+    }));
     SUBTEST("simdjson_result<ondemand::object>", test_ondemand_doc(json, [&](auto doc_result) {
       simdjson_result<ondemand::object> object_result = doc_result.get_object();
       size_t i = 0;
@@ -582,6 +605,44 @@ namespace object_tests {
       }
       ASSERT_EQUAL( i, 0 );
       doc_result.rewind();
+      i = 0;
+      for (auto field : object) {
+        (void)field;
+        i++;
+      }
+      ASSERT_EQUAL( i, 0 );
+      return true;
+    }));
+    SUBTEST("ondemand::object-rewind", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::object object;
+      ASSERT_RESULT( doc_result.type(), json_type::object );
+      ASSERT_SUCCESS( doc_result.get(object) );
+      size_t i = 0;
+      for (auto field : object) {
+        (void)field;
+        i++;
+      }
+      ASSERT_EQUAL( i, 0 );
+      object.rewind();
+      i = 0;
+      for (auto field : object) {
+        (void)field;
+        i++;
+      }
+      ASSERT_EQUAL( i, 0 );
+      return true;
+    }));
+    SUBTEST("ondemand::object-rewind", test_ondemand_doc(json, [&](auto doc_result) {
+      ondemand::object object;
+      ASSERT_RESULT( doc_result.type(), json_type::object );
+      ASSERT_SUCCESS( doc_result.get(object) );
+      size_t i = 0;
+      for (auto field : object) {
+        (void)field;
+        i++;
+      }
+      ASSERT_EQUAL( i, 0 );
+      object.rewind();
       i = 0;
       for (auto field : object) {
         (void)field;

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -305,6 +305,30 @@ bool using_the_parsed_json_rewind() {
   TEST_SUCCEED();
 }
 
+
+bool using_the_parsed_json_rewind_array() {
+  TEST_START();
+
+  ondemand::parser parser;
+  auto cars_json = R"( [
+    { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
+    { "make": "Kia",    "model": "Soul",   "year": 2012, "tire_pressure": [ 30.1, 31.0, 28.6, 28.7 ] },
+    { "make": "Toyota", "model": "Tercel", "year": 1999, "tire_pressure": [ 29.8, 30.0, 30.2, 30.5 ] }
+  ] )"_padded;
+
+  auto doc = parser.iterate(cars_json);
+  ondemand::array arr = doc.get_array();
+  size_t count = 0;
+  for (simdjson_unused ondemand::object car : arr) {
+    if(car["make"] == "Toyota") { count++; }
+  }
+  std::cout << "We have " << count << " Toyota cars.\n";
+  arr.rewind();
+  for (ondemand::object car : arr) {
+    cout << "Make/Model: " << std::string_view(car["make"]) << "/" << std::string_view(car["model"]) << endl;
+  }
+  TEST_SUCCEED();
+}
 bool using_the_parsed_json_4() {
   TEST_START();
 
@@ -738,6 +762,7 @@ int main() {
     && json_array_count_complex()
     && json_array_count()
     && using_the_parsed_json_rewind()
+    && using_the_parsed_json_rewind_array()
     && basics_2()
     && using_the_parsed_json_1()
     && using_the_parsed_json_2()

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -323,7 +323,7 @@ bool using_the_parsed_json_rewind_array() {
     if(car["make"] == "Toyota") { count++; }
   }
   std::cout << "We have " << count << " Toyota cars.\n";
-  arr.rewind();
+  arr.reset();
   for (ondemand::object car : arr) {
     cout << "Make/Model: " << std::string_view(car["make"]) << "/" << std::string_view(car["model"]) << endl;
   }


### PR DESCRIPTION
I am not super happy about exposing these methods, but it appears that we need to be able to scan arrays and objects twice (@NicolasJiaxin ?) in some instances. These rewind functions will do just that.

It is somewhat dangerous and should be used with caution because if you access string values multiple times, it will be unsafe (and inefficient). That is, they do not rewind the string buffer.

Note that this functionality competes with @jkeiser 's 'fork' idea but I really would prefer to release 1.0 in the near future and the fork functionality seems speculative. Currently, we have always just one json_iterator instance, and it seems that fork would allow us to copy that... which could potentially expose other bugs.

The benefit of this implementation is that it is non-invasive, so realistic for release 1.0.

If it works out for 1.0, we can revisit this design post-1.0.