### PR TITLE
Reduce #include bloat (<iostream>)

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <iostream>
 #include "simdjson.h"
 #include <sstream>
 

--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <iostream>
 #include "simdjson.h"
 using namespace simdjson;
 using namespace benchmark;

--- a/examples/quickstart/quickstart.cpp
+++ b/examples/quickstart/quickstart.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "simdjson.h"
 
 int main(void) {

--- a/examples/quickstart/quickstart2.cpp
+++ b/examples/quickstart/quickstart2.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "simdjson.h"
 
 int main(void) {

--- a/examples/quickstart/quickstart2_noexceptions.cpp
+++ b/examples/quickstart/quickstart2_noexceptions.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "simdjson.h"
 
 int main(void) {

--- a/examples/quickstart/quickstart_noexceptions.cpp
+++ b/examples/quickstart/quickstart_noexceptions.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "simdjson.h"
 
 int main(void) {

--- a/examples/quickstart/quickstart_ondemand.cpp
+++ b/examples/quickstart/quickstart_ondemand.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "simdjson.h"
 using namespace simdjson;
 int main(void) {

--- a/examples/quickstart/quickstart_ondemand_noexceptions.cpp
+++ b/examples/quickstart/quickstart_ondemand_noexceptions.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "simdjson.h"
 using namespace simdjson;
 int main(void) {

--- a/fuzz/fuzz_implementations.cpp
+++ b/fuzz/fuzz_implementations.cpp
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <iostream>
 #include <string>
 #include <array>
 #include "supported_implementations.h"

--- a/fuzz/fuzz_minifyimpl.cpp
+++ b/fuzz/fuzz_minifyimpl.cpp
@@ -12,6 +12,7 @@
 #include "simdjson.h"
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include <vector>
 #include "supported_implementations.h"
 

--- a/fuzz/fuzz_utf8.cpp
+++ b/fuzz/fuzz_utf8.cpp
@@ -10,6 +10,7 @@
 #include "simdjson.h"
 #include <cstddef>
 #include <cstdlib>
+#include <iostream>
 #include "supported_implementations.h"
 
 extern "C" int VerboseTestOneInput(const uint8_t *Data, size_t Size) {

--- a/include/simdjson/dom/parsedjson_iterator.h
+++ b/include/simdjson/dom/parsedjson_iterator.h
@@ -5,7 +5,7 @@
 
 #include <cstring>
 #include <string>
-#include <iostream>
+#include <ostream>
 #include <iterator>
 #include <limits>
 #include <stdexcept>

--- a/include/simdjson/internal/jsonformatutils.h
+++ b/include/simdjson/internal/jsonformatutils.h
@@ -2,7 +2,7 @@
 #define SIMDJSON_INTERNAL_JSONFORMATUTILS_H
 
 #include <iomanip>
-#include <iostream>
+#include <ostream>
 #include <sstream>
 
 namespace simdjson {

--- a/tests/dom/jsoncheck.cpp
+++ b/tests/dom/jsoncheck.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 
 #include "simdjson.h"
 

--- a/tests/dom/minefieldcheck.cpp
+++ b/tests/dom/minefieldcheck.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 
 #include "simdjson.h"
 /**

--- a/tests/dom/numberparsingcheck.cpp
+++ b/tests/dom/numberparsingcheck.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 
 #ifndef JSON_TEST_NUMBERS
 #define JSON_TEST_NUMBERS

--- a/tests/dom/parse_many_test.cpp
+++ b/tests/dom/parse_many_test.cpp
@@ -10,6 +10,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <iostream>
 
 #include "simdjson.h"
 

--- a/tests/dom/random_string_number_tests.cpp
+++ b/tests/dom/random_string_number_tests.cpp
@@ -4,6 +4,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstdint>
+#include <iostream>
 #include <random>
 #include <climits>
 #include <unistd.h>

--- a/tests/ondemand/test_ondemand.h
+++ b/tests/ondemand/test_ondemand.h
@@ -1,6 +1,7 @@
 #ifndef ONDEMAND_TEST_ONDEMAND_H
 #define ONDEMAND_TEST_ONDEMAND_H
 
+#include <iostream>
 #include <unistd.h>
 #include "simdjson.h"
 #include "cast_tester.h"

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -1,6 +1,8 @@
 #ifndef TEST_MACROS_H
 #define TEST_MACROS_H
 
+#include <iostream>
+
 #ifndef SIMDJSON_BENCHMARK_DATA_DIR
 #define SIMDJSON_BENCHMARK_DATA_DIR "jsonexamples/"
 #endif

--- a/tests/unicode_tests.cpp
+++ b/tests/unicode_tests.cpp
@@ -1,6 +1,7 @@
 #include "simdjson.h"
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <random>
 
 class RandomUTF8 final {


### PR DESCRIPTION
Including \<iostream\> has two problems:

* Compile times are worse because of over-inclusion
* Binary sizes are worse when statically linking libstdc++ because
  iostreams cannot be dead-code-stripped

simdjson only needs std::ostream. Include the header declaring only what
we need (\<ostream\>), omitting stuff we don't need (std::cout and its
initialization, for example).

This commit should not change behavior, but it might break users who
assume that including \<simdjson/simdjson.h\> will make std::cout
available (such as many of simdjson's own files).



Our tests check whether you have introduced trailing white space. If such a test fails, please check the "artifacts button" above, which if you click it gives a link to a downloadable file to help you identify the issue. You can also run scripts/remove_trailing_whitespace.sh locally if you have a bash shell and the sed command available on your system.

If you plan to contribute to simdjson, please read our

CONTRIBUTING guide: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md and our
HACKING guide: https://github.com/simdjson/simdjson/blob/master/HACKING.md
