### PR TITLE
Alive fix.

### DIFF
--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -79,6 +79,14 @@ public:
    */
   simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
 
+  /**
+   * Get the value at the given index. This function has linear-time complexity.
+   * This function should only be called once as the array iterator is not reset between each call.
+   *
+   * @return The value at the given index, or:
+   *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
+   */
+  simdjson_really_inline simdjson_result<value> at(size_t index) noexcept;
 protected:
   /**
    * Go to the end of the array, no matter where you are right now.
@@ -120,15 +128,6 @@ protected:
    *        into the resulting array.
    */
   simdjson_really_inline array(const value_iterator &iter) noexcept;
-
-  /**
-   * Get the value at the given index. This function has linear-time complexity.
-   * This function should only be called once as the array iterator is not reset between each call.
-   *
-   * @return The value at the given index, or:
-   *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
-   */
-  simdjson_really_inline simdjson_result<value> at(size_t index) noexcept;
 
   /**
    * Iterator marking current position.

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -19,7 +19,9 @@ inline void document::rewind() noexcept {
 inline std::string document::to_debug_string() noexcept {
   return iter.to_string();
 }
-
+inline bool document::is_alive() noexcept {
+  return iter.is_alive();
+}
 simdjson_really_inline value_iterator document::resume_value_iterator() noexcept {
   return value_iterator(&iter, 1, iter.root_position());
 }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -376,6 +376,11 @@ public:
    * Returns debugging information.
    */
   inline std::string to_debug_string() noexcept;
+  /**
+   * Some unrecoverable error conditions may render the document instance unusable.
+   * The is_alive() method returns true when the document is still suitable.
+   */
+  inline bool is_alive() noexcept;
 
   /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -216,7 +216,7 @@ public:
   simdjson_really_inline uint8_t *&string_buf_loc() noexcept;
 
   /**
-   * Report an error, preventing further iteration.
+   * Report an unrecoverable error, preventing further iteration.
    *
    * @param error The error to report. Must not be SUCCESS, UNINITIALIZED, INCORRECT_TYPE, or NO_SUCH_FIELD.
    * @param message An error message to report with the error.

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -40,6 +40,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   // Note that adding a check for 'streaming' is not expensive since we only have at most
   // one root element.
   if (! _json_iter->streaming() && (*_json_iter->peek_last() != '}')) {
+    _json_iter->abandon();
     return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing } at end");
   }
   return started_object();
@@ -408,6 +409,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   // Note that adding a check for 'streaming' is not expensive since we only have at most
   // one root element.
   if ( ! _json_iter->streaming() && (*_json_iter->peek_last() != ']')) {
+    _json_iter->abandon();
     return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing ] at end");
   }
   return started_array();

--- a/tests/ondemand/ondemand_array_error_tests.cpp
+++ b/tests/ondemand/ondemand_array_error_tests.cpp
@@ -8,8 +8,14 @@ namespace array_error_tests {
 
   template<typename V, typename T>
   bool assert_iterate(T array, V *expected, size_t N, simdjson::error_code *expected_error, size_t N2) {
+    /**
+     * We use printouts because the assert_iterate is abstract and hard to
+     * understand intuitively.
+     */
+    std::cout << "     --- assert_iterate ";
     size_t count = 0;
     for (auto elem : std::forward<T>(array)) {
+      std::cout << "-"; std::cout.flush();
       V actual;
       auto actual_error = elem.get(actual);
       if (count >= N) {
@@ -17,14 +23,19 @@ namespace array_error_tests {
           std::cerr << "FAIL: Extra error reported: " << actual_error << std::endl;
           return false;
         }
+        std::cout << "[ expect: " << expected_error[count - N] << " ]"; std::cout.flush();
         ASSERT_ERROR(actual_error, expected_error[count - N]);
       } else {
+        std::cout << "[ expect: SUCCESS ]"; std::cout.flush();
         ASSERT_SUCCESS(actual_error);
+        std::cout << "{ expect value : "<< expected[count] << " }"; std::cout.flush();
+
         ASSERT_EQUAL(actual, expected[count]);
       }
       count++;
     }
     ASSERT_EQUAL(count, N+N2);
+    std::cout << std::endl;
     return true;
   }
 


### PR DESCRIPTION
When accessing root arrays and root objects, we would not "abandon" on error. This PR fixes that. credit @NicolasJiaxin 

This PR adds a public "is_alive()" method to do document class. It has not be spread to other related classes such as document_reference since it is expected that it has a narrow usefulness (mostly for us).

The "at" method of the array class is made public (it was protected). Note that it was de facto publicly accessible via the simdjson_result wrapper.

The assert_iterate helper function in ondemand_array_error_tests.cpp has been made more verbose so we can understand what is happening.


