### PR TITLE
[no ci] remove references to bintray

### DIFF
--- a/fuzz/Fuzzing.md
+++ b/fuzz/Fuzzing.md
@@ -18,7 +18,7 @@ The fuzzers are used in several ways.
 * oss-fuzz - heavy duty 24/7 fuzzing provided by the google driven oss-fuzz project
 
 ## Local fuzzing
-Just invoke fuzz/quick_check.sh, it will download the latest corpus from bintray (kept up to date by the CI fuzzers) and run the fuzzers for a short time. In case you want to run the fuzzers for longer, modify the timeout value in the script or invoke the fuzzer directly.
+Just invoke fuzz/quick_check.sh, it will download the latest corpus (kept up to date by the CI fuzzers) and run the fuzzers for a short time. In case you want to run the fuzzers for longer, modify the timeout value in the script or invoke the fuzzer directly.
 
 This requires linux with clang and cmake installed (recent Debian and Ubuntu are known to work fine).
 
@@ -69,7 +69,7 @@ As little code as possible is kept at oss-fuzz since it is inconvenient to chang
 
 The simdjson library does not benefit from a corpus as much as other projects, because the library is very fast and explores the input space very well. With that said, it is still beneficial to have one. The CI job stores the corpus on a remote server between runs, and is available at [www.pauldreik.se](https://readonly:readonly@www.pauldreik.se/fuzzdata/index.php?project=simdjson).
 
-One can also grab the corpus as an artifact from the github actions job. Pick a run, then go to artifacts and download.
+One can also grab the corpus as an artifact from the github actions job if you are logged in at github. Pick a run, then go to artifacts and download.
 
 ## Fuzzing coverage
 

--- a/fuzz/quick_check.sh
+++ b/fuzz/quick_check.sh
@@ -4,7 +4,7 @@
 # good when working locally developing the fuzzers or making
 # sure code changes still pass the fuzzers.
 #
-# It will download the corpus from bintray (kept up to date
+# It will download the corpus from external store (kept up to date
 # by the crontab github actions) unless a local out/ directory
 # already exists.
 #
@@ -23,10 +23,9 @@ done
 
 #download the corpus if it does not already exist
 if [ ! -d out ] ; then
-  # ideally, we would download the github artifact but that requires being logged in which can not
-  # easily be fixed from this shell script.
-  echo "NOTE! please go to the artifacts page on https://github.com/simdjson/simdjson/actions/workflows/fuzzers.yml and download the latest corpus.tar.zip artifact manually to speed up fuzzing"
-  sleep 5s
+  # the corpus is also available for download from the artifacts page on https://github.com/simdjson/simdjson/actions/workflows/fuzzers.yml
+  # but that requires being logged in so can not be easily done from this script.
+  wget -O - https://readonly:readonly@www.pauldreik.se/fuzzdata/index.php?project=simdjson |tar xzf -
 fi
 
 # By default, use the debug friendly variant since this script is intended


### PR DESCRIPTION
bintray is gone and the fuzz corpus is stored on my server, with publicly available download (but password protected upload). this means the quick fuzz script can use the latest corpus.