### PR TITLE
simd8x64::compress optimisation for Apple M1

### DIFF
--- a/include/simdjson/arm64/simd.h
+++ b/include/simdjson/arm64/simd.h
@@ -473,7 +473,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     }
 
 
-    simdjson_really_inline void compress(uint64_t mask, T * output) const {
+    simdjson_really_inline uint64_t compress(uint64_t mask, T * output) const {
       uint64_t popcounts = vget_lane_u64(vreinterpret_u64_u8(vcnt_u8(vcreate_u8(~mask))), 0);
       // compute the prefix sum of the popcounts of each byte
       uint64_t offsets = popcounts * 0x0101010101010101;
@@ -481,6 +481,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       this->chunks[1].compress_halves(uint16_t(mask >> 16), &output[(offsets >> 8) & 0xFF], &output[(offsets >> 16) & 0xFF]);
       this->chunks[2].compress_halves(uint16_t(mask >> 32), &output[(offsets >> 24) & 0xFF], &output[(offsets >> 32) & 0xFF]);
       this->chunks[3].compress_halves(uint16_t(mask >> 48), &output[(offsets >> 40) & 0xFF], &output[(offsets >> 48) & 0xFF]);
+      return offsets >> 56;
     }
 
     simdjson_really_inline uint64_t to_bitmask() const {

--- a/include/simdjson/arm64/simd.h
+++ b/include/simdjson/arm64/simd.h
@@ -57,6 +57,19 @@ simdjson_really_inline uint8x16_t make_uint8x16_t(uint8_t x1,  uint8_t x2,  uint
   return x;
 }
 
+simdjson_really_inline uint8x8_t make_uint8x8_t(uint8_t x1,  uint8_t x2,  uint8_t x3,  uint8_t x4,
+                                         uint8_t x5,  uint8_t x6,  uint8_t x7,  uint8_t x8) {
+  uint8x8_t x{};
+  x = vset_lane_u8(x1, x, 0);
+  x = vset_lane_u8(x2, x, 1);
+  x = vset_lane_u8(x3, x, 2);
+  x = vset_lane_u8(x4, x, 3);
+  x = vset_lane_u8(x5, x, 4);
+  x = vset_lane_u8(x6, x, 5);
+  x = vset_lane_u8(x7, x, 6);
+  x = vset_lane_u8(x8, x, 7);
+  return x;
+}
 
 // We have to do the same work for make_int8x16_t
 simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x3,  int8_t x4,
@@ -289,6 +302,27 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       vst1q_u8(reinterpret_cast<uint8_t*>(output), answer);
     }
 
+    // Copies all bytes corresponding to a 0 in the low half of the mask (interpreted as a
+    // bitset) to output1, then those corresponding to a 0 in the high half to output2.
+    template<typename L>
+    simdjson_really_inline void compress_halves(uint16_t mask, L *output1, L *output2) const {
+      using internal::thintable_epi8;
+      uint8_t mask1 = uint8_t(mask); // least significant 8 bits
+      uint8_t mask2 = uint8_t(mask >> 8); // most significant 8 bits
+      uint8x8_t compactmask1 = vcreate_u8(thintable_epi8[mask1]);
+      uint8x8_t compactmask2 = vcreate_u8(thintable_epi8[mask2]);
+      // we increment by 0x08 the second half of the mask
+#ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
+      uint8x8_t inc = make_uint8x8_t(0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08);
+#else
+      uint8x8_t inc = {0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08, 0x08};
+#endif
+      compactmask2 = vadd_u8(compactmask2, inc);
+      // store each result (with the second store possibly overlapping the first)
+      vst1_u8((uint8_t*)output1, vqtbl1_u8(*this, compactmask1));
+      vst1_u8((uint8_t*)output2, vqtbl1_u8(*this, compactmask2));
+    }
+
     template<typename L>
     simdjson_really_inline simd8<L> lookup_16(
         L replace0,  L replace1,  L replace2,  L replace3,
@@ -440,10 +474,13 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
 
 
     simdjson_really_inline void compress(uint64_t mask, T * output) const {
-      this->chunks[0].compress(uint16_t(mask), output);
-      this->chunks[1].compress(uint16_t(mask >> 16), output + 16 - count_ones(mask & 0xFFFF));
-      this->chunks[2].compress(uint16_t(mask >> 32), output + 32 - count_ones(mask & 0xFFFFFFFF));
-      this->chunks[3].compress(uint16_t(mask >> 48), output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
+      uint64_t popcounts = vget_lane_u64(vreinterpret_u64_u8(vcnt_u8(vcreate_u8(~mask))), 0);
+      // compute the prefix sum of the popcounts of each byte
+      uint64_t offsets = popcounts * 0x0101010101010101;
+      this->chunks[0].compress_halves(uint16_t(mask), output, &output[popcounts & 0xFF]);
+      this->chunks[1].compress_halves(uint16_t(mask >> 16), &output[(offsets >> 8) & 0xFF], &output[(offsets >> 16) & 0xFF]);
+      this->chunks[2].compress_halves(uint16_t(mask >> 32), &output[(offsets >> 24) & 0xFF], &output[(offsets >> 32) & 0xFF]);
+      this->chunks[3].compress_halves(uint16_t(mask >> 48), &output[(offsets >> 40) & 0xFF], &output[(offsets >> 48) & 0xFF]);
     }
 
     simdjson_really_inline uint64_t to_bitmask() const {

--- a/include/simdjson/haswell/simd.h
+++ b/include/simdjson/haswell/simd.h
@@ -303,11 +303,12 @@ namespace simd {
     simdjson_really_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1) : chunks{chunk0, chunk1} {}
     simdjson_really_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+32)} {}
 
-    simdjson_really_inline void compress(uint64_t mask, T * output) const {
+    simdjson_really_inline uint64_t compress(uint64_t mask, T * output) const {
       uint32_t mask1 = uint32_t(mask);
       uint32_t mask2 = uint32_t(mask >> 32);
       this->chunks[0].compress(mask1, output);
       this->chunks[1].compress(mask2, output + 32 - count_ones(mask1));
+      return 64 - count_ones(mask);
     }
 
     simdjson_really_inline void store(T ptr[64]) const {

--- a/include/simdjson/ppc64/simd.h
+++ b/include/simdjson/ppc64/simd.h
@@ -422,7 +422,7 @@ template <typename T> struct simd8x64 {
            (this->chunks[2] | this->chunks[3]);
   }
 
-  simdjson_really_inline void compress(uint64_t mask, T *output) const {
+  simdjson_really_inline uint64_t compress(uint64_t mask, T *output) const {
     this->chunks[0].compress(uint16_t(mask), output);
     this->chunks[1].compress(uint16_t(mask >> 16),
                              output + 16 - count_ones(mask & 0xFFFF));
@@ -430,6 +430,7 @@ template <typename T> struct simd8x64 {
                              output + 32 - count_ones(mask & 0xFFFFFFFF));
     this->chunks[3].compress(uint16_t(mask >> 48),
                              output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
+    return 64 - count_ones(mask);
   }
 
   simdjson_really_inline uint64_t to_bitmask() const {

--- a/include/simdjson/westmere/simd.h
+++ b/include/simdjson/westmere/simd.h
@@ -284,11 +284,12 @@ namespace simd {
       return (this->chunks[0] | this->chunks[1]) | (this->chunks[2] | this->chunks[3]);
     }
 
-    simdjson_really_inline void compress(uint64_t mask, T * output) const {
+    simdjson_really_inline uint64_t compress(uint64_t mask, T * output) const {
       this->chunks[0].compress(uint16_t(mask), output);
       this->chunks[1].compress(uint16_t(mask >> 16), output + 16 - count_ones(mask & 0xFFFF));
       this->chunks[2].compress(uint16_t(mask >> 32), output + 32 - count_ones(mask & 0xFFFFFFFF));
       this->chunks[3].compress(uint16_t(mask >> 48), output + 48 - count_ones(mask & 0xFFFFFFFFFFFF));
+      return 64 - count_ones(mask);
     }
 
     simdjson_really_inline uint64_t to_bitmask() const {

--- a/src/generic/stage1/json_minifier.h
+++ b/src/generic/stage1/json_minifier.h
@@ -27,8 +27,7 @@ private:
 
 simdjson_really_inline void json_minifier::next(const simd::simd8x64<uint8_t>& in, const json_block& block) {
   uint64_t mask = block.whitespace();
-  in.compress(mask, dst);
-  dst += 64 - count_ones(mask);
+  dst += in.compress(mask, dst);
 }
 
 simdjson_really_inline error_code json_minifier::finish(uint8_t *dst_start, size_t &dst_len) {


### PR DESCRIPTION
This is an optimisation of the arm64 implementation of `simd8x64::compress` for the Apple M1, which increases `fast_minify` benchmark speed by ~39%. The idea is to do twice as many stores, but significantly fewer loads and SIMD operations. I also reduce the number of population counts (as they are four instructions on ARM64, with 15c latency on Apple M1 Firestorm). This PR has not been tested on other CPUs.

The second commit could be removed, as it only accounts for a 3-3.5% speedup, and required changes to non-ARM64-specific code. Theses changes shouldn't change behaviour, performance or code generation, but I'm not set up to test properly.

This PR:
```
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
fast_minify_twitter/repeats:10_mean        68231 ns        68231 ns           10 Gigabytes=9.25554G/s docs=14.6561k/s
fast_minify_twitter/repeats:10_median      68218 ns        68218 ns           10 Gigabytes=9.25733G/s docs=14.6589k/s
fast_minify_twitter/repeats:10_stddev       35.6 ns         35.5 ns           10 Gigabytes=4.81706M/s docs=7.62778/s
fast_minify_twitter/repeats:10_max         68299 ns        68299 ns           10 Gigabytes=9.25965G/s docs=14.6626k/s
fast_minify_gsoc/repeats:10_mean          367660 ns       367660 ns           10 Gigabytes=9.05138G/s docs=2.7199k/s
fast_minify_gsoc/repeats:10_median        367639 ns       367639 ns           10 Gigabytes=9.05189G/s docs=2.72006k/s
fast_minify_gsoc/repeats:10_stddev          72.2 ns         71.8 ns           10 Gigabytes=1.76873M/s docs=0.531496/s
fast_minify_gsoc/repeats:10_max           367746 ns       367747 ns           10 Gigabytes=9.05423G/s docs=2.72076k/s
```

Main branch:
```
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
fast_minify_twitter/repeats:10_mean        95862 ns        95861 ns           10 Gigabytes=6.58779G/s docs=10.4317k/s
fast_minify_twitter/repeats:10_median      95858 ns        95857 ns           10 Gigabytes=6.58806G/s docs=10.4322k/s
fast_minify_twitter/repeats:10_stddev       45.5 ns         45.6 ns           10 Gigabytes=3.12853M/s docs=4.954/s
fast_minify_twitter/repeats:10_max         95970 ns        95970 ns           10 Gigabytes=6.59135G/s docs=10.4374k/s
fast_minify_gsoc/repeats:10_mean          514316 ns       514314 ns           10 Gigabytes=6.47042G/s docs=1.94434k/s
fast_minify_gsoc/repeats:10_median        514275 ns       514275 ns           10 Gigabytes=6.47092G/s docs=1.94449k/s
fast_minify_gsoc/repeats:10_stddev           173 ns          172 ns           10 Gigabytes=2.16759M/s docs=0.651353/s
fast_minify_gsoc/repeats:10_max           514727 ns       514727 ns           10 Gigabytes=6.47256G/s docs=1.94498k/s
```

And using [docker_programming_station](https://github.com/lemire/docker_programming_station):
 
This PR (GCC 10):
```
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
fast_minify_twitter/repeats:10_mean        69493 ns        69491 ns           10 Gigabytes=9.08769G/s docs=14.3903k/s
fast_minify_twitter/repeats:10_median      69474 ns        69471 ns           10 Gigabytes=9.09031G/s docs=14.3944k/s
fast_minify_twitter/repeats:10_stddev       80.0 ns         80.5 ns           10 Gigabytes=10.4996M/s docs=16.626/s
fast_minify_twitter/repeats:10_max         69712 ns        69712 ns           10 Gigabytes=9.09667G/s docs=14.4045k/s
fast_minify_gsoc/repeats:10_mean          370108 ns       370098 ns           10 Gigabytes=8.99177G/s docs=2.70199k/s
fast_minify_gsoc/repeats:10_median        370227 ns       370210 ns           10 Gigabytes=8.98904G/s docs=2.70117k/s
fast_minify_gsoc/repeats:10_stddev           470 ns          468 ns           10 Gigabytes=11.3825M/s docs=3.42041/s
fast_minify_gsoc/repeats:10_max           370571 ns       370568 ns           10 Gigabytes=9.01268G/s docs=2.70828k/s
```

Main branch (GCC 10):
```
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
fast_minify_twitter/repeats:10_mean        96723 ns        96720 ns           10 Gigabytes=6.52931G/s docs=10.3391k/s
fast_minify_twitter/repeats:10_median      96632 ns        96630 ns           10 Gigabytes=6.53539G/s docs=10.3487k/s
fast_minify_twitter/repeats:10_stddev        179 ns          178 ns           10 Gigabytes=12.015M/s docs=19.0256/s
fast_minify_twitter/repeats:10_max         97084 ns        97081 ns           10 Gigabytes=6.5411G/s docs=10.3578k/s
fast_minify_gsoc/repeats:10_mean          515451 ns       515444 ns           10 Gigabytes=6.45625G/s docs=1.94008k/s
fast_minify_gsoc/repeats:10_median        515526 ns       515509 ns           10 Gigabytes=6.45542G/s docs=1.93983k/s
fast_minify_gsoc/repeats:10_stddev           545 ns          542 ns           10 Gigabytes=6.79287M/s docs=2.04123/s
fast_minify_gsoc/repeats:10_max           516098 ns       516079 ns           10 Gigabytes=6.46822G/s docs=1.94368k/s
```

(This seems to be neutral on `parse_gsoc` and `ondemand`, probably because they don't call `compress`.)