### PR TITLE
Add count_fields method for objects

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -401,6 +401,29 @@ support for users who avoid exceptions. See [the simdjson error handling documen
      std::cout << simdjson::to_string(elem);
   }
   ```
+* **Counting fields in objects:** Other times, it is useful to scan an object to determine the number of fields prior to
+  parsing it.
+  For this purpose, `object` instances have a `count_fields` method. Again, users should be
+  aware that the `count_fields` method can be costly since it requires scanning the
+  whole objects. You may use it as follows if your document is itself an object:
+
+  ```C++
+  ondemand::parser parser;
+  auto json = R"( { "test":{ "val1":1, "val2":2 } }   )"_padded;
+  auto doc = parser.iterate(json);
+  size_t count = doc.count_fields(); // requires simdjson 1.0 or better
+  std::cout << "Number of fields: " <<  new_count << std::endl; // Prints "Number of fields: 1"
+  ```
+  Similarly to `count_elements`, you should not let an object instance go out of scope before consuming it after calling
+  the `count_fields` method. If you access an object inside a document, you can use the `count_fields` method as follow.
+  ``` C++
+  ondemand::parser parser;
+  auto json = R"( { "test":{ "val1":1, "val2":2 } }   )"_padded;
+  auto doc = parser.iterate(json);
+  auto test_object = doc.find_field("test").get_object();
+  size_t count = test_object.count_fields(); // requires simdjson 1.0 or better
+  std::cout << "Number of fields: " <<  count << std::endl; // Prints "Number of fields: 2"
+  ```
 * **Tree Walking and JSON Element Types:** Sometimes you don't necessarily have a document
   with a known type, and are trying to generically inspect or walk over JSON elements. To do that, you can use iterators and the `type()` method. You can also represent arbitrary JSON values with
   `ondemand::value` instances: it can represent anything except a scalar document (lone number, string, null or Boolean). You can check for scalar documents with the method `scalar()`.

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -89,6 +89,7 @@ simdjson_really_inline simdjson_result<std::string_view> array::raw_json() noexc
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 
+SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
 simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcept {
   size_t count{0};
   // Important: we do not consume any of the values.

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -127,25 +127,19 @@ simdjson_really_inline document::operator value() noexcept(false) { return get_v
 
 #endif
 simdjson_really_inline simdjson_result<size_t> document::count_elements() & noexcept {
-  json_type t;
-  simdjson_result<size_t> answer;
-  SIMDJSON_TRY(type().get(t));
-  switch (t) {
-    case ondemand::json_type::array: {
-      auto a = get_array();
-      answer = a.count_elements();
-      break;
-    }
-    case ondemand::json_type::object: {
-      auto a = get_object();
-      answer = a.count_elements();
-      break;
-    }
-    default:
-      return INCORRECT_TYPE;
+  auto a = get_array();
+  simdjson_result<size_t> answer = a.count_elements();
+  /* If there was an array, we are now left pointing at its first element. */
+  if(answer.error() == SUCCESS) {
+    iter._depth = 1 ; /* undoing the increment so we go back at the doc depth.*/
+    iter.assert_at_document_depth();
   }
-
-  /* If there was an array/object, we are now left pointing at its first element. */
+  return answer;
+}
+simdjson_really_inline simdjson_result<size_t> document::count_fields() & noexcept {
+  auto a = get_object();
+  simdjson_result<size_t> answer = a.count_fields();
+  /* If there was an array, we are now left pointing at its first element. */
   if(answer.error() == SUCCESS) {
     iter._depth = 1 ; /* undoing the increment so we go back at the doc depth.*/
     iter.assert_at_document_depth();
@@ -259,6 +253,10 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::docume
 simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::count_elements() & noexcept {
   if (error()) { return error(); }
   return first.count_elements();
+}
+simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::count_fields() & noexcept {
+  if (error()) { return error(); }
+  return first.count_fields();
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::at(size_t index) & noexcept {
   if (error()) { return error(); }
@@ -467,6 +465,7 @@ simdjson_really_inline document_reference::operator bool() noexcept(false) { ret
 simdjson_really_inline document_reference::operator value() noexcept(false) { return value(*doc); }
 #endif
 simdjson_really_inline simdjson_result<size_t> document_reference::count_elements() & noexcept { return doc->count_elements(); }
+simdjson_really_inline simdjson_result<size_t> document_reference::count_fields() & noexcept { return doc->count_fields(); }
 simdjson_really_inline simdjson_result<value> document_reference::at(size_t index) & noexcept { return doc->at(index); }
 simdjson_really_inline simdjson_result<array_iterator> document_reference::begin() & noexcept { return doc->begin(); }
 simdjson_really_inline simdjson_result<array_iterator> document_reference::end() & noexcept { return doc->end(); }
@@ -497,6 +496,10 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::docume
 simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::count_elements() & noexcept {
   if (error()) { return error(); }
   return first.count_elements();
+}
+simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::count_fields() & noexcept {
+  if (error()) { return error(); }
+  return first.count_fields();
 }
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::at(size_t index) & noexcept {
   if (error()) { return error(); }

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -127,9 +127,25 @@ simdjson_really_inline document::operator value() noexcept(false) { return get_v
 
 #endif
 simdjson_really_inline simdjson_result<size_t> document::count_elements() & noexcept {
-  auto a = get_array();
-  simdjson_result<size_t> answer = a.count_elements();
-  /* If there was an array, we are now left pointing at its first element. */
+  json_type t;
+  simdjson_result<size_t> answer;
+  SIMDJSON_TRY(type().get(t));
+  switch (t) {
+    case ondemand::json_type::array: {
+      auto a = get_array();
+      answer = a.count_elements();
+      break;
+    }
+    case ondemand::json_type::object: {
+      auto a = get_object();
+      answer = a.count_elements();
+      break;
+    }
+    default:
+      return INCORRECT_TYPE;
+  }
+
+  /* If there was an array/object, we are now left pointing at its first element. */
   if(answer.error() == SUCCESS) {
     iter._depth = 1 ; /* undoing the increment so we go back at the doc depth.*/
     iter.assert_at_document_depth();

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -250,6 +250,21 @@ public:
    * safe to continue.
    */
   simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+   /**
+   * This method scans the object and counts the number of key-value pairs.
+   * The count_fields method should always be called before you have begun
+   * iterating through the object: it is expected that you are pointing at
+   * the beginning of the object.
+   * The runtime complexity is linear in the size of the object. After
+   * calling this function, if successful, the object is 'rewinded' at its
+   * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
+   * there is a missing comma), then an error is returned and it is no longer
+   * safe to continue.
+   *
+   * To check that an object is empty, it is more performant to use
+   * the is_empty() method.
+   */
+  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
   /**
    * Get the value at the given index in the array. This function has linear-time complexity.
    * This function should only be called once as the array iterator is not reset between each call.
@@ -486,6 +501,7 @@ public:
   simdjson_really_inline operator value() noexcept(false);
 #endif
   simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
   simdjson_really_inline simdjson_result<value> at(size_t index) & noexcept;
   simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
   simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
@@ -548,6 +564,7 @@ public:
   simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false);
 #endif
   simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
@@ -602,6 +619,7 @@ public:
   simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false);
 #endif
   simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -139,7 +139,7 @@ inline simdjson_result<value> object::at_pointer(std::string_view json_pointer) 
   return child;
 }
 
-simdjson_really_inline simdjson_result<size_t> object::count_elements() & noexcept {
+simdjson_really_inline simdjson_result<size_t> object::count_fields() & noexcept {
   size_t count{0};
   // Important: we do not consume any of the values.
   for(simdjson_unused auto v : *this) { count++; }
@@ -221,9 +221,9 @@ inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::
   return first.is_empty();
 }
 
-simdjson_really_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::count_elements() & noexcept {
+simdjson_really_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::count_fields() & noexcept {
   if (error()) { return error(); }
-  return first.count_elements();
+  return first.count_fields();
 }
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -221,4 +221,9 @@ inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::
   return first.is_empty();
 }
 
+simdjson_really_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::count_elements() & noexcept {
+  if (error()) { return error(); }
+  return first.count_elements();
+}
+
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -139,6 +139,17 @@ inline simdjson_result<value> object::at_pointer(std::string_view json_pointer) 
   return child;
 }
 
+simdjson_really_inline simdjson_result<size_t> object::count_elements() & noexcept {
+  size_t count{0};
+  // Important: we do not consume any of the values.
+  for(simdjson_unused auto v : *this) { count++; }
+  // The above loop will always succeed, but we want to report errors.
+  if(iter.error()) { return iter.error(); }
+  // We need to move back at the start because we expect users to iterate through
+  // the object after counting the number of elements.
+  iter.reset_object();
+  return count;
+}
 
 simdjson_really_inline simdjson_result<bool> object::is_empty() & noexcept {
   bool is_not_empty;

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -196,6 +196,7 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
   inline simdjson_result<bool> reset() noexcept;
   inline simdjson_result<bool> is_empty() noexcept;
+  inline simdjson_result<size_t> count_elements() & noexcept;
 
 };
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -131,8 +131,8 @@ public:
    */
   inline simdjson_result<bool> is_empty() & noexcept;
   /**
-   * This method scans the object and counts the number of elements (key-value pairs).
-   * The count_elements method should always be called before you have begun
+   * This method scans the object and counts the number of key-value pairs.
+   * The count_fields method should always be called before you have begun
    * iterating through the object: it is expected that you are pointing at
    * the beginning of the object.
    * The runtime complexity is linear in the size of the object. After
@@ -144,7 +144,7 @@ public:
    * To check that an object is empty, it is more performant to use
    * the is_empty() method.
    */
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
   /**
    * Consumes the object and returns a string_view instance corresponding to the
    * object as represented in JSON. It points inside the original byte array containg
@@ -196,7 +196,7 @@ public:
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
   inline simdjson_result<bool> reset() noexcept;
   inline simdjson_result<bool> is_empty() noexcept;
-  inline simdjson_result<size_t> count_elements() & noexcept;
+  inline simdjson_result<size_t> count_fields() & noexcept;
 
 };
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -131,6 +131,21 @@ public:
    */
   inline simdjson_result<bool> is_empty() & noexcept;
   /**
+   * This method scans the object and counts the number of elements (key-value pairs).
+   * The count_elements method should always be called before you have begun
+   * iterating through the object: it is expected that you are pointing at
+   * the beginning of the object.
+   * The runtime complexity is linear in the size of the object. After
+   * calling this function, if successful, the object is 'rewinded' at its
+   * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
+   * there is a missing comma), then an error is returned and it is no longer
+   * safe to continue.
+   *
+   * To check that an object is empty, it is more performant to use
+   * the is_empty() method.
+   */
+  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  /**
    * Consumes the object and returns a string_view instance corresponding to the
    * object as represented in JSON. It points inside the original byte array containg
    * the JSON document.

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -792,7 +792,7 @@ namespace object_tests {
         ASSERT_EQUAL( count, 0 );
         return true;
     }));
-    auto basic = R"( {"a":-1.234, "b":false, "c":null, "d":[1000.1,-2000.2,3000.3], "e":{"a":true, "b":false}})"_padded;
+    auto basic = R"( {"a":-1.234, "b":false, "c":null, "d":[1000.1,-2000.2,3000.3], "e":{"a":true, "b":false}} )"_padded;
     SUBTEST("ondemand::basic_doc_object", test_ondemand_doc(basic, [&](auto doc_result) {
         size_t count;
         ASSERT_RESULT( doc_result.type(), json_type::object );
@@ -804,7 +804,6 @@ namespace object_tests {
   }
 
   bool iterate_bad_doc_object_count() {
-    TEST_START();
     TEST_START();
     padded_string bad_jsons[4] = {R"( {"a":5 "b":3} )"_padded, R"( {"a":5, 3} )"_padded, R"( {"a":5, "b": } )"_padded, R"( {"a":5, "b":3 )"_padded};
     std::string names[4] = {"missing_comma", "missing_key", "missing_value", "missing_bracket"};

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -712,7 +712,7 @@ namespace object_tests {
     ondemand::object obj;
     size_t count;
     ASSERT_SUCCESS(doc.get_object().get(obj));
-    ASSERT_SUCCESS(obj.count_elements().get(count));
+    ASSERT_SUCCESS(obj.count_fields().get(count));
     ASSERT_EQUAL(count, 0);
     TEST_SUCCEED();
   }
@@ -726,7 +726,7 @@ namespace object_tests {
     ondemand::object obj;
     size_t count;
     ASSERT_SUCCESS(doc.get_object().get(obj));
-    ASSERT_SUCCESS(obj.count_elements().get(count));
+    ASSERT_SUCCESS(obj.count_fields().get(count));
     ASSERT_EQUAL(count, 5);
     TEST_SUCCEED();
   }
@@ -743,22 +743,22 @@ namespace object_tests {
     ondemand::object obj1;
     size_t count{0};
     ASSERT_SUCCESS(doc.get_object().get(obj1));
-    ASSERT_SUCCESS(obj1.count_elements().get(count));
+    ASSERT_SUCCESS(obj1.count_fields().get(count));
     ASSERT_EQUAL(count, 2);
     count = 0;
     ondemand::object obj2;
     ASSERT_SUCCESS(doc.find_field("first").get_object().get(obj2));
-    ASSERT_SUCCESS(obj2.count_elements().get(count));
+    ASSERT_SUCCESS(obj2.count_fields().get(count));
     ASSERT_EQUAL(count, 3);
     count = 0;
     ondemand::object obj3;
     ASSERT_SUCCESS(obj2.find_field("c").get_object().get(obj3));
-    ASSERT_SUCCESS(obj3.count_elements().get(count));
+    ASSERT_SUCCESS(obj3.count_fields().get(count));
     ASSERT_EQUAL(count, 0);
     count = 0;
     ondemand::object obj4;
     ASSERT_SUCCESS(doc.at_pointer("/second/3").get_object().get(obj4));
-    ASSERT_SUCCESS(obj4.count_elements().get(count));
+    ASSERT_SUCCESS(obj4.count_fields().get(count));
     ASSERT_EQUAL(count, 2);
     TEST_SUCCEED();
   }
@@ -774,7 +774,7 @@ namespace object_tests {
         ondemand::object object;
         ASSERT_RESULT( doc_result.type(), json_type::object );
         ASSERT_SUCCESS( doc_result.get(object) );
-        ASSERT_ERROR(object.count_elements(), TAPE_ERROR);
+        ASSERT_ERROR(object.count_fields(), TAPE_ERROR);
         return true;
       }));
     }
@@ -788,7 +788,7 @@ namespace object_tests {
     SUBTEST("ondemand::empty_doc_object", test_ondemand_doc(empty, [&](auto doc_result) {
         size_t count;
         ASSERT_RESULT( doc_result.type(), json_type::object );
-        ASSERT_SUCCESS( doc_result.count_elements().get(count) );
+        ASSERT_SUCCESS( doc_result.count_fields().get(count) );
         ASSERT_EQUAL( count, 0 );
         return true;
     }));
@@ -796,7 +796,7 @@ namespace object_tests {
     SUBTEST("ondemand::basic_doc_object", test_ondemand_doc(basic, [&](auto doc_result) {
         size_t count;
         ASSERT_RESULT( doc_result.type(), json_type::object );
-        ASSERT_SUCCESS( doc_result.count_elements().get(count) );
+        ASSERT_SUCCESS( doc_result.count_fields().get(count) );
         ASSERT_EQUAL( count, 5 );
         return true;
     }));
@@ -813,7 +813,7 @@ namespace object_tests {
     for (auto name : names) {
       SUBTEST("ondemand::" + name, test_ondemand_doc(bad_jsons[count], [&](auto doc_result) {
         ASSERT_RESULT( doc_result.type(), json_type::object );
-        ASSERT_ERROR(doc_result.count_elements(), errors[count]);
+        ASSERT_ERROR(doc_result.count_fields(), errors[count]);
         return true;
       }));
       count++;

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -196,6 +196,23 @@ bool json_array_count_complex() {
 
 }
 
+bool json_object_count() {
+  TEST_START();
+  auto json = R"( { "test":{ "val1":1, "val2":2 } }   )"_padded;
+  ondemand::parser parser;
+  ondemand::document doc;
+  ASSERT_SUCCESS(parser.iterate(json).get(doc));
+  size_t count;
+  ASSERT_SUCCESS(doc.count_fields().get(count));
+  ASSERT_EQUAL(count,1);
+  ondemand::object object;
+  size_t new_count;
+  ASSERT_SUCCESS(doc.find_field("test").get_object().get(object));
+  ASSERT_SUCCESS(object.count_fields().get(new_count));
+  ASSERT_EQUAL(new_count, 2);
+  TEST_SUCCEED();
+}
+
 bool using_the_parsed_json_1() {
   TEST_START();
 
@@ -761,6 +778,7 @@ int main() {
     && json_array_with_array_count()
     && json_array_count_complex()
     && json_array_count()
+    && json_object_count()
     && using_the_parsed_json_rewind()
     && using_the_parsed_json_rewind_array()
     && basics_2()


### PR DESCRIPTION
Fixes #1711 

This adds `count_fields()` for objects. It works the same way as `count_elements()` for arrays. Returns a `simdjson_result<size_t>`. 