### PR TITLE
Additional ndjson tests.

### DIFF
--- a/fuzz/fuzz_ndjson.cpp
+++ b/fuzz/fuzz_ndjson.cpp
@@ -8,24 +8,26 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
   FuzzData fd(Data, Size);
-  const auto batch_size=static_cast<size_t>(fd.getInt<0,1000>());
-  const auto json=simdjson::padded_string{fd.remainder_as_stringview()};
+  const auto batch_size = static_cast<size_t>(fd.getInt<0,1000>());
+  const auto json = simdjson::padded_string{fd.remainder_as_stringview()};
   simdjson::dom::parser parser;
-#if SIMDJSON_EXCEPTIONS
-  try {
-#endif
-    simdjson::dom::document_stream docs;
-    if(parser.parse_many(json,batch_size).get(docs)) {
-      return 0;
-    }
-
-  [[maybe_unused]] size_t bool_count=0;
+  simdjson::dom::document_stream docs;
+  if(parser.parse_many(json,batch_size).get(docs)) { return 0; }
+  size_t bool_count1 = 0;
+  size_t total_count1 = 0;
   for (auto doc : docs) {
-    bool_count+=doc.is_bool();
+    total_count1++;
+    bool_count1 += doc.is_bool();
   }
-#if SIMDJSON_EXCEPTIONS
-  } catch(...) {
+  // Restart, if we made it this far, the document *must* be accessible.
+  if(parser.parse_many(json,batch_size).get(docs)) { return EXIT_FAILURE; }
+  size_t bool_count2 = 0;
+  size_t total_count2 = 0;
+  for (auto doc : docs) {
+    total_count2++;
+    bool_count2 += doc.is_bool();
   }
-#endif
+  // They should agree!!!
+  if((total_count2 != total_count1) || (bool_count2 != bool_count1)) { return EXIT_FAILURE; }
   return 0;
 }

--- a/tests/dom/document_stream_tests.cpp
+++ b/tests/dom/document_stream_tests.cpp
@@ -863,7 +863,8 @@ namespace document_stream_tests {
 
   bool fuzzaccess() {
     std::cout << "Running " << __func__ << std::endl;
-    auto json = "^ {}"_padded;
+    // Issue 38801 in oss-fuzz
+    auto json = "\xff         \n~~\n{}"_padded;
     simdjson::dom::parser parser;
     simdjson::dom::document_stream docs;
     ASSERT_SUCCESS(parser.parse_many(json).get(docs));

--- a/tests/dom/document_stream_tests.cpp
+++ b/tests/dom/document_stream_tests.cpp
@@ -861,6 +861,22 @@ namespace document_stream_tests {
     return true;
   }
 
+  bool fuzzaccess() {
+    std::cout << "Running " << __func__ << std::endl;
+    auto json = "^ {}"_padded;
+    simdjson::dom::parser parser;
+    simdjson::dom::document_stream docs;
+    ASSERT_SUCCESS(parser.parse_many(json).get(docs));
+    size_t bool_count = 0;
+    size_t total_count = 0;
+
+    for (auto doc : docs) {
+      total_count++;
+      bool_count += doc.is_bool();
+    }
+    return (bool_count == 0) && (bool_count == 0);
+  }
+
   bool baby_fuzzer() {
     std::cout << "Running " << __func__ << std::endl;
     std::mt19937 gen(637);
@@ -892,7 +908,8 @@ namespace document_stream_tests {
   }
 
   bool run() {
-    return baby_fuzzer() &&
+    return fuzzaccess() &&
+           baby_fuzzer() &&
            issue1649() &&
            adversarial_single_document_array() &&
            adversarial_single_document() &&

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -513,7 +513,8 @@ namespace document_stream_tests {
 
     bool fuzzaccess() {
         TEST_START();
-        auto json = "^ {}"_padded;
+        // Issue 38801 in oss-fuzz
+        auto json = "\xff         \n~~\n{}"_padded;
         ondemand::parser parser;
         ondemand::document_stream docs;
         ASSERT_SUCCESS(parser.parse_many(json).get(docs));

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -511,6 +511,21 @@ namespace document_stream_tests {
         TEST_SUCCEED();
     }
 
+    bool fuzzaccess() {
+        TEST_START();
+        auto json = "^ {}"_padded;
+        ondemand::parser parser;
+        ondemand::document_stream docs;
+        ASSERT_SUCCESS(parser.parse_many(json).get(docs));
+        size_t bool_count = 0;
+        size_t total_count = 0;
+        for (auto doc : docs) {
+          total_count++;
+          bool_count += doc.is_bool();
+        }
+        return (bool_count == 0) && (bool_count == 0);
+    }
+
     bool run() {
         return
             issue1683() &&

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -517,12 +517,13 @@ namespace document_stream_tests {
         auto json = "\xff         \n~~\n{}"_padded;
         ondemand::parser parser;
         ondemand::document_stream docs;
-        ASSERT_SUCCESS(parser.parse_many(json).get(docs));
+        ASSERT_SUCCESS(parser.iterate_many(json).get(docs));
         size_t bool_count = 0;
         size_t total_count = 0;
         for (auto doc : docs) {
           total_count++;
-          bool_count += doc.is_bool();
+          bool b;
+          if(doc.get_bool().get(b) == SUCCESS) { bool_count +=b; }
         }
         return (bool_count == 0) && (bool_count == 0);
     }


### PR DESCRIPTION
Recently @pauldreik [made some changes to a fuzz test](https://github.com/simdjson/simdjson/compare/3bd8b0b575f43403705dcce57d427944c11421f8...d28e5534d96a57aae44a6604aa08ab6cea36fa84) and some (incomprehensible to me) warning/bug are reported. I have been unable to reproduce the issue, but this PR aims to help flush it out. The error seems to occur when we take in garbage (a non-UTF8 string input).
