### PR TITLE
Additional document following issue 1723

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -268,7 +268,8 @@ support for users who avoid exceptions. See [the simdjson error handling documen
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`. This will
   scan through the object looking for the field with the matching string, doing a character-by-character
   comparison. For efficiency reason, you should avoid looking up the same field repeatedly: e.g., do
-  not do `object["foo"]` followed by `object["foo"]` with the same `object` instance.
+  not do `object["foo"]` followed by `object["foo"]` with the same `object` instance. Furthermore, you can only consume one field at a time, on the same object. Thus
+  if you have retrieved `content["bids"].get_array()` and you later call `content["asks"].get_array()`, then the first array should no longer be accessed: it would be unsafe to do so.
 
   > NOTE: JSON allows you to escape characters in keys. E.g., the key `"date"` may be written as
   > `"\u0064\u0061\u0074\u0065"`. By default, simdjson does *not* unescape keys when matching by default.
@@ -683,30 +684,23 @@ auto cars_json = R"( [
 ] )"_padded;
 
 ondemand::parser parser;
-ondemand::document cars;
 std::vector<double> measured;
-parser.iterate(cars_json).get(cars);
+ondemand::document cars = parser.iterate(cars_json);
 std::vector<car_type> content;
 for (int i = 0; i < 3; i++) {
-    ondemand::object obj;
     std::string json_pointer = "/" + std::to_string(i);
     // Each successive at_pointer call invalidates
     // previously parsed values, strings, objects and array.
-    cars.at_pointer(json_pointer).get(obj);
+    ondemand::object obj(cars.at_pointer(json_pointer).get_object());
     // We materialize the object.
-    std::string_view make;
-    ASSERT_SUCCESS(obj["make"].get(make));
-    std::string_view model;
-    ASSERT_SUCCESS(obj["model"].get(model));
-    uint64_t year;
-    ASSERT_SUCCESS(obj["year"].get(year));
+    std::string_view make = obj["make"];
+    std::string_view model = obj["model"];
+    uint64_t year(obj["year"].get(year));
     // We materialize the array.
-    ondemand::array arr;
-    ASSERT_SUCCESS(obj["tire_pressure"].get(arr));
+    ondemand::array arr(obj["tire_pressure"].get_array());
     std::vector<double> values;
     for(auto x : arr) {
-        double value_double;
-        ASSERT_SUCCESS(x.get(value_double));
+        double value_double(x.get_double());
         values.push_back(value_double);
     }
     content.emplace_back(make, model, year, std::move(values));

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -303,6 +303,12 @@ public:
    * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    * e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
    *
+   *
+   * You must consume the fields on an object one at a time. A request for a new key
+   * invalidates previous field values: it makes them unsafe. E.g., the array
+   * given by content["bids"].get_array() should not be accessed after you have called
+   * content["asks"].get_array().
+   *
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
@@ -325,6 +331,11 @@ public:
    *
    * Use find_field() if you are sure fields will be in order (or are willing to treat it as if the
    * field wasn't there when they aren't).
+   *
+   * You must consume the fields on an object one at a time. A request for a new key
+   * invalidates previous field values: it makes them unsafe. E.g., the array
+   * given by content["bids"].get_array() should not be accessed after you have called
+   * content["asks"].get_array().
    *
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -37,6 +37,11 @@ public:
    * **Raw Keys:** The lookup will be done against the *raw* key, and will not unescape keys.
    * e.g. `object["a"]` will match `{ "a": 1 }`, but will *not* match `{ "\u0061": 1 }`.
    *
+   * You must consume the fields on an object one at a time. A request for a new key
+   * invalidates previous field values: it makes them unsafe. E.g., the array
+   * given by content["bids"].get_array() should not be accessed after you have called
+   * content["asks"].get_array().
+   *
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
@@ -62,6 +67,11 @@ public:
    *
    * If you have multiple fields with a matching key ({"x": 1,  "x": 1}) be mindful
    * that only one field is returned.
+   *
+   * You must consume the fields on an object one at a time. A request for a new key
+   * invalidates previous field values: it makes them unsafe. E.g., the array
+   * given by content["bids"].get_array() should not be accessed after you have called
+   * content["asks"].get_array().
    *
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.


### PR DESCRIPTION
Within an object, values instances must be consumed one at a time. If you load a new field value, the previous field value should no longer be accessed.

