### PR TITLE
Seeing if this fixes recently introduced issue.

### DIFF
--- a/include/simdjson/dom/serialization-inl.h
+++ b/include/simdjson/dom/serialization-inl.h
@@ -158,9 +158,9 @@ simdjson_really_inline void mini_formatter::string(std::string_view unescaped) {
   // Fast path for the case where we have no control character, no ", and no backslash.
   // This should include most keys.
   //
-  // We would like to use 'bool' but some compilers take offense to bitwise operation
+  // We like to use 'bool' but some compilers take offense to bitwise operation
   // with bool types.
-  constexpr static char needs_escaping[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  constexpr static bool needs_escaping[] = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0,


### PR DESCRIPTION
Conversion from bool to char in some cases seems to introduce an issue with msys2. This would revert the change.

It is a mystery why it would matter.