### PR TITLE
Add an option to get current location from value object

### DIFF
--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -169,6 +169,10 @@ simdjson_really_inline std::string_view value::raw_json_token() noexcept {
   return std::string_view(reinterpret_cast<const char*>(iter.peek_start()), iter.peek_start_length());
 }
 
+simdjson_really_inline simdjson_result<const char *> value::current_location() noexcept {
+  return iter.json_iter().current_location();
+}
+
 simdjson_really_inline simdjson_result<value> value::at_pointer(std::string_view json_pointer) noexcept {
   json_type t;
   SIMDJSON_TRY(type().get(t));
@@ -377,6 +381,11 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
 simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::raw_json_token() noexcept {
   if (error()) { return error(); }
   return first.raw_json_token();
+}
+
+simdjson_really_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::current_location() noexcept {
+  if (error()) { return error(); }
+  return first.current_location();
 }
 
 simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::at_pointer(std::string_view json_pointer) noexcept {

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -426,6 +426,11 @@ public:
   simdjson_really_inline std::string_view raw_json_token() noexcept;
 
   /**
+   * Returns the current location in the document if in bounds.
+   */
+  simdjson_really_inline simdjson_result<const char *> current_location() noexcept;
+
+  /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
    * https://tools.ietf.org/html/rfc6901 standard.
    *
@@ -623,6 +628,9 @@ public:
 
   /** @copydoc simdjson_really_inline std::string_view value::raw_json_token() const noexcept */
   simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+
+  /** @copydoc simdjson_really_inline simdjson_result<const char *> current_location() noexcept */
+  simdjson_really_inline simdjson_result<const char *> current_location() noexcept;
 
   simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };

--- a/tests/ondemand/ondemand_error_location_tests.cpp
+++ b/tests/ondemand/ondemand_error_location_tests.cpp
@@ -237,6 +237,27 @@ namespace error_location_tests {
         ASSERT_EQUAL(ptr, "13.34.514 ");
         TEST_SUCCEED();
     }
+    bool current_location_in_value() {
+      TEST_START();
+      auto json = R"( {"a": {"b": "c"}} )"_padded;
+      ondemand::parser parser;
+      ondemand::document doc;
+      ASSERT_SUCCESS(parser.iterate(json).get(doc));
+      simdjson_result<ondemand::value> a = doc["a"];
+      ASSERT_SUCCESS(a);
+      const char * ptr;
+      ASSERT_SUCCESS(a.current_location().get(ptr));
+      ASSERT_EQUAL(ptr, R"({"b": "c"}} )");
+      simdjson_result<ondemand::value> b = a["b"];
+      ASSERT_SUCCESS(b);
+      ASSERT_SUCCESS(b.current_location().get(ptr));
+      ASSERT_EQUAL(ptr, R"("c"}} )");
+      double d;
+      ASSERT_ERROR(b.get_double().get(d), INCORRECT_TYPE);
+      ASSERT_SUCCESS(b.current_location().get(ptr));
+      ASSERT_EQUAL(ptr, R"("c"}} )");
+      TEST_SUCCEED();
+    }
 
     bool run() {
         return  array() &&
@@ -253,6 +274,7 @@ namespace error_location_tests {
                 object_with_no_such_field() &&
                 number_parsing_error() &&
                 number_parsing_root_error() &&
+                current_location_in_value() &&
                 true;
     }
 


### PR DESCRIPTION
Currently it's possible to print current location in JSON using document object only. But imagine you have a function that processes a single JSON section, i. e.:
```
auto parse_specific_section(ondemand::value section) {
  ...
  int64_t i;
  auto error = section["integer"].get_int64().get(i);
  if (error) {
    std::cout << error << std::endl;
    std::cout << section.current_location() << std::endl; // <- currently impossible
  }
  ...
}
```
Since you don't have access to the whole document in this scope it's impossible to print the place where an error occured.
So it would be great to have an option to get the current location in the document from the value object as well.