### PR TITLE
Fixing issue 1755

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -766,7 +766,11 @@ auto error = parser.iterate(json).get(doc);
 if (error) { cerr << error << endl; exit(1); }
 ```
 
-When you use the code this way, it is your responsibility to check for error before using the
+When there is no error, the error code simdjson::SUCCESS is returned: it evaluates as false as a Boolean.
+We have several error codes to indicate errors, they all evaluate to true as a Boolean: your software should not generally not depend on exact
+error codes. We may change the error codes in future releases and the exact error codes could vary depending on your system.
+
+When you use the code without exceptions, it is your responsibility to check for error before using the
 result: if there is an error, the result value will not be valid and using it will caused undefined behavior. Most compilers should be able to help you if you activate the right
 set of warnings: they can identify variables that are written to but never otherwise accessed.
 
@@ -887,6 +891,7 @@ int main(void) {
   std::cout << identifier << std::endl;
 }
 ```
+
 
 ### Error Handling Examples without Exceptions
 

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -249,7 +249,11 @@ auto error = parser.parse(json).get(doc);
 if (error) { cerr << error << endl; exit(1); }
 ```
 
-When you use the code this way, it is your responsibility to check for error before using the
+When there is no error, the error code simdjson::SUCCESS is returned: it evaluates as false as a Boolean.
+We have several error codes to indicate errors, they all evaluate to true as a Boolean: your software should not generally not depend on exact
+error codes. We may change the error codes in future releases and the exact error codes could vary depending on your system.
+
+When you use the code without exceptions, it is your responsibility to check for error before using the
 result: if there is an error, the result value will not be valid and using it will caused undefined
 behavior.
 

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -7,7 +7,12 @@
 namespace simdjson {
 
 /**
- * All possible errors returned by simdjson.
+ * All possible errors returned by simdjson. These error codes are subject to change
+ * and not all simdjson kernel returns the same error code given the same input: it is not
+ * well defined which error a given input should produce.
+ *
+ * Only SUCCESS evaluates to false as a Boolean. All other error codes will evaluate
+ * to true as a Boolean.
  */
 enum error_code {
   SUCCESS = 0,                ///< No error


### PR DESCRIPTION
This fixes issue 1755 by clearly documenting that error codes are transient: one's application should not depend on specific error codes. We guarantee that the "false" error code (SUCCESS) indicates success, and that other error codes (evaluating to true) are errors... but specific error codes could change over time, and they are even kernel-specific.


Fixes https://github.com/simdjson/simdjson/issues/1755