### PR TITLE
Fix broken link in basics documentation.

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -54,7 +54,7 @@ c++ myproject.cpp simdjson.cpp
 
 Note:
 - Users on macOS and other platforms where default compilers do not provide C++11 compliant by default should request it with the appropriate flag (e.g., `c++ -std=c++17 myproject.cpp simdjson.cpp`).
-- The library relies on [runtime CPU detection](doc/implementation-selection.md): avoid specifying an architecture at compile time (e.g., `-march-native`).
+- The library relies on [runtime CPU detection](implementation-selection.md): avoid specifying an architecture at compile time (e.g., `-march-native`).
 
 Using simdjson with package managers
 ------------------


### PR DESCRIPTION
Link `runtime CPU detection` in `Including simdjson` was broken.

