### PR TITLE
Added SIMDJSON_ prefix to STRINGIFY and to NO_SANITIZE_UNDEFINED macros.

### DIFF
--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -8,7 +8,7 @@ namespace {
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
-NO_SANITIZE_UNDEFINED
+SIMDJSON_NO_SANITIZE_UNDEFINED
 simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long ret;
@@ -73,7 +73,7 @@ simdjson_really_inline uint64_t reverse_bits(uint64_t input_num) {
  * greating or equal to 63 in which case we trigger undefined behavior, but the output
  * of such undefined behavior is never used.
  **/
-NO_SANITIZE_UNDEFINED
+SIMDJSON_NO_SANITIZE_UNDEFINED
 simdjson_really_inline uint64_t zero_leading_bit(uint64_t rev_bits, int leading_zeroes) {
   return rev_bits ^ (uint64_t(0x8000000000000000) >> leading_zeroes);
 }

--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -361,7 +361,7 @@ error_code slow_float_parsing(simdjson_unused const uint8_t * src, W writer) {
 }
 
 template<typename I>
-NO_SANITIZE_UNDEFINED // We deliberately allow overflow here and check later
+SIMDJSON_NO_SANITIZE_UNDEFINED // We deliberately allow overflow here and check later
 simdjson_really_inline bool parse_digit(const uint8_t c, I &i) {
   const uint8_t digit = static_cast<uint8_t>(c - '0');
   if (digit > 9) {

--- a/include/simdjson/haswell/bitmanipulation.h
+++ b/include/simdjson/haswell/bitmanipulation.h
@@ -8,7 +8,7 @@ namespace {
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
-NO_SANITIZE_UNDEFINED
+SIMDJSON_NO_SANITIZE_UNDEFINED
 simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   return (int)_tzcnt_u64(input_num);

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -71,10 +71,10 @@ use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
 #endif // SIMDJSON_IS_32BITS
 
 // this is almost standard?
-#undef STRINGIFY_IMPLEMENTATION_
-#undef STRINGIFY
-#define STRINGIFY_IMPLEMENTATION_(a) #a
-#define STRINGIFY(a) STRINGIFY_IMPLEMENTATION_(a)
+#undef SIMDJSON_STRINGIFY_IMPLEMENTATION_
+#undef SIMDJSON_STRINGIFY
+#define SIMDJSON_STRINGIFY_IMPLEMENTATION_(a) #a
+#define SIMDJSON_STRINGIFY(a) SIMDJSON_STRINGIFY_IMPLEMENTATION_(a)
 
 // Our fast kernels require 64-bit systems.
 //
@@ -98,13 +98,13 @@ use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
 // til 8.0 so SIMDJSON_TARGET_REGION and SIMDJSON_UNTARGET_REGION must be *outside* of a
 // namespace.
 #define SIMDJSON_TARGET_REGION(T)                                                       \
-  _Pragma(STRINGIFY(                                                           \
+  _Pragma(SIMDJSON_STRINGIFY(                                                           \
       clang attribute push(__attribute__((target(T))), apply_to = function)))
 #define SIMDJSON_UNTARGET_REGION _Pragma("clang attribute pop")
 #elif defined(__GNUC__)
 // GCC is easier
 #define SIMDJSON_TARGET_REGION(T)                                                       \
-  _Pragma("GCC push_options") _Pragma(STRINGIFY(GCC target(T)))
+  _Pragma("GCC push_options") _Pragma(SIMDJSON_STRINGIFY(GCC target(T)))
 #define SIMDJSON_UNTARGET_REGION _Pragma("GCC pop_options")
 #endif // clang then gcc
 
@@ -138,11 +138,11 @@ use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
 
 
 #if defined(__clang__)
-#define NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
+#define SIMDJSON_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
 #elif defined(__GNUC__)
-#define NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
+#define SIMDJSON_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize_undefined))
 #else
-#define NO_SANITIZE_UNDEFINED
+#define SIMDJSON_NO_SANITIZE_UNDEFINED
 #endif
 
 #ifdef SIMDJSON_VISUAL_STUDIO

--- a/include/simdjson/ppc64/bitmanipulation.h
+++ b/include/simdjson/ppc64/bitmanipulation.h
@@ -8,7 +8,7 @@ namespace {
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
-NO_SANITIZE_UNDEFINED
+SIMDJSON_NO_SANITIZE_UNDEFINED
 simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long ret;

--- a/include/simdjson/westmere/bitmanipulation.h
+++ b/include/simdjson/westmere/bitmanipulation.h
@@ -8,7 +8,7 @@ namespace {
 // We sometimes call trailing_zero on inputs that are zero,
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
-NO_SANITIZE_UNDEFINED
+SIMDJSON_NO_SANITIZE_UNDEFINED
 simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long ret;

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -154,7 +154,7 @@ simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) noexcept {
 }
 
 const implementation * builtin_implementation() {
-  static const implementation * builtin_impl = available_implementations[STRINGIFY(SIMDJSON_BUILTIN_IMPLEMENTATION)];
+  static const implementation * builtin_impl = available_implementations[SIMDJSON_STRINGIFY(SIMDJSON_BUILTIN_IMPLEMENTATION)];
   assert(builtin_impl);
   return builtin_impl;
 }

--- a/tests/checkimplementation.cpp
+++ b/tests/checkimplementation.cpp
@@ -3,7 +3,7 @@
 #include <cstring>
 
 int main(int argc, const char *argv[]) {
-  std::cout << "simdjson v" << STRINGIFY(SIMDJSON_VERSION) << " is running the " << simdjson::active_implementation->name() << " implementation." << std::endl;
+  std::cout << "simdjson v" << SIMDJSON_STRINGIFY(SIMDJSON_VERSION) << " is running the " << simdjson::active_implementation->name() << " implementation." << std::endl;
   const char *expected_implementation = nullptr;
   if (argc > 1) {
     expected_implementation = argv[1];

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -32,7 +32,7 @@
 #endif
 
 const size_t AMAZON_CELLPHONES_NDJSON_DOC_COUNT = 793;
-#define SIMDJSON_SHOW_DEFINE(x) printf("%s=%s\n", #x, STRINGIFY(x))
+#define SIMDJSON_SHOW_DEFINE(x) printf("%s=%s\n", #x, SIMDJSON_STRINGIFY(x))
 
 namespace number_tests {
 

--- a/tests/dom/readme_examples.cpp
+++ b/tests/dom/readme_examples.cpp
@@ -263,7 +263,7 @@ void basics_ndjson_parse_many() {
   }
 }
 void implementation_selection_1() {
-  cout << "simdjson v" << STRINGIFY(SIMDJSON_VERSION) << endl;
+  cout << "simdjson v" << SIMDJSON_STRINGIFY(SIMDJSON_VERSION) << endl;
   cout << "Detected the best implementation for your machine: " << simdjson::active_implementation->name();
   cout << "(" << simdjson::active_implementation->description() << ")" << endl;
 }

--- a/tests/ondemand/test_ondemand.h
+++ b/tests/ondemand/test_ondemand.h
@@ -41,7 +41,7 @@ bool test_ondemand_doc(const simdjson::padded_string &json, const F& f) {
 }
 
 const size_t AMAZON_CELLPHONES_NDJSON_DOC_COUNT = 793;
-#define SIMDJSON_SHOW_DEFINE(x) printf("%s=%s\n", #x, STRINGIFY(x))
+#define SIMDJSON_SHOW_DEFINE(x) printf("%s=%s\n", #x, SIMDJSON_STRINGIFY(x))
 
 template<typename F>
 int test_main(int argc, char *argv[], const F& test_function) {

--- a/tools/json2json.cpp
+++ b/tools/json2json.cpp
@@ -20,7 +20,7 @@ int main(int argc, const char *argv[]) {
   std::string progName = "json2json";
 
   std::string progUsage = "json2json version ";
-  progUsage += STRINGIFY(SIMDJSON_VERSION);
+  progUsage += SIMDJSON_STRINGIFY(SIMDJSON_VERSION);
   progUsage += " (";
   progUsage += simdjson::active_implementation->name();
   progUsage += ")\n";


### PR DESCRIPTION
This patch is aimed to solve [macro name collisions with third-party libraries](https://github.com/search?q=%22define+NO_SANITIZE_UNDEFINED%22&type=Code). 

Also i guess it makes macro names conforming to CONTRIBUTING.md which states that
>All C macros introduced in public headers need to be prefixed with either SIMDJSON_ or simdjson_.
