### PR TITLE
build: add pkg-config support

### DIFF
--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -1,0 +1,33 @@
+name: Debian
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: sh
+
+permissions:
+  contents: read
+
+jobs:
+  pkg-config:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:testing
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        apt -y update
+        apt -y --no-install-recommends install g++ cmake make pkg-config
+
+    - name: Build and install
+      run: |
+        cmake -B build
+        cmake --build build
+        cmake --install build
+
+    - name: Test pkg-config
+      run: g++ examples/quickstart/quickstart.cpp $(pkg-config --cflags --libs simdjson)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,10 @@ install(
 )
 
 # pkg-config
+include(cmake/JoinPaths.cmake)
+join_paths(PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+join_paths(PKGCONFIG_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
+
 if(SIMDJSON_ENABLE_THREADS)
   set(PKGCONFIG_CFLAGS "-DSIMDJSON_THREADS_ENABLED=1")
   if(CMAKE_THREAD_LIBS_INIT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,20 @@ install(
     COMPONENT example_Development
 )
 
+# pkg-config
+if(SIMDJSON_ENABLE_THREADS)
+  set(PKGCONFIG_CFLAGS "-DSIMDJSON_THREADS_ENABLED=1")
+  if(CMAKE_THREAD_LIBS_INIT)
+    set(PKGCONFIG_LIBS_PRIVATE "Libs.private: ${CMAKE_THREAD_LIBS_INIT}")
+  endif()
+endif()
+
+configure_file("simdjson.pc.in" "simdjson.pc" @ONLY)
+install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/simdjson.pc"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)
+
 #
 # CPack
 #

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/simdjson.pc.in
+++ b/simdjson.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=@PKGCONFIG_INCLUDEDIR@
+libdir=@PKGCONFIG_LIBDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@

--- a/simdjson.pc.in
+++ b/simdjson.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir} @PKGCONFIG_CFLAGS@
+Libs: -L${libdir} -l@PROJECT_NAME@
+@PKGCONFIG_LIBS_PRIVATE@


### PR DESCRIPTION
Fixes #1763

I chose the "dynamic" route :)
It is a bit more complex than a more static solution, but it has the advantage of requiring just two lines of code (module inclusion and function call) in "user" code and should also work in every project. Of course this is not perfect (for example, it doesn't currently handle cases like generating a .pc file of a library that links to an imported target that has no imported location but only a list of more than one interface libraries), but works in most cases. Definitely works in a project like simdjson that doesn't have external dependencies ;)

Edit: oh right, tests... To test this you would need to test the library as installed - compiling the library, installing it, and compiling a sample program that links to this using pkg-config. I don't know if you already have a setup like this in your CI, but it is basically what Debian's autopkgtest ([DEP-8](https://dep-team.pages.debian.net/deps/dep8/)) does