### PR TITLE
Missing value::get() template specialization for number

### DIFF
--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -62,6 +62,7 @@ template<> simdjson_really_inline simdjson_result<array> value::get() noexcept {
 template<> simdjson_really_inline simdjson_result<object> value::get() noexcept { return get_object(); }
 template<> simdjson_really_inline simdjson_result<raw_json_string> value::get() noexcept { return get_raw_json_string(); }
 template<> simdjson_really_inline simdjson_result<std::string_view> value::get() noexcept { return get_string(); }
+template<> simdjson_really_inline simdjson_result<number> value::get() noexcept { return get_number(); }
 template<> simdjson_really_inline simdjson_result<double> value::get() noexcept { return get_double(); }
 template<> simdjson_really_inline simdjson_result<uint64_t> value::get() noexcept { return get_uint64(); }
 template<> simdjson_really_inline simdjson_result<int64_t> value::get() noexcept { return get_int64(); }


### PR DESCRIPTION
Small usability issue that prevents following code from compiling unless `get_number()` is called first on value type when getting a number:
```
simdjson::ondemand::number number;
doc.find_field("number").get(number);
doc["number"].get(number);
```
This would be on par with getting other types directly from value using get() via template argument deduction and it seems that only specialization for number type was missing. I am unsure whether this fix should require unit tests. However, I did manage to check that all tests are compiling and passing.