### PR TITLE
Make Markdown problems go away in VS Code markdownlint

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+    "default": true,
+    "MD003": { "style": "setext_with_atx" },
+    "no-inline-html": { "allowed_elements": [ "IMG" ]},
+    "line-length": false
+}

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,1 @@
+doc/basics_doxygen.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,6 @@ We discourage the following types of contributions:
 
 In short, most code changes should either bring new features or better performance. We want to avoid unmotivated code changes.
 
-
 Specific rules
 ----------
 
@@ -70,7 +69,7 @@ Pull requests are always invited. However, we ask that you follow these guidelin
 - Changes should be focused and minimal. You should change as few lines of code as possible. Please do not reformat or touch files needlessly.
 - New features must be accompanied of new tests, in general.
 - Your code should pass our continuous-integration tests. It is your responsibility to ensure that your proposal pass the tests. We do not merge pull requests that would break our build.
-   - An exception to this would be changes to non-code files, such as documentation and assets, or trivial changes to code, such as comments, where it is encouraged to explicitly ask for skipping a CI run using the `[skip ci]` prefix in your Pull Request title **and** in the first line of the most recent commit in a push. Example for such a commit: `[skip ci] Fixed typo in power_of_ten's docs`
+  - An exception to this would be changes to non-code files, such as documentation and assets, or trivial changes to code, such as comments, where it is encouraged to explicitly ask for skipping a CI run using the `[skip ci]` prefix in your Pull Request title **and** in the first line of the most recent commit in a push. Example for such a commit: `[skip ci] Fixed typo in power_of_ten's docs`
    This benefits the project in such a way that the CI pipeline is not burdened by running jobs on changes that don't change any behavior in the code, which reduces wait times for other Pull Requests that do change behavior and require testing.
 
 If the benefits of your proposed code remain unclear, we may choose to discard your code: that is not an insult, we frequently discard our own code. We may also consider various alternatives and choose another path. Again, that is not an insult or a sign that you have wasted your time.

--- a/HACKING.md
+++ b/HACKING.md
@@ -5,7 +5,6 @@ Here is wisdom about how to build, test and run simdjson from within the reposit
 
 If you plan to contribute to simdjson, please read our [CONTRIBUTING](https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md) guide.
 
-
 Design notes
 ------------------------------
 
@@ -13,7 +12,6 @@ The parser works in two stages:
 
 - Stage 1. (Find marks) Identifies quickly structure elements, strings, and so forth. We validate UTF-8 encoding at that stage.
 - Stage 2. (Structure building) Involves constructing a "tree" of sort (materialized as a tape) to navigate through the data. Strings and numbers are parsed at this stage.
-
 
 The role of stage 1 is to identify pseudo-structural characters as quickly as possible. A character is pseudo-structural if and only if:
 
@@ -50,21 +48,22 @@ Directory Structure and Source
 
 simdjson's source structure, from the top level, looks like this:
 
-* **CMakeLists.txt:** The main build system.
-* **include:** User-facing declarations and inline definitions (most user-facing functions are inlined).
-  * simdjson.h: A "main include" that includes files from include/simdjson/. This is equivalent to
+- **CMakeLists.txt:** The main build system.
+- **include:** User-facing declarations and inline definitions (most user-facing functions are inlined).
+  - simdjson.h: A "main include" that includes files from include/simdjson/. This is equivalent to
     the distributed simdjson.h.
-  * simdjson/*.h: Declarations for public simdjson classes and functions.
-  * simdjson/*-inl.h: Definitions for public simdjson classes and functions.
-* **src:** The source files for non-inlined functionality (e.g. the architecture-specific parser
+  - simdjson/*.h: Declarations for public simdjson classes and functions.
+  - simdjson/*-inl.h: Definitions for public simdjson classes and functions.
+- **src:** The source files for non-inlined functionality (e.g. the architecture-specific parser
   implementations).
-  * simdjson.cpp: A "main source" that includes all implementation files from src/. This is
+  - simdjson.cpp: A "main source" that includes all implementation files from src/. This is
     equivalent to the distributed simdjson.cpp.
-  * arm64/|fallback/|haswell/|ppc64/|westmere/: Architecture-specific implementations. All functions are
+  - arm64/|fallback/|haswell/|ppc64/|westmere/: Architecture-specific implementations. All functions are
     Each architecture defines its own namespace, e.g. simdjson::haswell.
-  * generic/: Generic implementations of the simdjson parser. These files may be included and
+  - generic/: Generic implementations of the simdjson parser. These files may be included and
     compiled multiple times, from whichever architectures use them. They assume they are already
     enclosed in a namespace, e.g.:
+
     ```c++
     namespace simdjson {
       namespace haswell {
@@ -74,15 +73,17 @@ simdjson's source structure, from the top level, looks like this:
     ```
 
 Other important files and directories:
-* **.drone.yml:** Definitions for Drone CI.
-* **.appveyor.yml:** Definitions for Appveyor CI (Windows).
-* **.circleci:** Definitions for Circle CI.
-* **.github/workflows:** Definitions for GitHub Actions (CI).
-* **singleheader:** Contains generated `simdjson.h` and `simdjson.cpp` that we release. The files `singleheader/simdjson.h` and `singleheader/simdjson.cpp` should never be edited by hand.
-* **singleheader/amalgamate.py:** Generates `singleheader/simdjson.h` and `singleheader/simdjson.cpp` for release (python script).
-* **benchmark:** This is where we do benchmarking. Benchmarking is core to every change we make; the
+
+- **.drone.yml:** Definitions for Drone CI.
+- **.appveyor.yml:** Definitions for Appveyor CI (Windows).
+- **.circleci:** Definitions for Circle CI.
+- **.github/workflows:** Definitions for GitHub Actions (CI).
+- **singleheader:** Contains generated `simdjson.h` and `simdjson.cpp` that we release. The files `singleheader/simdjson.h` and `singleheader/simdjson.cpp` should never be edited by hand.
+- **singleheader/amalgamate.py:** Generates `singleheader/simdjson.h` and `singleheader/simdjson.cpp` for release (python script).
+- **benchmark:** This is where we do benchmarking. Benchmarking is core to every change we make; the
   cardinal rule is don't regress performance without knowing exactly why, and what you're trading
   for it. Many of our benchmarks are microbenchmarks. We are effectively doing controlled scientific experiments for the purpose of understanding what affects our performance. So we simplify as much as possible. We try to avoid irrelevant factors such as page faults, interrupts, unnnecessary system calls. We recommend checking the performance as follows:
+
   ```bash
   mkdir build
   cd build
@@ -90,7 +91,9 @@ Other important files and directories:
   cmake --build . --config Release
   benchmark/dom/parse ../jsonexamples/twitter.json
   ```
+
   The last line becomes `./benchmark/Release/parse.exe ../jsonexample/twitter.json` under Windows. You may also use Google Benchmark:
+
   ```bash
   mkdir build
   cd build
@@ -98,33 +101,30 @@ Other important files and directories:
   cmake --build . --target bench_parse_call --config Release
   ./benchmark/bench_parse_call
   ```
+
   The last line becomes `./benchmark/Release/bench_parse_call.exe` under Windows. Under Windows, you can also build with the clang compiler by adding `-T ClangCL` to the call to `cmake ..`: `cmake -T ClangCL ..`.
-* **fuzz:** The source for fuzz testing. This lets us explore important edge and middle cases
-* **fuzz:** The source for fuzz testing. This lets us explore important edge and middle cases
+- **fuzz:** The source for fuzz testing. This lets us explore important edge and middle cases
+- **fuzz:** The source for fuzz testing. This lets us explore important edge and middle cases
   automatically, and is run in CI.
-* **jsonchecker:** A set of JSON files used to check different functionality of the parser.
-  * **pass*.json:** Files that should pass validation.
-  * **fail*.json:** Files that should fail validation.
-  * **jsonchecker/minefield/y_*.json:** Files that should pass validation.
-  * **jsonchecker/minefield/n_*.json:** Files that should fail validation.
-* **jsonexamples:** A wide spread of useful, real-world JSON files with different characteristics
+- **jsonchecker:** A set of JSON files used to check different functionality of the parser.
+  - **pass*.json:** Files that should pass validation.
+  - **fail*.json:** Files that should fail validation.
+  - **jsonchecker/minefield/y_*.json:** Files that should pass validation.
+  - **jsonchecker/minefield/n_*.json:** Files that should fail validation.
+- **jsonexamples:** A wide spread of useful, real-world JSON files with different characteristics
   and sizes.
-* **test:** The tests are here. basictests.cpp and errortests.cpp are the primary ones.
-* **tools:** Source for executables that can be distributed with simdjson. Some examples:
-  * `json2json mydoc.json` parses the document, constructs a model and then dumps back the result to standard output.
-  * `json2json -d mydoc.json` parses the document, constructs a model and then dumps model (as a tape) to standard output. The tape format is described in the accompanying file `tape.md`.
-  * `minify mydoc.json` minifies the JSON document, outputting the result to standard output. Minifying means to remove the unneeded white space characters.
+- **test:** The tests are here. basictests.cpp and errortests.cpp are the primary ones.
+- **tools:** Source for executables that can be distributed with simdjson. Some examples:
+  - `json2json mydoc.json` parses the document, constructs a model and then dumps back the result to standard output.
+  - `json2json -d mydoc.json` parses the document, constructs a model and then dumps model (as a tape) to standard output. The tape format is described in the accompanying file `tape.md`.
+  - `minify mydoc.json` minifies the JSON document, outputting the result to standard output. Minifying means to remove the unneeded white space characters.
   *`jsonpointer mydoc.json <jsonpath> <jsonpath> ... <jsonpath>` parses the document, constructs a model and then processes a series of [JSON Pointer paths](https://tools.ietf.org/html/rfc6901). The result is itself a JSON document.
 
-
 > **Don't modify the files in singleheader/ directly; these are automatically generated.**
-
 
 While simdjson distributes just two files from the singleheader/ directory, we *maintain* the code in
 multiple files under include/ and src/. The files include/simdjson.h and src/simdjson.cpp are the "spine" for
 these, and you can include them as if they were the corresponding singleheader/ files.
-
-
 
 Runtime Dispatching
 --------------------
@@ -145,11 +145,9 @@ to compile their code for a specific instruction set (e.g., AVX2), they are resp
 on a processor that does not support AVX2. Yet, if we were to entice these users to do so, we would share the blame: thus we carefully instruct
 users to compile their code in a generic way without doing anything to enable advanced instructions.
 
-
 We only use runtime dispatching on x64 (AMD/Intel) platforms, at the moment. On ARM processors, we would need a standard way to query, at runtime,
 the processor for its supported features. We do not know how to do so on ARM systems in general. Thankfully it is not yet a concern: 64-bit ARM
 processors are fairly uniform as far as the instruction sets they support.
-
 
 In all cases, simdjson uses advanced instructions by relying on  "intrinsic functions": we do not write assembly code. The intrinsic functions
 are special functions that the compiler might recognize and translate into fast code. To make runtime dispatching work, we rely on the fact that
@@ -163,13 +161,7 @@ At this point, we are require to use one of two main strategies.
 
 2. Under Visual Studio, the problem is somewhat simpler. Visual Studio will not only provide the intrinsic functions, but it will also allow us to use them. They will compile just fine. It is at runtime that they may cause a crash. So we do not need to mark regions of code for compilation toward advanced processors (e.g., with  `TARGET_HASWELL` macros). The downside of the Visual Studio approach is that the compiler is not allowed to use advanced instructions others than those we specify. In principle, this means that Visual Studio has weaker optimization opportunities.
 
-
-
 We also handle the special case where a user is compiling using LLVM clang under Windows, [using the Visual Studio toolchain](https://devblogs.microsoft.com/cppblog/clang-llvm-support-in-visual-studio/). If you compile with LLVM clang under Visual Studio, then the header files (intrin.h or x86intrin.h) no longer provides the intrinsic functions that are unsupported by the processor. This appears to be deliberate on the part of the LLVM engineers. With a few lines of code, we handle this scenario just like LLVM clang under a POSIX system, but forcing the inclusion of the specific headers, and rolling our own intrinsic function as needed.
-
-
-
-
 
 Regenerating Single-Header Files
 ---------------------------------------
@@ -198,27 +190,31 @@ times.
 Requirements: In addition to git, we require a recent version of CMake as well as bash.
 
 1. On macOS, the easiest way to install cmake might be to use [brew](https://brew.sh) and then type
-```
-brew install cmake
-```
+
+   ```bash
+   brew install cmake
+   ```
+
 2. Under Linux, you might be able to install CMake as follows:
-```
-apt-get update -qq
-apt-get install -y cmake
-```
+
+   ```bash
+   apt-get update -qq
+   apt-get install -y cmake
+   ```
+
 3. On FreeBSD, you might be able to install bash and CMake as follows:
-```
-pkg update -f
-pkg install bash
-pkg install cmake
-```
+
+   ```bash
+   pkg update -f
+   pkg install bash
+   pkg install cmake
+   ```
 
 You need a recent compiler like clang or gcc. We recommend at least GNU GCC/G++ 7 or LLVM clang 6.
 
-
 Building: While in the project repository, do the following:
 
-```
+```bash
 mkdir build
 cd build
 cmake -D SIMDJSON_DEVELOPER_MODE=ON ..
@@ -230,7 +226,7 @@ CMake will build a library. By default, it builds a static library (e.g., libsim
 
 You can build a shared library:
 
-```
+```bash
 mkdir buildshared
 cd buildshared
 cmake -D BUILD_SHARED_LIBS=ON -D SIMDJSON_DEVELOPER_MODE=ON ..
@@ -240,7 +236,7 @@ ctest
 
 In some cases, you may want to specify your compiler, especially if the default compiler on your system is too old.  You need to tell cmake which compiler you wish to use by setting the CC and CXX variables. Under bash, you can do so with commands such as `export CC=gcc-7` and `export CXX=g++-7`. You can also do it as part of the `cmake` command: `cmake -DCMAKE_CXX_COMPILER=g++ ..`.  You may proceed as follows:
 
-```
+```bash
 brew install gcc@8
 mkdir build
 cd build
@@ -254,8 +250,6 @@ If your compiler does not default on C++11 support or better you may get failing
 
 Note that the name of directory (`build`) is arbitrary, you can name it as you want (e.g., `buildgcc`) and you can have as many different such directories as you would like (one per configuration).
 
-
-
 ### Usage (CMake on 64-bit Windows using Visual Studio 2019)
 
 We assume you have a common 64-bit Windows PC with at least Visual Studio 2019.
@@ -267,7 +261,6 @@ We assume you have a common 64-bit Windows PC with at least Visual Studio 2019.
 - Type `cmake  ..` in the shell while in the `build` repository.
 - This last command (`cmake ...`) created a Visual Studio solution file in the newly created directory (e.g., `simdjson.sln`). Open this file in Visual Studio. You should now be able to build the project and run the tests. For example, in the `Solution Explorer` window (available from the `View` menu), right-click `ALL_BUILD` and select `Build`. To test the code, still in the `Solution Explorer` window, select `RUN_TESTS` and select `Build`.
 
-
 Though having Visual Studio installed is necessary, one can build simdjson using only cmake commands:
 
 - `mkdir build`
@@ -275,31 +268,28 @@ Though having Visual Studio installed is necessary, one can build simdjson using
 - `cmake ..`
 - `cmake --build . -config Release`
 
-
 Furthermore, if you have installed LLVM clang on Windows, for example as a component of Visual Studio 2019, you can configure and build simdjson using LLVM clang on Windows using cmake:
-
 
 - `mkdir build`
 - `cd build`
 - `cmake -T ClangCL ..`
 - `cmake --build . -config Release`
 
-
 ### Various References
 
 - [How to implement atoi using SIMD?](https://stackoverflow.com/questions/35127060/how-to-implement-atoi-using-simd)
 - [Parsing JSON is a Minefield 💣](http://seriot.ch/parsing_json.php)
-- https://tools.ietf.org/html/rfc7159
-- http://rapidjson.org/md_doc_sax.html
-- https://github.com/Geal/parser_benchmarks/tree/master/json
-- Gron: A command line tool that makes JSON greppable https://news.ycombinator.com/item?id=16727665
-- GoogleGson https://github.com/google/gson
-- Jackson https://github.com/FasterXML/jackson
-- https://www.yelp.com/dataset_challenge
-- RapidJSON. http://rapidjson.org/
+- <https://tools.ietf.org/html/rfc7159>
+- <http://rapidjson.org/md_doc_sax.html>
+- <https://github.com/Geal/parser_benchmarks/tree/master/json>
+- Gron: A command line tool that makes JSON greppable <https://news.ycombinator.com/item?id=16727665>
+- GoogleGson <https://github.com/google/gson>
+- Jackson <https://github.com/FasterXML/jackson>
+- <https://www.yelp.com/dataset_challenge>
+- RapidJSON. <http://rapidjson.org/>
 
 Inspiring links:
 
-- https://auth0.com/blog/beating-json-performance-with-protobuf/
-- https://gist.github.com/shijuvar/25ad7de9505232c87034b8359543404a
-- https://github.com/frankmcsherry/blog/blob/master/posts/2018-02-11.md
+- <https://auth0.com/blog/beating-json-performance-with-protobuf/>
+- <https://gist.github.com/shijuvar/25ad7de9505232c87034b8359543404a>
+- <https://github.com/frankmcsherry/blog/blob/master/posts/2018-02-11.md>

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-
+<!-- markdownlint-disable-next-line first-line-h1 -->
 ![Ubuntu 18.04 CI](https://github.com/simdjson/simdjson/workflows/Ubuntu%2018.04%20CI%20(GCC%207)/badge.svg)
 [![Ubuntu 20.04 CI](https://github.com/simdjson/simdjson/workflows/Ubuntu%2020.04%20CI%20(GCC%209)/badge.svg)](https://simdjson.org/plots.html)
 ![VS16-CI](https://github.com/simdjson/simdjson/workflows/VS16-CI/badge.svg)
 ![MinGW64-CI](https://github.com/simdjson/simdjson/workflows/MinGW64-CI/badge.svg)
-[![][license img]][license]  [![Doxygen Documentation](https://img.shields.io/badge/docs-doxygen-green.svg)](https://simdjson.org/api/1.0.0/index.html)
+[![License][license img]][license]  [![Doxygen Documentation](https://img.shields.io/badge/docs-doxygen-green.svg)](https://simdjson.org/api/1.0.0/index.html)
 
 simdjson : Parsing gigabytes of JSON per second
 ===============================================
 
-<img src="images/logo.png" width="10%" style="float: right">
+<img src="images/logo.png" alt="logo" width="10%" style="float: right">
 JSON is everywhere on the Internet. Servers spend a *lot* of time parsing it. We need a fresh
 approach. The simdjson library uses commonly available SIMD instructions and microparallel algorithms
 to parse JSON 4x  faster than RapidJSON and 25x faster than JSON for Modern C++.
@@ -47,26 +47,28 @@ The simdjson library is easily consumable with a single .h and .cpp file.
 1. Pull [simdjson.h](singleheader/simdjson.h) and [simdjson.cpp](singleheader/simdjson.cpp) into a
    directory, along with the sample file [twitter.json](jsonexamples/twitter.json).
 
-   ```
+   ```bash
    wget https://raw.githubusercontent.com/simdjson/simdjson/master/singleheader/simdjson.h https://raw.githubusercontent.com/simdjson/simdjson/master/singleheader/simdjson.cpp https://raw.githubusercontent.com/simdjson/simdjson/master/jsonexamples/twitter.json
    ```
+
 2. Create `quickstart.cpp`:
 
-```c++
-#include <iostream>
-#include "simdjson.h"
-using namespace simdjson;
-int main(void) {
-    ondemand::parser parser;
-    padded_string json = padded_string::load("twitter.json");
-    ondemand::document tweets = parser.iterate(json);
-    std::cout << uint64_t(tweets["search_metadata"]["count"]) << " results." << std::endl;
-}
-
+   ```c++
+   #include <iostream>
+   #include "simdjson.h"
+   using namespace simdjson;
+   int main(void) {
+      ondemand::parser parser;
+      padded_string json = padded_string::load("twitter.json");
+      ondemand::document tweets = parser.iterate(json);
+      std::cout << uint64_t(tweets["search_metadata"]["count"]) << " results." << std::endl;
+   }
    ```
+
 3. `c++ -o quickstart quickstart.cpp simdjson.cpp`
 4. `./quickstart`
-   ```
+
+   ```text
    100 results.
    ```
 
@@ -103,18 +105,15 @@ speed for [synthetic files over various sizes generated with a script](https://g
 
 [All our experiments are reproducible](https://github.com/simdjson/simdjson_experiments_vldb2019).
 
-
 For NDJSON files, we can exceed 3 GB/s with [our  multithreaded parsing functions](https://github.com/simdjson/simdjson/blob/master/doc/parse_many.md).
-
-
 
 Real-world usage
 ----------------
 
-- [Microsoft FishStore](https://github.com/microsoft/FishStore)
-- [Yandex ClickHouse](https://github.com/yandex/ClickHouse)
-- [Clang Build Analyzer](https://github.com/aras-p/ClangBuildAnalyzer)
-- [Shopify HeapProfiler](https://github.com/Shopify/heap-profiler)
+* [Microsoft FishStore](https://github.com/microsoft/FishStore)
+* [Yandex ClickHouse](https://github.com/yandex/ClickHouse)
+* [Clang Build Analyzer](https://github.com/aras-p/ClangBuildAnalyzer)
+* [Shopify HeapProfiler](https://github.com/Shopify/heap-profiler)
 
 If you are planning to use simdjson in a product, please work from one of our releases.
 
@@ -123,23 +122,22 @@ Bindings and Ports of simdjson
 
 We distinguish between "bindings" (which just wrap the C++ code) and a port to another programming language (which reimplements everything).
 
-- [ZippyJSON](https://github.com/michaeleisel/zippyjson): Swift bindings for the simdjson project.
-- [libpy_simdjson](https://github.com/gerrymanoim/libpy_simdjson/): high-speed Python bindings for simdjson using [libpy](https://github.com/quantopian/libpy).
-- [pysimdjson](https://github.com/TkTech/pysimdjson): Python bindings for the simdjson project.
-- [cysimdjson](https://github.com/TeskaLabs/cysimdjson): high-speed Python bindings for the simdjson project.
-- [simdjson-rs](https://github.com/simd-lite): Rust port.
-- [simdjson-rust](https://github.com/SunDoge/simdjson-rust): Rust wrapper (bindings).
-- [SimdJsonSharp](https://github.com/EgorBo/SimdJsonSharp): C# version for .NET Core (bindings and full port).
-- [simdjson_nodejs](https://github.com/luizperes/simdjson_nodejs): Node.js bindings for the simdjson project.
-- [simdjson_php](https://github.com/crazyxman/simdjson_php): PHP bindings for the simdjson project.
-- [simdjson_ruby](https://github.com/saka1/simdjson_ruby): Ruby bindings for the simdjson project.
-- [fast_jsonparser](https://github.com/anilmaurya/fast_jsonparser): Ruby bindings for the simdjson project.
-- [simdjson-go](https://github.com/minio/simdjson-go): Go port using Golang assembly.
-- [rcppsimdjson](https://github.com/eddelbuettel/rcppsimdjson): R bindings.
-- [simdjson_erlang](https://github.com/ChomperT/simdjson_erlang): erlang bindings.
-- [lua-simdjson](https://github.com/FourierTransformer/lua-simdjson): lua bindings.
-- [hermes-json](https://hackage.haskell.org/package/hermes-json): haskell bindings.
-
+* [ZippyJSON](https://github.com/michaeleisel/zippyjson): Swift bindings for the simdjson project.
+* [libpy_simdjson](https://github.com/gerrymanoim/libpy_simdjson/): high-speed Python bindings for simdjson using [libpy](https://github.com/quantopian/libpy).
+* [pysimdjson](https://github.com/TkTech/pysimdjson): Python bindings for the simdjson project.
+* [cysimdjson](https://github.com/TeskaLabs/cysimdjson): high-speed Python bindings for the simdjson project.
+* [simdjson-rs](https://github.com/simd-lite): Rust port.
+* [simdjson-rust](https://github.com/SunDoge/simdjson-rust): Rust wrapper (bindings).
+* [SimdJsonSharp](https://github.com/EgorBo/SimdJsonSharp): C# version for .NET Core (bindings and full port).
+* [simdjson_nodejs](https://github.com/luizperes/simdjson_nodejs): Node.js bindings for the simdjson project.
+* [simdjson_php](https://github.com/crazyxman/simdjson_php): PHP bindings for the simdjson project.
+* [simdjson_ruby](https://github.com/saka1/simdjson_ruby): Ruby bindings for the simdjson project.
+* [fast_jsonparser](https://github.com/anilmaurya/fast_jsonparser): Ruby bindings for the simdjson project.
+* [simdjson-go](https://github.com/minio/simdjson-go): Go port using Golang assembly.
+* [rcppsimdjson](https://github.com/eddelbuettel/rcppsimdjson): R bindings.
+* [simdjson_erlang](https://github.com/ChomperT/simdjson_erlang): erlang bindings.
+* [lua-simdjson](https://github.com/FourierTransformer/lua-simdjson): lua bindings.
+* [hermes-json](https://hackage.haskell.org/package/hermes-json): haskell bindings.
 
 About simdjson
 --------------
@@ -150,16 +148,19 @@ CPU's multiple execution cores.
 
 Some people [enjoy reading our paper](https://arxiv.org/abs/1902.08318): A description of the design
 and implementation of simdjson is in our research article:
-- Geoff Langdale, Daniel Lemire, [Parsing Gigabytes of JSON per Second](https://arxiv.org/abs/1902.08318), VLDB Journal 28 (6), 2019.
+
+* Geoff Langdale, Daniel Lemire, [Parsing Gigabytes of JSON per Second](https://arxiv.org/abs/1902.08318), VLDB Journal 28 (6), 2019.
 
 We have an in-depth paper focused on the UTF-8 validation:
 
-- John Keiser, Daniel Lemire, [Validating UTF-8 In Less Than One Instruction Per Byte](https://arxiv.org/abs/2010.03090), Software: Practice & Experience 51 (5), 2021.
+* John Keiser, Daniel Lemire, [Validating UTF-8 In Less Than One Instruction Per Byte](https://arxiv.org/abs/2010.03090), Software: Practice & Experience 51 (5), 2021.
 
 We also have an informal [blog post providing some background and context](https://branchfree.org/2019/02/25/paper-parsing-gigabytes-of-json-per-second/).
 
-For the video inclined, <br />
-[![simdjson at QCon San Francisco 2019](http://img.youtube.com/vi/wlvKAT7SZIQ/0.jpg)](http://www.youtube.com/watch?v=wlvKAT7SZIQ)<br />
+For the video inclined:
+
+[![simdjson at QCon San Francisco 2019](http://img.youtube.com/vi/wlvKAT7SZIQ/0.jpg)](http://www.youtube.com/watch?v=wlvKAT7SZIQ)
+
 (It was the best voted talk, we're kinda proud of it.)
 
 Funding

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -28,12 +28,11 @@ An overview of what you need to know to use simdjson, with examples.
 * [Thread Safety](#thread-safety)
 * [Standard Compliance](#standard-compliance)
 
-
 Requirements
 ------------------
 
-- A recent compiler (LLVM clang6 or better, GNU GCC 7.4 or better, Xcode 11 or better) on a 64-bit (PPC, ARM or x64 Intel/AMD) POSIX systems such as macOS, freeBSD or Linux. We require that the compiler supports the C++11 standard or better.
-- Visual Studio 2017 or better under 64-bit Windows. Users should target a 64-bit build (x64) instead of a 32-bit build (x86). We support the LLVM clang compiler under Visual Studio (clangcl) as well as as the regular Visual Studio compiler. We also support MinGW 64-bit under Windows.
+* A recent compiler (LLVM clang6 or better, GNU GCC 7.4 or better, Xcode 11 or better) on a 64-bit (PPC, ARM or x64 Intel/AMD) POSIX systems such as macOS, freeBSD or Linux. We require that the compiler supports the C++11 standard or better.
+* Visual Studio 2017 or better under 64-bit Windows. Users should target a 64-bit build (x64) instead of a 32-bit build (x86). We support the LLVM clang compiler under Visual Studio (clangcl) as well as as the regular Visual Studio compiler. We also support MinGW 64-bit under Windows.
 
 Including simdjson
 ------------------
@@ -48,13 +47,14 @@ using namespace simdjson; // optional
 
 You can compile with:
 
-```
+```bash
 c++ myproject.cpp simdjson.cpp
 ```
 
 Note:
-- Users on macOS and other platforms where default compilers do not provide C++11 compliant by default should request it with the appropriate flag (e.g., `c++ -std=c++17 myproject.cpp simdjson.cpp`).
-- The library relies on [runtime CPU detection](implementation-selection.md): avoid specifying an architecture at compile time (e.g., `-march-native`).
+
+* Users on macOS and other platforms where default compilers do not provide C++11 compliant by default should request it with the appropriate flag (e.g., `c++ -std=c++17 myproject.cpp simdjson.cpp`).
+* The library relies on [runtime CPU detection](implementation-selection.md): avoid specifying an architecture at compile time (e.g., `-march-native`).
 
 Using simdjson with package managers
 ------------------
@@ -93,7 +93,6 @@ See [our CMake demonstration](https://github.com/simdjson/cmake_demo_single_file
 
 The CMake build in simdjson can be taylored with a few variables. You can see the available variables and their default values by entering the `cmake -LA` command.
 
-
 Versions
 ------------------
 
@@ -110,7 +109,7 @@ are made of three numbers prefixed by the letter `v` and separated by periods.
 
 You can always find the latest release at the following hyperlink:
 
-https://github.com/simdjson/simdjson/releases/latest/
+<https://github.com/simdjson/simdjson/releases/latest/>
 
 The archive you download at this location contains its own corresponding
 documentation.
@@ -119,7 +118,7 @@ You can also choose to browse a specific version
 of the documentation and the code using GitHub,
 by appending the version number to the hyperlink, like so:
 
-https://github.com/simdjson/simdjson/blob/vx.y.z/doc/basics.md
+<https://github.com/simdjson/simdjson/blob/vx.y.z/doc/basics.md>
 
 where `x.y.z` should correspond to the version number you have
 chosen.
@@ -188,8 +187,8 @@ documents.
 
 For code safety, you should keep (1) the `parser` instance, (2) the input string and (3) the document instance alive throughout your parsing. Additionally, you should follow the following rules:
 
-- A `parser` may have at most one document open at a time, since it holds allocated memory used for the parsing.
-- By design, you should only have one `document` instance per JSON document. Thus, if you must pass a document instance to a function, you should avoid passing it by value: choose to pass it by reference instance to avoid the copy. (We also provide a `document_reference` class if you need to pass by value.)
+* A `parser` may have at most one document open at a time, since it holds allocated memory used for the parsing.
+* By design, you should only have one `document` instance per JSON document. Thus, if you must pass a document instance to a function, you should avoid passing it by value: choose to pass it by reference instance to avoid the copy. (We also provide a `document_reference` class if you need to pass by value.)
 
 During the `iterate` call, the original JSON text is never modified--only read. After you are done
 with the document, the source (whether file or string) can be safely discarded.
@@ -237,8 +236,6 @@ transcode the UTF-8 strings produced by the simdjson library to other formats. S
 Using the Parsed JSON
 ---------------------
 
-
-
 We recommend that you first compile and run your code in Debug mode (with `NDEBUG`
 undefined). When you do so, the simdjson library runs additional sanity tests on
 your code to help ensure that you are using the library in a safe manner. Once
@@ -266,6 +263,7 @@ or floating-point values, depending on how the numbers are formatted.
 floating-point values followed by an integer.
 
 We invite you to keep the following rules in mind:
+
 1. While you are accessing the document, the `document` instance should remain in scope: it is your "iterator" which keeps track of where you are in the JSON document. By design, there is one and only one `document` instance per JSON document.
 2. Because On Demand is really just an iterator, you must fully consume the current object or array before accessing a sibling object or array.
 3. Values can only be consumed once, you should get the values and store them if you plan to need them multiple times. You are expected to access the keys of an object just once. You are expected to go through the values of an array just once.
@@ -304,6 +302,7 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   > to support escaped keys, the method `unescaped_key()` provides the desired unescaped keys by
   > parsing and writing out the unescaped keys to a string buffer and returning a `std::string_view`
   > instance. You should expect a performance penalty when using `unescaped_key()`.
+  >
   > ```c++
   > auto json = R"({"k\u0065y": 1})"_padded;
   > ondemand::parser parser;
@@ -342,29 +341,34 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   > double y = doc["y"]; // The cursor is now after the 2 (at })
   > double x = doc["x"]; // Success: [] loops back around to find "x"
   > ```
+  >
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. This will
   step through each value in the JSON array.
 
   If you know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`.
 * **Object Iteration:** You can iterate through an object's fields, as well: `for (auto field : object) { ... }`
-  - `field.unescaped_key()` will get you the unescaped key string.
-  - `field.value()` will get you the value, which you can then use all these other methods on.
+  * `field.unescaped_key()` will get you the unescaped key string.
+  * `field.value()` will get you the value, which you can then use all these other methods on.
 * **Array Index:** Because it is forward-only, you cannot look up an array element by index by index. Instead,
   you should iterate through the array and keep an index yourself.
 * **Output to strings:** Given a document, a value, an array or an object in a JSON document, you can output a JSON string version suitable to be parsed again as JSON content: `simdjson::to_json_string(element)`. A call to `to_json_string` consumes fully the element: if you apply it on a document, the JSON pointer is advanced to the end of the document. The `simdjson::to_json_string` does not allocate memory. The `to_json_string` function should not be confused with retrieving the value of a string instance which are escaped and represented using a lightweight `std::string_view` instance pointing at an internal string buffer inside the parser instance. To illustrate, the first of the following two code segments will print the unescaped string `"test"` complete with the quote whereas the second one will print the escaped content of the string (without the quotes).
+  >
   > ```C++
   > // serialize a JSON to an escaped std::string instance so that it can be parsed again as JSON
   > auto silly_json = R"( { "test": "result"  }  )"_padded;
   > ondemand::document doc = parser.iterate(silly_json);
   > std::cout << simdjson::to_json_string(doc["test"]) << std::endl; // Requires simdjson 1.0 or better
   >````
+  >
   > ```C++
   > // retrieves an unescaped string value as a string_view instance
   > auto silly_json = R"( { "test": "result"  }  )"_padded;
   > ondemand::document doc = parser.iterate(silly_json);
   > std::cout << std::string_view(doc["test"]) << std::endl;
   >````
+  >
   You can use `to_json_string` to efficiently extract components of a JSON document to reconstruct a new JSON document, as in the following example:
+  >
   > ```C++
   > auto cars_json = R"( [
   >   { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
@@ -393,6 +397,7 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   > auto json_string = oss.str();
   > // json_string == "[[ 40.1, 39.9, 37.7, 40.4 ],[ 30.1, 31.0, 28.6, 28.7 ]]"
   >````
+  >
 * **Extracting Values (without exceptions):** You can use a variant usage of `get()` with error
   codes to avoid exceptions. You first declare the variable of the appropriate type (`double`,
   `uint64_t`, `int64_t`, `bool`, `ondemand::object` and `ondemand::array`) and pass it by reference
@@ -410,6 +415,7 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   cout << value << endl; // Prints 3.14
   ```
+
   This examples also show how we can string several operations and only check for the error once, a strategy we call  *error chaining*.
   Though error chaining makes the code very compact, it also makes error reporting less precise: in this instance, you may get the
   same error whether the field "str", "123" or "abc" is missing. If you need to break down error handling per operation, avoid error chaining.
@@ -426,8 +432,10 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   size_t index = 0;
   for(double x : doc) { values[index++] = x; }
   ```
+
   If you access an array inside a document, you can use the `count_elements` method as follow.
   You should not let the array instance go out of scope before consuming it after calling the `count_elements` method:
+
   ``` C++
   ondemand::parser parser;
   auto cars_json = R"( { "test":[ { "val1":1, "val2":2 }, { "val1":1, "val2":2 } ] }   )"_padded;
@@ -439,6 +447,7 @@ support for users who avoid exceptions. See [the simdjson error handling documen
      std::cout << simdjson::to_string(elem);
   }
   ```
+
 * **Counting fields in objects:** Other times, it is useful to scan an object to determine the number of fields prior to
   parsing it.
   For this purpose, `object` instances have a `count_fields` method. Again, users should be
@@ -452,8 +461,10 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   size_t count = doc.count_fields(); // requires simdjson 1.0 or better
   std::cout << "Number of fields: " <<  new_count << std::endl; // Prints "Number of fields: 1"
   ```
+
   Similarly to `count_elements`, you should not let an object instance go out of scope before consuming it after calling
   the `count_fields` method. If you access an object inside a document, you can use the `count_fields` method as follow.
+
   ``` C++
   ondemand::parser parser;
   auto json = R"( { "test":{ "val1":1, "val2":2 } }   )"_padded;
@@ -462,10 +473,12 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   size_t count = test_object.count_fields(); // requires simdjson 1.0 or better
   std::cout << "Number of fields: " <<  count << std::endl; // Prints "Number of fields: 2"
   ```
+
 * **Tree Walking and JSON Element Types:** Sometimes you don't necessarily have a document
   with a known type, and are trying to generically inspect or walk over JSON elements. To do that, you can use iterators and the `type()` method. You can also represent arbitrary JSON values with
   `ondemand::value` instances: it can represent anything except a scalar document (lone number, string, null or Boolean). You can check for scalar documents with the method `scalar()`.
   For example, the following is a quick and dirty recursive function that verbosely prints the JSON document as JSON. This example also illustrates lifecycle requirements: the `document` instance holds the iterator. The document must remain in scope while you are accessing instances of `value`, `object` and `array`.
+
   ```c++
   void recursive_print_json(ondemand::value element) {
     bool add_comma;
@@ -532,7 +545,6 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   ```
 
 ### Using the Parsed JSON: Additional examples
-
 
 Let us review these concepts with some additional examples. For simplicity, we omit the include clauses (`#include "simdjson.h"`) as well as namespace-using clauses (`using namespace simdjson;`).
 
@@ -628,7 +640,6 @@ In some cases, you may have valid JSON strings that you do not wish to parse but
 
 Though it does not validate the JSON input, it will detect when the document ends with an unterminated string. E.g., it would refuse to minify the string `"this string is not terminated` because of the missing final quote.
 
-
 UTF-8 validation (alone)
 ----------------------
 
@@ -644,7 +655,7 @@ The UTF-8 validation function merely checks that the input is valid UTF-8: it wo
 
 Your input string does not need any padding. Any string will do. The `validate_utf8` function does not do any memory allocation on the heap, and it does not throw exceptions.
 
-If you find yourself needing only fast Unicode functions, consider using the simdutf library instead: https://github.com/simdutf/simdutf
+If you find yourself needing only fast Unicode functions, consider using the simdutf library instead: <https://github.com/simdutf/simdutf>
 
 JSON Pointer
 ------------
@@ -745,7 +756,7 @@ ondemand::parser parser;
 auto doc = parser.iterate(json);
 std::cout << doc.at_pointer("/k1/1") << std::endl; // Prints 26
 std::cout << doc.at_pointer("/k2") << std::endl; // Prints true
-doc.rewind();	// Need to manually rewind to be able to use find_field properly from start of document
+doc.rewind(); // Need to manually rewind to be able to use find_field properly from start of document
 std::cout << doc.find_field("k0") << std::endl; // Prints 27
 ```
 
@@ -821,6 +832,7 @@ Notice how we can retrieve the exact error condition (in this instance `simdjson
 from the exception.
 
 We can write a "quick start" example where we attempt to parse the following JSON file and access some data, without triggering exceptions:
+
 ```JavaScript
 {
   "statuses": [
@@ -839,7 +851,6 @@ We can write a "quick start" example where we attempt to parse the following JSO
 
 Our program loads the file, selects value corresponding to key `"search_metadata"` which expected to be an object, and then
 it selects the key `"count"` within that object.
-
 
 ```C++
 #include <iostream>
@@ -866,12 +877,11 @@ int main(void) {
 The following is a similar example where one wants to get the id of the first tweet without
 triggering exceptions. To do this, we use `["statuses"].at(0)["id"]`. We break that expression down:
 
-- Get the list of tweets (the `"statuses"` key of the document) using `["statuses"]`). The result is expected to be an array.
-- Get the first tweet using `.at(0)`. The result is expected to be an object.
-- Get the id of the tweet using ["id"]. We expect the value to be a non-negative integer.
+* Get the list of tweets (the `"statuses"` key of the document) using `["statuses"]`). The result is expected to be an array.
+* Get the first tweet using `.at(0)`. The result is expected to be an object.
+* Get the id of the tweet using ["id"]. We expect the value to be a non-negative integer.
 
 Observe how we use the `at` method when querying an index into an array, and not the bracket operator.
-
 
 ```C++
 #include <iostream>
@@ -953,9 +963,9 @@ bool parse() {
 }
 ```
 
-
 The following examples illustrates how to iterate through the content of an object without
 having to handle exceptions.
+
 ```c++
   auto json = R"({"k\u0065y": 1})"_padded;
   ondemand::parser parser;
@@ -996,7 +1006,6 @@ simdjson::ondemande::document doc = parser.iterate(json); // Throws an exception
 
 When used this way, a `simdjson_error` exception will be thrown if an error occurs, preventing the
 program from continuing if there was an error.
-
 
 If one is willing to trigger exceptions, it is possible to write simpler code:
 
@@ -1175,8 +1184,6 @@ string_view token = obj["value"].raw_json_token();
 
 The `raw_json_token()` should be fast and free of allocation.
 
-
-
 Newline-Delimited JSON (ndjson) and JSON lines
 ----------------------------------------------
 
@@ -1206,15 +1213,12 @@ for (auto doc : docs) {
 // Prints 1 2 3
 ```
 
-
 Unlike `parser.iterate`, `parser.iterate_many` may parse "on demand" (lazily). That is, no parsing may have been done before you enter the loop
 `for (auto doc : docs) {` and you should expect the parser to only ever fully parse one JSON document at a time.
 
 As with `parser.iterate`, when calling  `parser.iterate_many(string)`, no copy is made of the provided string input. The provided memory buffer may be accessed each time a JSON document is parsed.  Calling `parser.iterate_many(string)` on a  temporary string buffer (e.g., `docs = parser.parse_many("[1,2,3]"_padded)`) is unsafe (and will not compile) because the  `document_stream` instance needs access to the buffer to return the JSON documents.
 
-
 The `iterate_many` function can also take an optional parameter `size_t batch_size` which defines the window processing size. It is set by default to a large value (`1000000` corresponding to 1 MB). None of your JSON documents should exceed this window size, or else you will get  the error `simdjson::CAPACITY`. You cannot set this window size larger than 4 GB: you will get  the error `simdjson::CAPACITY`. The smaller the window size is, the less memory the function will use. Setting the window size too small (e.g., less than 100 kB) may also impact performance negatively. Leaving it to 1 MB is expected to be a good choice, unless you have some larger documents.
-
 
 The following toy examples illustrates how to get capacity errors. It is an artificial example since you should never use a `batch_size` of 50 bytes (it is far too small).
 
@@ -1251,7 +1255,7 @@ for (auto doc: stream) {
 
 This example should print out:
 
-```
+```text
 5 = 5
 5 = 5
 5 = 5
@@ -1265,8 +1269,6 @@ This parser can't support a document that big
 If your documents are large (e.g., larger than a megabyte), then the `iterate_many` function is maybe ill-suited. It is really meant to support reading efficiently streams of relatively small documents (e.g., a few kilobytes each). If you have larger documents, you should use other functions like `iterate`.
 
 See [iterate_many.md](iterate_many.md) for detailed information and design.
-
-
 
 Parsing Numbers Inside Strings
 ------------------------------
@@ -1361,9 +1363,9 @@ if (error) {
   else { /* Handle wrong value */ }
 }
 ```
+
 It is also important to note that when dealing an invalid number inside a string, simdjson will report a `NUMBER_ERROR` error if the string begins with a number whereas simdjson
 will report a `INCORRECT_TYPE` error otherwise.
-
 
 Dynamic Number Types
 ------------------------------
@@ -1388,14 +1390,12 @@ If you need to determine both the type of the number (integer or floating-point)
 its value efficiently, you may call the `get_number()` method on the `ondemand::value`
 instance. Upon success, it returns an `ondemand::number` instance.
 
-
 An `ondemand::number` instance may contain an integer value or a floating-point value.
 Thus it is a dynamically typed number. Before accessing the value, you must determine the detected type:
 
 * `number.get_number_type()` has value `number_type::signed_integer` if we have a integer in [-9223372036854775808,9223372036854775808). You can recover the value by the `get_int64()` method applied on the `ondemand::number` instance. When `number.get_number_type()` has value `number_type::signed_integer`, you also have that `number.is_int64()` is true. Calling `get_int64()` on the `ondemand::number` instance when `number.get_number_type()` is not `number_type::signed_integer` is unsafe. You may replace `get_int64()` by a cast to a `int64_t` value.
 * `number.get_number_type()` has value `number_type::unsigned_integer` if we have a integer in [9223372036854775808,18446744073709551616). You can recover the value by the `get_uint64()` method applied on the `ondemand::number` instance.  When `number.get_number_type()` has value `number_type::unsigned_integer`, you also have that `number.is_uint64()` is true.  Calling `get_uint64()` on the `ondemand::number` instance when `number.get_number_type()` is not `number_type::unsigned_integer` is unsafe. You may replace `get_uint64()` by a cast to a `uint64_t` value.
 * `number.get_number_type()` has value `number_type::floating_point_number` if we have and we have a floating-point (binary64) number. You can recover the value by the `get_double()` method applied on the `ondemand::number` instance.  When `number.get_number_type()` has value `number_type::floating_point_number`, you also have that `number.is_double()` is true.  Calling `get_double()` on the `ondemand::number` instance when `number.get_number_type()` is not `number_type::floating_point_number` is unsafe. You may replace `get_double()` by a cast to a `double` value.
-
 
 You must check the type before accessing the value: it is an error to call `get_int64()` when `number.get_number_type()` is not `number_type::signed_integer` and when `number.is_int64()` is false. You are responsible for this check as the user of the library.
 
@@ -1407,6 +1407,7 @@ a `document` or `value` instance, you should call directly the faster method
 intermediate `number` instance.
 
 Consider the following example:
+
 ```C++
     ondemand::parser parser;
     padded_string docdata = R"([1.0, 3, 1, 3.1415,-13231232,9999999999999999999])"_padded;
@@ -1439,7 +1440,7 @@ Consider the following example:
 
 It will output:
 
-```
+```text
 1.0 negative: 0 is_integer: 0 float: 1 float: 1
 3 negative: 0 is_integer: 1 integer: 3 integer: 3
 1 negative: 0 is_integer: 1 integer: 1 integer: 1
@@ -1455,7 +1456,6 @@ We built simdjson with thread safety in mind.
 
 The simdjson library is single-threaded except for [`iterate_many`](iterate_many.md) and [`parse_many`](parse_many.md) which may use secondary threads under their control when the library is compiled with thread support.
 
-
 We recommend using one `parser` object per thread. When using the On Demand front-end (our default), you should access the `document` instances in a single-threaded manner since it
 acts as an iterator (and is therefore not thread safe).
 
@@ -1469,18 +1469,17 @@ Standard Compliance
 
 The simdjson library is fully compliant with  the [RFC 8259](https://www.tbray.org/ongoing/When/201x/2017/12/14/rfc8259.html) JSON specification.
 
-- The only insignificant whitespace characters allowed are the space, the horizontal tab, the line feed and the carriage return. In particular, a JSON document may not contain an unespaced null character.
-- A single string or a single number is considered to be a valid JSON document.
-- We fully validate the numbers according to the JSON specification. For example,  the string `01` is not valid JSON document since the specification states that *leading zeros are not allowed*.
-- The specification allows implementations to set limits on the range and precision of numbers accepted.  We support 64-bit floating-point numbers as well as integer values.
-  - We parse integers and floating-point numbers afloating-point number followed by an integer.s separate types which allows us to support all signed (two's complement) 64-bit integersfloating-point number followed by an integer., like a Java `long` or a C/C++ `long long` and all 64-bit unsigned integers. When we cannot represent exactly an integer as a signed or unsigned 64-bit value, we reject the JSON document.
-  - We support the full range of 64-bit floating-point numbers (binary64). The values range from `std::numeric_limits<double>::lowest()`  to `std::numefloating-point number followed by an integer.ric_limits<double>::max()`, so from -1.7976e308 all the way to 1.7975e308. Extreme values (less or equal to -1e308, greater or equal to 1e308) are rejected: we refuse to parse the input document. Numbers are parsed with a perfect accuracy (ULP 0): the nearest floating-point value is chosen, rounding to even when needed. If you serialized your floating-point numbers with 17floating-point value  followed by an integer. significant digits in a standard compliant manner, the simdjson library is guaranfloating-point number followed by an integer.teed to recover the same numbers, exactly.
-- The specification states that JSON text exchanged between systems that are not part of a closed ecosystem MUST be encoded using UTF-8. The simdjson library does full UTF-8 validation as part of the parsing. The specification states that implementations MUST NOT add a byte order mark: the simdjson library rejects documents starting with a  byte order mark.
-- The simdjson library validates string content for unescaped characters. Unescaped line breaks and tabs in strings are not allowed.
-- The simdjson library accepts objects with repeated keys: all of the name/value pairs, including duplicates, are reported. We do not enforce key uniqueness.
-- The specification states that an implementation may set limits on the size of texts that it accepts. The simdjson library limits single JSON documents to 4 GiB. It will refuse to parse a JSON document larger than 4294967295 bytes. (This limitation does not apply to streams of JSON documents, only to single JSON documents.)
-- The specification states that an implementation may set limits on the maximum depth of nesting. By default, the simdjson will refuse to parse documents with a depth exceeding 1024.
-
+* The only insignificant whitespace characters allowed are the space, the horizontal tab, the line feed and the carriage return. In particular, a JSON document may not contain an unespaced null character.
+* A single string or a single number is considered to be a valid JSON document.
+* We fully validate the numbers according to the JSON specification. For example,  the string `01` is not valid JSON document since the specification states that *leading zeros are not allowed*.
+* The specification allows implementations to set limits on the range and precision of numbers accepted.  We support 64-bit floating-point numbers as well as integer values.
+  * We parse integers and floating-point numbers afloating-point number followed by an integer.s separate types which allows us to support all signed (two's complement) 64-bit integersfloating-point number followed by an integer., like a Java `long` or a C/C++ `long long` and all 64-bit unsigned integers. When we cannot represent exactly an integer as a signed or unsigned 64-bit value, we reject the JSON document.
+  * We support the full range of 64-bit floating-point numbers (binary64). The values range from `std::numeric_limits<double>::lowest()`  to `std::numefloating-point number followed by an integer.ric_limits<double>::max()`, so from -1.7976e308 all the way to 1.7975e308. Extreme values (less or equal to -1e308, greater or equal to 1e308) are rejected: we refuse to parse the input document. Numbers are parsed with a perfect accuracy (ULP 0): the nearest floating-point value is chosen, rounding to even when needed. If you serialized your floating-point numbers with 17floating-point value  followed by an integer. significant digits in a standard compliant manner, the simdjson library is guaranfloating-point number followed by an integer.teed to recover the same numbers, exactly.
+* The specification states that JSON text exchanged between systems that are not part of a closed ecosystem MUST be encoded using UTF-8. The simdjson library does full UTF-8 validation as part of the parsing. The specification states that implementations MUST NOT add a byte order mark: the simdjson library rejects documents starting with a  byte order mark.
+* The simdjson library validates string content for unescaped characters. Unescaped line breaks and tabs in strings are not allowed.
+* The simdjson library accepts objects with repeated keys: all of the name/value pairs, including duplicates, are reported. We do not enforce key uniqueness.
+* The specification states that an implementation may set limits on the size of texts that it accepts. The simdjson library limits single JSON documents to 4 GiB. It will refuse to parse a JSON document larger than 4294967295 bytes. (This limitation does not apply to streams of JSON documents, only to single JSON documents.)
+* The specification states that an implementation may set limits on the maximum depth of nesting. By default, the simdjson will refuse to parse documents with a depth exceeding 1024.
 
 Backwards Compatibility
 -----------------------

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -56,7 +56,6 @@ For best performance, a `parser` instance should be reused over several files: o
 If you need a lower-level interface, you may call the function `parser.parse(const char * p, size_t l)` on a pointer `p` while specifying the
 length of your input `l` in bytes. To see how to get the very best performance from a low-level approach, you way want to read our [performance notes](https://github.com/simdjson/simdjson/blob/master/doc/performance.md#padding-and-temporary-copies) on this topic (see the Padding and Temporary Copies section).
 
-
 Using the Parsed JSON
 ---------------------
 
@@ -67,6 +66,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   dom::object and dom::array. An exception (`simdjson::simdjson_error`) is thrown if the cast is not possible.
 * **Extracting Values (without exceptions):** You can use a variant usage of `get()` with error codes to avoid exceptions. You first declare the variable of the appropriate type (`double`, `uint64_t`, `int64_t`, `bool`,
   `dom::object` and `dom::array`) and pass it by reference to `get()` which gives you back an error code: e.g.,
+
   ```c++
   simdjson::error_code error;
   simdjson::padded_string numberstring = "1.2"_padded; // our JSON input ("1.2")
@@ -76,6 +76,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
   ```
+
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`
@@ -149,7 +150,6 @@ for (dom::object obj : parser.parse(abstract_json)) {
 
 And another one:
 
-
 ```C++
   auto abstract_json = R"(
     {  "str" : { "123" : {"abc" : 3.14 } } } )"_padded;
@@ -157,7 +157,6 @@ And another one:
   double v = parser.parse(abstract_json)["str"]["123"]["abc"];
   cout << "number: " << v << endl;
 ```
-
 
 C++17 Support
 -------------
@@ -188,7 +187,6 @@ for (dom::key_value_pair field : object) {
   cout << field.key << " = " << field.value << endl;
 }
 ```
-
 
 JSON Pointer
 ------------
@@ -235,8 +233,6 @@ for (dom::element car_element : cars) {
 }
 ```
 
-
-
 Error Handling
 --------------
 
@@ -258,6 +254,7 @@ result: if there is an error, the result value will not be valid and using it wi
 behavior.
 
 We can write a "quick start" example where we attempt to parse the following JSON file and access some data, without triggering exceptions:
+
 ```JavaScript
 {
   "statuses": [
@@ -299,9 +296,9 @@ int main(void) {
 The following is a similar example where one wants to get the id of the first tweet without
 triggering exceptions. To do this, we use `["statuses"].at(0)["id"]`. We break that expression down:
 
-- Get the list of tweets (the `"statuses"` key of the document) using `["statuses"]`). The result is expected to be an array.
-- Get the first tweet using `.at(0)`. The result is expected to be an object.
-- Get the id of the tweet using ["id"]. We expect the value to be a non-negative integer.
+* Get the list of tweets (the `"statuses"` key of the document) using `["statuses"]`). The result is expected to be an array.
+* Get the first tweet using `.at(0)`. The result is expected to be an object.
+* Get the id of the tweet using ["id"]. We expect the value to be a non-negative integer.
 
 Observe how we use the `at` method when querying an index into an array, and not the bracket operator.
 
@@ -462,7 +459,6 @@ dom::element doc = parser.parse(json); // Throws an exception if there was an er
 When used this way, a `simdjson_error` exception will be thrown if an error occurs, preventing the
 program from continuing if there was an error.
 
-
 If one is willing to trigger exceptions, it is possible to write simpler code:
 
 ```C++
@@ -476,7 +472,6 @@ int main(void) {
   return EXIT_SUCCESS;
 }
 ```
-
 
 Tree Walking and JSON Element Types
 -----------------------------------
@@ -531,8 +526,6 @@ void basics_treewalk_1() {
   print_json(parser.load("twitter.json"));
 }
 ```
-
-
 
 Reusing the parser for maximum efficiency
 -----------------------------------------
@@ -615,7 +608,6 @@ without bound:
   }
   ```
 
-
 Best Use of the DOM API
 -------------------------
 
@@ -630,7 +622,6 @@ disk (`parser.load`), padding is automatically  handled.
 When calling `parser.parse` on a pointer (e.g., `parser.parse(my_char_pointer, my_length_in_bytes)`) a temporary copy  is made by default with adequate padding and you, again, do not need to be concerned with padding.
 
 Some users may not be able use our `padded_string` class or to load the data directly from disk (`parser.load`). They may need to pass data pointers to the library.  If these users wish to avoid temporary copies and corresponding temporary memory allocations, they may want to call `parser.parse` with the `realloc_if_needed` parameter set to false (e.g., `parser.parse(my_char_pointer, my_length_in_bytes, false)`). In such cases, they need to ensure that there are at least SIMDJSON_PADDING extra bytes at the end that can be safely accessed and read. They do not need to initialize the padded bytes to any value in particular. The following example is safe:
-
 
 ```C++
 const char *json      = R"({"key":"value"})";

--- a/doc/implementation-selection.md
+++ b/doc/implementation-selection.md
@@ -17,6 +17,7 @@ different version of the JSON parser for different CPU architectures, often with
 algorithms to take better advantage of a given CPU!
 
 The current implementations are:
+
 * haswell: AVX2 (2013 Intel Haswell or later)
 * westmere: SSE4.2 (2010 Westmere or later).
 * arm64: 64-bit ARMv8-A NEON
@@ -34,7 +35,7 @@ WESTMERE, ARM64, PPC64 and FALLBACK).
 The simdjson library automatically sets header flags for each implementation as it compiles; there
 is no need to set architecture-specific flags yourself (e.g., `-mavx2`, `/AVX2`  or
 `-march=haswell`), and it may even break runtime dispatch and your binaries will fail to run on
-older processors. _Note:_ for POWER9 processors make sure you compile it with `-mcpu=power9` and `-mtune=power9` to
+older processors. *Note:* for POWER9 processors make sure you compile it with `-mcpu=power9` and `-mtune=power9` to
 get maximum performance.
 
 Runtime CPU Detection
@@ -73,14 +74,13 @@ And look them up by name:
 ```c++
 cout << simdjson::get_available_implementations()["fallback"]->description() << endl;
 ```
+
 Though the fallback implementation should always be available, others might be missing. When
 an implementation is not available, the bracket call `simdjson::get_available_implementations()[name]`
 will return the null pointer.
 
 The available implementations have been compiled but may not necessarily be run safely on your system
 see [Checking that an Implementation can Run on your System](#checking-that-an-implementation-can-run-on-your-system).
-
-
 
 Manually Selecting the Implementation
 -------------------------------------

--- a/doc/iterate_many.md
+++ b/doc/iterate_many.md
@@ -4,12 +4,14 @@ iterate_many
 When serializing large databases, it is often better to write out many independent JSON
 documents, instead of one large monolithic document containing many records. The simdjson
 library provides high-speed access to files or streams containing multiple small JSON documents separated by ASCII white-space characters. Given an input such as
+
 ```JSON
 {"text":"a"}
 {"text":"b"}
 {"text":"c"}
 ...
 ```
+
 ... you want to read the entries (individual JSON documents) as quickly and as conveniently as possible. Importantly, the input might span several gigabytes, but you want to use a small (fixed) amount of memory. Ideally, you'd also like the parallelize the processing (using more than one core) to speed up the process.
 
 Contents
@@ -37,7 +39,6 @@ ending sequence of values, JSON may be inconvenient.
 Consider a sequence of one million values, each possibly one kilobyte
 when encoded -- roughly one gigabyte.  It is often desirable to process such a dataset incrementally
 without having to first read all of it before beginning to produce results.
-
 
 How it works
 ------------
@@ -76,17 +77,11 @@ big as the biggest document in your file, but not too big so that it submerges t
 The bigger the batch size, the fewer we need to make allocations. We found that 1MB is somewhat a
 sweet spot.
 
-1. When the user calls `iterate_many`, we return a `document_stream` which the user can iterate over
-   to receive parsed documents.
-2. We call stage 1 on the first batch_size bytes of JSON in the buffer, detecting structural
-	indexes for all documents in that batch.
-3. The `document_stream` owns a `document` instance that keeps track of the current document position
-	in the stream using a JSON iterator. To obtain a valid document, the `document_stream` returns a
-	**reference** to its document instance.
-4. Each time the user calls `++` to read the next document, the JSON iterator moves to the start the
-	next document.
-5. When we reach the end of the batch, we call stage 1 on the next batch, starting from the end of
-   the last document, and go to step 3.
+1. When the user calls `iterate_many`, we return a `document_stream` which the user can iterate over to receive parsed documents.
+2. We call stage 1 on the first batch_size bytes of JSON in the buffer, detecting structural indexes for all documents in that batch.
+3. The `document_stream` owns a `document` instance that keeps track of the current document position in the stream using a JSON iterator. To obtain a valid document, the `document_stream` returns a **reference** to its document instance.
+4. Each time the user calls `++` to read the next document, the JSON iterator moves to the start the next document.
+5. When we reach the end of the batch, we call stage 1 on the next batch, starting from the end of the last document, and go to step 3.
 
 ### Threads
 
@@ -112,6 +107,7 @@ or more character that is considered whitespace** by the JSON spec. Anything tha
  not whitespace will be parsed as a JSON document and could lead to failure.
 
 Whitespace Characters:
+
 - **Space**
 - **Linefeed**
 - **Carriage return**
@@ -121,6 +117,7 @@ If your documents are all objects or arrays, then you may even have nothing betw
 E.g., `[1,2]{"32":1}` is recognized as two documents.
 
 Some official formats **(non-exhaustive list)**:
+
 - [Newline-Delimited JSON (NDJSON)](http://ndjson.org/)
 - [JSON lines (JSONL)](http://jsonlines.org/)
 - [Record separator-delimited JSON (RFC 7464)](https://tools.ietf.org/html/rfc7464) <- Not supported by JsonStream!
@@ -131,11 +128,13 @@ API
 
 See [basics.md](basics.md#newline-delimited-json-ndjson-and-json-lines) for an overview of the API.
 
-## Use cases
+Use Cases
+---------
 
 From [jsonlines.org](http://jsonlines.org/examples/):
 
 - **Better than CSV**
+
     ```json
     ["Name", "Session", "Score", "Completed"]
     ["Gilbert", "2013", 24, true]
@@ -143,6 +142,7 @@ From [jsonlines.org](http://jsonlines.org/examples/):
     ["May", "2012B", 14, false]
     ["Deloise", "2012A", 19, true]
     ```
+
     CSV seems so easy that many programmers have written code to generate it themselves, and almost every implementation is
     different. Handling broken CSV files is a common and frustrating task. CSV has no standard encoding, no standard column
     separator and multiple character escaping standards. String is the only type supported for cell values, so some programs
@@ -154,15 +154,16 @@ From [jsonlines.org](http://jsonlines.org/examples/):
     this format.
 
 - **Easy Nested Data**
+
     ```json
     {"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
     {"name": "Alexa", "wins": [["two pair", "4♠"], ["two pair", "9♠"]]}
     {"name": "May", "wins": []}
     {"name": "Deloise", "wins": [["three of a kind", "5♣"]]}
     ```
+
     JSON Lines' biggest strength is in handling lots of similar nested data structures. One .jsonl file is easier to
     work with than a directory full of XML files.
-
 
 Tracking your position
 -----------
@@ -175,31 +176,31 @@ and `error()` to check if there were any error.
 
 Let us illustrate the idea with code:
 
-
 ```C++
     auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} [1,2,3]  )"_padded;
     simdjson::ondemand::parser parser;
     simdjson::ondemand::document_stream stream;
     auto error = parser.iterate_many(json).get(stream);
-    if( error ) { /* do something */ }
+    if (error) { /* do something */ }
     auto i = stream.begin();
-	 size_t count{0};
-    for(; i != stream.end(); ++i) {
+    size_t count{0};
+    for (; i != stream.end(); ++i) {
         auto doc = *i;
-        if(!i.error()) {
-          std::cout << "got full document at " << i.current_index() << std::endl;
-          std::cout << i.source() << std::endl;
-          count++;
+        if (!i.error()) {
+            std::cout << "got full document at " << i.current_index() << std::endl;
+            std::cout << i.source() << std::endl;
+            count++;
         } else {
-          std::cout << "got broken document at " << i.current_index() << std::endl;
-          return false;
+            std::cout << "got broken document at " << i.current_index() << std::endl;
+            return false;
         }
     }
 
 ```
 
 This code will print:
-```
+
+```text
 got full document at 0
 [1,2,3]
 got full document at 9
@@ -208,14 +209,12 @@ got full document at 29
 [1,2,3]
 ```
 
-
 Incomplete streams
 -----------
 
 Some users may need to work with truncated streams. The simdjson may truncate documents at the very end of the stream that cannot possibly be valid JSON (e.g., they contain unclosed strings, unmatched brackets, unmatched braces). After iterating through the stream, you may query the `truncated_bytes()` method which tells you how many bytes were truncated. If the stream is made of full (whole) documents, then you should expect `truncated_bytes()` to return zero.
 
-
-Consider the following example where a truncated document (`{"key":"intentionally unclosed string  `) containing 39 bytes has been left within the stream. In such cases, the first two whole documents are parsed and returned, and the `truncated_bytes()` method returns 39.
+Consider the following example where a truncated document (`{"key":"intentionally unclosed string`) containing 39 bytes has been left within the stream. In such cases, the first two whole documents are parsed and returned, and the `truncated_bytes()` method returns 39.
 
 ```C++
     auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} {"key":"intentionally unclosed string  )"_padded;
@@ -230,7 +229,8 @@ Consider the following example where a truncated document (`{"key":"intentionall
 ```
 
 This will print:
-```
+
+```text
 [1,2,3]
 {"1":1,"2":3,"4":4}
 39 bytes

--- a/doc/ondemand_design.md
+++ b/doc/ondemand_design.md
@@ -39,28 +39,29 @@ Such code would be apply to a JSON document such as the following JSON mimicking
 
 ```json
 {
-	"statuses": [{
-			"text": "@aym0566x \n\n名前:前田あゆみ\n第一印象:なんか怖っ！\n今の印象:とりあえずキモい。噛み合わない\n好きなところ:ぶすでキモいとこ😋✨✨\n思い出:んーーー、ありすぎ😊❤️\nLINE交換できる？:あぁ……ごめん✋\nトプ画をみて:照れますがな😘✨\n一言:お前は一生もんのダチ💖",
-			"user": {
-				"name": "AYUMI",
-				"screen_name": "ayuu0123",
-				"followers_count": 262,
-				"friends_count": 252
-			},
-			"retweet_count": 0,
-			"favorite_count": 0
-		},
-		{
-			"text": "RT @KATANA77: えっそれは・・・（一同） http://t.co/PkCJAcSuYK",
-			"user": {
-				"name": "RT&ファボ魔のむっつんさっm",
-				"screen_name": "yuttari1998",
-				"followers_count": 95,
-				"friends_count": 158
-			},
-			"retweet_count": 82,
-			"favorite_count": 42
-		}
+  "statuses": [
+    {
+      "text": "@aym0566x \n\n名前:前田あゆみ\n第一印象:なんか怖っ！\n今の印象:とりあえずキモい。噛み合わない\n好きなところ:ぶすでキモいとこ😋✨✨\n思い出:んーーー、ありすぎ😊❤️\nLINE交換できる？:あぁ……ごめん✋\nトプ画をみて:照れますがな😘✨\n一言:お前は一生もんのダチ💖",
+      "user": {
+        "name": "AYUMI",
+        "screen_name": "ayuu0123",
+        "followers_count": 262,
+        "friends_count": 252
+      },
+      "retweet_count": 0,
+      "favorite_count": 0
+    },
+    {
+      "text": "RT @KATANA77: えっそれは・・・（一同） http://t.co/PkCJAcSuYK",
+      "user": {
+        "name": "RT&ファボ魔のむっつんさっm",
+        "screen_name": "yuttari1998",
+        "followers_count": 95,
+        "friends_count": 158
+      },
+      "retweet_count": 82,
+      "favorite_count": 42
+    }
   ],
   "search_metadata": {
     "count": 100,
@@ -77,22 +78,21 @@ Further, the On Demand API does not parse a value *at all* until you try to conv
 may not convert the pair of characters `82` to the binary integer 82. Because the programmer specifies the data
 type, we avoid branch mispredictions related to data type determination and improve the performance.
 
-
 We expect users of an On Demand API to work in terms of a JSON dialect, which is a set of expectations and
 specifications that come in addition to the [JSON specification](https://www.rfc-editor.org/rfc/rfc8259.txt).
 The On Demand approach is designed around several principles:
 
-* **Streaming (\*):** It avoids preparsing values, keeping the memory usage and the latency down.
-* **Forward-Only:** To prevent reiteration of the same values and to keep the number of variables down (literally), only a single index is maintained and everything uses it (even if you have nested for loops). This means when you are going through an array of arrays, for example, that the inner array loop will advance the index to the next comma, and the array can just pick it up and look at it.
-* **Natural Iteration:** A JSON array or object can be iterated with a normal C++ for loop. Nested arrays and objects are supported by nested for loops.
-* **Use-Specific Parsing:** Parsing is always specific to the type required by the programmer. For example, if the programmer asks for an unsigned integer, we just start parsing digits. If there were no digits, we toss an error. There are even different parsers for `double`, `uint64_t` and `int64_t` values. This use-specific parsing avoids the branchiness of a generic "type switch," and makes the code more inlineable and compact.
-* **Validate What You Use:** On Demand deliberately validates the values you use and the structure leading to it, but nothing else. The goal is a guarantee that the value you asked for is the correct one and is not malformed: there must be no confusion over whether you got the right value.
-
+- **Streaming (\*):** It avoids preparsing values, keeping the memory usage and the latency down.
+- **Forward-Only:** To prevent reiteration of the same values and to keep the number of variables down (literally), only a single index is maintained and everything uses it (even if you have nested for loops). This means when you are going through an array of arrays, for example, that the inner array loop will advance the index to the next comma, and the array can just pick it up and look at it.
+- **Natural Iteration:** A JSON array or object can be iterated with a normal C++ for loop. Nested arrays and objects are supported by nested for loops.
+- **Use-Specific Parsing:** Parsing is always specific to the type required by the programmer. For example, if the programmer asks for an unsigned integer, we just start parsing digits. If there were no digits, we toss an error. There are even different parsers for `double`, `uint64_t` and `int64_t` values. This use-specific parsing avoids the branchiness of a generic "type switch," and makes the code more inlineable and compact.
+- **Validate What You Use:** On Demand deliberately validates the values you use and the structure leading to it, but nothing else. The goal is a guarantee that the value you asked for is the correct one and is not malformed: there must be no confusion over whether you got the right value.
 
 To understand why On Demand is different, it is helpful to review the major
 approaches to parsing and parser APIs in use today.
 
-### DOM Parsers
+DOM Parsers
+-----------
 
 Many of the most usable, popular JSON APIs (including simdjson) deserialize into a **DOM**: an intermediate tree of
 objects, arrays and values. In this model, we convert the input data all at once into a tree-like structure (the DOM).
@@ -121,21 +121,21 @@ for (auto tweet : doc["statuses"]) {
 ```
 
 Pros of the DOM approach:
-* Straightforward, programmer-friendly interface (arrays and objects).
-* Safe: all of the input data has been validated before it is accessed.
-* All of the JSON document is available at once to the programmer.
+
+- Straightforward, programmer-friendly interface (arrays and objects).
+- Safe: all of the input data has been validated before it is accessed.
+- All of the JSON document is available at once to the programmer.
 
 Cons of the DOM approach:
-* The memory usage scales linearly with the size of the input document.
-* Parses and stores everything, using memory and CPU cycles even on unused values.
-* Performance drain from [type blindness](#type-blindness).
 
+- The memory usage scales linearly with the size of the input document.
+- Parses and stores everything, using memory and CPU cycles even on unused values.
+- Performance drain from [type blindness](#type-blindness).
 
 What the simdjson library demonstrates is that a DOM API may be quite fast indeed: we can parse files at speeds
 of several gigabytes per second. However, in some instances, it may be possible to achieve even higher speeds.
 
 ### Event-Based Parsers (SAX, SAJ, etc.)
-
 
 The event-based model (originally from the "Streaming API for XML") uses streaming to eliminate the cost of
 parsing and storing the entire JSON. In the event-based model, a core JSON engine parses the JSON document
@@ -195,21 +195,21 @@ parser.parse(twitter_callbacks());
 This is a large amount of code, requiring mental gymnastics even to read. An actual implementation is  harder to write
 and to maintain.
 
-
 Pros of the event-based approach:
-* Speed and space benefits from low, predictable memory usage.
-* Parsing can be done more lazily: the API can delegate work to the programmer for better performance.
-* It is highly flexible: given enough effort, most tasks can be accomplished efficiently.
+
+- Speed and space benefits from low, predictable memory usage.
+- Parsing can be done more lazily: the API can delegate work to the programmer for better performance.
+- It is highly flexible: given enough effort, most tasks can be accomplished efficiently.
 
 Cons of the event-based approach:
-* Performance drain from context blindness (e.g., switch statements for "where am I in the document")
-* Difficult to use (high code complexity, high maintenance, difficult to debug)
-* Lacks the safety of DOM: malformed documents could be ingested.
+
+- Performance drain from context blindness (e.g., switch statements for "where am I in the document")
+- Difficult to use (high code complexity, high maintenance, difficult to debug)
+- Lacks the safety of DOM: malformed documents could be ingested.
 
 Though an event-based approach might have its niche uses, we believe that it is rarely ideally suited. We suspect that it is mostly used when performance and memory is a concern, and no other option (except DOM) is readily available.
 
 ### Schema-Based Parser Generators
-
 
 In a schema-based model, the programmer provides a description of a data structure, and the parser constructs the data structure in question during parsing. These parsers take a schema--a description of
 your JSON, with field names, types, everything--and generate classes/structs in your language of
@@ -219,18 +219,18 @@ Though not all of these schema-based parser generators generate a parser or even
 streaming, but they are *able* to in principle. Unlike the DOM and the event-based models, a schema-based approach assumes
  that the structure of the document is known at compile-time.
 
-
 Pros of the schema-based approach:
-* Ease of Use is on par with DOM
-* Parsers that generate iterators and lazy values in structs can keep memory pressure down to event-based levels.
-* Type Blindness can be entirely solved with specific parsers for each type, saving many branches.
-* Context Blindness can be solved, especially if object fields are required and in order, saving even more branches.
-* Can be made a safe as DOM: the input can be entirely validated prior to ingestion.
+
+- Ease of Use is on par with DOM
+- Parsers that generate iterators and lazy values in structs can keep memory pressure down to event-based levels.
+- Type Blindness can be entirely solved with specific parsers for each type, saving many branches.
+- Context Blindness can be solved, especially if object fields are required and in order, saving even more branches.
+- Can be made a safe as DOM: the input can be entirely validated prior to ingestion.
 
 Cons of the schema-based approach:
-* It is less flexible than the DOM or event-based approaches, sometimes limited to a deserialization-to-objects scenario.
-* The structure of the data must be fully known at compile-time.
 
+- It is less flexible than the DOM or event-based approaches, sometimes limited to a deserialization-to-objects scenario.
+- The structure of the data must be fully known at compile-time.
 
 ### Type Blindness and Branch Misprediction
 
@@ -433,7 +433,7 @@ To help visualize the algorithm, we'll walk through the example C++ given at the
    }
    ```
 
-4. We get the `"screen_name"` from the `"user"` object.
+5. We get the `"screen_name"` from the `"user"` object.
 
    ```c++
       ondemand::object user        = tweet["user"];
@@ -467,7 +467,7 @@ To help visualize the algorithm, we'll walk through the example C++ given at the
    }
    ```
 
-5. We get `"retweet_count"` as an unsigned integer.
+6. We get `"retweet_count"` as an unsigned integer.
 
    ```c++
    uint64_t         retweets    = tweet["retweet_count"];
@@ -511,7 +511,7 @@ To help visualize the algorithm, we'll walk through the example C++ given at the
    }
    ```
 
-6. We loop to the next tweet.
+7. We loop to the next tweet.
 
    ```c++
    for (ondemand::object tweet : doc["statuses"]) {
@@ -551,7 +551,7 @@ To help visualize the algorithm, we'll walk through the example C++ given at the
    }
    ```
 
-7. This tweet is processed just like the previous one, leaving the iterator here:
+8. This tweet is processed just like the previous one, leaving the iterator here:
 
    ```json
    {
@@ -564,7 +564,7 @@ To help visualize the algorithm, we'll walk through the example C++ given at the
    }
    ```
 
-8. The loop ends. Recall the relevant parts of the statuses loop:
+9. The loop ends. Recall the relevant parts of the statuses loop:
 
    ```c++
    while (iter != statuses.end()) {
@@ -590,7 +590,7 @@ To help visualize the algorithm, we'll walk through the example C++ given at the
    }
    ```
 
-9. The remainder of the file is skipped.
+10. The remainder of the file is skipped.
 
    Because no more action is taken, JSON processing stops: processing only occurs when you ask for
    values.
@@ -644,7 +644,6 @@ has no longer a key (that is by design). Like other strings, the resulting `std:
 from the `unescaped_key()` method has a lifecycle tied to the `parser` instance: once the parser
 is destroyed or reused with another document, the `std::string_view` instance becomes invalid.
 
-
 ```C++
 auto doc = parser.iterate(json);
 for(auto field : doc.get_object())  {
@@ -657,13 +656,13 @@ for(auto field : doc.get_object())  {
 The On Demand API is powerful. To compensate, we add some safeguards to ensure that it can be used without fear
 in production systems:
 
-  - If the value fails to be parsed as one type, the program can try to parse it as something else until the program succeeds. Thus
+- If the value fails to be parsed as one type, the program can try to parse it as something else until the program succeeds. Thus
     the programmer can engineer fall back routines.
-  - If the value succeeds in being parsed or converted to a type, the program cannot try again. An attempt to parse the same node twice will
+- If the value succeeds in being parsed or converted to a type, the program cannot try again. An attempt to parse the same node twice will
     cause the program to abort. We put this safety measure in the API to prevent double iteration of an array which
     would cause inconsistent iterator state or double-unescaping a string which may cause memory
     overruns if done.
-  - Guaranteed Iteration: If you discard a value without using it--perhaps you just wanted to know
+- Guaranteed Iteration: If you discard a value without using it--perhaps you just wanted to know
     if it was `nullptr` but did not care what the actual value was--it will iterate. The destructor automates
     the iteration.
 
@@ -686,7 +685,7 @@ in production systems:
     // if(std::string_view(c2["name"]) != "Daniel") { return false; }
 ```
 
-    A correct usage is given by the following example:
+A correct usage is given by the following example:
 
 ```C++
     ondemand::parser parser;
@@ -713,21 +712,21 @@ in production systems:
 
 We expect that the On Demand approach has many of the performance benefits of the schema-based approach, while providing a flexibility that is similar to that of the DOM-based approach.
 
-* Faster than DOM in some cases. Reduced memory usage.
-* Straightforward, programmer-friendly interface (arrays and objects).
-* Highly expressive, beyond deserialization and pointer queries: many tasks can be accomplished with little code.
+- Faster than DOM in some cases. Reduced memory usage.
+- Straightforward, programmer-friendly interface (arrays and objects).
+- Highly expressive, beyond deserialization and pointer queries: many tasks can be accomplished with little code.
 
 ### Limitations of the On Demand Approach
 
 The On Demand approach has some limitations:
 
-* Because it operates in streaming mode, you only have access to the current element in the JSON document. Furthermore, the document is traversed in order so the code is sensitive to the order of the JSON nodes in the same manner as an event-based approach (e.g., SAX). (The one exception to this is field lookup, which is more *performant* when the order of lookups matches the order of fields in the document, but which will still work with out-of-order fields, with a performance hit.)
-* The On Demand approach is less safe than DOM: we only validate the components of the JSON document that are used and it is possible to begin ingesting an invalid document only to find out later that the document is invalid. Are you fine ingesting a large JSON document that starts with well formed JSON but ends with invalid JSON content?
+- Because it operates in streaming mode, you only have access to the current element in the JSON document. Furthermore, the document is traversed in order so the code is sensitive to the order of the JSON nodes in the same manner as an event-based approach (e.g., SAX). (The one exception to this is field lookup, which is more *performant* when the order of lookups matches the order of fields in the document, but which will still work with out-of-order fields, with a performance hit.)
+- The On Demand approach is less safe than DOM: we only validate the components of the JSON document that are used and it is possible to begin ingesting an invalid document only to find out later that the document is invalid. Are you fine ingesting a large JSON document that starts with well formed JSON but ends with invalid JSON content?
 
 There are currently additional technical limitations which we expect to resolve in future releases of the simdjson library:
 
-* The simdjson library offers runtime dispatching which allows you to compile one binary and have it run at full speed on different processors, taking advantage of the specific features of the processor. The On Demand API has limited runtime dispatch support. Under x64 systems, to fully benefit from the On Demand API, we recommend that you compile your code for a specific processor. E.g., if your processor supports AVX2 instructions, you should compile your binary executable with AVX2 instruction support (by using your compiler's commands). If you are sufficiently technically proficient, you can implement runtime dispatching within your application, by compiling your On Demand code for different processors.
-* There is an initial phase which scans the entire document quickly, irrespective of the size of the document. We plan to break this phase into distinct steps for large files in a future release as we have done with other components of our API (e.g., `parse_many`).
+- The simdjson library offers runtime dispatching which allows you to compile one binary and have it run at full speed on different processors, taking advantage of the specific features of the processor. The On Demand API has limited runtime dispatch support. Under x64 systems, to fully benefit from the On Demand API, we recommend that you compile your code for a specific processor. E.g., if your processor supports AVX2 instructions, you should compile your binary executable with AVX2 instruction support (by using your compiler's commands). If you are sufficiently technically proficient, you can implement runtime dispatching within your application, by compiling your On Demand code for different processors.
+- There is an initial phase which scans the entire document quickly, irrespective of the size of the document. We plan to break this phase into distinct steps for large files in a future release as we have done with other components of our API (e.g., `parse_many`).
 
 ### Applicability of the On Demand Approach
 
@@ -740,13 +739,14 @@ At this time we recommend the On Demand API in the following cases:
 
 Good applications for the On Demand API might be:
 
-* You are working from pre-existing large JSON files that have been vetted. You expect them to be well formed according to a known JSON dialect and to have a consistent layout. For example, you might be doing biomedical research or machine learning on top of static data dumps in JSON.
-* Both the generation and the consumption of JSON data is within your system. Your team controls both the software that produces the JSON and the software the parses it, your team knows and control the hardware. Thus you can fully test your system.
-* You are working with stable JSON APIs which have a consistent layout and JSON dialect.
+- You are working from pre-existing large JSON files that have been vetted. You expect them to be well formed according to a known JSON dialect and to have a consistent layout. For example, you might be doing biomedical research or machine learning on top of static data dumps in JSON.
+- Both the generation and the consumption of JSON data is within your system. Your team controls both the software that produces the JSON and the software the parses it, your team knows and control the hardware. Thus you can fully test your system.
+- You are working with stable JSON APIs which have a consistent layout and JSON dialect.
 
-## Checking Your CPU Selection (x64 systems)
+Checking Your CPU Selection (x64 systems)
+-----------------------------------------
 
-The On Demand API uses advanced architecture-specific code for many common processors to make JSON preprocessing and string parsing faster. By default, however, most c++ compilers will compile to the	least common denominator (since the program could theoretically be run anywhere). Since On Demand is inlined into your own code, it cannot always use these advanced versions unless the compiler is told to target them.
+The On Demand API uses advanced architecture-specific code for many common processors to make JSON preprocessing and string parsing faster. By default, however, most c++ compilers will compile to the least common denominator (since the program could theoretically be run anywhere). Since On Demand is inlined into your own code, it cannot always use these advanced versions unless the compiler is told to target them.
 
 On relevant systems, the On Demand API provides some support for runtime dispatching: that is, it will attempt to detect, at runtime, the instructions that your processor supports and optimize the code accordingly. However, it cannot always make full use of the features of your processor.
 
@@ -762,14 +762,14 @@ If the `simdjson::builtin_implementation()->name()` call does not return the arc
 
 If you are using CMake for your C++ project, then you can pass compilation flags to your compiler by using the `CMAKE_CXX_FLAGS` variable:
 
-```
+```bash
 cmake  -DCMAKE_CXX_FLAGS="-march=haswell" -B build_haswell
 cmake --build build_haswell
 ```
 
 You can also pass the flags directly to your compiler when compiling 'by hand':
 
-````
+````bash
 c++ -march=haswell -O3 myproject.cpp simdjson.cpp
 ````
 
@@ -777,6 +777,6 @@ In these examples, the `-march=haswell` flags targets a haswell processor and th
 
 Instead of specifying a specific microarchitecture, you can let your compiler do the work. The `-march=native` flags says "target the current computer," which is a reasonable default for many applications which both compile and run on the same processor.
 
-Passing `-march=native` to the compiler may make On Demand faster by allowing it to use optimizations specific to your machine. You cannot do this, however, if you are compiling code	that might be run on less advanced machines. That is, be mindful that when compiling with the `-march=native` flag, the resulting binary will run on the current system but may not run on other systems (e.g., on an old processor).
+Passing `-march=native` to the compiler may make On Demand faster by allowing it to use optimizations specific to your machine. You cannot do this, however, if you are compiling code that might be run on less advanced machines. That is, be mindful that when compiling with the `-march=native` flag, the resulting binary will run on the current system but may not run on other systems (e.g., on an old processor).
 
 If you are compiling on an ARM or POWER system, you do not need to be concerned with CPU selection during compilation. The `-march=native` flag useful for best performance on x64 (e.g., Intel) systems but it is generally unsupported on some platforms such as ARM (aarch64) or POWER.

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -2,12 +2,14 @@ parse_many
 ==========
 
 An interface providing features to work with files or streams containing multiple small JSON documents. Given an input such as
+
 ```JSON
 {"text":"a"}
 {"text":"b"}
 {"text":"c"}
 ...
 ```
+
 ... you want to read the entries (individual JSON documents) as quickly and as conveniently as possible. Importantly, the input might span several gigabytes, but you want to use a small (fixed) amount of memory. Ideally, you'd also like the parallelize the processing (using more than one core) to speed up the process.
 
 Contents
@@ -118,6 +120,7 @@ or more character that is considered whitespace** by the JSON spec. Anything tha
  not whitespace will be parsed as a JSON document and could lead to failure.
 
 Whitespace Characters:
+
 - **Space**
 - **Linefeed**
 - **Carriage return**
@@ -125,6 +128,7 @@ Whitespace Characters:
 - **Nothing**
 
 Some official formats **(non-exhaustive list)**:
+
 - [Newline-Delimited JSON (NDJSON)](http://ndjson.org/)
 - [JSON lines (JSONL)](http://jsonlines.org/)
 - [Record separator-delimited JSON (RFC 7464)](https://tools.ietf.org/html/rfc7464) <- Not supported by JsonStream!
@@ -135,11 +139,13 @@ API
 
 See [basics.md](basics.md#newline-delimited-json-ndjson-and-json-lines) for an overview of the API.
 
-## Use cases
+Use Cases
+---------
 
 From [jsonlines.org](http://jsonlines.org/examples/):
 
 - **Better than CSV**
+
     ```json
     ["Name", "Session", "Score", "Completed"]
     ["Gilbert", "2013", 24, true]
@@ -147,6 +153,7 @@ From [jsonlines.org](http://jsonlines.org/examples/):
     ["May", "2012B", 14, false]
     ["Deloise", "2012A", 19, true]
     ```
+
     CSV seems so easy that many programmers have written code to generate it themselves, and almost every implementation is
     different. Handling broken CSV files is a common and frustrating task. CSV has no standard encoding, no standard column
     separator and multiple character escaping standards. String is the only type supported for cell values, so some programs
@@ -158,15 +165,16 @@ From [jsonlines.org](http://jsonlines.org/examples/):
     this format.
 
 - **Easy Nested Data**
+
     ```json
     {"name": "Gilbert", "wins": [["straight", "7♣"], ["one pair", "10♥"]]}
     {"name": "Alexa", "wins": [["two pair", "4♠"], ["two pair", "9♠"]]}
     {"name": "May", "wins": []}
     {"name": "Deloise", "wins": [["three of a kind", "5♣"]]}
     ```
+
     JSON Lines' biggest strength is in handling lots of similar nested data structures. One .jsonl file is easier to
     work with than a directory full of XML files.
-
 
 Tracking your position
 -----------
@@ -177,7 +185,6 @@ method which reports the location (in bytes) of the current document in the inpu
 You may also call the `source()` method to get a `std::string_view` instance on the document.
 
 Let us illustrate the idea with code:
-
 
 ```C++
     auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} [1,2,3]  )"_padded;
@@ -202,7 +209,8 @@ Let us illustrate the idea with code:
 ```
 
 This code will print:
-```
+
+```text
 got full document at 0
 [1,2,3]
 got full document at 9
@@ -211,14 +219,12 @@ got full document at 29
 [1,2,3]
 ```
 
-
 Incomplete streams
 -----------
 
 Some users may need to work with truncated streams. The simdjson may truncate documents at the very end of the stream that cannot possibly be valid JSON (e.g., they contain unclosed strings, unmatched brackets, unmatched braces). After iterating through the stream, you may query the `truncated_bytes()` method which tells you how many bytes were truncated. If the stream is made of full (whole) documents, then you should expect `truncated_bytes()` to return zero.
 
-
-Consider the following example where a truncated document (`{"key":"intentionally unclosed string  `) containing 39 bytes has been left within the stream. In such cases, the first two whole documents are parsed and returned, and the `truncated_bytes()` method returns 39.
+Consider the following example where a truncated document (`{"key":"intentionally unclosed string`) containing 39 bytes has been left within the stream. In such cases, the first two whole documents are parsed and returned, and the `truncated_bytes()` method returns 39.
 
 ```C++
     auto json = R"([1,2,3]  {"1":1,"2":3,"4":4} {"key":"intentionally unclosed string  )"_padded;
@@ -231,6 +237,5 @@ Consider the following example where a truncated document (`{"key":"intentionall
     }
     std::cout << stream.truncated_bytes() << " bytes "<< std::endl; // returns 39 bytes
 ```
-
 
 Importantly, you should only call `truncated_bytes()` after iterating through all of the documents since the stream cannot tell whether there are truncated documents at the very end when it may not have accessed that part of the data yet.

--- a/doc/performance.md
+++ b/doc/performance.md
@@ -38,7 +38,6 @@ for(int64_t i : doc.get_array()) {
 }
 ```
 
-
 Reusing string buffers
 -----------------------------------------
 
@@ -50,11 +49,9 @@ We recommend against creating many `std::string` or `simdjson::padded_string` in
 
 or simply
 
-
 ```c++
  auto doc = parser.iterate(json_str, length, capacity);
 ```
-
 
 Server Loops: Long-Running Processes and Memory Capacity
 ---------------------------------
@@ -62,6 +59,7 @@ Server Loops: Long-Running Processes and Memory Capacity
 The On Demand approach also automatically expands its memory capacity when larger documents are parsed. However, for longer processes where very large files are processed (such as server loops), this capacity is not resized down. On Demand also lets you adjust the maximal capacity that the parser can process:
 
 * You can set an upper bound (*max_capacity*) when construction the parser:
+
 ```C++
     ondemand::parser parser(1000*1000);  // Never grows past documents > 1 MB
     auto doc = parser.iterate(json);
@@ -78,6 +76,7 @@ The On Demand approach also automatically expands its memory capacity when large
 The capacity will grow as the parser encounters larger documents up to 1 MB.
 
 * You can also allocate a *fixed capacity* that will never grow:
+
 ```C++
     ondemand::parser parser(1000*1000);
     parser.allocate(1000*1000)  // Fix the capacity to 1 MB
@@ -91,6 +90,7 @@ The capacity will grow as the parser encounters larger documents up to 1 MB.
       // ...
     }
 ```
+
 You can also manually set the maximal capacity using the method `set_max_capacity()`.
 
 Large files and huge page support
@@ -115,7 +115,7 @@ by parsing several large files) to distinguish the time spent parsing from the t
 memory. If you are using the `parse` benchmarking tool provided with the simdjson library, you can
 use the `-H` flag to omit the memory allocation cost from the benchmark results.
 
-```
+```bash
 ./parse largefile # includes memory allocation cost
 ./parse -H largefile # without memory allocation
 ```
@@ -129,11 +129,9 @@ our knowledge, it is not possible, in general, to parse streams of numbers at gi
 using a single core. While using the simdjson library, it is possible that you might be limited to a
 few hundred megabytes per second if your JSON documents are densely packed with floating-point values.
 
-
-- When possible, you should favor integer values written without a decimal point, as it simpler and faster to parse decimal integer values.
-- When serializing numbers, you should not use more digits than necessary: 17 digits is all that is needed to exactly represent double-precision floating-point numbers. Using many more digits than necessary will make your files larger and slower to parse.
-- When benchmarking parsing speeds, always report whether your JSON documents are made mostly of floating-point numbers when it is the case, since number parsing can then dominate the parsing time.
-
+* When possible, you should favor integer values written without a decimal point, as it simpler and faster to parse decimal integer values.
+* When serializing numbers, you should not use more digits than necessary: 17 digits is all that is needed to exactly represent double-precision floating-point numbers. Using many more digits than necessary will make your files larger and slower to parse.
+* When benchmarking parsing speeds, always report whether your JSON documents are made mostly of floating-point numbers when it is the case, since number parsing can then dominate the parsing time.
 
 Visual Studio
 --------------
@@ -146,7 +144,6 @@ Recent versions of Microsoft Visual Studio on Windows provides support for the L
 
 Under Windows, we also support the GNU GCC compiler via MSYS2. The performance of 64-bit MSYS2 under Windows excellent (on par with Linux).
 
-
 Power Usage and Downclocking
 --------------
 
@@ -154,11 +151,10 @@ The simdjson library relies on SIMD instructions. SIMD instructions are the publ
 
 The SIMD instructions that simdjson relies upon (SSE and AVX under x64, NEON under ARM, ALTIVEC under PPC) are routinely part of runtime libraries (e.g., [Go](https://golang.org/src/runtime/memmove_amd64.s), [Glibc](https://github.com/ihtsae/glibc/commit/5f3d0b78e011d2a72f9e88b0e9ef5bc081d18f97), [LLVM](https://github.com/llvm/llvm-project/blob/96f3ea0d21b48ca088355db10d4d1a2e9bc9f884/lldb/tools/debugserver/source/MacOSX/i386/DNBArchImplI386.cpp), [Rust](https://github.com/rust-lang/rust/commit/070fad1701fb36b112853b0a6a9787a7bb7ff34c), [Java](http://hg.openjdk.java.net/jdk8u/jdk8u/hotspot/file/c1374141598c/src/cpu/x86/vm/stubGenerator_x86_64.cpp#l1297), [PHP](https://github.com/php/php-src/blob/e5cb53ec68603d4dbdd780fd3ecfca943b4fd383/ext/standard/string.c)). What distinguishes the simdjson library is that it is built from the ground up to benefit from these instructions.
 
-
 You should not expect the simdjson library to cause *downclocking* of your recent Intel CPU cores. On some Intel processors, using SIMD instructions in a sustained manner on the same CPU core may result in a phenomenon called downclocking whereas the processor initially runs these instructions at a slow speed before reducing the frequency of the core for a short time (milliseconds). Intel refers to these states as licenses. On some current Intel processors, it occurs under two scenarios:
 
-- [Whenever 512-bit AVX-512 instructions are used](https://lemire.me/blog/2018/09/07/avx-512-when-and-how-to-use-these-new-instructions/).
-- Whenever heavy 256-bit or wider instructions are used. Heavy instructions are those involving floating point operations or integer multiplications (since these execute on the floating point unit).
+* [Whenever 512-bit AVX-512 instructions are used](https://lemire.me/blog/2018/09/07/avx-512-when-and-how-to-use-these-new-instructions/).
+* Whenever heavy 256-bit or wider instructions are used. Heavy instructions are those involving floating point operations or integer multiplications (since these execute on the floating point unit).
 
 The simdjson library does not currently support AVX-512 instructions and it does not make use of heavy 256-bit instructions. We do use vectorized multiplications, but only using 128-bit registers. Thus there should be no downclocking due to simdjson on recent processors.
 

--- a/doc/tape.md
+++ b/doc/tape.md
@@ -1,40 +1,43 @@
 
-# Tape structure in simdjson
+Tape structure in simdjson
+==========================
 
 We parse a JSON document to a tape. A tape is an array of 64-bit values. Each node encountered in the JSON document is written to the tape using one or more 64-bit tape elements; the layout of the tape is in "document order": elements are stored as they are encountered in the JSON document.
 
 Throughout, little endian encoding is assumed. The tape is indexed starting at 0 (the first element is at index 0).
 
-## Example
+Example
+-------
 
 It is sometimes useful to start with an example. Consider the following JSON document:
 
 ```json
 {
-	"Image": {
-		"Width": 800,
-		"Height": 600,
-		"Title": "View from 15th Floor",
-		"Thumbnail": {
-			"Url": "http://www.example.com/image/481989943",
-			"Height": 125,
-			"Width": 100
-		},
-		"Animated": false,
-		"IDs": [116, 943, 234, 38793]
-	}
+  "Image": {
+    "Width": 800,
+    "Height": 600,
+    "Title": "View from 15th Floor",
+    "Thumbnail": {
+      "Url": "http://www.example.com/image/481989943",
+      "Height": 125,
+      "Width": 100
+    },
+    "Animated": false,
+    "IDs": [116, 943, 234, 38793]
+  }
 }
 ```
 
 The following is a dump of the content of the tape, with the first number of each line representing the index of a tape element.
 
 ### The Tape
+
 | index | element (64 bit word)                                               |
 | ----- | ------------------------------------------------------------------- |
-| 0     | r	// pointing to 39 (right after last node)                         |
-| 1     | {	// pointing to next tape location 38 (first node after the scope) |
+| 0     | r // pointing to 39 (right after last node)                         |
+| 1     | { // pointing to next tape location 38 (first node after the scope) |
 | 2     | string "Image"                                                      |
-| 3     | {	// pointing to next tape location 37 (first node after the scope) |
+| 3     | { // pointing to next tape location 37 (first node after the scope) |
 | 4     | string "Width"                                                      |
 | 5     | integer 800                                                         |
 | 7     | string "Height"                                                     |
@@ -42,37 +45,36 @@ The following is a dump of the content of the tape, with the first number of eac
 | 10    | string "Title"                                                      |
 | 11    | string "View from 15th Floor"                                       |
 | 12    | string "Thumbnail"                                                  |
-| 13    | {	// pointing to next tape location 23 (first node after the scope) |
+| 13    | { // pointing to next tape location 23 (first node after the scope) |
 | 14    | string "Url"                                                        |
 | 15    | string "http://www.example.com/image/481989943"                     |
 | 16    | string "Height"                                                     |
 | 17    | integer 125                                                         |
 | 19    | string "Width"                                                      |
 | 20    | integer 100                                                         |
-| 22    | }	// pointing to previous tape location 13 (start of the scope)     |
+| 22    | } // pointing to previous tape location 13 (start of the scope)     |
 | 23    | string "Animated"                                                   |
 | 24    | false                                                               |
 | 25    | string "IDs"                                                        |
-| 26    | [	// pointing to next tape location 36 (first node after the scope) |
+| 26    | [ // pointing to next tape location 36 (first node after the scope) |
 | 27    | integer 116                                                         |
 | 29    | integer 943                                                         |
 | 31    | integer 234                                                         |
 | 33    | integer 38793                                                       |
-| 35    | ]	// pointing to previous tape location 26 (start of the scope)     |
-| 36    | }	// pointing to previous tape location 3 (start of the scope)      |
-| 37    | }	// pointing to previous tape location 1 (start of the scope)      |
-| 38    | r	// pointing to 0 (start root)                                     |
+| 35    | ] // pointing to previous tape location 26 (start of the scope)     |
+| 36    | } // pointing to previous tape location 3 (start of the scope)      |
+| 37    | } // pointing to previous tape location 1 (start of the scope)      |
+| 38    | r // pointing to 0 (start root)                                     |
 
-
-
-## General formal of the tape elements
+General formal of the tape elements
+-----------------------------------
 
 Most tape elements are written as `('c' << 56) + x` where `'c'` is some ASCII character determining the type of the element (out of 't', 'f', 'n', 'l', 'u', 'd', '"', '{', '}', '[', ']' ,'r') and where `x` is a 56-bit value called the payload. The payload is normally interpreted as an unsigned 56-bit integer. Note that 56-bit integers can be quite large.
 
-
 Performance consideration: We believe that accessing the tape in regular units of 64 bits is more important for performance than saving memory.
 
-## Simple JSON values
+Simple JSON values
+------------------
 
 Simple JSON nodes are represented with one tape element:
 
@@ -80,20 +82,22 @@ Simple JSON nodes are represented with one tape element:
 - true is  represented as the 64-bit value `('t' << 56)`.
 - false is  represented as the 64-bit value `('f' << 56)`.
 
-
-## Integer and Double values
+Integer and Double values
+-------------------------
 
 Integer values are represented as two 64-bit tape elements:
+
 - The 64-bit value `('l' << 56)` followed by the 64-bit integer value literally. Integer values are assumed to be signed 64-bit values, using two's complement notation.
 - The 64-bit value `('u' << 56)` followed by the 64-bit integer value literally. Integer values are assumed to be unsigned 64-bit values.
 
-
 Float values are represented as two 64-bit tape elements:
+
 - The 64-bit value `('d' << 56)` followed by the 64-bit double value literally in standard IEEE 754 notation.
 
 Performance consideration: We store numbers of the main tape because we believe that locality of reference is helpful for performance.
 
-## Root node
+Root node
+---------
 
 Each JSON document will have two special 64-bit tape elements representing a root node, one at the beginning and one at the end.
 
@@ -104,14 +108,15 @@ All of the parsed document is located between these two 64-bit tape elements.
 
 Hint: We can read the first tape element to determine the length of the tape.
 
-
-## Strings
+Strings
+-------
 
 We prefix the string data itself by a 32-bit header to be interpreted as a 32-bit integer. It indicates the length of the string. The actual string data starts at an offset of 4 bytes.
 
 We store string values using UTF-8 encoding with null termination on a separate tape. A string value is represented on the main tape as the 64-bit tape element `('"' << 56) + x` where the payload `x` is the location on the string tape of the null-terminated string.
 
-## Arrays
+Arrays
+------
 
 JSON arrays are represented using two 64-bit tape elements.
 
@@ -122,7 +127,8 @@ All the content of the array is located between these two tape elements, includi
 
 Performance consideration: We can skip the content of an array entirely by accessing the first 64-bit tape element, reading the payload and moving to the corresponding index on the tape.
 
-## Objects
+Objects
+-------
 
 JSON objects are represented using two 64-bit tape elements.
 


### PR DESCRIPTION
I opened README.md in VS Code and noticed a bunch of lint errors. This fixes them and adds a few to ignore.

I don't really care what the rules are, just that my Problems tab is empty :)