### PR TITLE
Added -fPIC compile option. Fix bug in Linux build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,10 @@ set_target_properties(
     WINDOWS_EXPORT_ALL_SYMBOLS YES
 )
 
+if(NOT WIN32)
+  target_compile_options(simdjson PUBLIC -fPIC)
+endif()
+
 # FIXME: Use proper CMake integration for exports
 if(MSVC AND BUILD_SHARED_LIBS)
   target_compile_definitions(


### PR DESCRIPTION
Fixes PIC error when building and linking on Linux as a non-top project. It was only currently available when developer mode was enabled but it should be always used.