### PR TITLE
This runs the streaming amazon benchmarks in two modes: threaded and unthreaded

### DIFF
--- a/benchmark/amazon_cellphones/amazon_cellphones.h
+++ b/benchmark/amazon_cellphones/amazon_cellphones.h
@@ -4,7 +4,11 @@
 #include <map>
 #include <string>
 
+
 namespace amazon_cellphones {
+
+const bool UNTHREADED = false;
+const bool THREADED = true;
 
 using namespace json_benchmark;
 
@@ -59,10 +63,11 @@ struct runner : public file_runner<I> {
     }
 };
 
+template<bool threaded>
 struct simdjson_dom;
 
 template<typename I> simdjson_really_inline static void amazon_cellphones(benchmark::State &state) {
-  run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
+  run_json_benchmark<runner<I>, runner<simdjson_dom<UNTHREADED>>>(state);
 }
 
 }   // namespace amazon_cellphones

--- a/benchmark/amazon_cellphones/simdjson_dom.h
+++ b/benchmark/amazon_cellphones/simdjson_dom.h
@@ -8,12 +8,16 @@ namespace amazon_cellphones {
 
 using namespace simdjson;
 
+template<bool threaded>
 struct simdjson_dom {
   using StringType = std::string;
 
   dom::parser parser{};
 
   bool run(simdjson::padded_string &json, std::map<StringType, brand> &result) {
+#ifdef SIMDJSON_THREADS_ENABLED
+    parser.threaded = threaded;
+#endif
     auto stream = parser.parse_many(json);
     auto i = stream.begin();
     ++i;  // Skip first line
@@ -37,7 +41,10 @@ struct simdjson_dom {
 
 };
 
-BENCHMARK_TEMPLATE(amazon_cellphones, simdjson_dom)->UseManualTime();
+BENCHMARK_TEMPLATE(amazon_cellphones, simdjson_dom<UNTHREADED>)->UseManualTime();
+#ifdef SIMDJSON_THREADS_ENABLED
+BENCHMARK_TEMPLATE(amazon_cellphones, simdjson_dom<THREADED>)->UseManualTime();
+#endif
 
 } // namespace amazon_cellphones
 

--- a/benchmark/amazon_cellphones/simdjson_ondemand.h
+++ b/benchmark/amazon_cellphones/simdjson_ondemand.h
@@ -8,12 +8,16 @@ namespace amazon_cellphones {
 
 using namespace simdjson;
 
+template<bool threaded>
 struct simdjson_ondemand {
   using StringType = std::string;
 
   ondemand::parser parser{};
 
   bool run(simdjson::padded_string &json, std::map<StringType, brand> &result) {
+#ifdef SIMDJSON_THREADS_ENABLED
+    parser.threaded = threaded;
+#endif
     ondemand::document_stream stream = parser.iterate_many(json);
     ondemand::document_stream::iterator i = stream.begin();
     ++i;  // Skip first line
@@ -58,7 +62,10 @@ struct simdjson_ondemand {
 
 };
 
-BENCHMARK_TEMPLATE(amazon_cellphones, simdjson_ondemand)->UseManualTime();
+BENCHMARK_TEMPLATE(amazon_cellphones, simdjson_ondemand<UNTHREADED>)->UseManualTime();
+#ifdef SIMDJSON_THREADS_ENABLED
+BENCHMARK_TEMPLATE(amazon_cellphones, simdjson_ondemand<THREADED>)->UseManualTime();
+#endif
 
 } // namespace amazon_cellphones
 

--- a/benchmark/large_amazon_cellphones/large_amazon_cellphones.h
+++ b/benchmark/large_amazon_cellphones/large_amazon_cellphones.h
@@ -6,6 +6,9 @@
 
 namespace large_amazon_cellphones {
 
+const bool UNTHREADED = false;
+const bool THREADED = true;
+
 static const simdjson::padded_string &get_built_json();
 
 using namespace json_benchmark;
@@ -81,11 +84,11 @@ static const simdjson::padded_string &get_built_json() {
   return json;
 }
 
-
+template<bool threaded>
 struct simdjson_dom;
 
 template<typename I> simdjson_really_inline static void large_amazon_cellphones(benchmark::State &state) {
-  run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
+  run_json_benchmark<runner<I>, runner<simdjson_dom<UNTHREADED>>>(state);
 }
 
 }   // namespace large_amazon_cellphones

--- a/benchmark/large_amazon_cellphones/simdjson_dom.h
+++ b/benchmark/large_amazon_cellphones/simdjson_dom.h
@@ -9,12 +9,16 @@ namespace large_amazon_cellphones {
 
 using namespace simdjson;
 
+template<bool threaded>
 struct simdjson_dom {
   using StringType = std::string;
 
   dom::parser parser{};
 
   bool run(simdjson::padded_string &json, std::map<StringType, brand> &result) {
+#ifdef SIMDJSON_THREADS_ENABLED
+    parser.threaded = threaded;
+#endif
     auto stream = parser.parse_many(json);
     auto i = stream.begin();
     ++i;  // Skip first line
@@ -38,7 +42,10 @@ struct simdjson_dom {
 
 };
 
-BENCHMARK_TEMPLATE(large_amazon_cellphones, simdjson_dom)->UseManualTime();
+BENCHMARK_TEMPLATE(large_amazon_cellphones, simdjson_dom<UNTHREADED>)->UseManualTime();
+#ifdef SIMDJSON_THREADS_ENABLED
+BENCHMARK_TEMPLATE(large_amazon_cellphones, simdjson_dom<THREADED>)->UseManualTime();
+#endif
 
 } // namespace large_amazon_cellphones
 

--- a/benchmark/large_amazon_cellphones/simdjson_ondemand.h
+++ b/benchmark/large_amazon_cellphones/simdjson_ondemand.h
@@ -8,12 +8,16 @@ namespace large_amazon_cellphones {
 
 using namespace simdjson;
 
+template<bool threaded>
 struct simdjson_ondemand {
   using StringType = std::string;
 
   ondemand::parser parser{};
 
   bool run(simdjson::padded_string &json, std::map<StringType, brand> &result) {
+#ifdef SIMDJSON_THREADS_ENABLED
+    parser.threaded = threaded;
+#endif
     ondemand::document_stream stream = parser.iterate_many(json);
     ondemand::document_stream::iterator i = stream.begin();
     ++i;  // Skip first line
@@ -58,7 +62,10 @@ struct simdjson_ondemand {
 
 };
 
-BENCHMARK_TEMPLATE(large_amazon_cellphones, simdjson_ondemand)->UseManualTime();
+BENCHMARK_TEMPLATE(large_amazon_cellphones, simdjson_ondemand<UNTHREADED>)->UseManualTime();
+#ifdef SIMDJSON_THREADS_ENABLED
+BENCHMARK_TEMPLATE(large_amazon_cellphones, simdjson_ondemand<THREADED>)->UseManualTime();
+#endif
 
 } // namespace amazon_cellphones
 


### PR DESCRIPTION
In the large case, we find that the threaded scenario with
ondemand has a 40% speed benefit over the unthreaded scenario.

```
# ./build/benchmark/bench_ondemand  --benchmark_filter=amazon
2022-05-20T16:25:50+00:00
Running ./build/benchmark/bench_ondemand
Run on (4 X 1396.9 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x4)
  L1 Instruction 32 KiB (x4)
  L2 Unified 1024 KiB (x4)
  L3 Unified 8448 KiB (x1)
Load Average: 0.72, 0.33, 0.13
simdjson::dom implementation:      haswell
simdjson::ondemand implementation (stage 1): haswell
simdjson::ondemand implementation (stage 2): fallback
-----------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                   Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------------------------------
amazon_cellphones<simdjson_dom<UNTHREADED>>/manual_time                189976 ns       212451 ns         3662 best_branch_miss=3.131k best_bytes_per_sec=1.48292G best_cache_miss=0 best_cache_ref=244 best_cycles=598.04k best_cycles_per_byte=2.15376 best_docs_per_sec=5.34054k best_frequency=3.19386G best_instructions=1.69581M best_instructions_per_byte=6.10721 best_instructions_per_cycle=2.83561 best_items_per_sec=53.4054k branch_miss=3.27651k bytes=277.673k bytes_per_second=1.36124G/s cache_miss=0.113053 cache_ref=261.514 cycles=605.626k cycles_per_byte=2.18108 docs_per_sec=5.26381k/s frequency=3.1879G/s instructions=1.69581M instructions_per_byte=6.10721 instructions_per_cycle=2.80009 items=10 items_per_second=52.6381k/s [BEST: throughput=  1.48 GB/s doc_throughput=  5340 docs/s instructions=     1695806 cycles=      598040 branch_miss=    3131 cache_miss=       0 cache_ref=       244 items=        10 avg_time=    189976 ns]
amazon_cellphones<simdjson_dom<THREADED>>/manual_time                  185636 ns       207465 ns         3770 best_branch_miss=3.131k best_bytes_per_sec=1.50948G best_cache_miss=0 best_cache_ref=55 best_cycles=587.559k best_cycles_per_byte=2.11601 best_docs_per_sec=5.43617k best_frequency=3.19407G best_instructions=1.69581M best_instructions_per_byte=6.10723 best_instructions_per_cycle=2.8862 best_items_per_sec=54.3617k branch_miss=3.23861k bytes=277.673k bytes_per_second=1.39306G/s cache_miss=0.0297082 cache_ref=55.2631 cycles=591.959k cycles_per_byte=2.13185 docs_per_sec=5.38687k/s frequency=3.18881G/s instructions=1.69581M instructions_per_byte=6.10723 instructions_per_cycle=2.86475 items=10 items_per_second=53.8687k/s [BEST: throughput=  1.51 GB/s doc_throughput=  5436 docs/s instructions=     1695814 cycles=      587559 branch_miss=    3131 cache_miss=       0 cache_ref=        55 items=        10 avg_time=    185636 ns]
amazon_cellphones<simdjson_ondemand<UNTHREADED>>/manual_time           150412 ns       172005 ns         4671 best_branch_miss=2.366k best_bytes_per_sec=1.87308G best_cache_miss=0 best_cache_ref=76 best_cycles=473.519k best_cycles_per_byte=1.70531 best_docs_per_sec=6.74564k best_frequency=3.19419G best_instructions=1.42749M best_instructions_per_byte=5.1409 best_instructions_per_cycle=3.01464 best_items_per_sec=67.4564k branch_miss=2.44373k bytes=277.673k bytes_per_second=1.71929G/s cache_miss=0.107686 cache_ref=74.4442 cycles=479.642k cycles_per_byte=1.72736 docs_per_sec=6.64839k/s frequency=3.18885G/s instructions=1.42749M instructions_per_byte=5.1409 instructions_per_cycle=2.97616 items=10 items_per_second=66.4839k/s [BEST: throughput=  1.87 GB/s doc_throughput=  6745 docs/s instructions=     1427489 cycles=      473519 branch_miss=    2366 cache_miss=       0 cache_ref=        76 items=        10 avg_time=    150412 ns]
amazon_cellphones<simdjson_ondemand<THREADED>>/manual_time             151339 ns       172592 ns         4620 best_branch_miss=2.092k best_bytes_per_sec=1.85983G best_cache_miss=0 best_cache_ref=2 best_cycles=476.851k best_cycles_per_byte=1.71731 best_docs_per_sec=6.69792k best_frequency=3.19391G best_instructions=1.4275M best_instructions_per_byte=5.14092 best_instructions_per_cycle=2.99359 best_items_per_sec=66.9792k branch_miss=2.24658k bytes=277.673k bytes_per_second=1.70876G/s cache_miss=0.0222944 cache_ref=6.86667 cycles=482.615k cycles_per_byte=1.73807 docs_per_sec=6.60766k/s frequency=3.18896G/s instructions=1.4275M instructions_per_byte=5.14093 instructions_per_cycle=2.95783 items=10 items_per_second=66.0766k/s [BEST: throughput=  1.86 GB/s doc_throughput=  6697 docs/s instructions=     1427496 cycles=      476851 branch_miss=    2092 cache_miss=       0 cache_ref=         2 items=        10 avg_time=    151339 ns]
Creating a source file spanning 10 MB (38 copies of original file)
large_amazon_cellphones<simdjson_dom<UNTHREADED>>/manual_time         7633862 ns      9136874 ns           92 best_branch_miss=153.123k best_bytes_per_sec=1.38761G best_cache_miss=188.666k best_cache_ref=352.598k best_cycles=24.2092M best_cycles_per_byte=2.29505 best_docs_per_sec=131.546 best_frequency=3.18463G best_instructions=64.3612M best_instructions_per_byte=6.10147 best_instructions_per_cycle=2.65854 best_items_per_sec=1.31546k branch_miss=153.413k bytes=10.5485M bytes_per_second=1.2869G/s cache_miss=188.886k cache_ref=352.115k cycles=24.3033M cycles_per_byte=2.30397 docs_per_sec=130.995/s frequency=3.18362G/s instructions=64.3612M instructions_per_byte=6.10147 instructions_per_cycle=2.64825 items=10 items_per_second=1.30995k/s [BEST: throughput=  1.39 GB/s doc_throughput=   131 docs/s instructions=    64361153 cycles=    24209217 branch_miss=  153123 cache_miss=  188666 cache_ref=    352598 items=        10 avg_time=   7633861 ns]
large_amazon_cellphones<simdjson_dom<THREADED>>/manual_time           5534035 ns      6960097 ns          126 best_branch_miss=90.692k best_bytes_per_sec=1.91752G best_cache_miss=132.11k best_cache_ref=220.891k best_cycles=17.3299M best_cycles_per_byte=1.64289 best_docs_per_sec=181.782 best_frequency=3.15028G best_instructions=45.3613M best_instructions_per_byte=4.30027 best_instructions_per_cycle=2.61751 best_items_per_sec=1.81782k branch_miss=90.9179k bytes=10.5485M bytes_per_second=1.7752G/s cache_miss=132.713k cache_ref=221.019k cycles=17.4143M cycles_per_byte=1.65089 docs_per_sec=180.7/s frequency=3.14677G/s instructions=45.3614M instructions_per_byte=4.30028 instructions_per_cycle=2.60484 items=10 items_per_second=1.807k/s [BEST: throughput=  1.92 GB/s doc_throughput=   181 docs/s instructions=    45361299 cycles=    17329948 branch_miss=   90692 cache_miss=  132110 cache_ref=    220891 items=        10 avg_time=   5534035 ns]
large_amazon_cellphones<simdjson_ondemand<UNTHREADED>>/manual_time    6330288 ns      7828806 ns          111 best_branch_miss=127.347k best_bytes_per_sec=1.67395G best_cache_miss=187.072k best_cache_ref=340.63k best_cycles=20.0651M best_cycles_per_byte=1.90218 best_docs_per_sec=158.691 best_frequency=3.18415G best_instructions=54.1787M best_instructions_per_byte=5.13616 best_instructions_per_cycle=2.70015 best_items_per_sec=1.58691k branch_miss=127.326k bytes=10.5485M bytes_per_second=1.55191G/s cache_miss=187.639k cache_ref=340.502k cycles=20.145M cycles_per_byte=1.90976 docs_per_sec=157.971/s frequency=3.18232G/s instructions=54.1787M instructions_per_byte=5.13616 instructions_per_cycle=2.68944 items=10 items_per_second=1.57971k/s [BEST: throughput=  1.67 GB/s doc_throughput=   158 docs/s instructions=    54178653 cycles=    20065051 branch_miss=  127347 cache_miss=  187072 cache_ref=    340630 items=        10 avg_time=   6330287 ns]
large_amazon_cellphones<simdjson_ondemand<THREADED>>/manual_time      4540744 ns      5937250 ns          155 best_branch_miss=65.868k best_bytes_per_sec=2.3357G best_cache_miss=132.7k best_cache_ref=219.111k best_cycles=14.1948M best_cycles_per_byte=1.34567 best_docs_per_sec=221.425 best_frequency=3.14308G best_instructions=35.1781M best_instructions_per_byte=3.33491 best_instructions_per_cycle=2.47824 best_items_per_sec=2.21425k branch_miss=66.3233k bytes=10.5485M bytes_per_second=2.16353G/s cache_miss=132.78k cache_ref=219.234k cycles=14.2515M cycles_per_byte=1.35105 docs_per_sec=220.228/s frequency=3.13858G/s instructions=35.1781M instructions_per_byte=3.3349 instructions_per_cycle=2.46838 items=10 items_per_second=2.20228k/s [BEST: throughput=  2.34 GB/s doc_throughput=   221 docs/s instructions=    35178147 cycles=    14194784 branch_miss=   65868 cache_miss=  132700 cache_ref=    219111 items=        10 avg_time=   4540744 ns]
```