### PR TITLE
This verifies and fixes issue 1834.

### DIFF
--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -47,6 +47,27 @@ inline void json_iterator::rewind() noexcept {
   _depth = 1;
 }
 
+inline bool json_iterator::balanced() const noexcept {
+  token_iterator ti(token);
+  int32_t count{0};
+  ti.set_position( root_position() );
+  while(ti.peek() <= peek_last()) {
+    switch (*ti.return_current_and_advance())
+    {
+    case '[': case '{':
+      count++;
+      break;
+    case ']': case '}':
+      count--;
+      break;
+    default:
+      break;
+    }
+  }
+  return count == 0;
+}
+
+
 // GCC 7 warns when the first line of this function is inlined away into oblivion due to the caller
 // relating depth and parent_depth, which is a desired effect. The warning does not show up if the
 // skip_child() function is not marked inline).

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -251,6 +251,13 @@ public:
    * as if it had just been created.
    */
   inline void rewind() noexcept;
+  /**
+   * This checks whether the {,},[,] are balanced so that the document
+   * ends with proper zero depth. This requires scanning the whole document
+   * and it may be expensive. It is expected that it will be rarely called.
+   * It does not attempt to match { with } and [ with ].
+   */
+  inline bool balanced() const noexcept;
 protected:
   simdjson_really_inline json_iterator(const uint8_t *buf, ondemand::parser *parser) noexcept;
   /// The last token before the end

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -6,6 +6,26 @@ using namespace simdjson;
 namespace error_tests {
   using namespace std;
 
+  bool issue1834() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "[[]"_padded;
+    json.data()[json.size()] = ']';
+    auto doc = parser.iterate(json);
+    size_t cnt{};
+    auto error = doc.count_elements().get(cnt);
+    return error != simdjson::SUCCESS;
+  }
+  bool issue1834_2() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "{\"a\":{}"_padded;
+    json.data()[json.size()] = '}';
+    auto doc = parser.iterate(json);
+    size_t cnt{};
+    auto error = doc.count_fields().get(cnt);
+    return error != simdjson::SUCCESS;
+  }
   bool empty_document_error() {
     TEST_START();
     ondemand::parser parser;
@@ -272,6 +292,8 @@ namespace error_tests {
 
   bool run() {
     return
+           issue1834() &&
+           issue1834_2() &&
 #if SIMDJSON_EXCEPTIONS
            raw_json_string_except() &&
            raw_json_string_except_with_io() &&


### PR DESCRIPTION
Basically, there are pathological cases where on-demand will use the first padding character to close an array or an object. This is unlikely to happen in practice but can lead to failing to recognize that an array or an object is unclosed. 

The fix chosen here is that when the proper condition are recognized, when the root object or root array is first access, we scan all of the structural elements and check that the document is balanced, if not we immediately fail. This full scan is potentially expensive, but it will only be done in the uncommon case that the first padding character is a potential match for the first structural character. That is, if you document starts with '[' and your last character is ']' *and* your first padding character is ']', there is a potential for confusion and we need a full scan.




Fixes: https://github.com/simdjson/simdjson/issues/1834