### PR TITLE
adding msgpack benchmarks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,6 +86,16 @@
         "vector": "cpp",
         "*.ipp": "cpp",
         "__functional_base_03": "cpp",
-        "filesystem": "cpp"
+        "filesystem": "cpp",
+        "*.inc": "cpp",
+        "compare": "cpp",
+        "concepts": "cpp",
+        "variant": "cpp",
+        "__bits": "cpp",
+        "csignal": "cpp",
+        "future": "cpp",
+        "queue": "cpp",
+        "shared_mutex": "cpp",
+        "ranges": "cpp"
     }
 }

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -27,6 +27,7 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 SIMDJSON_POP_DISABLE_WARNINGS
 #include "json2msgpack/simdjson_ondemand.h"
 #include "json2msgpack/rapidjson.h"
+#include "json2msgpack/yyjson.h"
 #include "json2msgpack/sajson.h"
 #include "json2msgpack/nlohmann_json.h"
 

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -25,6 +25,8 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 
 SIMDJSON_POP_DISABLE_WARNINGS
+#include "json2msgpack/simdjson_ondemand.h"
+#include "json2msgpack/rapidjson.h"
 
 #include "amazon_cellphones/simdjson_dom.h"
 #include "amazon_cellphones/simdjson_ondemand.h"

--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -27,6 +27,8 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 SIMDJSON_POP_DISABLE_WARNINGS
 #include "json2msgpack/simdjson_ondemand.h"
 #include "json2msgpack/rapidjson.h"
+#include "json2msgpack/sajson.h"
+#include "json2msgpack/nlohmann_json.h"
 
 #include "amazon_cellphones/simdjson_dom.h"
 #include "amazon_cellphones/simdjson_ondemand.h"

--- a/benchmark/distinct_user_id/rapidjson.h
+++ b/benchmark/distinct_user_id/rapidjson.h
@@ -48,7 +48,7 @@ BENCHMARK_TEMPLATE(distinct_user_id, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, rapidjson_insitu)->UseManualTime();

--- a/benchmark/distinct_user_id/sajson.h
+++ b/benchmark/distinct_user_id/sajson.h
@@ -9,6 +9,8 @@ namespace distinct_user_id {
 struct sajson {
   size_t ast_buffer_size{0};
   size_t *ast_buffer{nullptr};
+  ~sajson() { free(ast_buffer); }
+
   simdjson_really_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field is not a string"; }

--- a/benchmark/find_tweet/rapidjson.h
+++ b/benchmark/find_tweet/rapidjson.h
@@ -42,7 +42,7 @@ BENCHMARK_TEMPLATE(find_tweet, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), find_id, result);
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), find_id, result);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson_insitu)->UseManualTime();

--- a/benchmark/find_tweet/sajson.h
+++ b/benchmark/find_tweet/sajson.h
@@ -11,6 +11,8 @@ struct sajson {
 
   size_t ast_buffer_size{0};
   size_t *ast_buffer{nullptr};
+  ~sajson() { free(ast_buffer); }
+
   simdjson_really_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field is not a string"; }

--- a/benchmark/json2msgpack/json2msgpack.h
+++ b/benchmark/json2msgpack/json2msgpack.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "json_benchmark/file_runner.h"
+
+namespace json2msgpack {
+
+using namespace json_benchmark;
+
+inline bool diff_str(const std::string_view &result,
+                     const std::string_view &reference) {
+  if (result != reference) {
+    std::stringstream str;
+    str << "result incorrect: " << result << " ... reference: " << reference;
+    printf("result 1 : ");
+    for (size_t i = 0; i < result.size(); i++) {
+      printf("%x ", uint32_t(result[i]));
+    }
+    printf("\n");
+    printf("result 2 : ");
+    for (size_t i = 0; i < reference.size(); i++) {
+      printf("%x ", uint32_t(reference[i]));
+    }
+    printf("\n");
+    return false;
+  }
+  return true;
+}
+
+template <typename I> struct runner : public file_runner<I> {
+  std::string_view result;
+  std::unique_ptr<char[]> buffer;
+
+  bool setup(benchmark::State &state) {
+    bool isok = this->load_json(state, TWITTER_JSON);
+    if (isok) {
+      // Let us allocate a sizeable buffer.
+      buffer = std::unique_ptr<char[]>(new char[this->json.size() * 4]);
+    }
+    return isok;
+  }
+
+  bool before_run(benchmark::State &state) {
+    if (!file_runner<I>::before_run(state)) {
+      return false;
+    }
+    // Clear the buffer.
+    ::memset(buffer.get(), 0, this->json.size() * 4);
+    return true;
+  }
+
+  bool run(benchmark::State &) {
+    return this->implementation.run(this->json, buffer.get(), result);
+  }
+
+  template <typename R>
+  bool diff(benchmark::State &state, runner<R> &reference) {
+    diff_str(result, reference.result);
+    return diff_results(state, result, reference.result, diff_flags::NONE);
+  }
+};
+
+struct simdjson_ondemand;
+
+template <typename I>
+simdjson_really_inline static void json2msgpack(benchmark::State &state) {
+  run_json_benchmark<runner<I>, runner<simdjson_ondemand>>(state);
+}
+
+} // namespace json2msgpack

--- a/benchmark/json2msgpack/json2msgpack.h
+++ b/benchmark/json2msgpack/json2msgpack.h
@@ -12,9 +12,6 @@ template <typename I> struct runner : public file_runner<I> {
 
   bool setup(benchmark::State &state) {
     bool isok = this->load_json(state, TWITTER_JSON);
-    //this->json = "[\"a\"]"_padded;
-   // this->original_json = "[\"a\"]"_padded;
-
     if (isok) {
       // Let us allocate a sizeable buffer.
       buffer = std::unique_ptr<char[]>(new char[this->json.size() * 4 + 1024]);

--- a/benchmark/json2msgpack/json2msgpack.h
+++ b/benchmark/json2msgpack/json2msgpack.h
@@ -6,35 +6,18 @@ namespace json2msgpack {
 
 using namespace json_benchmark;
 
-inline bool diff_str(const std::string_view &result,
-                     const std::string_view &reference) {
-  if (result != reference) {
-    std::stringstream str;
-    str << "result incorrect: " << result << " ... reference: " << reference;
-    printf("result 1 : ");
-    for (size_t i = 0; i < result.size(); i++) {
-      printf("%x ", uint32_t(result[i]));
-    }
-    printf("\n");
-    printf("result 2 : ");
-    for (size_t i = 0; i < reference.size(); i++) {
-      printf("%x ", uint32_t(reference[i]));
-    }
-    printf("\n");
-    return false;
-  }
-  return true;
-}
-
 template <typename I> struct runner : public file_runner<I> {
   std::string_view result;
   std::unique_ptr<char[]> buffer;
 
   bool setup(benchmark::State &state) {
     bool isok = this->load_json(state, TWITTER_JSON);
+    //this->json = "\"a\""_padded;
+    //this->original_json = "\"a\""_padded;
+
     if (isok) {
       // Let us allocate a sizeable buffer.
-      buffer = std::unique_ptr<char[]>(new char[this->json.size() * 4]);
+      buffer = std::unique_ptr<char[]>(new char[this->json.size() * 4 + 1024]);
     }
     return isok;
   }
@@ -44,7 +27,7 @@ template <typename I> struct runner : public file_runner<I> {
       return false;
     }
     // Clear the buffer.
-    ::memset(buffer.get(), 0, this->json.size() * 4);
+    ::memset(buffer.get(), 0, this->json.size() * 4 + 1024);
     return true;
   }
 
@@ -54,8 +37,7 @@ template <typename I> struct runner : public file_runner<I> {
 
   template <typename R>
   bool diff(benchmark::State &state, runner<R> &reference) {
-    diff_str(result, reference.result);
-    return diff_results(state, result, reference.result, diff_flags::NONE);
+    return diff_results(state, result.size(), reference.result.size(), diff_flags::NONE);
   }
 };
 

--- a/benchmark/json2msgpack/json2msgpack.h
+++ b/benchmark/json2msgpack/json2msgpack.h
@@ -12,8 +12,8 @@ template <typename I> struct runner : public file_runner<I> {
 
   bool setup(benchmark::State &state) {
     bool isok = this->load_json(state, TWITTER_JSON);
-    //this->json = "\"a\""_padded;
-    //this->original_json = "\"a\""_padded;
+    //this->json = "[\"a\"]"_padded;
+   // this->original_json = "[\"a\"]"_padded;
 
     if (isok) {
       // Let us allocate a sizeable buffer.

--- a/benchmark/json2msgpack/nlohmann_json.h
+++ b/benchmark/json2msgpack/nlohmann_json.h
@@ -1,0 +1,117 @@
+#pragma once
+#if SIMDJSON_EXCEPTIONS
+
+#include "json2msgpack.h"
+
+namespace json2msgpack {
+
+using namespace nlohmann;
+
+struct nlohmann_json2msgpack {
+  inline std::string_view to_msgpack(const simdjson::padded_string &json,
+                                     uint8_t *buf);
+
+private:
+  inline void write_double(const double d) noexcept;
+  inline void write_byte(const uint8_t b) noexcept;
+  inline void write_uint32(const uint32_t w) noexcept;
+  inline void write_string(const std::string& str);
+  inline void recursive_processor(basic_json<> element);
+
+  uint8_t *buff{};
+};
+
+std::string_view nlohmann_json2msgpack::to_msgpack(const simdjson::padded_string &json,
+                             uint8_t *buf) {
+  buff = buf;
+  auto val = nlohmann::json::parse(json.data(), json.data() + json.size());
+  recursive_processor(val);
+  return std::string_view(reinterpret_cast<char *>(buf), size_t(buff - buf));
+}
+
+void nlohmann_json2msgpack::write_double(const double d) noexcept {
+  *buff++ = 0xcb;
+  ::memcpy(buff, &d, sizeof(d));
+  buff += sizeof(d);
+}
+
+void nlohmann_json2msgpack::write_byte(const uint8_t b) noexcept {
+  *buff = b;
+  buff++;
+}
+
+void nlohmann_json2msgpack::write_uint32(const uint32_t w) noexcept {
+  ::memcpy(buff, &w, sizeof(w));
+  buff += sizeof(w);
+}
+
+void nlohmann_json2msgpack::write_string(const std::string & str) {
+  write_byte(0xdb);
+  write_uint32(str.size());
+  ::memcpy(buff, str.data(), str.size());
+  buff += str.size();
+}
+
+void nlohmann_json2msgpack::recursive_processor(basic_json<> element) {
+  switch (element.type()) {
+  case nlohmann::detail::value_t::array: {
+    uint32_t counter = 0;
+    write_byte(0xdd);
+    std::vector<basic_json<>> array(element);
+    write_uint32(array.size());
+    for (auto child : array) {
+       recursive_processor(child);
+    }
+  } break;
+  case nlohmann::detail::value_t::object: {
+    write_byte(0xdf);
+    std::map<std::string,basic_json<>> object(element);
+    write_uint32(object.size());
+    for (auto field : object) {
+      write_string(field.first);
+      recursive_processor(field.second);
+    }
+  } break;
+
+  case nlohmann::detail::value_t::number_integer:
+  case nlohmann::detail::value_t::number_unsigned:
+  case nlohmann::detail::value_t::number_float:
+    write_double(double(element));
+    break;
+  case nlohmann::detail::value_t::string:
+    write_string(std::string(element));
+    break;
+  case nlohmann::detail::value_t::boolean:
+    write_byte(0xc2 + bool(element));
+    break;
+  case nlohmann::detail::value_t::null:
+    write_byte(0xc0);
+    break;
+  case nlohmann::detail::value_t::discarded:
+  case nlohmann::detail::value_t::binary:
+  default:
+    printf("unexpected\n");
+    break;
+  }
+}
+
+struct nlohmann_json {
+  using StringType = std::string_view;
+
+  nlohmann_json2msgpack parser{};
+
+  bool run(simdjson::padded_string &json, char *buffer,
+           std::string_view &result) {
+    result = parser.to_msgpack(json, reinterpret_cast<uint8_t *>(buffer));
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(json2msgpack, nlohmann_json)->UseManualTime();
+
+} // namespace json2msgpack
+
+#endif // SIMDJSON_EXCEPTIONS
+
+
+

--- a/benchmark/json2msgpack/nlohmann_json.h
+++ b/benchmark/json2msgpack/nlohmann_json.h
@@ -1,5 +1,5 @@
 #pragma once
-#if SIMDJSON_EXCEPTIONS
+#ifdef SIMDJSON_COMPETITION_NLOHMANN_JSON
 
 #include "json2msgpack.h"
 
@@ -111,7 +111,7 @@ BENCHMARK_TEMPLATE(json2msgpack, nlohmann_json)->UseManualTime();
 
 } // namespace json2msgpack
 
-#endif // SIMDJSON_EXCEPTIONS
+#endif // SIMDJSON_COMPETITION_NLOHMANN_JSON
 
 
 

--- a/benchmark/json2msgpack/nlohmann_json.h
+++ b/benchmark/json2msgpack/nlohmann_json.h
@@ -47,26 +47,26 @@ void nlohmann_json2msgpack::write_uint32(const uint32_t w) noexcept {
 
 void nlohmann_json2msgpack::write_string(const std::string & str) {
   write_byte(0xdb);
-  write_uint32(str.size());
+  write_uint32(uint32_t(str.size()));
   ::memcpy(buff, str.data(), str.size());
   buff += str.size();
 }
 
-void nlohmann_json2msgpack::recursive_processor(basic_json<> element) {
+void nlohmann_json2msgpack::recursive_processor(json element) {
   switch (element.type()) {
   case nlohmann::detail::value_t::array: {
     uint32_t counter = 0;
     write_byte(0xdd);
-    std::vector<basic_json<>> array(element);
-    write_uint32(array.size());
+    std::vector<json> array = element.get<std::vector<json>>();
+    write_uint32(uint32_t(array.size()));
     for (auto child : array) {
        recursive_processor(child);
     }
   } break;
   case nlohmann::detail::value_t::object: {
     write_byte(0xdf);
-    std::map<std::string,basic_json<>> object(element);
-    write_uint32(object.size());
+    std::map<std::string,json> object = element.get<std::map<std::string,json>>();
+    write_uint32(uint32_t(object.size()));
     for (auto field : object) {
       write_string(field.first);
       recursive_processor(field.second);

--- a/benchmark/json2msgpack/rapidjson.h
+++ b/benchmark/json2msgpack/rapidjson.h
@@ -11,26 +11,28 @@ using namespace rapidjson;
 
 template <int parseflag>
 struct rapidjson2msgpack {
-
-  inline std::string_view to_msgpack(const char *json, uint8_t *buf);
+  inline std::string_view to_msgpack(char *json, uint8_t *buf);
 
 private:
   inline void write_double(const double d) noexcept;
   inline void write_byte(const uint8_t b) noexcept;
   inline void write_uint32(const uint32_t w) noexcept;
-  inline uint8_t *skip_uint32() noexcept;
   inline void write_uint32_at(const uint32_t w, uint8_t *p) noexcept;
-  void write_string(const std::string &str) noexcept;
-  inline void recursive_processor(const rapidjson::Value &v);
+  void write_string(const char * s, size_t length) noexcept;
+  inline void recursive_processor(rapidjson::Value &v);
 
   rapidjson::Document doc{};
   uint8_t *buff{};
 };
 
 template <int parseflag>
-std::string_view rapidjson2msgpack<parseflag>::to_msgpack(const char *json, uint8_t *buf) {
+std::string_view rapidjson2msgpack<parseflag>::to_msgpack(char *json, uint8_t *buf) {
   buff = buf;
-  doc.Parse<parseflag>(json);
+  if(parseflag & kParseInsituFlag) {
+    doc.ParseInsitu<parseflag>(json);
+  } else {
+    doc.Parse<parseflag>(json);
+  }
   recursive_processor(doc);
   return std::string_view(reinterpret_cast<char *>(buf), size_t(buff - buf));
 }
@@ -49,11 +51,11 @@ void rapidjson2msgpack<parseflag>::write_byte(const uint8_t b) noexcept {
 }
 
 template <int parseflag>
-void rapidjson2msgpack<parseflag>::write_string(const std::string &str) noexcept {
+void rapidjson2msgpack<parseflag>::write_string(const char * c, size_t len) noexcept {
   write_byte(0xdb);
-  write_uint32(str.size());
-  ::memcpy(buff, str.data(), str.size());
-  buff += str.size();
+  write_uint32(len);
+  ::memcpy(buff, c, len);
+  buff += len;
 }
 
 template <int parseflag>
@@ -63,41 +65,31 @@ void rapidjson2msgpack<parseflag>::write_uint32(const uint32_t w) noexcept {
 }
 
 template <int parseflag>
-uint8_t *rapidjson2msgpack<parseflag>::skip_uint32() noexcept {
-  uint8_t *ret = buff;
-  buff += sizeof(uint32_t);
-  return ret;
-}
-
-template <int parseflag>
 void rapidjson2msgpack<parseflag>::write_uint32_at(const uint32_t w, uint8_t *p) noexcept {
   ::memcpy(p, &w, sizeof(w));
 }
 
 template <int parseflag>
-void rapidjson2msgpack<parseflag>::recursive_processor(const rapidjson::Value &v) {
+void rapidjson2msgpack<parseflag>::recursive_processor(rapidjson::Value &v) {
   switch (v.GetType()) {
-
   case kArrayType:
     write_byte(0xdd);
     write_uint32(v.Size());
-    for (Value::ConstValueIterator i = v.Begin(); i != v.End(); ++i) {
+    for (Value::ValueIterator i = v.Begin(); i != v.End(); ++i) {
       recursive_processor(*i);
     }
     break;
-
   case kObjectType:
     write_byte(0xdf);
-    write_uint32(v.Size());
-    for (Value::ConstMemberIterator m = v.MemberBegin(); m != v.MemberEnd();
+    write_uint32(v.MemberEnd()-v.MemberBegin());
+    for (Value::MemberIterator m = v.MemberBegin(); m != v.MemberEnd();
          ++m) {
-      write_string(m->name.GetString());
+      write_string(m->name.GetString(), m->name.GetStringLength());
       recursive_processor(m->value);
     }
     break;
-
   case kStringType:
-    write_string(v.GetString());
+    write_string(v.GetString(), v.GetStringLength());
     break;
   case kNumberType:
     write_double(v.GetDouble());
@@ -115,7 +107,7 @@ void rapidjson2msgpack<parseflag>::recursive_processor(const rapidjson::Value &v
 }
 
 template <int parseflag>
-struct rapidjson {
+struct rapidjson_base {
   using StringType = std::string_view;
 
   rapidjson2msgpack<parseflag> parser{};
@@ -129,9 +121,21 @@ struct rapidjson {
   }
 };
 
-using rapidjson_lossless = rapidjson<kParseValidateEncodingFlag|kParseFullPrecisionFlag>;
+
+using rapidjson_lossless = rapidjson_base<kParseValidateEncodingFlag|kParseFullPrecisionFlag>;
 
 BENCHMARK_TEMPLATE(json2msgpack, rapidjson_lossless)->UseManualTime();
+
+
+using rapidjson = rapidjson_base<kParseValidateEncodingFlag>;
+
+BENCHMARK_TEMPLATE(json2msgpack, rapidjson)->UseManualTime();
+
+
+
+using rapidjson_insitu = rapidjson_base<kParseValidateEncodingFlag|kParseInsituFlag>;
+
+BENCHMARK_TEMPLATE(json2msgpack, rapidjson_insitu)->UseManualTime();
 
 } // namespace json2msgpack
 

--- a/benchmark/json2msgpack/rapidjson.h
+++ b/benchmark/json2msgpack/rapidjson.h
@@ -1,7 +1,7 @@
 
 
 #pragma once
-#if SIMDJSON_EXCEPTIONS
+#ifdef SIMDJSON_COMPETITION_RAPIDJSON
 
 #include "json2msgpack.h"
 
@@ -131,12 +131,10 @@ using rapidjson = rapidjson_base<kParseValidateEncodingFlag>;
 
 BENCHMARK_TEMPLATE(json2msgpack, rapidjson)->UseManualTime();
 
-
-
 using rapidjson_insitu = rapidjson_base<kParseValidateEncodingFlag|kParseInsituFlag>;
 
 BENCHMARK_TEMPLATE(json2msgpack, rapidjson_insitu)->UseManualTime();
 
 } // namespace json2msgpack
 
-#endif // SIMDJSON_EXCEPTIONS
+#endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/json2msgpack/rapidjson.h
+++ b/benchmark/json2msgpack/rapidjson.h
@@ -1,0 +1,138 @@
+
+
+#pragma once
+#if SIMDJSON_EXCEPTIONS
+
+#include "json2msgpack.h"
+
+namespace json2msgpack {
+
+using namespace rapidjson;
+
+template <int parseflag>
+struct rapidjson2msgpack {
+
+  inline std::string_view to_msgpack(const char *json, uint8_t *buf);
+
+private:
+  inline void write_double(const double d) noexcept;
+  inline void write_byte(const uint8_t b) noexcept;
+  inline void write_uint32(const uint32_t w) noexcept;
+  inline uint8_t *skip_uint32() noexcept;
+  inline void write_uint32_at(const uint32_t w, uint8_t *p) noexcept;
+  void write_string(const std::string &str) noexcept;
+  inline void recursive_processor(const rapidjson::Value &v);
+
+  rapidjson::Document doc{};
+  uint8_t *buff{};
+};
+
+template <int parseflag>
+std::string_view rapidjson2msgpack<parseflag>::to_msgpack(const char *json, uint8_t *buf) {
+  buff = buf;
+  doc.Parse<parseflag>(json);
+  recursive_processor(doc);
+  return std::string_view(reinterpret_cast<char *>(buf), size_t(buff - buf));
+}
+
+template <int parseflag>
+void rapidjson2msgpack<parseflag>::write_double(const double d) noexcept {
+  *buff++ = 0xcb;
+  ::memcpy(buff, &d, sizeof(d));
+  buff += sizeof(d);
+}
+
+template <int parseflag>
+void rapidjson2msgpack<parseflag>::write_byte(const uint8_t b) noexcept {
+  *buff = b;
+  buff++;
+}
+
+template <int parseflag>
+void rapidjson2msgpack<parseflag>::write_string(const std::string &str) noexcept {
+  write_byte(0xdb);
+  write_uint32(str.size());
+  ::memcpy(buff, str.data(), str.size());
+  buff += str.size();
+}
+
+template <int parseflag>
+void rapidjson2msgpack<parseflag>::write_uint32(const uint32_t w) noexcept {
+  ::memcpy(buff, &w, sizeof(w));
+  buff += sizeof(w);
+}
+
+template <int parseflag>
+uint8_t *rapidjson2msgpack<parseflag>::skip_uint32() noexcept {
+  uint8_t *ret = buff;
+  buff += sizeof(uint32_t);
+  return ret;
+}
+
+template <int parseflag>
+void rapidjson2msgpack<parseflag>::write_uint32_at(const uint32_t w, uint8_t *p) noexcept {
+  ::memcpy(p, &w, sizeof(w));
+}
+
+template <int parseflag>
+void rapidjson2msgpack<parseflag>::recursive_processor(const rapidjson::Value &v) {
+  switch (v.GetType()) {
+
+  case kArrayType:
+    write_byte(0xdd);
+    write_uint32(v.Size());
+    for (Value::ConstValueIterator i = v.Begin(); i != v.End(); ++i) {
+      recursive_processor(*i);
+    }
+    break;
+
+  case kObjectType:
+    write_byte(0xdf);
+    write_uint32(v.Size());
+    for (Value::ConstMemberIterator m = v.MemberBegin(); m != v.MemberEnd();
+         ++m) {
+      write_string(m->name.GetString());
+      recursive_processor(m->value);
+    }
+    break;
+
+  case kStringType:
+    write_string(v.GetString());
+    break;
+  case kNumberType:
+    write_double(v.GetDouble());
+    break;
+  case kFalseType:
+    write_byte(0xc2);
+    break;
+  case kTrueType:
+    write_byte(0xc3);
+    break;
+  case kNullType:
+    write_byte(0xc0);
+    break;
+  }
+}
+
+template <int parseflag>
+struct rapidjson {
+  using StringType = std::string_view;
+
+  rapidjson2msgpack<parseflag> parser{};
+
+  bool run(simdjson::padded_string &json, char *buffer,
+           std::string_view &result) {
+    result =
+        parser.to_msgpack(json.data(), reinterpret_cast<uint8_t *>(buffer));
+
+    return true;
+  }
+};
+
+using rapidjson_lossless = rapidjson<kParseValidateEncodingFlag|kParseFullPrecisionFlag>;
+
+BENCHMARK_TEMPLATE(json2msgpack, rapidjson_lossless)->UseManualTime();
+
+} // namespace json2msgpack
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/json2msgpack/rapidjson.h
+++ b/benchmark/json2msgpack/rapidjson.h
@@ -19,15 +19,15 @@ private:
   inline void write_uint32(const uint32_t w) noexcept;
   inline void write_uint32_at(const uint32_t w, uint8_t *p) noexcept;
   void write_string(const char * s, size_t length) noexcept;
-  inline void recursive_processor(rapidjson::Value &v);
+  inline void recursive_processor(Value &v);
 
-  rapidjson::Document doc{};
   uint8_t *buff{};
 };
 
 template <int parseflag>
 std::string_view rapidjson2msgpack<parseflag>::to_msgpack(char *json, uint8_t *buf) {
   buff = buf;
+  Document doc{};
   if(parseflag & kParseInsituFlag) {
     doc.ParseInsitu<parseflag>(json);
   } else {
@@ -53,7 +53,7 @@ void rapidjson2msgpack<parseflag>::write_byte(const uint8_t b) noexcept {
 template <int parseflag>
 void rapidjson2msgpack<parseflag>::write_string(const char * c, size_t len) noexcept {
   write_byte(0xdb);
-  write_uint32(len);
+  write_uint32(uint32_t(len));
   ::memcpy(buff, c, len);
   buff += len;
 }
@@ -70,7 +70,7 @@ void rapidjson2msgpack<parseflag>::write_uint32_at(const uint32_t w, uint8_t *p)
 }
 
 template <int parseflag>
-void rapidjson2msgpack<parseflag>::recursive_processor(rapidjson::Value &v) {
+void rapidjson2msgpack<parseflag>::recursive_processor(Value &v) {
   switch (v.GetType()) {
   case kArrayType:
     write_byte(0xdd);
@@ -81,7 +81,7 @@ void rapidjson2msgpack<parseflag>::recursive_processor(rapidjson::Value &v) {
     break;
   case kObjectType:
     write_byte(0xdf);
-    write_uint32(v.MemberEnd()-v.MemberBegin());
+    write_uint32(uint32_t(v.MemberEnd()-v.MemberBegin()));
     for (Value::MemberIterator m = v.MemberBegin(); m != v.MemberEnd();
          ++m) {
       write_string(m->name.GetString(), m->name.GetStringLength());

--- a/benchmark/json2msgpack/sajson.h
+++ b/benchmark/json2msgpack/sajson.h
@@ -44,7 +44,7 @@ std::string_view sajson2msgpack::to_msgpack(char *json, size_t size, uint8_t *bu
 
 void sajson2msgpack::write_string(const char * c, size_t len) noexcept {
   write_byte(0xdb);
-  write_uint32(len);
+  write_uint32(uint32_t(len));
   ::memcpy(buff, c, len);
   buff += len;
 }
@@ -80,7 +80,7 @@ void sajson2msgpack::recursive_processor(const sajson::value &node) {
   case TYPE_ARRAY: {
     auto length = node.get_length();
     write_byte(0xdf);
-    write_uint32(length);
+    write_uint32(uint32_t(length));
     for (size_t i = 0; i < length; ++i) {
       recursive_processor(node.get_array_element(i));
     }
@@ -89,7 +89,7 @@ void sajson2msgpack::recursive_processor(const sajson::value &node) {
   case TYPE_OBJECT: {
     auto length = node.get_length();
     write_byte(0xdd);
-    write_uint32(length);
+    write_uint32(uint32_t(length));
     for (auto i = 0u; i < length; ++i) {
       auto s = node.get_object_key(i);
       write_string(s.data(), s.length());

--- a/benchmark/json2msgpack/sajson.h
+++ b/benchmark/json2msgpack/sajson.h
@@ -1,5 +1,5 @@
 #pragma once
-#if SIMDJSON_EXCEPTIONS
+#ifdef SIMDJSON_COMPETITION_SAJSON
 
 #include "json2msgpack.h"
 
@@ -128,4 +128,4 @@ BENCHMARK_TEMPLATE(json2msgpack, sajson)->UseManualTime();
 
 } // namespace json2msgpack
 
-#endif // SIMDJSON_EXCEPTIONS
+#endif // SIMDJSON_COMPETITION_SAJSON

--- a/benchmark/json2msgpack/sajson.h
+++ b/benchmark/json2msgpack/sajson.h
@@ -1,0 +1,131 @@
+#pragma once
+#if SIMDJSON_EXCEPTIONS
+
+#include "json2msgpack.h"
+
+namespace json2msgpack {
+
+using namespace sajson;
+
+
+struct sajson2msgpack {
+  inline std::string_view to_msgpack(char *json, size_t size, uint8_t *buf);
+  virtual ~sajson2msgpack() { free(ast_buffer); }
+
+private:
+  inline void write_double(const double d) noexcept;
+  inline void write_byte(const uint8_t b) noexcept;
+  inline void write_uint32(const uint32_t w) noexcept;
+  inline void write_string(const char * s, size_t length) noexcept;
+  inline void recursive_processor(const sajson::value &v);
+
+  uint8_t *buff{};
+  size_t ast_buffer_size{0};
+  size_t *ast_buffer{nullptr};
+};
+
+
+std::string_view sajson2msgpack::to_msgpack(char *json, size_t size, uint8_t *buf) {
+  buff = buf;
+
+  if (!ast_buffer) {
+    ast_buffer_size = size;
+    ast_buffer = (size_t *)std::malloc(ast_buffer_size * sizeof(size_t));
+  }
+  auto doc = parse(
+      bounded_allocation(ast_buffer, ast_buffer_size),
+      mutable_string_view(size, json)
+  );
+
+  auto root = doc.get_root();
+  recursive_processor(root);
+  return std::string_view(reinterpret_cast<char *>(buf), size_t(buff - buf));
+}
+
+void sajson2msgpack::write_string(const char * c, size_t len) noexcept {
+  write_byte(0xdb);
+  write_uint32(len);
+  ::memcpy(buff, c, len);
+  buff += len;
+}
+
+void sajson2msgpack::write_double(const double d) noexcept {
+  *buff++ = 0xcb;
+  ::memcpy(buff, &d, sizeof(d));
+  buff += sizeof(d);
+}
+
+void sajson2msgpack::write_byte(const uint8_t b) noexcept {
+  *buff = b;
+  buff++;
+}
+
+void sajson2msgpack::write_uint32(const uint32_t w) noexcept {
+  ::memcpy(buff, &w, sizeof(w));
+  buff += sizeof(w);
+}
+
+void sajson2msgpack::recursive_processor(const sajson::value &node) {
+  using namespace sajson;
+  switch (node.get_type()) {
+  case TYPE_NULL:
+    write_byte(0xc0);
+    break;
+  case TYPE_FALSE:
+    write_byte(0xc2);
+    break;
+  case TYPE_TRUE:
+    write_byte(0xc3);
+    break;
+  case TYPE_ARRAY: {
+    auto length = node.get_length();
+    write_byte(0xdf);
+    write_uint32(length);
+    for (size_t i = 0; i < length; ++i) {
+      recursive_processor(node.get_array_element(i));
+    }
+    break;
+  }
+  case TYPE_OBJECT: {
+    auto length = node.get_length();
+    write_byte(0xdd);
+    write_uint32(length);
+    for (auto i = 0u; i < length; ++i) {
+      auto s = node.get_object_key(i);
+      write_string(s.data(), s.length());
+      recursive_processor(node.get_object_value(i));
+    }
+    break;
+  }
+  case TYPE_STRING:
+    write_string(node.as_cstring(), node.get_string_length());
+    break;
+  case TYPE_DOUBLE:
+  case TYPE_INTEGER:
+    write_double(node.get_number_value());
+    break;
+  default:
+    assert(false && "unknown node type");
+  }
+}
+
+
+struct sajson {
+  using StringType = std::string_view;
+
+  sajson2msgpack parser{};
+
+  bool run(simdjson::padded_string &json, char *buffer,
+           std::string_view &result) {
+    result =
+        parser.to_msgpack(json.data(), json.size(), reinterpret_cast<uint8_t *>(buffer));
+
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(json2msgpack, sajson)->UseManualTime();
+
+} // namespace json2msgpack
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/json2msgpack/simdjson_ondemand.h
+++ b/benchmark/json2msgpack/simdjson_ondemand.h
@@ -149,6 +149,8 @@ void simdjson2msgpack::recursive_processor(simdjson::ondemand::value element) {
   case simdjson::ondemand::json_type::null:
     write_byte(0xc0);
     break;
+  defaut:
+    SIMDJSON_UNREACHABLE();
   }
 }
 

--- a/benchmark/json2msgpack/simdjson_ondemand.h
+++ b/benchmark/json2msgpack/simdjson_ondemand.h
@@ -1,0 +1,168 @@
+#pragma once
+#if SIMDJSON_EXCEPTIONS
+
+#include "json2msgpack.h"
+
+namespace json2msgpack {
+
+using namespace simdjson;
+
+/**
+ * @brief Recommended usage:
+ *
+ * simdjson2msgpack parser{};
+ * simdjson::padded_string json = "[1,2]"_padded; // some JSON
+ * uint8_t * buffer = new uint8_t[4*json.size()]; // large buffer
+ *
+ * std::string_view msgpack = parser.to_msgpack(json, buffer);
+ *
+ * You may reuse the simdjson2msgpack instance though you should use
+ * one per thread.
+ */
+struct simdjson2msgpack {
+  /**
+   * @brief Converts the provided JSON into msgpack.
+   *
+   * @param json JSON input
+   * @param buf temporary buffer (must be large enough, with 32 bytes of
+   * padding)
+   * @return std::string_view msgpack output, writting to the temporary buffer
+   */
+  inline std::string_view to_msgpack(const simdjson::padded_string &json,
+                                     uint8_t *buf);
+
+private:
+  simdjson_really_inline void write_double(const double d) noexcept;
+  simdjson_really_inline void write_byte(const uint8_t b) noexcept;
+  simdjson_really_inline void write_uint32(const uint32_t w) noexcept;
+  simdjson_really_inline uint8_t *skip_uint32() noexcept;
+  simdjson_really_inline void write_uint32_at(const uint32_t w,
+                                              uint8_t *p) noexcept;
+  simdjson_really_inline void
+  write_raw_string(simdjson::ondemand::raw_json_string rjs);
+  inline void recursive_processor(simdjson::ondemand::value element);
+
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc;
+  uint8_t *buff{};
+};
+
+std::string_view
+simdjson2msgpack::to_msgpack(const simdjson::padded_string &json,
+                             uint8_t *buf) {
+  buff = buf;
+  ondemand::document doc = parser.iterate(json);
+  if (doc.is_scalar()) {
+    // we have a special case where the JSON document is a single document...
+    switch (doc.type()) {
+    case simdjson::ondemand::json_type::number:
+      write_double(doc.get_double());
+      break;
+    case simdjson::ondemand::json_type::string:
+      write_raw_string(doc.get_raw_json_string());
+      break;
+    case simdjson::ondemand::json_type::boolean:
+      write_byte(0xc2 + doc.get_bool());
+      break;
+    case simdjson::ondemand::json_type::null:
+      write_byte(0xc0);
+      break;
+    case simdjson::ondemand::json_type::array:
+    case simdjson::ondemand::json_type::object:
+    default:
+      // impossible
+      break;
+    }
+  }
+  simdjson::ondemand::value val = doc;
+  recursive_processor(val);
+  return std::string_view(reinterpret_cast<char *>(buf), size_t(buff - buf));
+}
+
+void simdjson2msgpack::write_double(const double d) noexcept {
+  *buff++ = 0xcb;
+  ::memcpy(buff, &d, sizeof(d));
+  buff += sizeof(d);
+}
+void simdjson2msgpack::write_byte(const uint8_t b) noexcept {
+  *buff = b;
+  buff++;
+}
+
+void simdjson2msgpack::write_uint32(const uint32_t w) noexcept {
+  ::memcpy(buff, &w, sizeof(w));
+  buff += sizeof(w);
+}
+
+uint8_t *simdjson2msgpack::skip_uint32() noexcept {
+  uint8_t *ret = buff;
+  buff += sizeof(uint32_t);
+  return ret;
+}
+void simdjson2msgpack::write_uint32_at(const uint32_t w, uint8_t *p) noexcept {
+  ::memcpy(p, &w, sizeof(w));
+}
+
+void simdjson2msgpack::write_raw_string(
+    simdjson::ondemand::raw_json_string in) {
+  write_byte(0xdb);
+  uint8_t *location = skip_uint32();
+  std::string_view v = parser.unescape(in, buff);
+  write_uint32_at(v.size(), location);
+}
+
+void simdjson2msgpack::recursive_processor(simdjson::ondemand::value element) {
+  switch (element.type()) {
+  case simdjson::ondemand::json_type::array: {
+    uint32_t counter = 0;
+    write_byte(0xdd);
+    uint8_t *location = skip_uint32();
+    for (auto child : element.get_array()) {
+      counter++;
+      recursive_processor(child.value());
+    }
+    write_uint32_at(counter, location);
+  } break;
+  case simdjson::ondemand::json_type::object: {
+    uint32_t counter = 0;
+    write_byte(0xdf);
+    uint8_t *location = skip_uint32();
+    for (auto field : element.get_object()) {
+      counter++;
+      write_raw_string(field.key());
+      recursive_processor(field.value());
+    }
+    write_uint32_at(counter, location);
+  } break;
+  case simdjson::ondemand::json_type::number:
+    write_double(element.get_double());
+    break;
+  case simdjson::ondemand::json_type::string:
+    write_raw_string(element.get_raw_json_string());
+    break;
+  case simdjson::ondemand::json_type::boolean:
+    write_byte(0xc2 + element.get_bool());
+    break;
+  case simdjson::ondemand::json_type::null:
+    write_byte(0xc0);
+    break;
+  }
+}
+
+struct simdjson_ondemand {
+  using StringType = std::string_view;
+
+  simdjson2msgpack parser{};
+
+  bool run(simdjson::padded_string &json, char *buffer,
+           std::string_view &result) {
+    result = parser.to_msgpack(json, reinterpret_cast<uint8_t *>(buffer));
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(json2msgpack, simdjson_ondemand)->UseManualTime();
+
+} // namespace json2msgpack
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/json2msgpack/simdjson_ondemand.h
+++ b/benchmark/json2msgpack/simdjson_ondemand.h
@@ -73,9 +73,10 @@ simdjson2msgpack::to_msgpack(const simdjson::padded_string &json,
       // impossible
       break;
     }
+  } else {
+    simdjson::ondemand::value val = doc;
+    recursive_processor(val);
   }
-  simdjson::ondemand::value val = doc;
-  recursive_processor(val);
   return std::string_view(reinterpret_cast<char *>(buf), size_t(buff - buf));
 }
 
@@ -84,6 +85,7 @@ void simdjson2msgpack::write_double(const double d) noexcept {
   ::memcpy(buff, &d, sizeof(d));
   buff += sizeof(d);
 }
+
 void simdjson2msgpack::write_byte(const uint8_t b) noexcept {
   *buff = b;
   buff++;
@@ -99,6 +101,7 @@ uint8_t *simdjson2msgpack::skip_uint32() noexcept {
   buff += sizeof(uint32_t);
   return ret;
 }
+
 void simdjson2msgpack::write_uint32_at(const uint32_t w, uint8_t *p) noexcept {
   ::memcpy(p, &w, sizeof(w));
 }

--- a/benchmark/json2msgpack/yyjson.h
+++ b/benchmark/json2msgpack/yyjson.h
@@ -28,7 +28,7 @@ std::string_view yyjson2msgpack::to_msgpack(yyjson_doc *doc, uint8_t *buf) {
 
 void yyjson2msgpack::write_string(const char *c, size_t len) noexcept {
   write_byte(0xdb);
-  write_uint32(len);
+  write_uint32(uint32_t(len));
   ::memcpy(buff, c, len);
   buff += len;
 }
@@ -59,12 +59,12 @@ void yyjson2msgpack::recursive_processor(yyjson_val *obj) {
     break;
   case YYJSON_TYPE_ARR:
     write_byte(0xdf);
-    write_uint32(yyjson_arr_size(obj));
+    write_uint32(uint32_t(yyjson_arr_size(obj)));
     yyjson_arr_foreach(obj, idx, max, val) { recursive_processor(val); }
    break;
   case YYJSON_TYPE_OBJ:
     write_byte(0xdd);
-    write_uint32(yyjson_obj_size(obj));
+    write_uint32(uint32_t(yyjson_obj_size(obj)));
     yyjson_obj_foreach(obj, idx, max, key, val) {
       write_string(yyjson_get_str(key), yyjson_get_len(key));
       recursive_processor(val);
@@ -79,10 +79,10 @@ void yyjson2msgpack::recursive_processor(yyjson_val *obj) {
   case YYJSON_TYPE_NUM:
     switch (yyjson_get_subtype(obj)) {
     case YYJSON_SUBTYPE_UINT:
-      write_double(yyjson_get_uint(obj));
+      write_double(double(yyjson_get_uint(obj)));
       break;
     case YYJSON_SUBTYPE_SINT:
-      write_double(yyjson_get_sint(obj));
+      write_double(double(yyjson_get_sint(obj)));
       break;
     case YYJSON_SUBTYPE_REAL:
       write_double(yyjson_get_real(obj));

--- a/benchmark/json2msgpack/yyjson.h
+++ b/benchmark/json2msgpack/yyjson.h
@@ -1,10 +1,9 @@
 #pragma once
-#if SIMDJSON_EXCEPTIONS
+#ifdef SIMDJSON_COMPETITION_YYJSON
 
 #include "json2msgpack.h"
 
 namespace json2msgpack {
-
 
 struct yyjson2msgpack {
   inline std::string_view to_msgpack(yyjson_doc *doc, uint8_t *buf);
@@ -120,4 +119,4 @@ BENCHMARK_TEMPLATE(json2msgpack, yyjson_insitu)->UseManualTime();
 
 } // namespace json2msgpack
 
-#endif // SIMDJSON_EXCEPTIONS
+#endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/json2msgpack/yyjson.h
+++ b/benchmark/json2msgpack/yyjson.h
@@ -1,0 +1,123 @@
+#pragma once
+#if SIMDJSON_EXCEPTIONS
+
+#include "json2msgpack.h"
+
+namespace json2msgpack {
+
+
+struct yyjson2msgpack {
+  inline std::string_view to_msgpack(yyjson_doc *doc, uint8_t *buf);
+
+private:
+  inline void write_double(const double d) noexcept;
+  inline void write_byte(const uint8_t b) noexcept;
+  inline void write_uint32(const uint32_t w) noexcept;
+  inline void write_string(const char *s, size_t length) noexcept;
+  inline void recursive_processor(yyjson_val *obj);
+
+  uint8_t *buff{};
+};
+
+std::string_view yyjson2msgpack::to_msgpack(yyjson_doc *doc, uint8_t *buf) {
+  buff = buf;
+  yyjson_val *root = yyjson_doc_get_root(doc);
+  recursive_processor(root);
+  return std::string_view(reinterpret_cast<char *>(buf), size_t(buff - buf));
+}
+
+void yyjson2msgpack::write_string(const char *c, size_t len) noexcept {
+  write_byte(0xdb);
+  write_uint32(len);
+  ::memcpy(buff, c, len);
+  buff += len;
+}
+
+void yyjson2msgpack::write_double(const double d) noexcept {
+  *buff++ = 0xcb;
+  ::memcpy(buff, &d, sizeof(d));
+  buff += sizeof(d);
+}
+
+void yyjson2msgpack::write_byte(const uint8_t b) noexcept {
+  *buff = b;
+  buff++;
+}
+
+void yyjson2msgpack::write_uint32(const uint32_t w) noexcept {
+  ::memcpy(buff, &w, sizeof(w));
+  buff += sizeof(w);
+}
+
+void yyjson2msgpack::recursive_processor(yyjson_val *obj) {
+  size_t idx, max;
+  yyjson_val *val;
+  yyjson_val *key;
+  switch (yyjson_get_type(obj)) {
+  case YYJSON_TYPE_STR:
+    write_string(yyjson_get_str(obj), yyjson_get_len(obj));
+    break;
+  case YYJSON_TYPE_ARR:
+    write_byte(0xdf);
+    write_uint32(yyjson_arr_size(obj));
+    yyjson_arr_foreach(obj, idx, max, val) { recursive_processor(val); }
+   break;
+  case YYJSON_TYPE_OBJ:
+    write_byte(0xdd);
+    write_uint32(yyjson_obj_size(obj));
+    yyjson_obj_foreach(obj, idx, max, key, val) {
+      write_string(yyjson_get_str(key), yyjson_get_len(key));
+      recursive_processor(val);
+    }
+    break;
+  case YYJSON_TYPE_BOOL:
+    write_byte(0xc2 + yyjson_get_bool(obj));
+    break;
+  case YYJSON_TYPE_NULL:
+    write_byte(0xc0);
+    break;
+  case YYJSON_TYPE_NUM:
+    switch (yyjson_get_subtype(obj)) {
+    case YYJSON_SUBTYPE_UINT:
+      write_double(yyjson_get_uint(obj));
+      break;
+    case YYJSON_SUBTYPE_SINT:
+      write_double(yyjson_get_sint(obj));
+      break;
+    case YYJSON_SUBTYPE_REAL:
+      write_double(yyjson_get_real(obj));
+      break;
+    default:
+      SIMDJSON_UNREACHABLE();
+    }
+    break;
+  default:
+    SIMDJSON_UNREACHABLE();
+  }
+}
+
+struct yyjson : yyjson2msgpack {
+  bool run(simdjson::padded_string &json, char *buffer,
+           std::string_view &result) {
+    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+    result = to_msgpack(doc, reinterpret_cast<uint8_t*>(buffer));
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(json2msgpack, yyjson)->UseManualTime();
+
+struct yyjson_insitu : yyjson2msgpack {
+  bool run(simdjson::padded_string &json, char *buffer,
+           std::string_view &result) {
+    yyjson_doc *doc =
+        yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
+    result = to_msgpack(doc, reinterpret_cast<uint8_t*>(buffer));
+    return true;
+  }
+};
+BENCHMARK_TEMPLATE(json2msgpack, yyjson_insitu)->UseManualTime();
+
+} // namespace json2msgpack
+
+#endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/kostya/nlohmann_json_sax.h
+++ b/benchmark/kostya/nlohmann_json_sax.h
@@ -42,7 +42,7 @@ struct nlohmann_json_sax {
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {  // Need this event because coordinate value can be equal to 1
-            buffer[k] = val;
+            buffer[k] = double(val);
             if (k == 2) {
                 result.emplace_back(json_benchmark::point{buffer[0],buffer[1],buffer[2]});
                 k = 0;

--- a/benchmark/kostya/rapidjson.h
+++ b/benchmark/kostya/rapidjson.h
@@ -51,7 +51,7 @@ BENCHMARK_TEMPLATE(kostya, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson_insitu)->UseManualTime();

--- a/benchmark/kostya/sajson.h
+++ b/benchmark/kostya/sajson.h
@@ -11,6 +11,7 @@ struct sajson {
 
   size_t ast_buffer_size{0};
   size_t *ast_buffer{nullptr};
+  ~sajson() { free(ast_buffer); }
 
   simdjson_really_inline double get_double(const ::sajson::value &obj, std::string_view key) {
     using namespace sajson;

--- a/benchmark/large_random/nlohmann_json_sax.h
+++ b/benchmark/large_random/nlohmann_json_sax.h
@@ -34,7 +34,7 @@ struct nlohmann_json_sax {
             return true;
         }
         bool number_unsigned(number_unsigned_t val) override {
-            buffer[k] = val;
+            buffer[k] = double(val);
             if (k == 2) {
                 result.emplace_back(json_benchmark::point{buffer[0],buffer[1],buffer[2]});
                 k = 0;

--- a/benchmark/large_random/rapidjson.h
+++ b/benchmark/large_random/rapidjson.h
@@ -48,7 +48,7 @@ BENCHMARK_TEMPLATE(large_random, rapidjson_lossless)->UseManualTime();
 
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson_insitu)->UseManualTime();

--- a/benchmark/large_random/sajson.h
+++ b/benchmark/large_random/sajson.h
@@ -11,6 +11,7 @@ struct sajson {
 
   size_t ast_buffer_size{0};
   size_t *ast_buffer{nullptr};
+  ~sajson() { free(ast_buffer); }
 
   simdjson_really_inline double get_double(const ::sajson::value &obj, std::string_view key) {
     using namespace sajson;

--- a/benchmark/partial_tweets/rapidjson.h
+++ b/benchmark/partial_tweets/rapidjson.h
@@ -70,7 +70,7 @@ BENCHMARK_TEMPLATE(partial_tweets, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), result);
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, rapidjson_insitu)->UseManualTime();

--- a/benchmark/partial_tweets/sajson.h
+++ b/benchmark/partial_tweets/sajson.h
@@ -11,6 +11,8 @@ struct sajson {
 
   size_t ast_buffer_size{0};
   size_t *ast_buffer{nullptr};
+  ~sajson() { free(ast_buffer); }
+
   simdjson_really_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field is not a string"; }

--- a/benchmark/top_tweet/nlohmann_json_sax.h
+++ b/benchmark/top_tweet/nlohmann_json_sax.h
@@ -48,7 +48,7 @@ struct nlohmann_json_sax {
         }
         bool number_unsigned(number_unsigned_t val) override {
             if (values & key_rt && !(values & found_rt)) {   // retweet_count
-                rt = val;
+                rt = int(val);
                 values &= ~(key_rt);
                 values |= (found_rt);
                 if (rt <= max_rt && rt >= result.retweet_count) {    // Check if current tweet has more retweet than previous top tweet

--- a/benchmark/top_tweet/rapidjson.h
+++ b/benchmark/top_tweet/rapidjson.h
@@ -59,7 +59,7 @@ BENCHMARK_TEMPLATE(top_tweet, rapidjson)->UseManualTime();
 
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
-    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag>(json.data()), max_retweet_count, result);
+    return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), max_retweet_count, result);
   }
 };
 BENCHMARK_TEMPLATE(top_tweet, rapidjson_insitu)->UseManualTime();

--- a/benchmark/top_tweet/sajson.h
+++ b/benchmark/top_tweet/sajson.h
@@ -11,6 +11,7 @@ struct sajson {
 
   size_t ast_buffer_size{0};
   size_t *ast_buffer{nullptr};
+  ~sajson() { free(ast_buffer); }
 
   bool run(simdjson::padded_string &json, int32_t max_retweet_count, top_tweet_result<StringType> &result) {
     if (!ast_buffer) {


### PR DESCRIPTION
Should be self-explanatory: adding benchmarks where we transcode from json to msgpack.

```
$ cmake --build build --target bench_ondemand && ./build/benchmark/bench_ondemand --benchmark_filter="json2msgpack"
[  0%] Built target generated-data
Consolidate compiler generated dependencies of target simdjson
[  0%] Building CXX object CMakeFiles/simdjson.dir/src/simdjson.cpp.o
[ 10%] Linking CXX static library libsimdjson.a
[ 10%] Built target simdjson
Consolidate compiler generated dependencies of target yyjson
[ 20%] Built target yyjson
Consolidate compiler generated dependencies of target benchmark
[ 90%] Built target benchmark
Consolidate compiler generated dependencies of target bench_ondemand
[100%] Building CXX object benchmark/CMakeFiles/bench_ondemand.dir/bench_ondemand.cpp.o
[100%] Linking CXX executable bench_ondemand
[100%] Built target bench_ondemand
2022-06-25T18:50:33+00:00
Running ./build/benchmark/bench_ondemand
Run on (2 X 3501.45 MHz CPU s)
CPU Caches:
  L1 Data 48 KiB (x1)
  L1 Instruction 32 KiB (x1)
  L2 Unified 1280 KiB (x1)
  L3 Unified 55296 KiB (x1)
Load Average: 0.44, 0.11, 0.04
simdjson::dom implementation:      icelake
simdjson::ondemand implementation (stage 1): icelake
simdjson::ondemand implementation (stage 2): fallback
-------------------------------------------------------------------------------------------------------
Benchmark                                             Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------------------
json2msgpack<simdjson_ondemand>/manual_time      238494 ns       353227 ns         2947 best_bytes_per_sec=2.69005G best_docs_per_sec=4.25967k best_items_per_sec=4.25967k bytes=631.515k bytes_per_second=2.46608G/s docs_per_sec=4.19299k/s items=1 items_per_second=4.19299k/s [BEST: throughput=  2.69 GB/s doc_throughput=  4259 docs/s items=         1 avg_time=    238493 ns]
json2msgpack<rapidjson_lossless>/manual_time    1811034 ns      1931976 ns          389 best_bytes_per_sec=361.856M best_docs_per_sec=572.996 best_items_per_sec=572.996 bytes=631.515k bytes_per_second=332.55M/s docs_per_sec=552.171/s items=1 items_per_second=552.171/s [BEST: throughput=  0.36 GB/s doc_throughput=   572 docs/s items=         1 avg_time=   1811033 ns]
json2msgpack<rapidjson>/manual_time             1741477 ns      1862749 ns          404 best_bytes_per_sec=378.209M best_docs_per_sec=598.891 best_items_per_sec=598.891 bytes=631.515k bytes_per_second=345.833M/s docs_per_sec=574.225/s items=1 items_per_second=574.225/s [BEST: throughput=  0.38 GB/s doc_throughput=   598 docs/s items=         1 avg_time=   1741476 ns]
json2msgpack<rapidjson_insitu>/manual_time      1458942 ns      1572830 ns          480 best_bytes_per_sec=443.217M best_docs_per_sec=701.832 best_items_per_sec=701.832 bytes=631.515k bytes_per_second=412.806M/s docs_per_sec=685.428/s items=1 items_per_second=685.428/s [BEST: throughput=  0.44 GB/s doc_throughput=   701 docs/s items=         1 avg_time=   1458941 ns]
json2msgpack<yyjson>/manual_time                 783344 ns       905245 ns          902 best_bytes_per_sec=891.715M best_docs_per_sec=1.41202k best_items_per_sec=1.41202k bytes=631.515k bytes_per_second=768.831M/s docs_per_sec=1.27658k/s items=1 items_per_second=1.27658k/s [BEST: throughput=  0.89 GB/s doc_throughput=  1412 docs/s items=         1 avg_time=    783344 ns]
json2msgpack<yyjson_insitu>/manual_time          581970 ns       697006 ns         1228 best_bytes_per_sec=1.23918G best_docs_per_sec=1.96223k best_items_per_sec=1.96223k bytes=631.515k bytes_per_second=1034.86M/s docs_per_sec=1.7183k/s items=1 items_per_second=1.7183k/s [BEST: throughput=  1.24 GB/s doc_throughput=  1962 docs/s items=         1 avg_time=    581970 ns]
json2msgpack<sajson>/manual_time                 570235 ns       684098 ns         1174 best_bytes_per_sec=1.16855G best_docs_per_sec=1.85039k best_items_per_sec=1.85039k bytes=631.515k bytes_per_second=1056.16M/s docs_per_sec=1.75366k/s items=1 items_per_second=1.75366k/s [BEST: throughput=  1.17 GB/s doc_throughput=  1850 docs/s items=         1 avg_time=    570234 ns]
json2msgpack<nlohmann_json>/manual_time        25432545 ns     25596593 ns           28 best_bytes_per_sec=25.4988M best_docs_per_sec=40.3771 best_items_per_sec=40.3771 bytes=631.515k bytes_per_second=23.6807M/s docs_per_sec=39.3197/s items=1 items_per_second=39.3197/s [BEST: throughput=  0.03 GB/s doc_throughput=    40 docs/s items=         1 avg_time=  25432544 ns]
```