### PR TITLE
Improve build times for debug builds

### DIFF
--- a/benchmark/amazon_cellphones/amazon_cellphones.h
+++ b/benchmark/amazon_cellphones/amazon_cellphones.h
@@ -15,11 +15,11 @@ using namespace json_benchmark;
 struct brand {
     double cumulative_rating;
     uint64_t reviews_count;
-    simdjson_really_inline bool operator==(const brand &other) const {
+    simdjson_inline bool operator==(const brand &other) const {
         return cumulative_rating == other.cumulative_rating &&
             reviews_count == other.reviews_count;
     }
-    simdjson_really_inline bool operator!=(const brand &other) const { return !(*this == other); }
+    simdjson_inline bool operator!=(const brand &other) const { return !(*this == other); }
 };
 
 simdjson_unused static std::ostream &operator<<(std::ostream &o, const brand &b) {
@@ -66,7 +66,7 @@ struct runner : public file_runner<I> {
 template<bool threaded>
 struct simdjson_dom;
 
-template<typename I> simdjson_really_inline static void amazon_cellphones(benchmark::State &state) {
+template<typename I> simdjson_inline static void amazon_cellphones(benchmark::State &state) {
   run_json_benchmark<runner<I>, runner<simdjson_dom<UNTHREADED>>>(state);
 }
 

--- a/benchmark/benchfeatures.cpp
+++ b/benchmark/benchfeatures.cpp
@@ -164,7 +164,7 @@ struct feature_benchmarker {
 
   }
 
-  simdjson_really_inline void run_iterations(size_t iterations, bool stage1_only=false) {
+  simdjson_inline void run_iterations(size_t iterations, bool stage1_only=false) {
     struct7.run_iterations(iterations, stage1_only);
     struct7_miss.run_iterations(iterations, stage1_only);
     struct7_full.run_iterations(iterations, stage1_only);

--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -308,7 +308,7 @@ struct benchmarker {
     return all_stages_without_allocation.iterations;
   }
 
-  simdjson_really_inline void run_iteration(bool stage1_only, bool hotbuffers=false) {
+  simdjson_inline void run_iteration(bool stage1_only, bool hotbuffers=false) {
     // Allocate dom::parser
     collector.start();
     dom::parser parser;
@@ -384,7 +384,7 @@ struct benchmarker {
     loop << all_loop_count;
   }
 
-  simdjson_really_inline void run_iterations(size_t iterations, bool stage1_only, bool hotbuffers=false) {
+  simdjson_inline void run_iterations(size_t iterations, bool stage1_only, bool hotbuffers=false) {
     for (size_t i = 0; i<iterations; i++) {
       run_iteration(stage1_only, hotbuffers);
     }

--- a/benchmark/distinct_user_id/distinct_user_id.h
+++ b/benchmark/distinct_user_id/distinct_user_id.h
@@ -46,7 +46,7 @@ struct runner : public file_runner<I> {
 
 struct simdjson_dom;
 
-template<typename I> simdjson_really_inline static void distinct_user_id(benchmark::State &state) {
+template<typename I> simdjson_inline static void distinct_user_id(benchmark::State &state) {
   run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
 }
 

--- a/benchmark/distinct_user_id/sajson.h
+++ b/benchmark/distinct_user_id/sajson.h
@@ -11,12 +11,12 @@ struct sajson {
   size_t *ast_buffer{nullptr};
   ~sajson() { free(ast_buffer); }
 
-  simdjson_really_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field is not a string"; }
     return { val.as_cstring(), val.get_string_length() };
   }
-  simdjson_really_inline uint64_t get_str_uint64(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline uint64_t get_str_uint64(const ::sajson::value &obj, std::string_view key) {
     // Since sajson only supports 53-bit numbers, and IDs in twitter.json can be > 53 bits, we read the corresponding id_str and parse that.
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field not a string"; }

--- a/benchmark/dom/statisticalmodel.cpp
+++ b/benchmark/dom/statisticalmodel.cpp
@@ -41,7 +41,7 @@ using stat_t = struct stat_s;
 
 
 
-simdjson_really_inline void simdjson_process_atom(stat_t &s,
+simdjson_inline void simdjson_process_atom(stat_t &s,
                                          simdjson::dom::element element) {
   if (element.is<int64_t>()) {
     s.integer_count++;

--- a/benchmark/event_counter.h
+++ b/benchmark/event_counter.h
@@ -156,13 +156,13 @@ struct event_collector {
   }
 #endif
 
-  simdjson_really_inline void start() {
+  simdjson_inline void start() {
 #if defined(__linux)
     linux_events.start();
 #endif
     start_clock = steady_clock::now();
   }
-  simdjson_really_inline event_count& end() {
+  simdjson_inline event_count& end() {
     time_point<steady_clock> end_clock = steady_clock::now();
 #if defined(__linux)
     linux_events.end(count.event_counts);

--- a/benchmark/find_tweet/find_tweet.h
+++ b/benchmark/find_tweet/find_tweet.h
@@ -33,7 +33,7 @@ struct runner : public file_runner<I> {
 
 struct simdjson_dom;
 
-template<typename I> simdjson_really_inline static void find_tweet(benchmark::State &state) {
+template<typename I> simdjson_inline static void find_tweet(benchmark::State &state) {
   run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
 }
 

--- a/benchmark/find_tweet/sajson.h
+++ b/benchmark/find_tweet/sajson.h
@@ -13,12 +13,12 @@ struct sajson {
   size_t *ast_buffer{nullptr};
   ~sajson() { free(ast_buffer); }
 
-  simdjson_really_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field is not a string"; }
     return { val.as_cstring(), val.get_string_length() };
   }
-  simdjson_really_inline uint64_t get_str_uint64(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline uint64_t get_str_uint64(const ::sajson::value &obj, std::string_view key) {
     // Since sajson only supports 53-bit numbers, and IDs in twitter.json can be > 53 bits, we read the corresponding id_str and parse that.
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field not a string"; }

--- a/benchmark/json2msgpack/json2msgpack.h
+++ b/benchmark/json2msgpack/json2msgpack.h
@@ -41,7 +41,7 @@ template <typename I> struct runner : public file_runner<I> {
 struct simdjson_ondemand;
 
 template <typename I>
-simdjson_really_inline static void json2msgpack(benchmark::State &state) {
+simdjson_inline static void json2msgpack(benchmark::State &state) {
   run_json_benchmark<runner<I>, runner<simdjson_ondemand>>(state);
 }
 

--- a/benchmark/json2msgpack/simdjson_ondemand.h
+++ b/benchmark/json2msgpack/simdjson_ondemand.h
@@ -42,13 +42,13 @@ struct simdjson2msgpack {
                                      uint8_t *buf);
 
 private:
-  simdjson_really_inline void write_double(const double d) noexcept;
-  simdjson_really_inline void write_byte(const uint8_t b) noexcept;
-  simdjson_really_inline void write_uint32(const uint32_t w) noexcept;
-  simdjson_really_inline uint8_t *skip_uint32() noexcept;
-  simdjson_really_inline void write_uint32_at(const uint32_t w,
+  simdjson_inline void write_double(const double d) noexcept;
+  simdjson_inline void write_byte(const uint8_t b) noexcept;
+  simdjson_inline void write_uint32(const uint32_t w) noexcept;
+  simdjson_inline uint8_t *skip_uint32() noexcept;
+  simdjson_inline void write_uint32_at(const uint32_t w,
                                               uint8_t *p) noexcept;
-  simdjson_really_inline void
+  simdjson_inline void
   write_raw_string(simdjson::ondemand::raw_json_string rjs);
   inline void recursive_processor(simdjson::ondemand::value element);
 

--- a/benchmark/kostya/kostya.h
+++ b/benchmark/kostya/kostya.h
@@ -79,7 +79,7 @@ static const simdjson::padded_string &get_built_json_array() {
 
 struct simdjson_dom;
 
-template<typename I> simdjson_really_inline static void kostya(benchmark::State &state) {
+template<typename I> simdjson_inline static void kostya(benchmark::State &state) {
   run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
 }
 

--- a/benchmark/kostya/rapidjson.h
+++ b/benchmark/kostya/rapidjson.h
@@ -13,7 +13,7 @@ struct rapidjson_base {
 
   Document doc;
 
-  simdjson_really_inline double get_double(Value &object, std::string_view key) {
+  simdjson_inline double get_double(Value &object, std::string_view key) {
     auto field = object.FindMember(key.data());
     if (field == object.MemberEnd()) { throw "Missing double field"; }
     if (!field->value.IsNumber()) { throw "Field is not double"; }

--- a/benchmark/kostya/sajson.h
+++ b/benchmark/kostya/sajson.h
@@ -13,7 +13,7 @@ struct sajson {
   size_t *ast_buffer{nullptr};
   ~sajson() { free(ast_buffer); }
 
-  simdjson_really_inline double get_double(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline double get_double(const ::sajson::value &obj, std::string_view key) {
     using namespace sajson;
 
     auto val = obj.get_value_of_key({key.data(), key.length()});

--- a/benchmark/kostya/yyjson.h
+++ b/benchmark/kostya/yyjson.h
@@ -9,7 +9,7 @@ namespace kostya {
 struct yyjson_base {
   static constexpr diff_flags DiffFlags = diff_flags::NONE;
 
-  simdjson_really_inline double get_double(yyjson_val *obj, std::string_view key) {
+  simdjson_inline double get_double(yyjson_val *obj, std::string_view key) {
     yyjson_val *val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!val) { throw "missing point field!"; }
     if (yyjson_get_type(val) != YYJSON_TYPE_NUM) { throw "Number is not a type!"; }

--- a/benchmark/large_amazon_cellphones/large_amazon_cellphones.h
+++ b/benchmark/large_amazon_cellphones/large_amazon_cellphones.h
@@ -16,11 +16,11 @@ using namespace json_benchmark;
 struct brand {
     double cumulative_rating;
     uint64_t reviews_count;
-    simdjson_really_inline bool operator==(const brand &other) const {
+    simdjson_inline bool operator==(const brand &other) const {
         return cumulative_rating == other.cumulative_rating &&
             reviews_count == other.reviews_count;
     }
-    simdjson_really_inline bool operator!=(const brand &other) const { return !(*this == other); }
+    simdjson_inline bool operator!=(const brand &other) const { return !(*this == other); }
 };
 
 simdjson_unused static std::ostream &operator<<(std::ostream &o, const brand &b) {
@@ -87,7 +87,7 @@ static const simdjson::padded_string &get_built_json() {
 template<bool threaded>
 struct simdjson_dom;
 
-template<typename I> simdjson_really_inline static void large_amazon_cellphones(benchmark::State &state) {
+template<typename I> simdjson_inline static void large_amazon_cellphones(benchmark::State &state) {
   run_json_benchmark<runner<I>, runner<simdjson_dom<UNTHREADED>>>(state);
 }
 

--- a/benchmark/large_random/rapidjson.h
+++ b/benchmark/large_random/rapidjson.h
@@ -13,7 +13,7 @@ struct rapidjson_base {
 
   Document doc;
 
-  simdjson_really_inline double get_double(Value &object, std::string_view key) {
+  simdjson_inline double get_double(Value &object, std::string_view key) {
     auto field = object.FindMember(key.data());
     if (field == object.MemberEnd()) { throw "Missing double field"; }
     if (!field->value.IsNumber()) { throw "Field is not double"; }

--- a/benchmark/large_random/sajson.h
+++ b/benchmark/large_random/sajson.h
@@ -13,7 +13,7 @@ struct sajson {
   size_t *ast_buffer{nullptr};
   ~sajson() { free(ast_buffer); }
 
-  simdjson_really_inline double get_double(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline double get_double(const ::sajson::value &obj, std::string_view key) {
     using namespace sajson;
 
     auto val = obj.get_value_of_key({key.data(), key.length()});

--- a/benchmark/large_random/yyjson.h
+++ b/benchmark/large_random/yyjson.h
@@ -9,7 +9,7 @@ namespace large_random {
 struct yyjson_base {
   static constexpr diff_flags DiffFlags = diff_flags::NONE;
 
-  simdjson_really_inline double get_double(yyjson_val *obj, std::string_view key) {
+  simdjson_inline double get_double(yyjson_val *obj, std::string_view key) {
     yyjson_val *val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!val) { throw "missing point field!"; }
     if (yyjson_get_type(val) != YYJSON_TYPE_NUM) { throw "Number is not a type!"; }

--- a/benchmark/largerandom/iter.h
+++ b/benchmark/largerandom/iter.h
@@ -10,28 +10,28 @@ using namespace simdjson;
 
 class Iter {
 public:
-  simdjson_really_inline bool Run(const padded_string &json);
+  simdjson_inline bool Run(const padded_string &json);
 
-  simdjson_really_inline const std::vector<my_point> &Result() { return container; }
-  simdjson_really_inline size_t ItemCount() { return container.size(); }
+  simdjson_inline const std::vector<my_point> &Result() { return container; }
+  simdjson_inline size_t ItemCount() { return container.size(); }
 
 private:
   ondemand::parser parser{};
   std::vector<my_point> container{};
 
-  simdjson_really_inline double first_double(ondemand::json_iterator &iter) {
+  simdjson_inline double first_double(ondemand::json_iterator &iter) {
     if (iter.start_object().error() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
     return iter.consume_double();
   }
 
-  simdjson_really_inline double next_double(ondemand::json_iterator &iter) {
+  simdjson_inline double next_double(ondemand::json_iterator &iter) {
     if (!iter.has_next_field() || iter.field_key().error() || iter.field_value()) { throw "Invalid field"; }
     return iter.consume_double();
   }
 
 };
 
-simdjson_really_inline bool Iter::Run(const padded_string &json) {
+simdjson_inline bool Iter::Run(const padded_string &json) {
   container.clear();
 
   auto iter = parser.iterate_raw(json).value();

--- a/benchmark/largerandom/ondemand.h
+++ b/benchmark/largerandom/ondemand.h
@@ -10,16 +10,16 @@ using namespace simdjson;
 
 class OnDemand {
 public:
-  simdjson_really_inline bool Run(const padded_string &json);
-  simdjson_really_inline const std::vector<my_point> &Result() { return container; }
-  simdjson_really_inline size_t ItemCount() { return container.size(); }
+  simdjson_inline bool Run(const padded_string &json);
+  simdjson_inline const std::vector<my_point> &Result() { return container; }
+  simdjson_inline size_t ItemCount() { return container.size(); }
 
 private:
   ondemand::parser parser{};
   std::vector<my_point> container{};
 };
 
-simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
+simdjson_inline bool OnDemand::Run(const padded_string &json) {
   container.clear();
 
   auto doc = parser.iterate(json);

--- a/benchmark/largerandom/sax.h
+++ b/benchmark/largerandom/sax.h
@@ -11,13 +11,13 @@ using namespace simdjson::builtin::stage2;
 
 class Sax {
 public:
-  simdjson_really_inline bool Run(const padded_string &json) noexcept;
+  simdjson_inline bool Run(const padded_string &json) noexcept;
 
-  simdjson_really_inline const std::vector<my_point> &Result() { return container; }
-  simdjson_really_inline size_t ItemCount() { return container.size(); }
+  simdjson_inline const std::vector<my_point> &Result() { return container; }
+  simdjson_inline size_t ItemCount() { return container.size(); }
 
 private:
-  simdjson_really_inline error_code RunNoExcept(const padded_string &json) noexcept;
+  simdjson_inline error_code RunNoExcept(const padded_string &json) noexcept;
   error_code Allocate(size_t new_capacity);
   std::unique_ptr<uint8_t[]> string_buf{};
   size_t capacity{};
@@ -34,21 +34,21 @@ public:
 
   explicit sax_point_reader_visitor(std::vector<my_point> &_points) : points(_points) {}
 
-  simdjson_really_inline error_code visit_object_start(json_iterator &) {
+  simdjson_inline error_code visit_object_start(json_iterator &) {
     idx = 0;
     return SUCCESS;
   }
-  simdjson_really_inline error_code visit_primitive(json_iterator &, const uint8_t *value) {
+  simdjson_inline error_code visit_primitive(json_iterator &, const uint8_t *value) {
     if(idx == GOT_SOMETHING_ELSE) { return simdjson::SUCCESS; }
     return numberparsing::parse_double(value).get(buffer[idx]);
   }
-  simdjson_really_inline error_code visit_object_end(json_iterator &)  {
+  simdjson_inline error_code visit_object_end(json_iterator &)  {
     points.emplace_back(my_point{buffer[0], buffer[1], buffer[2]});
     return SUCCESS;
   }
 
-  simdjson_really_inline error_code visit_document_start(json_iterator &) { return SUCCESS; }
-  simdjson_really_inline error_code visit_key(json_iterator &, const uint8_t * key) {
+  simdjson_inline error_code visit_document_start(json_iterator &) { return SUCCESS; }
+  simdjson_inline error_code visit_key(json_iterator &, const uint8_t * key) {
     switch(key[1]) {
       // Technically, we should check the other characters
       // in the key, but we are cheating to go as fast
@@ -67,13 +67,13 @@ public:
     }
     return SUCCESS;
   }
-  simdjson_really_inline error_code visit_array_start(json_iterator &)  { return SUCCESS; }
-  simdjson_really_inline error_code visit_array_end(json_iterator &) { return SUCCESS; }
-  simdjson_really_inline error_code visit_document_end(json_iterator &)  { return SUCCESS; }
-  simdjson_really_inline error_code visit_empty_array(json_iterator &)  { return SUCCESS; }
-  simdjson_really_inline error_code visit_empty_object(json_iterator &)  { return SUCCESS; }
-  simdjson_really_inline error_code visit_root_primitive(json_iterator &, const uint8_t *)  { return SUCCESS; }
-  simdjson_really_inline error_code increment_count(json_iterator &) { return SUCCESS; }
+  simdjson_inline error_code visit_array_start(json_iterator &)  { return SUCCESS; }
+  simdjson_inline error_code visit_array_end(json_iterator &) { return SUCCESS; }
+  simdjson_inline error_code visit_document_end(json_iterator &)  { return SUCCESS; }
+  simdjson_inline error_code visit_empty_array(json_iterator &)  { return SUCCESS; }
+  simdjson_inline error_code visit_empty_object(json_iterator &)  { return SUCCESS; }
+  simdjson_inline error_code visit_root_primitive(json_iterator &, const uint8_t *)  { return SUCCESS; }
+  simdjson_inline error_code increment_count(json_iterator &) { return SUCCESS; }
 };
 
 // NOTE: this assumes the dom_parser is already allocated

--- a/benchmark/partial_tweets/nlohmann_json.h
+++ b/benchmark/partial_tweets/nlohmann_json.h
@@ -9,7 +9,7 @@ namespace partial_tweets {
 struct nlohmann_json {
   using StringType=std::string;
 
-  simdjson_really_inline uint64_t nullable_int(nlohmann::json value) {
+  simdjson_inline uint64_t nullable_int(nlohmann::json value) {
     if (value.is_null()) { return 0; }
     return value;
   }

--- a/benchmark/partial_tweets/ondemand.h
+++ b/benchmark/partial_tweets/ondemand.h
@@ -17,27 +17,27 @@ public:
       displayed_implementation = true;
     }
   }
-  simdjson_really_inline bool Run(const padded_string &json);
-  simdjson_really_inline const std::vector<tweet> &Result() { return tweets; }
-  simdjson_really_inline size_t ItemCount() { return tweets.size(); }
+  simdjson_inline bool Run(const padded_string &json);
+  simdjson_inline const std::vector<tweet> &Result() { return tweets; }
+  simdjson_inline size_t ItemCount() { return tweets.size(); }
 
 private:
   ondemand::parser parser{};
   std::vector<tweet> tweets{};
 
-  simdjson_really_inline uint64_t nullable_int(ondemand::value value) {
+  simdjson_inline uint64_t nullable_int(ondemand::value value) {
     if (value.is_null()) { return 0; }
     return value;
   }
 
-  simdjson_really_inline twitter_user read_user(ondemand::object user) {
+  simdjson_inline twitter_user read_user(ondemand::object user) {
     return { user.find_field("id"), user.find_field("screen_name") };
   }
 
   static inline bool displayed_implementation = false;
 };
 
-simdjson_really_inline bool OnDemand::Run(const padded_string &json) {
+simdjson_inline bool OnDemand::Run(const padded_string &json) {
   tweets.clear();
 
   // Walk the document, parsing the tweets as we go

--- a/benchmark/partial_tweets/partial_tweets.h
+++ b/benchmark/partial_tweets/partial_tweets.h
@@ -39,7 +39,7 @@ struct runner : public file_runner<I> {
 
 struct simdjson_dom;
 
-template<typename I> simdjson_really_inline static void partial_tweets(benchmark::State &state) {
+template<typename I> simdjson_inline static void partial_tweets(benchmark::State &state) {
   run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
 }
 

--- a/benchmark/partial_tweets/rapidjson.h
+++ b/benchmark/partial_tweets/rapidjson.h
@@ -13,27 +13,27 @@ struct rapidjson_base {
 
   Document doc{};
 
-  simdjson_really_inline std::string_view get_string_view(Value &object, std::string_view key) {
+  simdjson_inline std::string_view get_string_view(Value &object, std::string_view key) {
     // TODO use version that supports passing string length?
     auto field = object.FindMember(key.data());
     if (field == object.MemberEnd()) { throw "Missing object field"; }
     if (!field->value.IsString()) { throw "Field is not a string"; }
     return { field->value.GetString(), field->value.GetStringLength() };
   }
-  simdjson_really_inline uint64_t get_uint64(Value &object, std::string_view key) {
+  simdjson_inline uint64_t get_uint64(Value &object, std::string_view key) {
     auto field = object.FindMember(key.data());
     if (field == object.MemberEnd()) { throw "Missing object field"; }
     if (!field->value.IsUint64()) { throw "Field is not uint64"; }
     return field->value.GetUint64();
   }
-  simdjson_really_inline uint64_t get_nullable_uint64(Value &object, std::string_view key) {
+  simdjson_inline uint64_t get_nullable_uint64(Value &object, std::string_view key) {
     auto field = object.FindMember(key.data());
     if (field == object.MemberEnd()) { throw "Missing nullable uint64 field"; }
     if (field->value.IsNull()) { return 0; }
     if (!field->value.IsUint64()) { throw "Field is not nullable uint64"; }
     return field->value.GetUint64();
   }
-  simdjson_really_inline partial_tweets::twitter_user<std::string_view> get_user(Value &object, std::string_view key) {
+  simdjson_inline partial_tweets::twitter_user<std::string_view> get_user(Value &object, std::string_view key) {
     auto field = object.FindMember(key.data());
     if (field == object.MemberEnd()) { throw "Missing user field"; }
     if (!field->value.IsObject()) { throw "User field is not an object"; }

--- a/benchmark/partial_tweets/sajson.h
+++ b/benchmark/partial_tweets/sajson.h
@@ -13,12 +13,12 @@ struct sajson {
   size_t *ast_buffer{nullptr};
   ~sajson() { free(ast_buffer); }
 
-  simdjson_really_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline std::string_view get_string_view(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field is not a string"; }
     return { val.as_cstring(), val.get_string_length() };
   }
-  simdjson_really_inline uint64_t get_uint52(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline uint64_t get_uint52(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     switch (val.get_type()) {
       case ::sajson::TYPE_INTEGER: {
@@ -30,7 +30,7 @@ struct sajson {
         throw "field not integer";
     }
   }
-  simdjson_really_inline uint64_t get_str_uint64(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline uint64_t get_str_uint64(const ::sajson::value &obj, std::string_view key) {
     // Since sajson only supports 53-bit numbers, and IDs in twitter.json can be > 53 bits, we read the corresponding id_str and parse that.
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field not a string"; }
@@ -40,7 +40,7 @@ struct sajson {
     if (endptr != &str[val.get_string_length()]) { throw "field is a string, but not an integer string"; }
     return result;
   }
-  simdjson_really_inline uint64_t get_nullable_str_uint64(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline uint64_t get_nullable_str_uint64(const ::sajson::value &obj, std::string_view key) {
     auto val = obj.get_value_of_key({key.data(), key.length()});
     if (val.get_type() == ::sajson::TYPE_NULL) { return 0; }
     if (val.get_type() != ::sajson::TYPE_STRING) { throw "field not a string"; }
@@ -50,7 +50,7 @@ struct sajson {
     if (endptr != &str[val.get_string_length()]) { throw "field is a string, but not an integer string"; }
     return result;
   }
-  simdjson_really_inline partial_tweets::twitter_user<std::string_view> get_user(const ::sajson::value &obj, std::string_view key) {
+  simdjson_inline partial_tweets::twitter_user<std::string_view> get_user(const ::sajson::value &obj, std::string_view key) {
     auto user = obj.get_value_of_key({key.data(), key.length()});
     if (user.get_type() != ::sajson::TYPE_OBJECT) { throw "user is not an object"; }
     return { get_str_uint64(user, "id_str"), get_string_view(user, "screen_name") };

--- a/benchmark/partial_tweets/simdjson_dom.h
+++ b/benchmark/partial_tweets/simdjson_dom.h
@@ -13,7 +13,7 @@ struct simdjson_dom {
 
   dom::parser parser{};
 
-  simdjson_really_inline uint64_t nullable_int(dom::element element) {
+  simdjson_inline uint64_t nullable_int(dom::element element) {
     if (element.is_null()) { return 0; }
     return element;
   }

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -13,12 +13,12 @@ struct simdjson_ondemand {
 
   ondemand::parser parser{};
 
-  simdjson_really_inline uint64_t nullable_int(ondemand::value value) {
+  simdjson_inline uint64_t nullable_int(ondemand::value value) {
     if (value.is_null()) { return 0; }
     return value;
   }
 
-  simdjson_really_inline twitter_user<std::string_view> read_user(ondemand::object user) {
+  simdjson_inline twitter_user<std::string_view> read_user(ondemand::object user) {
     return { user.find_field("id"), user.find_field("screen_name") };
   }
 

--- a/benchmark/partial_tweets/tweet.h
+++ b/benchmark/partial_tweets/tweet.h
@@ -32,7 +32,7 @@ struct tweet {
   uint64_t retweet_count{};
   uint64_t favorite_count{};
   template<typename OtherStringType>
-  simdjson_really_inline bool operator==(const tweet<OtherStringType> &other) const {
+  simdjson_inline bool operator==(const tweet<OtherStringType> &other) const {
     return created_at == other.created_at &&
            id == other.id &&
            result == other.result &&
@@ -42,7 +42,7 @@ struct tweet {
            favorite_count == other.favorite_count;
   }
   template<typename OtherStringType>
-  simdjson_really_inline bool operator!=(const tweet<OtherStringType> &other) const { return !(*this == other); }
+  simdjson_inline bool operator!=(const tweet<OtherStringType> &other) const { return !(*this == other); }
 };
 
 template<typename StringType>

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -9,24 +9,24 @@ namespace partial_tweets {
 struct yyjson_base {
   using StringType=std::string_view;
 
-  simdjson_really_inline std::string_view get_string_view(yyjson_val *obj, std::string_view key) {
+  simdjson_inline std::string_view get_string_view(yyjson_val *obj, std::string_view key) {
     auto val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!yyjson_is_str(val)) { throw "field is not uint64 or null!"; }
     return { yyjson_get_str(val), yyjson_get_len(val) };
   }
-  simdjson_really_inline uint64_t get_uint64(yyjson_val *obj, std::string_view key) {
+  simdjson_inline uint64_t get_uint64(yyjson_val *obj, std::string_view key) {
     auto val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!yyjson_is_uint(val)) { throw "field is not uint64 or null!"; }
     return yyjson_get_uint(val);
   }
-  simdjson_really_inline uint64_t get_nullable_uint64(yyjson_val *obj, std::string_view key) {
+  simdjson_inline uint64_t get_nullable_uint64(yyjson_val *obj, std::string_view key) {
     auto val = yyjson_obj_getn(obj, key.data(), key.length());
     if (!yyjson_is_uint(val)) { }
     auto type = yyjson_get_type(val);
     if (type != YYJSON_TYPE_NUM && type != YYJSON_TYPE_NULL ) { throw "field is not uint64 or null!"; }
     return yyjson_get_uint(val);
   }
-  simdjson_really_inline partial_tweets::twitter_user<std::string_view> get_user(yyjson_val *obj, std::string_view key) {
+  simdjson_inline partial_tweets::twitter_user<std::string_view> get_user(yyjson_val *obj, std::string_view key) {
     auto user = yyjson_obj_getn(obj, key.data(), key.length());
     if (!yyjson_is_obj(user)) { throw "missing twitter user field!"; }
     return { get_uint64(user, "id"), get_string_view(user, "screen_name") };

--- a/benchmark/top_tweet/top_tweet.h
+++ b/benchmark/top_tweet/top_tweet.h
@@ -13,13 +13,13 @@ struct top_tweet_result {
   StringType screen_name{};
   StringType text{};
   template<typename OtherStringType>
-  simdjson_really_inline bool operator==(const top_tweet_result<OtherStringType> &other) const {
+  simdjson_inline bool operator==(const top_tweet_result<OtherStringType> &other) const {
     return retweet_count == other.retweet_count &&
            screen_name == other.screen_name &&
            text == other.text;
   }
   template<typename OtherStringType>
-  simdjson_really_inline bool operator!=(const top_tweet_result<OtherStringType> &other) const { return !(*this == other); }
+  simdjson_inline bool operator!=(const top_tweet_result<OtherStringType> &other) const { return !(*this == other); }
 };
 
 template<typename StringType>
@@ -60,7 +60,7 @@ struct runner : public file_runner<I> {
 
 struct simdjson_dom;
 
-template<typename I> simdjson_really_inline static void top_tweet(benchmark::State &state) {
+template<typename I> simdjson_inline static void top_tweet(benchmark::State &state) {
   json_benchmark::run_json_benchmark<runner<I>, runner<simdjson_dom>>(state);
 }
 

--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -9,7 +9,7 @@ namespace {
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
 SIMDJSON_NO_SANITIZE_UNDEFINED
-simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
+simdjson_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long ret;
   // Search the mask data from least significant bit (LSB)
@@ -22,12 +22,12 @@ simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline uint64_t clear_lowest_bit(uint64_t input_num) {
+simdjson_inline uint64_t clear_lowest_bit(uint64_t input_num) {
   return input_num & (input_num-1);
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline int leading_zeroes(uint64_t input_num) {
+simdjson_inline int leading_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)
@@ -42,7 +42,7 @@ simdjson_really_inline int leading_zeroes(uint64_t input_num) {
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline int count_ones(uint64_t input_num) {
+simdjson_inline int count_ones(uint64_t input_num) {
    return vaddv_u8(vcnt_u8(vcreate_u8(input_num)));
 }
 
@@ -61,7 +61,7 @@ simdjson_really_inline int count_ones(uint64_t input_num) {
 #define SIMDJSON_PREFER_REVERSE_BITS 1
 
 /* reverse the bits */
-simdjson_really_inline uint64_t reverse_bits(uint64_t input_num) {
+simdjson_inline uint64_t reverse_bits(uint64_t input_num) {
   uint64_t rev_bits;
   __asm("rbit %0, %1" : "=r"(rev_bits) : "r"(input_num));
   return rev_bits;
@@ -74,13 +74,13 @@ simdjson_really_inline uint64_t reverse_bits(uint64_t input_num) {
  * of such undefined behavior is never used.
  **/
 SIMDJSON_NO_SANITIZE_UNDEFINED
-simdjson_really_inline uint64_t zero_leading_bit(uint64_t rev_bits, int leading_zeroes) {
+simdjson_inline uint64_t zero_leading_bit(uint64_t rev_bits, int leading_zeroes) {
   return rev_bits ^ (uint64_t(0x8000000000000000) >> leading_zeroes);
 }
 
 #endif
 
-simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
+simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   *result = value1 + value2;
   return *result < value1;

--- a/include/simdjson/arm64/bitmask.h
+++ b/include/simdjson/arm64/bitmask.h
@@ -10,7 +10,7 @@ namespace {
 //
 // For example, prefix_xor(00100100) == 00011100
 //
-simdjson_really_inline uint64_t prefix_xor(uint64_t bitmask) {
+simdjson_inline uint64_t prefix_xor(uint64_t bitmask) {
   /////////////
   // We could do this with PMULL, but it is apparently slow.
   //

--- a/include/simdjson/arm64/implementation.h
+++ b/include/simdjson/arm64/implementation.h
@@ -14,7 +14,7 @@ using namespace simdjson::dom;
 
 class implementation final : public simdjson::implementation {
 public:
-  simdjson_really_inline implementation() : simdjson::implementation("arm64", "ARM NEON", internal::instruction_set::NEON) {}
+  simdjson_inline implementation() : simdjson::implementation("arm64", "ARM NEON", internal::instruction_set::NEON) {}
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,

--- a/include/simdjson/arm64/numberparsing.h
+++ b/include/simdjson/arm64/numberparsing.h
@@ -7,7 +7,7 @@ namespace {
 
 // we don't have SSE, so let us use a scalar function
 // credit: https://johnnylee-sde.github.io/Fast-numeric-string-to-int/
-static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
+static simdjson_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   uint64_t val;
   std::memcpy(&val, chars, sizeof(uint64_t));
   val = (val & 0x0F0F0F0F0F0F0F0F) * 2561 >> 8;

--- a/include/simdjson/arm64/simd.h
+++ b/include/simdjson/arm64/simd.h
@@ -28,7 +28,7 @@ namespace {
  * You should not use this function except for compile-time constants:
  * it is not efficient.
  */
-simdjson_really_inline uint8x16_t make_uint8x16_t(uint8_t x1,  uint8_t x2,  uint8_t x3,  uint8_t x4,
+simdjson_inline uint8x16_t make_uint8x16_t(uint8_t x1,  uint8_t x2,  uint8_t x3,  uint8_t x4,
                                          uint8_t x5,  uint8_t x6,  uint8_t x7,  uint8_t x8,
                                          uint8_t x9,  uint8_t x10, uint8_t x11, uint8_t x12,
                                          uint8_t x13, uint8_t x14, uint8_t x15, uint8_t x16) {
@@ -57,7 +57,7 @@ simdjson_really_inline uint8x16_t make_uint8x16_t(uint8_t x1,  uint8_t x2,  uint
   return x;
 }
 
-simdjson_really_inline uint8x8_t make_uint8x8_t(uint8_t x1,  uint8_t x2,  uint8_t x3,  uint8_t x4,
+simdjson_inline uint8x8_t make_uint8x8_t(uint8_t x1,  uint8_t x2,  uint8_t x3,  uint8_t x4,
                                          uint8_t x5,  uint8_t x6,  uint8_t x7,  uint8_t x8) {
   uint8x8_t x{};
   x = vset_lane_u8(x1, x, 0);
@@ -72,7 +72,7 @@ simdjson_really_inline uint8x8_t make_uint8x8_t(uint8_t x1,  uint8_t x2,  uint8_
 }
 
 // We have to do the same work for make_int8x16_t
-simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x3,  int8_t x4,
+simdjson_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x3,  int8_t x4,
                                        int8_t x5,  int8_t x6,  int8_t x7,  int8_t x8,
                                        int8_t x9,  int8_t x10, int8_t x11, int8_t x12,
                                        int8_t x13, int8_t x14, int8_t x15, int8_t x16) {
@@ -118,24 +118,24 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     static const int SIZE = sizeof(value);
 
     // Conversion from/to SIMD register
-    simdjson_really_inline base_u8(const uint8x16_t _value) : value(_value) {}
-    simdjson_really_inline operator const uint8x16_t&() const { return this->value; }
-    simdjson_really_inline operator uint8x16_t&() { return this->value; }
+    simdjson_inline base_u8(const uint8x16_t _value) : value(_value) {}
+    simdjson_inline operator const uint8x16_t&() const { return this->value; }
+    simdjson_inline operator uint8x16_t&() { return this->value; }
 
     // Bit operations
-    simdjson_really_inline simd8<T> operator|(const simd8<T> other) const { return vorrq_u8(*this, other); }
-    simdjson_really_inline simd8<T> operator&(const simd8<T> other) const { return vandq_u8(*this, other); }
-    simdjson_really_inline simd8<T> operator^(const simd8<T> other) const { return veorq_u8(*this, other); }
-    simdjson_really_inline simd8<T> bit_andnot(const simd8<T> other) const { return vbicq_u8(*this, other); }
-    simdjson_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
-    simdjson_really_inline simd8<T>& operator|=(const simd8<T> other) { auto this_cast = static_cast<simd8<T>*>(this); *this_cast = *this_cast | other; return *this_cast; }
-    simdjson_really_inline simd8<T>& operator&=(const simd8<T> other) { auto this_cast = static_cast<simd8<T>*>(this); *this_cast = *this_cast & other; return *this_cast; }
-    simdjson_really_inline simd8<T>& operator^=(const simd8<T> other) { auto this_cast = static_cast<simd8<T>*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
+    simdjson_inline simd8<T> operator|(const simd8<T> other) const { return vorrq_u8(*this, other); }
+    simdjson_inline simd8<T> operator&(const simd8<T> other) const { return vandq_u8(*this, other); }
+    simdjson_inline simd8<T> operator^(const simd8<T> other) const { return veorq_u8(*this, other); }
+    simdjson_inline simd8<T> bit_andnot(const simd8<T> other) const { return vbicq_u8(*this, other); }
+    simdjson_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
+    simdjson_inline simd8<T>& operator|=(const simd8<T> other) { auto this_cast = static_cast<simd8<T>*>(this); *this_cast = *this_cast | other; return *this_cast; }
+    simdjson_inline simd8<T>& operator&=(const simd8<T> other) { auto this_cast = static_cast<simd8<T>*>(this); *this_cast = *this_cast & other; return *this_cast; }
+    simdjson_inline simd8<T>& operator^=(const simd8<T> other) { auto this_cast = static_cast<simd8<T>*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
 
-    friend simdjson_really_inline Mask operator==(const simd8<T> lhs, const simd8<T> rhs) { return vceqq_u8(lhs, rhs); }
+    friend simdjson_inline Mask operator==(const simd8<T> lhs, const simd8<T> rhs) { return vceqq_u8(lhs, rhs); }
 
     template<int N=1>
-    simdjson_really_inline simd8<T> prev(const simd8<T> prev_chunk) const {
+    simdjson_inline simd8<T> prev(const simd8<T> prev_chunk) const {
       return vextq_u8(prev_chunk, *this, 16 - N);
     }
   };
@@ -146,17 +146,17 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     typedef uint16_t bitmask_t;
     typedef uint32_t bitmask2_t;
 
-    static simdjson_really_inline simd8<bool> splat(bool _value) { return vmovq_n_u8(uint8_t(-(!!_value))); }
+    static simdjson_inline simd8<bool> splat(bool _value) { return vmovq_n_u8(uint8_t(-(!!_value))); }
 
-    simdjson_really_inline simd8(const uint8x16_t _value) : base_u8<bool>(_value) {}
+    simdjson_inline simd8(const uint8x16_t _value) : base_u8<bool>(_value) {}
     // False constructor
-    simdjson_really_inline simd8() : simd8(vdupq_n_u8(0)) {}
+    simdjson_inline simd8() : simd8(vdupq_n_u8(0)) {}
     // Splat constructor
-    simdjson_really_inline simd8(bool _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(bool _value) : simd8(splat(_value)) {}
 
     // We return uint32_t instead of uint16_t because that seems to be more efficient for most
     // purposes (cutting it down to uint16_t costs performance in some compilers).
-    simdjson_really_inline uint32_t to_bitmask() const {
+    simdjson_inline uint32_t to_bitmask() const {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
       const uint8x16_t bit_mask =  make_uint8x16_t(0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
                                                    0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80);
@@ -170,26 +170,26 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       tmp = vpaddq_u8(tmp, tmp);
       return vgetq_lane_u16(vreinterpretq_u16_u8(tmp), 0);
     }
-    simdjson_really_inline bool any() const { return vmaxvq_u8(*this) != 0; }
+    simdjson_inline bool any() const { return vmaxvq_u8(*this) != 0; }
   };
 
   // Unsigned bytes
   template<>
   struct simd8<uint8_t>: base_u8<uint8_t> {
-    static simdjson_really_inline uint8x16_t splat(uint8_t _value) { return vmovq_n_u8(_value); }
-    static simdjson_really_inline uint8x16_t zero() { return vdupq_n_u8(0); }
-    static simdjson_really_inline uint8x16_t load(const uint8_t* values) { return vld1q_u8(values); }
+    static simdjson_inline uint8x16_t splat(uint8_t _value) { return vmovq_n_u8(_value); }
+    static simdjson_inline uint8x16_t zero() { return vdupq_n_u8(0); }
+    static simdjson_inline uint8x16_t load(const uint8_t* values) { return vld1q_u8(values); }
 
-    simdjson_really_inline simd8(const uint8x16_t _value) : base_u8<uint8_t>(_value) {}
+    simdjson_inline simd8(const uint8x16_t _value) : base_u8<uint8_t>(_value) {}
     // Zero constructor
-    simdjson_really_inline simd8() : simd8(zero()) {}
+    simdjson_inline simd8() : simd8(zero()) {}
     // Array constructor
-    simdjson_really_inline simd8(const uint8_t values[16]) : simd8(load(values)) {}
+    simdjson_inline simd8(const uint8_t values[16]) : simd8(load(values)) {}
     // Splat constructor
-    simdjson_really_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
     // Member-by-member initialization
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15
     ) : simd8(make_uint8x16_t(
@@ -197,7 +197,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       v8, v9, v10,v11,v12,v13,v14,v15
     )) {}
 #else
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15
     ) : simd8(uint8x16_t{
@@ -207,7 +207,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
 #endif
 
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<uint8_t> repeat_16(
+    simdjson_inline static simd8<uint8_t> repeat_16(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15
     ) {
@@ -218,44 +218,44 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     }
 
     // Store to array
-    simdjson_really_inline void store(uint8_t dst[16]) const { return vst1q_u8(dst, *this); }
+    simdjson_inline void store(uint8_t dst[16]) const { return vst1q_u8(dst, *this); }
 
     // Saturated math
-    simdjson_really_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return vqaddq_u8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return vqsubq_u8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return vqaddq_u8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return vqsubq_u8(*this, other); }
 
     // Addition/subtraction are the same for signed and unsigned
-    simdjson_really_inline simd8<uint8_t> operator+(const simd8<uint8_t> other) const { return vaddq_u8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> operator-(const simd8<uint8_t> other) const { return vsubq_u8(*this, other); }
-    simdjson_really_inline simd8<uint8_t>& operator+=(const simd8<uint8_t> other) { *this = *this + other; return *this; }
-    simdjson_really_inline simd8<uint8_t>& operator-=(const simd8<uint8_t> other) { *this = *this - other; return *this; }
+    simdjson_inline simd8<uint8_t> operator+(const simd8<uint8_t> other) const { return vaddq_u8(*this, other); }
+    simdjson_inline simd8<uint8_t> operator-(const simd8<uint8_t> other) const { return vsubq_u8(*this, other); }
+    simdjson_inline simd8<uint8_t>& operator+=(const simd8<uint8_t> other) { *this = *this + other; return *this; }
+    simdjson_inline simd8<uint8_t>& operator-=(const simd8<uint8_t> other) { *this = *this - other; return *this; }
 
     // Order-specific operations
-    simdjson_really_inline uint8_t max_val() const { return vmaxvq_u8(*this); }
-    simdjson_really_inline uint8_t min_val() const { return vminvq_u8(*this); }
-    simdjson_really_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return vmaxq_u8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return vminq_u8(*this, other); }
-    simdjson_really_inline simd8<bool> operator<=(const simd8<uint8_t> other) const { return vcleq_u8(*this, other); }
-    simdjson_really_inline simd8<bool> operator>=(const simd8<uint8_t> other) const { return vcgeq_u8(*this, other); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return vcltq_u8(*this, other); }
-    simdjson_really_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return vcgtq_u8(*this, other); }
+    simdjson_inline uint8_t max_val() const { return vmaxvq_u8(*this); }
+    simdjson_inline uint8_t min_val() const { return vminvq_u8(*this); }
+    simdjson_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return vmaxq_u8(*this, other); }
+    simdjson_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return vminq_u8(*this, other); }
+    simdjson_inline simd8<bool> operator<=(const simd8<uint8_t> other) const { return vcleq_u8(*this, other); }
+    simdjson_inline simd8<bool> operator>=(const simd8<uint8_t> other) const { return vcgeq_u8(*this, other); }
+    simdjson_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return vcltq_u8(*this, other); }
+    simdjson_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return vcgtq_u8(*this, other); }
     // Same as >, but instead of guaranteeing all 1's == true, false = 0 and true = nonzero. For ARM, returns all 1's.
-    simdjson_really_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return simd8<uint8_t>(*this > other); }
+    simdjson_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return simd8<uint8_t>(*this > other); }
     // Same as <, but instead of guaranteeing all 1's == true, false = 0 and true = nonzero. For ARM, returns all 1's.
-    simdjson_really_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return simd8<uint8_t>(*this < other); }
+    simdjson_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return simd8<uint8_t>(*this < other); }
 
     // Bit-specific operations
-    simdjson_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return vtstq_u8(*this, bits); }
-    simdjson_really_inline bool any_bits_set_anywhere() const { return this->max_val() != 0; }
-    simdjson_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return (*this & bits).any_bits_set_anywhere(); }
+    simdjson_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return vtstq_u8(*this, bits); }
+    simdjson_inline bool any_bits_set_anywhere() const { return this->max_val() != 0; }
+    simdjson_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return (*this & bits).any_bits_set_anywhere(); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shr() const { return vshrq_n_u8(*this, N); }
+    simdjson_inline simd8<uint8_t> shr() const { return vshrq_n_u8(*this, N); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shl() const { return vshlq_n_u8(*this, N); }
+    simdjson_inline simd8<uint8_t> shl() const { return vshlq_n_u8(*this, N); }
 
     // Perform a lookup assuming the value is between 0 and 16 (undefined behavior for out of range values)
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
+    simdjson_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
       return lookup_table.apply_lookup_16_to(*this);
     }
 
@@ -268,7 +268,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     // signature simd8<L> compress(uint16_t mask) would be
     // sensible, but the AVX ISA makes this kind of approach difficult.
     template<typename L>
-    simdjson_really_inline void compress(uint16_t mask, L * output) const {
+    simdjson_inline void compress(uint16_t mask, L * output) const {
       using internal::thintable_epi8;
       using internal::BitsSetTable256mul2;
       using internal::pshufb_combine_table;
@@ -305,7 +305,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     // Copies all bytes corresponding to a 0 in the low half of the mask (interpreted as a
     // bitset) to output1, then those corresponding to a 0 in the high half to output2.
     template<typename L>
-    simdjson_really_inline void compress_halves(uint16_t mask, L *output1, L *output2) const {
+    simdjson_inline void compress_halves(uint16_t mask, L *output1, L *output2) const {
       using internal::thintable_epi8;
       uint8_t mask1 = uint8_t(mask); // least significant 8 bits
       uint8_t mask2 = uint8_t(mask >> 8); // most significant 8 bits
@@ -324,7 +324,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     }
 
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(
+    simdjson_inline simd8<L> lookup_16(
         L replace0,  L replace1,  L replace2,  L replace3,
         L replace4,  L replace5,  L replace6,  L replace7,
         L replace8,  L replace9,  L replace10, L replace11,
@@ -338,7 +338,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     }
 
     template<typename T>
-    simdjson_really_inline simd8<uint8_t> apply_lookup_16_to(const simd8<T> original) {
+    simdjson_inline simd8<uint8_t> apply_lookup_16_to(const simd8<T> original) {
       return vqtbl1q_u8(*this, simd8<uint8_t>(original));
     }
   };
@@ -348,24 +348,24 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
   struct simd8<int8_t> {
     int8x16_t value;
 
-    static simdjson_really_inline simd8<int8_t> splat(int8_t _value) { return vmovq_n_s8(_value); }
-    static simdjson_really_inline simd8<int8_t> zero() { return vdupq_n_s8(0); }
-    static simdjson_really_inline simd8<int8_t> load(const int8_t values[16]) { return vld1q_s8(values); }
+    static simdjson_inline simd8<int8_t> splat(int8_t _value) { return vmovq_n_s8(_value); }
+    static simdjson_inline simd8<int8_t> zero() { return vdupq_n_s8(0); }
+    static simdjson_inline simd8<int8_t> load(const int8_t values[16]) { return vld1q_s8(values); }
 
     // Conversion from/to SIMD register
-    simdjson_really_inline simd8(const int8x16_t _value) : value{_value} {}
-    simdjson_really_inline operator const int8x16_t&() const { return this->value; }
-    simdjson_really_inline operator int8x16_t&() { return this->value; }
+    simdjson_inline simd8(const int8x16_t _value) : value{_value} {}
+    simdjson_inline operator const int8x16_t&() const { return this->value; }
+    simdjson_inline operator int8x16_t&() { return this->value; }
 
     // Zero constructor
-    simdjson_really_inline simd8() : simd8(zero()) {}
+    simdjson_inline simd8() : simd8(zero()) {}
     // Splat constructor
-    simdjson_really_inline simd8(int8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(int8_t _value) : simd8(splat(_value)) {}
     // Array constructor
-    simdjson_really_inline simd8(const int8_t* values) : simd8(load(values)) {}
+    simdjson_inline simd8(const int8_t* values) : simd8(load(values)) {}
     // Member-by-member initialization
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3, int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15
     ) : simd8(make_int8x16_t(
@@ -373,7 +373,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       v8, v9, v10,v11,v12,v13,v14,v15
     )) {}
 #else
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3, int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15
     ) : simd8(int8x16_t{
@@ -382,7 +382,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     }) {}
 #endif
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<int8_t> repeat_16(
+    simdjson_inline static simd8<int8_t> repeat_16(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3,  int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15
     ) {
@@ -393,7 +393,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     }
 
     // Store to array
-    simdjson_really_inline void store(int8_t dst[16]) const { return vst1q_s8(dst, *this); }
+    simdjson_inline void store(int8_t dst[16]) const { return vst1q_s8(dst, *this); }
 
     // Explicit conversion to/from unsigned
     //
@@ -401,35 +401,35 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     // In theory, we could check this occurrence with std::same_as and std::enabled_if but it is C++14
     // and relatively ugly and hard to read.
 #ifndef SIMDJSON_REGULAR_VISUAL_STUDIO
-    simdjson_really_inline explicit simd8(const uint8x16_t other): simd8(vreinterpretq_s8_u8(other)) {}
+    simdjson_inline explicit simd8(const uint8x16_t other): simd8(vreinterpretq_s8_u8(other)) {}
 #endif
-    simdjson_really_inline explicit operator simd8<uint8_t>() const { return vreinterpretq_u8_s8(this->value); }
+    simdjson_inline explicit operator simd8<uint8_t>() const { return vreinterpretq_u8_s8(this->value); }
 
     // Math
-    simdjson_really_inline simd8<int8_t> operator+(const simd8<int8_t> other) const { return vaddq_s8(*this, other); }
-    simdjson_really_inline simd8<int8_t> operator-(const simd8<int8_t> other) const { return vsubq_s8(*this, other); }
-    simdjson_really_inline simd8<int8_t>& operator+=(const simd8<int8_t> other) { *this = *this + other; return *this; }
-    simdjson_really_inline simd8<int8_t>& operator-=(const simd8<int8_t> other) { *this = *this - other; return *this; }
+    simdjson_inline simd8<int8_t> operator+(const simd8<int8_t> other) const { return vaddq_s8(*this, other); }
+    simdjson_inline simd8<int8_t> operator-(const simd8<int8_t> other) const { return vsubq_s8(*this, other); }
+    simdjson_inline simd8<int8_t>& operator+=(const simd8<int8_t> other) { *this = *this + other; return *this; }
+    simdjson_inline simd8<int8_t>& operator-=(const simd8<int8_t> other) { *this = *this - other; return *this; }
 
     // Order-sensitive comparisons
-    simdjson_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return vmaxq_s8(*this, other); }
-    simdjson_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return vminq_s8(*this, other); }
-    simdjson_really_inline simd8<bool> operator>(const simd8<int8_t> other) const { return vcgtq_s8(*this, other); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<int8_t> other) const { return vcltq_s8(*this, other); }
-    simdjson_really_inline simd8<bool> operator==(const simd8<int8_t> other) const { return vceqq_s8(*this, other); }
+    simdjson_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return vmaxq_s8(*this, other); }
+    simdjson_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return vminq_s8(*this, other); }
+    simdjson_inline simd8<bool> operator>(const simd8<int8_t> other) const { return vcgtq_s8(*this, other); }
+    simdjson_inline simd8<bool> operator<(const simd8<int8_t> other) const { return vcltq_s8(*this, other); }
+    simdjson_inline simd8<bool> operator==(const simd8<int8_t> other) const { return vceqq_s8(*this, other); }
 
     template<int N=1>
-    simdjson_really_inline simd8<int8_t> prev(const simd8<int8_t> prev_chunk) const {
+    simdjson_inline simd8<int8_t> prev(const simd8<int8_t> prev_chunk) const {
       return vextq_s8(prev_chunk, *this, 16 - N);
     }
 
     // Perform a lookup assuming no value is larger than 16
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
+    simdjson_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
       return lookup_table.apply_lookup_16_to(*this);
     }
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(
+    simdjson_inline simd8<L> lookup_16(
         L replace0,  L replace1,  L replace2,  L replace3,
         L replace4,  L replace5,  L replace6,  L replace7,
         L replace8,  L replace9,  L replace10, L replace11,
@@ -443,7 +443,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     }
 
     template<typename T>
-    simdjson_really_inline simd8<int8_t> apply_lookup_16_to(const simd8<T> original) {
+    simdjson_inline simd8<int8_t> apply_lookup_16_to(const simd8<T> original) {
       return vqtbl1q_s8(*this, simd8<uint8_t>(original));
     }
   };
@@ -458,22 +458,22 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
     simd8x64<T>& operator=(const simd8<T>& other) = delete; // no assignment allowed
     simd8x64() = delete; // no default constructor allowed
 
-    simdjson_really_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1, const simd8<T> chunk2, const simd8<T> chunk3) : chunks{chunk0, chunk1, chunk2, chunk3} {}
-    simdjson_really_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+16), simd8<T>::load(ptr+32), simd8<T>::load(ptr+48)} {}
+    simdjson_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1, const simd8<T> chunk2, const simd8<T> chunk3) : chunks{chunk0, chunk1, chunk2, chunk3} {}
+    simdjson_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+16), simd8<T>::load(ptr+32), simd8<T>::load(ptr+48)} {}
 
-    simdjson_really_inline void store(T ptr[64]) const {
+    simdjson_inline void store(T ptr[64]) const {
       this->chunks[0].store(ptr+sizeof(simd8<T>)*0);
       this->chunks[1].store(ptr+sizeof(simd8<T>)*1);
       this->chunks[2].store(ptr+sizeof(simd8<T>)*2);
       this->chunks[3].store(ptr+sizeof(simd8<T>)*3);
     }
 
-    simdjson_really_inline simd8<T> reduce_or() const {
+    simdjson_inline simd8<T> reduce_or() const {
       return (this->chunks[0] | this->chunks[1]) | (this->chunks[2] | this->chunks[3]);
     }
 
 
-    simdjson_really_inline uint64_t compress(uint64_t mask, T * output) const {
+    simdjson_inline uint64_t compress(uint64_t mask, T * output) const {
       uint64_t popcounts = vget_lane_u64(vreinterpret_u64_u8(vcnt_u8(vcreate_u8(~mask))), 0);
       // compute the prefix sum of the popcounts of each byte
       uint64_t offsets = popcounts * 0x0101010101010101;
@@ -484,7 +484,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       return offsets >> 56;
     }
 
-    simdjson_really_inline uint64_t to_bitmask() const {
+    simdjson_inline uint64_t to_bitmask() const {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
       const uint8x16_t bit_mask = make_uint8x16_t(
         0x01, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
@@ -504,7 +504,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       return vgetq_lane_u64(vreinterpretq_u64_u8(sum0), 0);
     }
 
-    simdjson_really_inline uint64_t eq(const T m) const {
+    simdjson_inline uint64_t eq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(
         this->chunks[0] == mask,
@@ -514,7 +514,7 @@ simdjson_really_inline int8x16_t make_int8x16_t(int8_t x1,  int8_t x2,  int8_t x
       ).to_bitmask();
     }
 
-    simdjson_really_inline uint64_t lteq(const T m) const {
+    simdjson_inline uint64_t lteq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(
         this->chunks[0] <= mask,

--- a/include/simdjson/arm64/stringparsing.h
+++ b/include/simdjson/arm64/stringparsing.h
@@ -15,18 +15,18 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_really_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_really_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_really_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_really_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_really_inline int backslash_index() { return trailing_zeroes(bs_bits); }
+  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
+  simdjson_inline bool has_backslash() { return bs_bits != 0; }
+  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
+  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
 
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote
 
-simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
+simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // this can read up to 31 bytes beyond the buffer size, but we require
   // SIMDJSON_PADDING of padding
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -168,6 +168,8 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 
 #endif // MSC_VER
 
+#define simdjson_inline simdjson_really_inline
+
 #if defined(SIMDJSON_VISUAL_STUDIO)
     /**
      * Windows users need to do some extra work when building

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -168,7 +168,17 @@ constexpr size_t DEFAULT_MAX_DEPTH = 1024;
 
 #endif // MSC_VER
 
-#define simdjson_inline simdjson_really_inline
+#if defined(simdjson_inline)
+  // Prefer the user's definition of simdjson_inline; don't define it ourselves.
+#elif defined(__GNUC__) && !defined(__OPTIMIZE__)
+  // If optimizations are disabled, forcing inlining can lead to significant
+  // code bloat and high compile times. Don't use simdjson_really_inline for
+  // unoptimized builds.
+  #define simdjson_inline inline
+#else
+  // Force inlining for most simdjson functions.
+  #define simdjson_inline simdjson_really_inline
+#endif
 
 #if defined(SIMDJSON_VISUAL_STUDIO)
     /**

--- a/include/simdjson/dom/array-inl.h
+++ b/include/simdjson/dom/array-inl.h
@@ -12,11 +12,11 @@ namespace simdjson {
 //
 // simdjson_result<dom::array> inline implementation
 //
-simdjson_really_inline simdjson_result<dom::array>::simdjson_result() noexcept
+simdjson_inline simdjson_result<dom::array>::simdjson_result() noexcept
     : internal::simdjson_result_base<dom::array>() {}
-simdjson_really_inline simdjson_result<dom::array>::simdjson_result(dom::array value) noexcept
+simdjson_inline simdjson_result<dom::array>::simdjson_result(dom::array value) noexcept
     : internal::simdjson_result_base<dom::array>(std::forward<dom::array>(value)) {}
-simdjson_really_inline simdjson_result<dom::array>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<dom::array>::simdjson_result(error_code error) noexcept
     : internal::simdjson_result_base<dom::array>(error) {}
 
 #if SIMDJSON_EXCEPTIONS
@@ -50,8 +50,8 @@ namespace dom {
 //
 // array inline implementation
 //
-simdjson_really_inline array::array() noexcept : tape{} {}
-simdjson_really_inline array::array(const internal::tape_ref &_tape) noexcept : tape{_tape} {}
+simdjson_inline array::array() noexcept : tape{} {}
+simdjson_inline array::array(const internal::tape_ref &_tape) noexcept : tape{_tape} {}
 inline array::iterator array::begin() const noexcept {
   return internal::tape_ref(tape.doc, tape.json_index + 1);
 }
@@ -116,7 +116,7 @@ inline simdjson_result<element> array::at(size_t index) const noexcept {
 //
 // array::iterator inline implementation
 //
-simdjson_really_inline array::iterator::iterator(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
+simdjson_inline array::iterator::iterator(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 inline element array::iterator::operator*() const noexcept {
   return element(tape);
 }

--- a/include/simdjson/dom/array.h
+++ b/include/simdjson/dom/array.h
@@ -22,7 +22,7 @@ class element;
 class array {
 public:
   /** Create a new, invalid array */
-  simdjson_really_inline array() noexcept;
+  simdjson_inline array() noexcept;
 
   class iterator {
   public:
@@ -62,7 +62,7 @@ public:
     iterator(const iterator&) noexcept = default;
     iterator& operator=(const iterator&) noexcept = default;
   private:
-    simdjson_really_inline iterator(const internal::tape_ref &tape) noexcept;
+    simdjson_inline iterator(const internal::tape_ref &tape) noexcept;
     internal::tape_ref tape;
     friend class array;
   };
@@ -133,7 +133,7 @@ public:
   inline simdjson_result<element> at(size_t index) const noexcept;
 
 private:
-  simdjson_really_inline array(const internal::tape_ref &tape) noexcept;
+  simdjson_inline array(const internal::tape_ref &tape) noexcept;
   internal::tape_ref tape;
   friend class element;
   friend struct simdjson_result<element>;
@@ -148,9 +148,9 @@ private:
 template<>
 struct simdjson_result<dom::array> : public internal::simdjson_result_base<dom::array> {
 public:
-  simdjson_really_inline simdjson_result() noexcept; ///< @private
-  simdjson_really_inline simdjson_result(dom::array value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept; ///< @private
+  simdjson_inline simdjson_result(dom::array value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
 
   inline simdjson_result<dom::element> at_pointer(std::string_view json_pointer) const noexcept;
   inline simdjson_result<dom::element> at(size_t index) const noexcept;

--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -81,7 +81,7 @@ inline void stage1_worker::run(document_stream * ds, dom::parser * stage1, size_
 }
 #endif
 
-simdjson_really_inline document_stream::document_stream(
+simdjson_inline document_stream::document_stream(
   dom::parser &_parser,
   const uint8_t *_buf,
   size_t _len,
@@ -103,7 +103,7 @@ simdjson_really_inline document_stream::document_stream(
 #endif
 }
 
-simdjson_really_inline document_stream::document_stream() noexcept
+simdjson_inline document_stream::document_stream() noexcept
   : parser{nullptr},
     buf{nullptr},
     len{0},
@@ -115,31 +115,31 @@ simdjson_really_inline document_stream::document_stream() noexcept
 {
 }
 
-simdjson_really_inline document_stream::~document_stream() noexcept {
+simdjson_inline document_stream::~document_stream() noexcept {
 #ifdef SIMDJSON_THREADS_ENABLED
   worker.reset();
 #endif
 }
 
-simdjson_really_inline document_stream::iterator::iterator() noexcept
+simdjson_inline document_stream::iterator::iterator() noexcept
   : stream{nullptr}, finished{true} {
 }
 
-simdjson_really_inline document_stream::iterator document_stream::begin() noexcept {
+simdjson_inline document_stream::iterator document_stream::begin() noexcept {
   start();
   // If there are no documents, we're finished.
   return iterator(this, error == EMPTY);
 }
 
-simdjson_really_inline document_stream::iterator document_stream::end() noexcept {
+simdjson_inline document_stream::iterator document_stream::end() noexcept {
   return iterator(this, true);
 }
 
-simdjson_really_inline document_stream::iterator::iterator(document_stream* _stream, bool is_end) noexcept
+simdjson_inline document_stream::iterator::iterator(document_stream* _stream, bool is_end) noexcept
   : stream{_stream}, finished{is_end} {
 }
 
-simdjson_really_inline document_stream::iterator::reference document_stream::iterator::operator*() noexcept {
+simdjson_inline document_stream::iterator::reference document_stream::iterator::operator*() noexcept {
   // Note that in case of error, we do not yet mark
   // the iterator as "finished": this detection is done
   // in the operator++ function since it is possible
@@ -149,7 +149,7 @@ simdjson_really_inline document_stream::iterator::reference document_stream::ite
   return stream->parser->doc.root();
 }
 
-simdjson_really_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
+simdjson_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
   // If there is an error, then we want the iterator
   // to be finished, no matter what. (E.g., we do not
   // keep generating documents with errors, or go beyond
@@ -176,7 +176,7 @@ simdjson_really_inline document_stream::iterator& document_stream::iterator::ope
   return *this;
 }
 
-simdjson_really_inline bool document_stream::iterator::operator!=(const document_stream::iterator &other) const noexcept {
+simdjson_inline bool document_stream::iterator::operator!=(const document_stream::iterator &other) const noexcept {
   return finished != other.finished;
 }
 
@@ -207,11 +207,11 @@ inline void document_stream::start() noexcept {
   next();
 }
 
-simdjson_really_inline size_t document_stream::iterator::current_index() const noexcept {
+simdjson_inline size_t document_stream::iterator::current_index() const noexcept {
   return stream->doc_index;
 }
 
-simdjson_really_inline std::string_view document_stream::iterator::source() const noexcept {
+simdjson_inline std::string_view document_stream::iterator::source() const noexcept {
   const char* start = reinterpret_cast<const char*>(stream->buf) + current_index();
   bool object_or_array = ((*start == '[') || (*start == '{'));
   if(object_or_array) {
@@ -304,32 +304,32 @@ inline void document_stream::start_stage1_thread() noexcept {
 
 } // namespace dom
 
-simdjson_really_inline simdjson_result<dom::document_stream>::simdjson_result() noexcept
+simdjson_inline simdjson_result<dom::document_stream>::simdjson_result() noexcept
   : simdjson_result_base() {
 }
-simdjson_really_inline simdjson_result<dom::document_stream>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<dom::document_stream>::simdjson_result(error_code error) noexcept
   : simdjson_result_base(error) {
 }
-simdjson_really_inline simdjson_result<dom::document_stream>::simdjson_result(dom::document_stream &&value) noexcept
+simdjson_inline simdjson_result<dom::document_stream>::simdjson_result(dom::document_stream &&value) noexcept
   : simdjson_result_base(std::forward<dom::document_stream>(value)) {
 }
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::begin() noexcept(false) {
+simdjson_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::begin() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.begin();
 }
-simdjson_really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::end() noexcept(false) {
+simdjson_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::end() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.end();
 }
 #else // SIMDJSON_EXCEPTIONS
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
-simdjson_really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::begin() noexcept {
+simdjson_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::begin() noexcept {
   first.error = error();
   return first.begin();
 }
-simdjson_really_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::end() noexcept {
+simdjson_inline dom::document_stream::iterator simdjson_result<dom::document_stream>::end() noexcept {
   first.error = error();
   return first.end();
 }

--- a/include/simdjson/dom/document_stream.h
+++ b/include/simdjson/dom/document_stream.h
@@ -80,13 +80,13 @@ public:
    *  error = parser.parse_many(json).get(docs);
    *  ```
    */
-  simdjson_really_inline document_stream() noexcept;
+  simdjson_inline document_stream() noexcept;
   /** Move one document_stream to another. */
-  simdjson_really_inline document_stream(document_stream &&other) noexcept = default;
+  simdjson_inline document_stream(document_stream &&other) noexcept = default;
   /** Move one document_stream to another. */
-  simdjson_really_inline document_stream &operator=(document_stream &&other) noexcept = default;
+  simdjson_inline document_stream &operator=(document_stream &&other) noexcept = default;
 
-  simdjson_really_inline ~document_stream() noexcept;
+  simdjson_inline ~document_stream() noexcept;
   /**
    * Returns the input size in bytes.
    */
@@ -125,11 +125,11 @@ public:
     /**
      * Default constructor.
      */
-    simdjson_really_inline iterator() noexcept;
+    simdjson_inline iterator() noexcept;
     /**
      * Get the current document (or error).
      */
-    simdjson_really_inline reference operator*() noexcept;
+    simdjson_inline reference operator*() noexcept;
     /**
      * Advance to the next document (prefix).
      */
@@ -138,7 +138,7 @@ public:
      * Check if we're at the end yet.
      * @param other the end iterator to compare to.
      */
-    simdjson_really_inline bool operator!=(const iterator &other) const noexcept;
+    simdjson_inline bool operator!=(const iterator &other) const noexcept;
     /**
      * @private
      *
@@ -154,7 +154,7 @@ public:
      * may change in future versions of simdjson: we find the API somewhat
      * awkward and we would like to offer something friendlier.
      */
-     simdjson_really_inline size_t current_index() const noexcept;
+     simdjson_inline size_t current_index() const noexcept;
     /**
      * @private
      *
@@ -174,10 +174,10 @@ public:
      * may change in future versions of simdjson: we find the API somewhat
      * awkward and we would like to offer something friendlier.
      */
-     simdjson_really_inline std::string_view source() const noexcept;
+     simdjson_inline std::string_view source() const noexcept;
 
   private:
-    simdjson_really_inline iterator(document_stream *s, bool finished) noexcept;
+    simdjson_inline iterator(document_stream *s, bool finished) noexcept;
     /** The document_stream we're iterating through. */
     document_stream* stream;
     /** Whether we're finished or not. */
@@ -188,11 +188,11 @@ public:
   /**
    * Start iterating the documents in the stream.
    */
-  simdjson_really_inline iterator begin() noexcept;
+  simdjson_inline iterator begin() noexcept;
   /**
    * The end of the stream, for iterator comparison purposes.
    */
-  simdjson_really_inline iterator end() noexcept;
+  simdjson_inline iterator end() noexcept;
 
 private:
 
@@ -208,7 +208,7 @@ private:
    * @param len is the length of the raw byte buffer in bytes
    * @param batch_size is the size of the windows (must be strictly greater or equal to the largest JSON document)
    */
-  simdjson_really_inline document_stream(
+  simdjson_inline document_stream(
     dom::parser &parser,
     const uint8_t *buf,
     size_t len,
@@ -302,19 +302,19 @@ private:
 template<>
 struct simdjson_result<dom::document_stream> : public internal::simdjson_result_base<dom::document_stream> {
 public:
-  simdjson_really_inline simdjson_result() noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(dom::document_stream &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result(dom::document_stream &&value) noexcept; ///< @private
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline dom::document_stream::iterator begin() noexcept(false);
-  simdjson_really_inline dom::document_stream::iterator end() noexcept(false);
+  simdjson_inline dom::document_stream::iterator begin() noexcept(false);
+  simdjson_inline dom::document_stream::iterator end() noexcept(false);
 #else // SIMDJSON_EXCEPTIONS
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
   [[deprecated("parse_many() and load_many() may return errors. Use document_stream stream; error = parser.parse_many().get(doc); instead.")]]
-  simdjson_really_inline dom::document_stream::iterator begin() noexcept;
+  simdjson_inline dom::document_stream::iterator begin() noexcept;
   [[deprecated("parse_many() and load_many() may return errors. Use document_stream stream; error = parser.parse_many().get(doc); instead.")]]
-  simdjson_really_inline dom::document_stream::iterator end() noexcept;
+  simdjson_inline dom::document_stream::iterator end() noexcept;
 #endif // SIMDJSON_DISABLE_DEPRECATED_API
 #endif // SIMDJSON_EXCEPTIONS
 }; // struct simdjson_result<dom::document_stream>

--- a/include/simdjson/dom/element-inl.h
+++ b/include/simdjson/dom/element-inl.h
@@ -12,11 +12,11 @@ namespace simdjson {
 //
 // simdjson_result<dom::element> inline implementation
 //
-simdjson_really_inline simdjson_result<dom::element>::simdjson_result() noexcept
+simdjson_inline simdjson_result<dom::element>::simdjson_result() noexcept
     : internal::simdjson_result_base<dom::element>() {}
-simdjson_really_inline simdjson_result<dom::element>::simdjson_result(dom::element &&value) noexcept
+simdjson_inline simdjson_result<dom::element>::simdjson_result(dom::element &&value) noexcept
     : internal::simdjson_result_base<dom::element>(std::forward<dom::element>(value)) {}
-simdjson_really_inline simdjson_result<dom::element>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<dom::element>::simdjson_result(error_code error) noexcept
     : internal::simdjson_result_base<dom::element>(error) {}
 inline simdjson_result<dom::element_type> simdjson_result<dom::element>::type() const noexcept {
   if (error()) { return error(); }
@@ -24,101 +24,101 @@ inline simdjson_result<dom::element_type> simdjson_result<dom::element>::type() 
 }
 
 template<typename T>
-simdjson_really_inline bool simdjson_result<dom::element>::is() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is() const noexcept {
   return !error() && first.is<T>();
 }
 template<typename T>
-simdjson_really_inline simdjson_result<T> simdjson_result<dom::element>::get() const noexcept {
+simdjson_inline simdjson_result<T> simdjson_result<dom::element>::get() const noexcept {
   if (error()) { return error(); }
   return first.get<T>();
 }
 template<typename T>
-simdjson_warn_unused simdjson_really_inline error_code simdjson_result<dom::element>::get(T &value) const noexcept {
+simdjson_warn_unused simdjson_inline error_code simdjson_result<dom::element>::get(T &value) const noexcept {
   if (error()) { return error(); }
   return first.get<T>(value);
 }
 
-simdjson_really_inline simdjson_result<dom::array> simdjson_result<dom::element>::get_array() const noexcept {
+simdjson_inline simdjson_result<dom::array> simdjson_result<dom::element>::get_array() const noexcept {
   if (error()) { return error(); }
   return first.get_array();
 }
-simdjson_really_inline simdjson_result<dom::object> simdjson_result<dom::element>::get_object() const noexcept {
+simdjson_inline simdjson_result<dom::object> simdjson_result<dom::element>::get_object() const noexcept {
   if (error()) { return error(); }
   return first.get_object();
 }
-simdjson_really_inline simdjson_result<const char *> simdjson_result<dom::element>::get_c_str() const noexcept {
+simdjson_inline simdjson_result<const char *> simdjson_result<dom::element>::get_c_str() const noexcept {
   if (error()) { return error(); }
   return first.get_c_str();
 }
-simdjson_really_inline simdjson_result<size_t> simdjson_result<dom::element>::get_string_length() const noexcept {
+simdjson_inline simdjson_result<size_t> simdjson_result<dom::element>::get_string_length() const noexcept {
   if (error()) { return error(); }
   return first.get_string_length();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<dom::element>::get_string() const noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<dom::element>::get_string() const noexcept {
   if (error()) { return error(); }
   return first.get_string();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<dom::element>::get_int64() const noexcept {
+simdjson_inline simdjson_result<int64_t> simdjson_result<dom::element>::get_int64() const noexcept {
   if (error()) { return error(); }
   return first.get_int64();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<dom::element>::get_uint64() const noexcept {
+simdjson_inline simdjson_result<uint64_t> simdjson_result<dom::element>::get_uint64() const noexcept {
   if (error()) { return error(); }
   return first.get_uint64();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<dom::element>::get_double() const noexcept {
+simdjson_inline simdjson_result<double> simdjson_result<dom::element>::get_double() const noexcept {
   if (error()) { return error(); }
   return first.get_double();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<dom::element>::get_bool() const noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<dom::element>::get_bool() const noexcept {
   if (error()) { return error(); }
   return first.get_bool();
 }
 
-simdjson_really_inline bool simdjson_result<dom::element>::is_array() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_array() const noexcept {
   return !error() && first.is_array();
 }
-simdjson_really_inline bool simdjson_result<dom::element>::is_object() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_object() const noexcept {
   return !error() && first.is_object();
 }
-simdjson_really_inline bool simdjson_result<dom::element>::is_string() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_string() const noexcept {
   return !error() && first.is_string();
 }
-simdjson_really_inline bool simdjson_result<dom::element>::is_int64() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_int64() const noexcept {
   return !error() && first.is_int64();
 }
-simdjson_really_inline bool simdjson_result<dom::element>::is_uint64() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_uint64() const noexcept {
   return !error() && first.is_uint64();
 }
-simdjson_really_inline bool simdjson_result<dom::element>::is_double() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_double() const noexcept {
   return !error() && first.is_double();
 }
-simdjson_really_inline bool simdjson_result<dom::element>::is_number() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_number() const noexcept {
   return !error() && first.is_number();
 }
-simdjson_really_inline bool simdjson_result<dom::element>::is_bool() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_bool() const noexcept {
   return !error() && first.is_bool();
 }
 
-simdjson_really_inline bool simdjson_result<dom::element>::is_null() const noexcept {
+simdjson_inline bool simdjson_result<dom::element>::is_null() const noexcept {
   return !error() && first.is_null();
 }
 
-simdjson_really_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](std::string_view key) const noexcept {
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](std::string_view key) const noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const char *key) const noexcept {
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::operator[](const char *key) const noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_pointer(const std::string_view json_pointer) const noexcept {
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_pointer(const std::string_view json_pointer) const noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
 }
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
 [[deprecated("For standard compliance, use at_pointer instead, and prefix your pointers with a slash '/', see RFC6901 ")]]
-simdjson_really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(const std::string_view json_pointer) const noexcept {
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(const std::string_view json_pointer) const noexcept {
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_DEPRECATED_WARNING
   if (error()) { return error(); }
@@ -126,51 +126,51 @@ SIMDJSON_DISABLE_DEPRECATED_WARNING
 SIMDJSON_POP_DISABLE_WARNINGS
 }
 #endif // SIMDJSON_DISABLE_DEPRECATED_API
-simdjson_really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(size_t index) const noexcept {
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at(size_t index) const noexcept {
   if (error()) { return error(); }
   return first.at(index);
 }
-simdjson_really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key(std::string_view key) const noexcept {
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key(std::string_view key) const noexcept {
   if (error()) { return error(); }
   return first.at_key(key);
 }
-simdjson_really_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key_case_insensitive(std::string_view key) const noexcept {
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_key_case_insensitive(std::string_view key) const noexcept {
   if (error()) { return error(); }
   return first.at_key_case_insensitive(key);
 }
 
 #if SIMDJSON_EXCEPTIONS
 
-simdjson_really_inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator bool() const noexcept(false) {
   return get<bool>();
 }
-simdjson_really_inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator const char *() const noexcept(false) {
   return get<const char *>();
 }
-simdjson_really_inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator std::string_view() const noexcept(false) {
   return get<std::string_view>();
 }
-simdjson_really_inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator uint64_t() const noexcept(false) {
   return get<uint64_t>();
 }
-simdjson_really_inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator int64_t() const noexcept(false) {
   return get<int64_t>();
 }
-simdjson_really_inline simdjson_result<dom::element>::operator double() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator double() const noexcept(false) {
   return get<double>();
 }
-simdjson_really_inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator dom::array() const noexcept(false) {
   return get<dom::array>();
 }
-simdjson_really_inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
+simdjson_inline simdjson_result<dom::element>::operator dom::object() const noexcept(false) {
   return get<dom::object>();
 }
 
-simdjson_really_inline dom::array::iterator simdjson_result<dom::element>::begin() const noexcept(false) {
+simdjson_inline dom::array::iterator simdjson_result<dom::element>::begin() const noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.begin();
 }
-simdjson_really_inline dom::array::iterator simdjson_result<dom::element>::end() const noexcept(false) {
+simdjson_inline dom::array::iterator simdjson_result<dom::element>::end() const noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first.end();
 }
@@ -182,8 +182,8 @@ namespace dom {
 //
 // element inline implementation
 //
-simdjson_really_inline element::element() noexcept : tape{} {}
-simdjson_really_inline element::element(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
+simdjson_inline element::element() noexcept : tape{} {}
+simdjson_inline element::element(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 
 inline element_type element::type() const noexcept {
   auto tape_type = tape.tape_ref_type();
@@ -290,12 +290,12 @@ inline simdjson_result<object> element::get_object() const noexcept {
 }
 
 template<typename T>
-simdjson_warn_unused simdjson_really_inline error_code element::get(T &value) const noexcept {
+simdjson_warn_unused simdjson_inline error_code element::get(T &value) const noexcept {
   return get<T>().get(value);
 }
 // An element-specific version prevents recursion with simdjson_result::get<element>(value)
 template<>
-simdjson_warn_unused simdjson_really_inline error_code element::get<element>(element &value) const noexcept {
+simdjson_warn_unused simdjson_inline error_code element::get<element>(element &value) const noexcept {
   value = element(tape);
   return SUCCESS;
 }
@@ -305,7 +305,7 @@ inline void element::tie(T &value, error_code &error) && noexcept {
 }
 
 template<typename T>
-simdjson_really_inline bool element::is() const noexcept {
+simdjson_inline bool element::is() const noexcept {
   auto result = get<T>();
   return !result.error();
 }

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -40,10 +40,10 @@ enum class element_type {
 class element {
 public:
   /** Create a new, invalid element. */
-  simdjson_really_inline element() noexcept;
+  simdjson_inline element() noexcept;
 
   /** The type of this element. */
-  simdjson_really_inline element_type type() const noexcept;
+  simdjson_inline element_type type() const noexcept;
 
   /**
    * Cast this element to an array.
@@ -195,7 +195,7 @@ public:
    * @tparam T bool, double, uint64_t, int64_t, std::string_view, const char *, dom::array, dom::object
    */
   template<typename T>
-  simdjson_really_inline bool is() const noexcept;
+  simdjson_inline bool is() const noexcept;
 
   /**
    * Get the value as the provided type (T).
@@ -240,7 +240,7 @@ public:
    * @returns The error that occurred, or SUCCESS if there was no error.
    */
   template<typename T>
-  simdjson_warn_unused simdjson_really_inline error_code get(T &value) const noexcept;
+  simdjson_warn_unused simdjson_inline error_code get(T &value) const noexcept;
 
   /**
    * Get the value as the provided type (T), setting error if it's not the given type.
@@ -464,7 +464,7 @@ public:
   inline bool dump_raw_tape(std::ostream &out) const noexcept;
 
 private:
-  simdjson_really_inline element(const internal::tape_ref &tape) noexcept;
+  simdjson_inline element(const internal::tape_ref &tape) noexcept;
   internal::tape_ref tape;
   friend class document;
   friend class object;
@@ -481,59 +481,59 @@ private:
 template<>
 struct simdjson_result<dom::element> : public internal::simdjson_result_base<dom::element> {
 public:
-  simdjson_really_inline simdjson_result() noexcept; ///< @private
-  simdjson_really_inline simdjson_result(dom::element &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept; ///< @private
+  simdjson_inline simdjson_result(dom::element &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
 
-  simdjson_really_inline simdjson_result<dom::element_type> type() const noexcept;
+  simdjson_inline simdjson_result<dom::element_type> type() const noexcept;
   template<typename T>
-  simdjson_really_inline bool is() const noexcept;
+  simdjson_inline bool is() const noexcept;
   template<typename T>
-  simdjson_really_inline simdjson_result<T> get() const noexcept;
+  simdjson_inline simdjson_result<T> get() const noexcept;
   template<typename T>
-  simdjson_warn_unused simdjson_really_inline error_code get(T &value) const noexcept;
+  simdjson_warn_unused simdjson_inline error_code get(T &value) const noexcept;
 
-  simdjson_really_inline simdjson_result<dom::array> get_array() const noexcept;
-  simdjson_really_inline simdjson_result<dom::object> get_object() const noexcept;
-  simdjson_really_inline simdjson_result<const char *> get_c_str() const noexcept;
-  simdjson_really_inline simdjson_result<size_t> get_string_length() const noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() const noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() const noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() const noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() const noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() const noexcept;
+  simdjson_inline simdjson_result<dom::array> get_array() const noexcept;
+  simdjson_inline simdjson_result<dom::object> get_object() const noexcept;
+  simdjson_inline simdjson_result<const char *> get_c_str() const noexcept;
+  simdjson_inline simdjson_result<size_t> get_string_length() const noexcept;
+  simdjson_inline simdjson_result<std::string_view> get_string() const noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64() const noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64() const noexcept;
+  simdjson_inline simdjson_result<double> get_double() const noexcept;
+  simdjson_inline simdjson_result<bool> get_bool() const noexcept;
 
-  simdjson_really_inline bool is_array() const noexcept;
-  simdjson_really_inline bool is_object() const noexcept;
-  simdjson_really_inline bool is_string() const noexcept;
-  simdjson_really_inline bool is_int64() const noexcept;
-  simdjson_really_inline bool is_uint64() const noexcept;
-  simdjson_really_inline bool is_double() const noexcept;
-  simdjson_really_inline bool is_number() const noexcept;
-  simdjson_really_inline bool is_bool() const noexcept;
-  simdjson_really_inline bool is_null() const noexcept;
+  simdjson_inline bool is_array() const noexcept;
+  simdjson_inline bool is_object() const noexcept;
+  simdjson_inline bool is_string() const noexcept;
+  simdjson_inline bool is_int64() const noexcept;
+  simdjson_inline bool is_uint64() const noexcept;
+  simdjson_inline bool is_double() const noexcept;
+  simdjson_inline bool is_number() const noexcept;
+  simdjson_inline bool is_bool() const noexcept;
+  simdjson_inline bool is_null() const noexcept;
 
-  simdjson_really_inline simdjson_result<dom::element> operator[](std::string_view key) const noexcept;
-  simdjson_really_inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
-  simdjson_really_inline simdjson_result<dom::element> at_pointer(const std::string_view json_pointer) const noexcept;
+  simdjson_inline simdjson_result<dom::element> operator[](std::string_view key) const noexcept;
+  simdjson_inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
+  simdjson_inline simdjson_result<dom::element> at_pointer(const std::string_view json_pointer) const noexcept;
   [[deprecated("For standard compliance, use at_pointer instead, and prefix your pointers with a slash '/', see RFC6901 ")]]
-  simdjson_really_inline simdjson_result<dom::element> at(const std::string_view json_pointer) const noexcept;
-  simdjson_really_inline simdjson_result<dom::element> at(size_t index) const noexcept;
-  simdjson_really_inline simdjson_result<dom::element> at_key(std::string_view key) const noexcept;
-  simdjson_really_inline simdjson_result<dom::element> at_key_case_insensitive(std::string_view key) const noexcept;
+  simdjson_inline simdjson_result<dom::element> at(const std::string_view json_pointer) const noexcept;
+  simdjson_inline simdjson_result<dom::element> at(size_t index) const noexcept;
+  simdjson_inline simdjson_result<dom::element> at_key(std::string_view key) const noexcept;
+  simdjson_inline simdjson_result<dom::element> at_key_case_insensitive(std::string_view key) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator bool() const noexcept(false);
-  simdjson_really_inline explicit operator const char*() const noexcept(false);
-  simdjson_really_inline operator std::string_view() const noexcept(false);
-  simdjson_really_inline operator uint64_t() const noexcept(false);
-  simdjson_really_inline operator int64_t() const noexcept(false);
-  simdjson_really_inline operator double() const noexcept(false);
-  simdjson_really_inline operator dom::array() const noexcept(false);
-  simdjson_really_inline operator dom::object() const noexcept(false);
+  simdjson_inline operator bool() const noexcept(false);
+  simdjson_inline explicit operator const char*() const noexcept(false);
+  simdjson_inline operator std::string_view() const noexcept(false);
+  simdjson_inline operator uint64_t() const noexcept(false);
+  simdjson_inline operator int64_t() const noexcept(false);
+  simdjson_inline operator double() const noexcept(false);
+  simdjson_inline operator dom::array() const noexcept(false);
+  simdjson_inline operator dom::object() const noexcept(false);
 
-  simdjson_really_inline dom::array::iterator begin() const noexcept(false);
-  simdjson_really_inline dom::array::iterator end() const noexcept(false);
+  simdjson_inline dom::array::iterator begin() const noexcept(false);
+  simdjson_inline dom::array::iterator end() const noexcept(false);
 #endif // SIMDJSON_EXCEPTIONS
 };
 

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -12,11 +12,11 @@ namespace simdjson {
 //
 // simdjson_result<dom::object> inline implementation
 //
-simdjson_really_inline simdjson_result<dom::object>::simdjson_result() noexcept
+simdjson_inline simdjson_result<dom::object>::simdjson_result() noexcept
     : internal::simdjson_result_base<dom::object>() {}
-simdjson_really_inline simdjson_result<dom::object>::simdjson_result(dom::object value) noexcept
+simdjson_inline simdjson_result<dom::object>::simdjson_result(dom::object value) noexcept
     : internal::simdjson_result_base<dom::object>(std::forward<dom::object>(value)) {}
-simdjson_really_inline simdjson_result<dom::object>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<dom::object>::simdjson_result(error_code error) noexcept
     : internal::simdjson_result_base<dom::object>(error) {}
 
 inline simdjson_result<dom::element> simdjson_result<dom::object>::operator[](std::string_view key) const noexcept {
@@ -62,8 +62,8 @@ namespace dom {
 //
 // object inline implementation
 //
-simdjson_really_inline object::object() noexcept : tape{} {}
-simdjson_really_inline object::object(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
+simdjson_inline object::object() noexcept : tape{} {}
+simdjson_inline object::object(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 inline object::iterator object::begin() const noexcept {
   return internal::tape_ref(tape.doc, tape.json_index + 1);
 }
@@ -149,7 +149,7 @@ inline simdjson_result<element> object::at_key_case_insensitive(std::string_view
 //
 // object::iterator inline implementation
 //
-simdjson_really_inline object::iterator::iterator(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
+simdjson_inline object::iterator::iterator(const internal::tape_ref &_tape) noexcept : tape{_tape} { }
 inline const key_value_pair object::iterator::operator*() const noexcept {
   return key_value_pair(key(), value());
 }

--- a/include/simdjson/dom/object.h
+++ b/include/simdjson/dom/object.h
@@ -22,7 +22,7 @@ class key_value_pair;
 class object {
 public:
   /** Create a new, invalid object */
-  simdjson_really_inline object() noexcept;
+  simdjson_inline object() noexcept;
 
   class iterator {
   public:
@@ -92,7 +92,7 @@ public:
     iterator(const iterator&) noexcept = default;
     iterator& operator=(const iterator&) noexcept = default;
   private:
-    simdjson_really_inline iterator(const internal::tape_ref &tape) noexcept;
+    simdjson_inline iterator(const internal::tape_ref &tape) noexcept;
 
     internal::tape_ref tape;
 
@@ -206,7 +206,7 @@ public:
   inline simdjson_result<element> at_key_case_insensitive(std::string_view key) const noexcept;
 
 private:
-  simdjson_really_inline object(const internal::tape_ref &tape) noexcept;
+  simdjson_inline object(const internal::tape_ref &tape) noexcept;
 
   internal::tape_ref tape;
 
@@ -227,7 +227,7 @@ public:
   element value;
 
 private:
-  simdjson_really_inline key_value_pair(std::string_view _key, element _value) noexcept;
+  simdjson_inline key_value_pair(std::string_view _key, element _value) noexcept;
   friend class object;
 };
 
@@ -237,9 +237,9 @@ private:
 template<>
 struct simdjson_result<dom::object> : public internal::simdjson_result_base<dom::object> {
 public:
-  simdjson_really_inline simdjson_result() noexcept; ///< @private
-  simdjson_really_inline simdjson_result(dom::object value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept; ///< @private
+  simdjson_inline simdjson_result(dom::object value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
 
   inline simdjson_result<dom::element> operator[](std::string_view key) const noexcept;
   inline simdjson_result<dom::element> operator[](const char *key) const noexcept;

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -15,12 +15,12 @@ namespace dom {
 //
 // parser inline implementation
 //
-simdjson_really_inline parser::parser(size_t max_capacity) noexcept
+simdjson_inline parser::parser(size_t max_capacity) noexcept
   : _max_capacity{max_capacity},
     loaded_bytes(nullptr) {
 }
-simdjson_really_inline parser::parser(parser &&other) noexcept = default;
-simdjson_really_inline parser &parser::operator=(parser &&other) noexcept = default;
+simdjson_inline parser::parser(parser &&other) noexcept = default;
+simdjson_inline parser &parser::operator=(parser &&other) noexcept = default;
 
 inline bool parser::is_valid() const noexcept { return valid; }
 inline int parser::get_error_code() const noexcept { return error; }
@@ -118,13 +118,13 @@ inline simdjson_result<element> parser::parse_into_document(document& provided_d
   return provided_doc.root();
 }
 
-simdjson_really_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const char *buf, size_t len, bool realloc_if_needed) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const char *buf, size_t len, bool realloc_if_needed) & noexcept {
   return parse_into_document(provided_doc, reinterpret_cast<const uint8_t *>(buf), len, realloc_if_needed);
 }
-simdjson_really_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const std::string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const std::string &s) & noexcept {
   return parse_into_document(provided_doc, s.data(), s.length(), s.capacity() - s.length() < SIMDJSON_PADDING);
 }
-simdjson_really_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const padded_string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const padded_string &s) & noexcept {
   return parse_into_document(provided_doc, s.data(), s.length(), false);
 }
 
@@ -133,13 +133,13 @@ inline simdjson_result<element> parser::parse(const uint8_t *buf, size_t len, bo
   return parse_into_document(doc, buf, len, realloc_if_needed);
 }
 
-simdjson_really_inline simdjson_result<element> parser::parse(const char *buf, size_t len, bool realloc_if_needed) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse(const char *buf, size_t len, bool realloc_if_needed) & noexcept {
   return parse(reinterpret_cast<const uint8_t *>(buf), len, realloc_if_needed);
 }
-simdjson_really_inline simdjson_result<element> parser::parse(const std::string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse(const std::string &s) & noexcept {
   return parse(s.data(), s.length(), s.capacity() - s.length() < SIMDJSON_PADDING);
 }
-simdjson_really_inline simdjson_result<element> parser::parse(const padded_string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse(const padded_string &s) & noexcept {
   return parse(s.data(), s.length(), false);
 }
 
@@ -157,13 +157,13 @@ inline simdjson_result<document_stream> parser::parse_many(const padded_string &
   return parse_many(s.data(), s.length(), batch_size);
 }
 
-simdjson_really_inline size_t parser::capacity() const noexcept {
+simdjson_inline size_t parser::capacity() const noexcept {
   return implementation ? implementation->capacity() : 0;
 }
-simdjson_really_inline size_t parser::max_capacity() const noexcept {
+simdjson_inline size_t parser::max_capacity() const noexcept {
   return _max_capacity;
 }
-simdjson_really_inline size_t parser::max_depth() const noexcept {
+simdjson_inline size_t parser::max_depth() const noexcept {
   return implementation ? implementation->max_depth() : DEFAULT_MAX_DEPTH;
 }
 
@@ -216,7 +216,7 @@ inline error_code parser::ensure_capacity(document& target_document, size_t desi
   return SUCCESS;
 }
 
-simdjson_really_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
+simdjson_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
   if(max_capacity < MINIMAL_DOCUMENT_CAPACITY) {
     _max_capacity = max_capacity;
   } else {

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -68,20 +68,20 @@ public:
    *    to allocate an initial capacity, call allocate() after constructing the parser.
    *    Defaults to SIMDJSON_MAXSIZE_BYTES (the largest single document simdjson can process).
    */
-  simdjson_really_inline explicit parser(size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
+  simdjson_inline explicit parser(size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
   /**
    * Take another parser's buffers and state.
    *
    * @param other The parser to take. Its capacity is zeroed.
    */
-  simdjson_really_inline parser(parser &&other) noexcept;
+  simdjson_inline parser(parser &&other) noexcept;
   parser(const parser &) = delete; ///< @private Disallow copying
   /**
    * Take another parser's buffers and state.
    *
    * @param other The parser to take. Its capacity is zeroed.
    */
-  simdjson_really_inline parser &operator=(parser &&other) noexcept;
+  simdjson_inline parser &operator=(parser &&other) noexcept;
   parser &operator=(const parser &) = delete; ///< @private Disallow copying
 
   /** Deallocate the JSON parser. */
@@ -191,17 +191,17 @@ public:
   inline simdjson_result<element> parse(const uint8_t *buf, size_t len, bool realloc_if_needed = true) & noexcept;
   inline simdjson_result<element> parse(const uint8_t *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_really_inline simdjson_result<element> parse(const char *buf, size_t len, bool realloc_if_needed = true) & noexcept;
-  simdjson_really_inline simdjson_result<element> parse(const char *buf, size_t len, bool realloc_if_needed = true) && =delete;
+  simdjson_inline simdjson_result<element> parse(const char *buf, size_t len, bool realloc_if_needed = true) & noexcept;
+  simdjson_inline simdjson_result<element> parse(const char *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_really_inline simdjson_result<element> parse(const std::string &s) & noexcept;
-  simdjson_really_inline simdjson_result<element> parse(const std::string &s) && =delete;
+  simdjson_inline simdjson_result<element> parse(const std::string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse(const std::string &s) && =delete;
   /** @overload parse(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_really_inline simdjson_result<element> parse(const padded_string &s) & noexcept;
-  simdjson_really_inline simdjson_result<element> parse(const padded_string &s) && =delete;
+  simdjson_inline simdjson_result<element> parse(const padded_string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse(const padded_string &s) && =delete;
 
   /** @private We do not want to allow implicit conversion from C string to std::string. */
-  simdjson_really_inline simdjson_result<element> parse(const char *buf) noexcept = delete;
+  simdjson_inline simdjson_result<element> parse(const char *buf) noexcept = delete;
 
   /**
    * Parse a JSON document into a provide document instance and return a temporary reference to it.
@@ -250,17 +250,17 @@ public:
   inline simdjson_result<element> parse_into_document(document& doc, const uint8_t *buf, size_t len, bool realloc_if_needed = true) & noexcept;
   inline simdjson_result<element> parse_into_document(document& doc, const uint8_t *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse_into_document(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_really_inline simdjson_result<element> parse_into_document(document& doc, const char *buf, size_t len, bool realloc_if_needed = true) & noexcept;
-  simdjson_really_inline simdjson_result<element> parse_into_document(document& doc, const char *buf, size_t len, bool realloc_if_needed = true) && =delete;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const char *buf, size_t len, bool realloc_if_needed = true) & noexcept;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const char *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse_into_document(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_really_inline simdjson_result<element> parse_into_document(document& doc, const std::string &s) & noexcept;
-  simdjson_really_inline simdjson_result<element> parse_into_document(document& doc, const std::string &s) && =delete;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const std::string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const std::string &s) && =delete;
   /** @overload parse_into_document(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_really_inline simdjson_result<element> parse_into_document(document& doc, const padded_string &s) & noexcept;
-  simdjson_really_inline simdjson_result<element> parse_into_document(document& doc, const padded_string &s) && =delete;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const padded_string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const padded_string &s) && =delete;
 
   /** @private We do not want to allow implicit conversion from C string to std::string. */
-  simdjson_really_inline simdjson_result<element> parse_into_document(document& doc, const char *buf) noexcept = delete;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const char *buf) noexcept = delete;
 
   /**
    * Load a file containing many JSON documents.
@@ -472,7 +472,7 @@ public:
    *
    * @return Current capacity, in bytes.
    */
-  simdjson_really_inline size_t capacity() const noexcept;
+  simdjson_inline size_t capacity() const noexcept;
 
   /**
    * The largest document this parser can automatically support.
@@ -481,14 +481,14 @@ public:
    *
    * @return Maximum capacity, in bytes.
    */
-  simdjson_really_inline size_t max_capacity() const noexcept;
+  simdjson_inline size_t max_capacity() const noexcept;
 
   /**
    * The maximum level of nested object and arrays supported by this parser.
    *
    * @return Maximum depth, in bytes.
    */
-  simdjson_really_inline size_t max_depth() const noexcept;
+  simdjson_inline size_t max_depth() const noexcept;
 
   /**
    * Set max_capacity. This is the largest document this parser can automatically support.
@@ -504,7 +504,7 @@ public:
    *
    * @param max_capacity The new maximum capacity, in bytes.
    */
-  simdjson_really_inline void set_max_capacity(size_t max_capacity) noexcept;
+  simdjson_inline void set_max_capacity(size_t max_capacity) noexcept;
 
 #ifdef SIMDJSON_THREADS_ENABLED
   /**

--- a/include/simdjson/dom/serialization-inl.h
+++ b/include/simdjson/dom/serialization-inl.h
@@ -107,19 +107,19 @@ namespace internal {
  * Minifier/formatter code.
  **/
 
-simdjson_really_inline void mini_formatter::number(uint64_t x) {
+simdjson_inline void mini_formatter::number(uint64_t x) {
   char number_buffer[24];
   char *newp = fast_itoa(number_buffer, x);
   buffer.insert(buffer.end(), number_buffer, newp);
 }
 
-simdjson_really_inline void mini_formatter::number(int64_t x) {
+simdjson_inline void mini_formatter::number(int64_t x) {
   char number_buffer[24];
   char *newp = fast_itoa(number_buffer, x);
   buffer.insert(buffer.end(), number_buffer, newp);
 }
 
-simdjson_really_inline void mini_formatter::number(double x) {
+simdjson_inline void mini_formatter::number(double x) {
   char number_buffer[24];
   // Currently, passing the nullptr to the second argument is
   // safe because our implementation does not check the second
@@ -128,31 +128,31 @@ simdjson_really_inline void mini_formatter::number(double x) {
   buffer.insert(buffer.end(), number_buffer, newp);
 }
 
-simdjson_really_inline void mini_formatter::start_array() { one_char('['); }
-simdjson_really_inline void mini_formatter::end_array() { one_char(']'); }
-simdjson_really_inline void mini_formatter::start_object() { one_char('{'); }
-simdjson_really_inline void mini_formatter::end_object() { one_char('}'); }
-simdjson_really_inline void mini_formatter::comma() { one_char(','); }
+simdjson_inline void mini_formatter::start_array() { one_char('['); }
+simdjson_inline void mini_formatter::end_array() { one_char(']'); }
+simdjson_inline void mini_formatter::start_object() { one_char('{'); }
+simdjson_inline void mini_formatter::end_object() { one_char('}'); }
+simdjson_inline void mini_formatter::comma() { one_char(','); }
 
 
-simdjson_really_inline void mini_formatter::true_atom() {
+simdjson_inline void mini_formatter::true_atom() {
   const char * s = "true";
   buffer.insert(buffer.end(), s, s + 4);
 }
-simdjson_really_inline void mini_formatter::false_atom() {
+simdjson_inline void mini_formatter::false_atom() {
   const char * s = "false";
   buffer.insert(buffer.end(), s, s + 5);
 }
-simdjson_really_inline void mini_formatter::null_atom() {
+simdjson_inline void mini_formatter::null_atom() {
   const char * s = "null";
   buffer.insert(buffer.end(), s, s + 4);
 }
-simdjson_really_inline void mini_formatter::one_char(char c) { buffer.push_back(c); }
-simdjson_really_inline void mini_formatter::key(std::string_view unescaped) {
+simdjson_inline void mini_formatter::one_char(char c) { buffer.push_back(c); }
+simdjson_inline void mini_formatter::key(std::string_view unescaped) {
   string(unescaped);
   one_char(':');
 }
-simdjson_really_inline void mini_formatter::string(std::string_view unescaped) {
+simdjson_inline void mini_formatter::string(std::string_view unescaped) {
   one_char('\"');
   size_t i = 0;
   // Fast path for the case where we have no control character, no ", and no backslash.
@@ -235,7 +235,7 @@ inline void mini_formatter::clear() {
   buffer.clear();
 }
 
-simdjson_really_inline std::string_view mini_formatter::str() const {
+simdjson_inline std::string_view mini_formatter::str() const {
   return std::string_view(buffer.data(), buffer.size());
 }
 
@@ -406,18 +406,18 @@ inline void string_builder<serializer>::append(simdjson::dom::array value) {
 }
 
 template <class serializer>
-simdjson_really_inline void string_builder<serializer>::append(simdjson::dom::key_value_pair kv) {
+simdjson_inline void string_builder<serializer>::append(simdjson::dom::key_value_pair kv) {
   format.key(kv.key);
   append(kv.value);
 }
 
 template <class serializer>
-simdjson_really_inline void string_builder<serializer>::clear() {
+simdjson_inline void string_builder<serializer>::clear() {
   format.clear();
 }
 
 template <class serializer>
-simdjson_really_inline std::string_view string_builder<serializer>::str() const {
+simdjson_inline std::string_view string_builder<serializer>::str() const {
   return format.str();
 }
 

--- a/include/simdjson/dom/serialization.h
+++ b/include/simdjson/dom/serialization.h
@@ -40,7 +40,7 @@ public:
   /** Append an object to the builder (to be printed) **/
   inline void append(simdjson::dom::object value);
   /** Reset the builder (so that it would print the empty string) **/
-  simdjson_really_inline void clear();
+  simdjson_inline void clear();
   /**
    * Get access to the string. The string_view is owned by the builder
    * and it is invalid to use it after the string_builder has been
@@ -48,9 +48,9 @@ public:
    * However you can make a copy of the string_view on memory that you
    * own.
    */
-  simdjson_really_inline std::string_view str() const;
+  simdjson_inline std::string_view str() const;
   /** Append a key_value_pair to the builder (to be printed) **/
-  simdjson_really_inline void append(simdjson::dom::key_value_pair value);
+  simdjson_inline void append(simdjson::dom::key_value_pair value);
 private:
   formatter format{};
 };
@@ -64,43 +64,43 @@ class mini_formatter {
 public:
   mini_formatter() = default;
   /** Add a comma **/
-  simdjson_really_inline void comma();
+  simdjson_inline void comma();
   /** Start an array, prints [ **/
-  simdjson_really_inline void start_array();
+  simdjson_inline void start_array();
   /** End an array, prints ] **/
-  simdjson_really_inline void end_array();
+  simdjson_inline void end_array();
   /** Start an array, prints { **/
-  simdjson_really_inline void start_object();
+  simdjson_inline void start_object();
   /** Start an array, prints } **/
-  simdjson_really_inline void end_object();
+  simdjson_inline void end_object();
   /** Prints a true **/
-  simdjson_really_inline void true_atom();
+  simdjson_inline void true_atom();
   /** Prints a false **/
-  simdjson_really_inline void false_atom();
+  simdjson_inline void false_atom();
   /** Prints a null **/
-  simdjson_really_inline void null_atom();
+  simdjson_inline void null_atom();
   /** Prints a number **/
-  simdjson_really_inline void number(int64_t x);
+  simdjson_inline void number(int64_t x);
   /** Prints a number **/
-  simdjson_really_inline void number(uint64_t x);
+  simdjson_inline void number(uint64_t x);
   /** Prints a number **/
-  simdjson_really_inline void number(double x);
+  simdjson_inline void number(double x);
   /** Prints a key (string + colon) **/
-  simdjson_really_inline void key(std::string_view unescaped);
+  simdjson_inline void key(std::string_view unescaped);
   /** Prints a string. The string is escaped as needed. **/
-  simdjson_really_inline void string(std::string_view unescaped);
+  simdjson_inline void string(std::string_view unescaped);
   /** Clears out the content. **/
-  simdjson_really_inline void clear();
+  simdjson_inline void clear();
   /**
    * Get access to the buffer, it is owned by the instance, but
    * the user can make a copy.
    **/
-  simdjson_really_inline std::string_view str() const;
+  simdjson_inline std::string_view str() const;
 
 private:
   // implementation details (subject to change)
   /** Prints one character **/
-  simdjson_really_inline void one_char(char c);
+  simdjson_inline void one_char(char c);
   /** Backing buffer **/
   std::vector<char> buffer{}; // not ideal!
 };

--- a/include/simdjson/error-inl.h
+++ b/include/simdjson/error-inl.h
@@ -44,7 +44,7 @@ namespace internal {
 //
 
 template<typename T>
-simdjson_really_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
+simdjson_inline void simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
   error = this->second;
   if (!error) {
     value = std::forward<simdjson_result_base<T>>(*this).first;
@@ -52,64 +52,64 @@ simdjson_really_inline void simdjson_result_base<T>::tie(T &value, error_code &e
 }
 
 template<typename T>
-simdjson_warn_unused simdjson_really_inline error_code simdjson_result_base<T>::get(T &value) && noexcept {
+simdjson_warn_unused simdjson_inline error_code simdjson_result_base<T>::get(T &value) && noexcept {
   error_code error;
   std::forward<simdjson_result_base<T>>(*this).tie(value, error);
   return error;
 }
 
 template<typename T>
-simdjson_really_inline error_code simdjson_result_base<T>::error() const noexcept {
+simdjson_inline error_code simdjson_result_base<T>::error() const noexcept {
   return this->second;
 }
 
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline T& simdjson_result_base<T>::value() & noexcept(false) {
+simdjson_inline T& simdjson_result_base<T>::value() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return this->first;
 }
 
 template<typename T>
-simdjson_really_inline T&& simdjson_result_base<T>::value() && noexcept(false) {
+simdjson_inline T&& simdjson_result_base<T>::value() && noexcept(false) {
   return std::forward<simdjson_result_base<T>>(*this).take_value();
 }
 
 template<typename T>
-simdjson_really_inline T&& simdjson_result_base<T>::take_value() && noexcept(false) {
+simdjson_inline T&& simdjson_result_base<T>::take_value() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<T>(this->first);
 }
 
 template<typename T>
-simdjson_really_inline simdjson_result_base<T>::operator T&&() && noexcept(false) {
+simdjson_inline simdjson_result_base<T>::operator T&&() && noexcept(false) {
   return std::forward<simdjson_result_base<T>>(*this).take_value();
 }
 
 #endif // SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline const T& simdjson_result_base<T>::value_unsafe() const& noexcept {
+simdjson_inline const T& simdjson_result_base<T>::value_unsafe() const& noexcept {
   return this->first;
 }
 
 template<typename T>
-simdjson_really_inline T&& simdjson_result_base<T>::value_unsafe() && noexcept {
+simdjson_inline T&& simdjson_result_base<T>::value_unsafe() && noexcept {
   return std::forward<T>(this->first);
 }
 
 template<typename T>
-simdjson_really_inline simdjson_result_base<T>::simdjson_result_base(T &&value, error_code error) noexcept
+simdjson_inline simdjson_result_base<T>::simdjson_result_base(T &&value, error_code error) noexcept
     : std::pair<T, error_code>(std::forward<T>(value), error) {}
 template<typename T>
-simdjson_really_inline simdjson_result_base<T>::simdjson_result_base(error_code error) noexcept
+simdjson_inline simdjson_result_base<T>::simdjson_result_base(error_code error) noexcept
     : simdjson_result_base(T{}, error) {}
 template<typename T>
-simdjson_really_inline simdjson_result_base<T>::simdjson_result_base(T &&value) noexcept
+simdjson_inline simdjson_result_base<T>::simdjson_result_base(T &&value) noexcept
     : simdjson_result_base(std::forward<T>(value), SUCCESS) {}
 template<typename T>
-simdjson_really_inline simdjson_result_base<T>::simdjson_result_base() noexcept
+simdjson_inline simdjson_result_base<T>::simdjson_result_base() noexcept
     : simdjson_result_base(T{}, UNINITIALIZED) {}
 
 } // namespace internal
@@ -119,65 +119,65 @@ simdjson_really_inline simdjson_result_base<T>::simdjson_result_base() noexcept
 ///
 
 template<typename T>
-simdjson_really_inline void simdjson_result<T>::tie(T &value, error_code &error) && noexcept {
+simdjson_inline void simdjson_result<T>::tie(T &value, error_code &error) && noexcept {
   std::forward<internal::simdjson_result_base<T>>(*this).tie(value, error);
 }
 
 template<typename T>
-simdjson_warn_unused simdjson_really_inline error_code simdjson_result<T>::get(T &value) && noexcept {
+simdjson_warn_unused simdjson_inline error_code simdjson_result<T>::get(T &value) && noexcept {
   return std::forward<internal::simdjson_result_base<T>>(*this).get(value);
 }
 
 template<typename T>
-simdjson_really_inline error_code simdjson_result<T>::error() const noexcept {
+simdjson_inline error_code simdjson_result<T>::error() const noexcept {
   return internal::simdjson_result_base<T>::error();
 }
 
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline T& simdjson_result<T>::value() & noexcept(false) {
+simdjson_inline T& simdjson_result<T>::value() & noexcept(false) {
   return internal::simdjson_result_base<T>::value();
 }
 
 template<typename T>
-simdjson_really_inline T&& simdjson_result<T>::value() && noexcept(false) {
+simdjson_inline T&& simdjson_result<T>::value() && noexcept(false) {
   return std::forward<internal::simdjson_result_base<T>>(*this).value();
 }
 
 template<typename T>
-simdjson_really_inline T&& simdjson_result<T>::take_value() && noexcept(false) {
+simdjson_inline T&& simdjson_result<T>::take_value() && noexcept(false) {
   return std::forward<internal::simdjson_result_base<T>>(*this).take_value();
 }
 
 template<typename T>
-simdjson_really_inline simdjson_result<T>::operator T&&() && noexcept(false) {
+simdjson_inline simdjson_result<T>::operator T&&() && noexcept(false) {
   return std::forward<internal::simdjson_result_base<T>>(*this).take_value();
 }
 
 #endif // SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline const T& simdjson_result<T>::value_unsafe() const& noexcept {
+simdjson_inline const T& simdjson_result<T>::value_unsafe() const& noexcept {
   return internal::simdjson_result_base<T>::value_unsafe();
 }
 
 template<typename T>
-simdjson_really_inline T&& simdjson_result<T>::value_unsafe() && noexcept {
+simdjson_inline T&& simdjson_result<T>::value_unsafe() && noexcept {
   return std::forward<internal::simdjson_result_base<T>>(*this).value_unsafe();
 }
 
 template<typename T>
-simdjson_really_inline simdjson_result<T>::simdjson_result(T &&value, error_code error) noexcept
+simdjson_inline simdjson_result<T>::simdjson_result(T &&value, error_code error) noexcept
     : internal::simdjson_result_base<T>(std::forward<T>(value), error) {}
 template<typename T>
-simdjson_really_inline simdjson_result<T>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<T>::simdjson_result(error_code error) noexcept
     : internal::simdjson_result_base<T>(error) {}
 template<typename T>
-simdjson_really_inline simdjson_result<T>::simdjson_result(T &&value) noexcept
+simdjson_inline simdjson_result<T>::simdjson_result(T &&value) noexcept
     : internal::simdjson_result_base<T>(std::forward<T>(value)) {}
 template<typename T>
-simdjson_really_inline simdjson_result<T>::simdjson_result() noexcept
+simdjson_inline simdjson_result<T>::simdjson_result() noexcept
     : internal::simdjson_result_base<T>() {}
 
 } // namespace simdjson

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -111,22 +111,22 @@ struct simdjson_result_base : protected std::pair<T, error_code> {
   /**
    * Create a new empty result with error = UNINITIALIZED.
    */
-  simdjson_really_inline simdjson_result_base() noexcept;
+  simdjson_inline simdjson_result_base() noexcept;
 
   /**
    * Create a new error result.
    */
-  simdjson_really_inline simdjson_result_base(error_code error) noexcept;
+  simdjson_inline simdjson_result_base(error_code error) noexcept;
 
   /**
    * Create a new successful result.
    */
-  simdjson_really_inline simdjson_result_base(T &&value) noexcept;
+  simdjson_inline simdjson_result_base(T &&value) noexcept;
 
   /**
    * Create a new result with both things (use if you don't want to branch when creating the result).
    */
-  simdjson_really_inline simdjson_result_base(T &&value, error_code error) noexcept;
+  simdjson_inline simdjson_result_base(T &&value, error_code error) noexcept;
 
   /**
    * Move the value and the error to the provided variables.
@@ -134,19 +134,19 @@ struct simdjson_result_base : protected std::pair<T, error_code> {
    * @param value The variable to assign the value to. May not be set if there is an error.
    * @param error The variable to assign the error to. Set to SUCCESS if there is no error.
    */
-  simdjson_really_inline void tie(T &value, error_code &error) && noexcept;
+  simdjson_inline void tie(T &value, error_code &error) && noexcept;
 
   /**
    * Move the value to the provided variable.
    *
    * @param value The variable to assign the value to. May not be set if there is an error.
    */
-  simdjson_really_inline error_code get(T &value) && noexcept;
+  simdjson_inline error_code get(T &value) && noexcept;
 
   /**
    * The error.
    */
-  simdjson_really_inline error_code error() const noexcept;
+  simdjson_inline error_code error() const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
 
@@ -155,41 +155,41 @@ struct simdjson_result_base : protected std::pair<T, error_code> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T& value() & noexcept(false);
+  simdjson_inline T& value() & noexcept(false);
 
   /**
    * Take the result value (move it).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T&& value() && noexcept(false);
+  simdjson_inline T&& value() && noexcept(false);
 
   /**
    * Take the result value (move it).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T&& take_value() && noexcept(false);
+  simdjson_inline T&& take_value() && noexcept(false);
 
   /**
    * Cast to the value (will throw on error).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline operator T&&() && noexcept(false);
+  simdjson_inline operator T&&() && noexcept(false);
 #endif // SIMDJSON_EXCEPTIONS
 
   /**
    * Get the result value. This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
-  simdjson_really_inline const T& value_unsafe() const& noexcept;
+  simdjson_inline const T& value_unsafe() const& noexcept;
 
   /**
    * Take the result value (move it). This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
-  simdjson_really_inline T&& value_unsafe() && noexcept;
+  simdjson_inline T&& value_unsafe() && noexcept;
 
 }; // struct simdjson_result_base
 
@@ -205,19 +205,19 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
   /**
    * @private Create a new empty result with error = UNINITIALIZED.
    */
-  simdjson_really_inline simdjson_result() noexcept;
+  simdjson_inline simdjson_result() noexcept;
   /**
    * @private Create a new error result.
    */
-  simdjson_really_inline simdjson_result(T &&value) noexcept;
+  simdjson_inline simdjson_result(T &&value) noexcept;
   /**
    * @private Create a new successful result.
    */
-  simdjson_really_inline simdjson_result(error_code error_code) noexcept;
+  simdjson_inline simdjson_result(error_code error_code) noexcept;
   /**
    * @private Create a new result with both things (use if you don't want to branch when creating the result).
    */
-  simdjson_really_inline simdjson_result(T &&value, error_code error) noexcept;
+  simdjson_inline simdjson_result(T &&value, error_code error) noexcept;
 
   /**
    * Move the value and the error to the provided variables.
@@ -225,19 +225,19 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
    * @param value The variable to assign the value to. May not be set if there is an error.
    * @param error The variable to assign the error to. Set to SUCCESS if there is no error.
    */
-  simdjson_really_inline void tie(T &value, error_code &error) && noexcept;
+  simdjson_inline void tie(T &value, error_code &error) && noexcept;
 
   /**
    * Move the value to the provided variable.
    *
    * @param value The variable to assign the value to. May not be set if there is an error.
    */
-  simdjson_warn_unused simdjson_really_inline error_code get(T &value) && noexcept;
+  simdjson_warn_unused simdjson_inline error_code get(T &value) && noexcept;
 
   /**
    * The error.
    */
-  simdjson_really_inline error_code error() const noexcept;
+  simdjson_inline error_code error() const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
 
@@ -246,41 +246,41 @@ struct simdjson_result : public internal::simdjson_result_base<T> {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T& value() & noexcept(false);
+  simdjson_inline T& value() & noexcept(false);
 
   /**
    * Take the result value (move it).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T&& value() && noexcept(false);
+  simdjson_inline T&& value() && noexcept(false);
 
   /**
    * Take the result value (move it).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T&& take_value() && noexcept(false);
+  simdjson_inline T&& take_value() && noexcept(false);
 
   /**
    * Cast to the value (will throw on error).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline operator T&&() && noexcept(false);
+  simdjson_inline operator T&&() && noexcept(false);
 #endif // SIMDJSON_EXCEPTIONS
 
   /**
    * Get the result value. This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
-  simdjson_really_inline const T& value_unsafe() const& noexcept;
+  simdjson_inline const T& value_unsafe() const& noexcept;
 
   /**
    * Take the result value (move it). This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
-  simdjson_really_inline T&& value_unsafe() && noexcept;
+  simdjson_inline T&& value_unsafe() && noexcept;
 
 }; // struct simdjson_result
 

--- a/include/simdjson/fallback/bitmanipulation.h
+++ b/include/simdjson/fallback/bitmanipulation.h
@@ -26,7 +26,7 @@ static unsigned char _BitScanReverse64(unsigned long* ret, uint64_t x) {
 #endif
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline int leading_zeroes(uint64_t input_num) {
+simdjson_inline int leading_zeroes(uint64_t input_num) {
 #ifdef _MSC_VER
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)

--- a/include/simdjson/fallback/implementation.h
+++ b/include/simdjson/fallback/implementation.h
@@ -13,7 +13,7 @@ using namespace simdjson::dom;
 
 class implementation final : public simdjson::implementation {
 public:
-  simdjson_really_inline implementation() : simdjson::implementation(
+  simdjson_inline implementation() : simdjson::implementation(
       "fallback",
       "Generic fallback implementation",
       0

--- a/include/simdjson/fallback/numberparsing.h
+++ b/include/simdjson/fallback/numberparsing.h
@@ -12,14 +12,14 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 // credit: https://johnnylee-sde.github.io/Fast-numeric-string-to-int/
-static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const char *chars) {
+static simdjson_inline uint32_t parse_eight_digits_unrolled(const char *chars) {
   uint64_t val;
   memcpy(&val, chars, sizeof(uint64_t));
   val = (val & 0x0F0F0F0F0F0F0F0F) * 2561 >> 8;
   val = (val & 0x00FF00FF00FF00FF) * 6553601 >> 16;
   return uint32_t((val & 0x0000FFFF0000FFFF) * 42949672960001 >> 32);
 }
-static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
+static simdjson_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   return parse_eight_digits_unrolled(reinterpret_cast<const char *>(chars));
 }
 

--- a/include/simdjson/fallback/stringparsing.h
+++ b/include/simdjson/fallback/stringparsing.h
@@ -11,17 +11,17 @@ namespace {
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 1;
-  simdjson_really_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_really_inline bool has_quote_first() { return c == '"'; }
-  simdjson_really_inline bool has_backslash() { return c == '\\'; }
-  simdjson_really_inline int quote_index() { return c == '"' ? 0 : 1; }
-  simdjson_really_inline int backslash_index() { return c == '\\' ? 0 : 1; }
+  simdjson_inline bool has_quote_first() { return c == '"'; }
+  simdjson_inline bool has_backslash() { return c == '\\'; }
+  simdjson_inline int quote_index() { return c == '"' ? 0 : 1; }
+  simdjson_inline int backslash_index() { return c == '\\' ? 0 : 1; }
 
   uint8_t c;
 }; // struct backslash_and_quote
 
-simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
+simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // store to dest unconditionally - we can overwrite the bits we don't like later
   dst[0] = src[0];
   return { src[0] };

--- a/include/simdjson/generic/atomparsing.h
+++ b/include/simdjson/generic/atomparsing.h
@@ -10,13 +10,13 @@ namespace atomparsing {
 // You might think that using memcpy makes this function expensive, but you'd be wrong.
 // All decent optimizing compilers (GCC, clang, Visual Studio) will compile string_to_uint32("false");
 // to the compile-time constant 1936482662.
-simdjson_really_inline uint32_t string_to_uint32(const char* str) { uint32_t val; std::memcpy(&val, str, sizeof(uint32_t)); return val; }
+simdjson_inline uint32_t string_to_uint32(const char* str) { uint32_t val; std::memcpy(&val, str, sizeof(uint32_t)); return val; }
 
 
 // Again in str4ncmp we use a memcpy to avoid undefined behavior. The memcpy may appear expensive.
 // Yet all decent optimizing compilers will compile memcpy to a single instruction, just about.
 simdjson_warn_unused
-simdjson_really_inline uint32_t str4ncmp(const uint8_t *src, const char* atom) {
+simdjson_inline uint32_t str4ncmp(const uint8_t *src, const char* atom) {
   uint32_t srcval; // we want to avoid unaligned 32-bit loads (undefined in C/C++)
   static_assert(sizeof(uint32_t) <= SIMDJSON_PADDING, "SIMDJSON_PADDING must be larger than 4 bytes");
   std::memcpy(&srcval, src, sizeof(uint32_t));
@@ -24,36 +24,36 @@ simdjson_really_inline uint32_t str4ncmp(const uint8_t *src, const char* atom) {
 }
 
 simdjson_warn_unused
-simdjson_really_inline bool is_valid_true_atom(const uint8_t *src) {
+simdjson_inline bool is_valid_true_atom(const uint8_t *src) {
   return (str4ncmp(src, "true") | jsoncharutils::is_not_structural_or_whitespace(src[4])) == 0;
 }
 
 simdjson_warn_unused
-simdjson_really_inline bool is_valid_true_atom(const uint8_t *src, size_t len) {
+simdjson_inline bool is_valid_true_atom(const uint8_t *src, size_t len) {
   if (len > 4) { return is_valid_true_atom(src); }
   else if (len == 4) { return !str4ncmp(src, "true"); }
   else { return false; }
 }
 
 simdjson_warn_unused
-simdjson_really_inline bool is_valid_false_atom(const uint8_t *src) {
+simdjson_inline bool is_valid_false_atom(const uint8_t *src) {
   return (str4ncmp(src+1, "alse") | jsoncharutils::is_not_structural_or_whitespace(src[5])) == 0;
 }
 
 simdjson_warn_unused
-simdjson_really_inline bool is_valid_false_atom(const uint8_t *src, size_t len) {
+simdjson_inline bool is_valid_false_atom(const uint8_t *src, size_t len) {
   if (len > 5) { return is_valid_false_atom(src); }
   else if (len == 5) { return !str4ncmp(src+1, "alse"); }
   else { return false; }
 }
 
 simdjson_warn_unused
-simdjson_really_inline bool is_valid_null_atom(const uint8_t *src) {
+simdjson_inline bool is_valid_null_atom(const uint8_t *src) {
   return (str4ncmp(src, "null") | jsoncharutils::is_not_structural_or_whitespace(src[4])) == 0;
 }
 
 simdjson_warn_unused
-simdjson_really_inline bool is_valid_null_atom(const uint8_t *src, size_t len) {
+simdjson_inline bool is_valid_null_atom(const uint8_t *src, size_t len) {
   if (len > 4) { return is_valid_null_atom(src); }
   else if (len == 4) { return !str4ncmp(src, "null"); }
   else { return false; }

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -39,7 +39,7 @@ public:
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;
   inline simdjson_warn_unused error_code set_max_depth(size_t max_depth) noexcept final;
 private:
-  simdjson_really_inline simdjson_warn_unused error_code set_capacity_stage1(size_t capacity);
+  simdjson_inline simdjson_warn_unused error_code set_capacity_stage1(size_t capacity);
 
 };
 

--- a/include/simdjson/generic/implementation_simdjson_result_base-inl.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base-inl.h
@@ -6,7 +6,7 @@ namespace SIMDJSON_IMPLEMENTATION {
 //
 
 template<typename T>
-simdjson_really_inline void implementation_simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
+simdjson_inline void implementation_simdjson_result_base<T>::tie(T &value, error_code &error) && noexcept {
   error = this->second;
   if (!error) {
     value = std::forward<implementation_simdjson_result_base<T>>(*this).first;
@@ -14,66 +14,66 @@ simdjson_really_inline void implementation_simdjson_result_base<T>::tie(T &value
 }
 
 template<typename T>
-simdjson_warn_unused simdjson_really_inline error_code implementation_simdjson_result_base<T>::get(T &value) && noexcept {
+simdjson_warn_unused simdjson_inline error_code implementation_simdjson_result_base<T>::get(T &value) && noexcept {
   error_code error;
   std::forward<implementation_simdjson_result_base<T>>(*this).tie(value, error);
   return error;
 }
 
 template<typename T>
-simdjson_really_inline error_code implementation_simdjson_result_base<T>::error() const noexcept {
+simdjson_inline error_code implementation_simdjson_result_base<T>::error() const noexcept {
   return this->second;
 }
 
 #if SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline T& implementation_simdjson_result_base<T>::value() & noexcept(false) {
+simdjson_inline T& implementation_simdjson_result_base<T>::value() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return this->first;
 }
 
 template<typename T>
-simdjson_really_inline T&& implementation_simdjson_result_base<T>::value() && noexcept(false) {
+simdjson_inline T&& implementation_simdjson_result_base<T>::value() && noexcept(false) {
   return std::forward<implementation_simdjson_result_base<T>>(*this).take_value();
 }
 
 template<typename T>
-simdjson_really_inline T&& implementation_simdjson_result_base<T>::take_value() && noexcept(false) {
+simdjson_inline T&& implementation_simdjson_result_base<T>::take_value() && noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return std::forward<T>(this->first);
 }
 
 template<typename T>
-simdjson_really_inline implementation_simdjson_result_base<T>::operator T&&() && noexcept(false) {
+simdjson_inline implementation_simdjson_result_base<T>::operator T&&() && noexcept(false) {
   return std::forward<implementation_simdjson_result_base<T>>(*this).take_value();
 }
 
 #endif // SIMDJSON_EXCEPTIONS
 
 template<typename T>
-simdjson_really_inline const T& implementation_simdjson_result_base<T>::value_unsafe() const& noexcept {
+simdjson_inline const T& implementation_simdjson_result_base<T>::value_unsafe() const& noexcept {
   return this->first;
 }
 
 template<typename T>
-simdjson_really_inline T& implementation_simdjson_result_base<T>::value_unsafe() & noexcept {
+simdjson_inline T& implementation_simdjson_result_base<T>::value_unsafe() & noexcept {
   return this->first;
 }
 
 template<typename T>
-simdjson_really_inline T&& implementation_simdjson_result_base<T>::value_unsafe() && noexcept {
+simdjson_inline T&& implementation_simdjson_result_base<T>::value_unsafe() && noexcept {
   return std::forward<T>(this->first);
 }
 
 template<typename T>
-simdjson_really_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(T &&value, error_code error) noexcept
+simdjson_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(T &&value, error_code error) noexcept
     : first{std::forward<T>(value)}, second{error} {}
 template<typename T>
-simdjson_really_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(error_code error) noexcept
+simdjson_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(error_code error) noexcept
     : implementation_simdjson_result_base(T{}, error) {}
 template<typename T>
-simdjson_really_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(T &&value) noexcept
+simdjson_inline implementation_simdjson_result_base<T>::implementation_simdjson_result_base(T &&value) noexcept
     : implementation_simdjson_result_base(std::forward<T>(value), SUCCESS) {}
 
 } // namespace SIMDJSON_IMPLEMENTATION

--- a/include/simdjson/generic/implementation_simdjson_result_base.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base.h
@@ -30,22 +30,22 @@ struct implementation_simdjson_result_base {
   /**
    * Create a new empty result with error = UNINITIALIZED.
    */
-  simdjson_really_inline implementation_simdjson_result_base() noexcept = default;
+  simdjson_inline implementation_simdjson_result_base() noexcept = default;
 
   /**
    * Create a new error result.
    */
-  simdjson_really_inline implementation_simdjson_result_base(error_code error) noexcept;
+  simdjson_inline implementation_simdjson_result_base(error_code error) noexcept;
 
   /**
    * Create a new successful result.
    */
-  simdjson_really_inline implementation_simdjson_result_base(T &&value) noexcept;
+  simdjson_inline implementation_simdjson_result_base(T &&value) noexcept;
 
   /**
    * Create a new result with both things (use if you don't want to branch when creating the result).
    */
-  simdjson_really_inline implementation_simdjson_result_base(T &&value, error_code error) noexcept;
+  simdjson_inline implementation_simdjson_result_base(T &&value, error_code error) noexcept;
 
   /**
    * Move the value and the error to the provided variables.
@@ -53,19 +53,19 @@ struct implementation_simdjson_result_base {
    * @param value The variable to assign the value to. May not be set if there is an error.
    * @param error The variable to assign the error to. Set to SUCCESS if there is no error.
    */
-  simdjson_really_inline void tie(T &value, error_code &error) && noexcept;
+  simdjson_inline void tie(T &value, error_code &error) && noexcept;
 
   /**
    * Move the value to the provided variable.
    *
    * @param value The variable to assign the value to. May not be set if there is an error.
    */
-  simdjson_really_inline error_code get(T &value) && noexcept;
+  simdjson_inline error_code get(T &value) && noexcept;
 
   /**
    * The error.
    */
-  simdjson_really_inline error_code error() const noexcept;
+  simdjson_inline error_code error() const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
 
@@ -74,28 +74,28 @@ struct implementation_simdjson_result_base {
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T& value() & noexcept(false);
+  simdjson_inline T& value() & noexcept(false);
 
   /**
    * Take the result value (move it).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T&& value() && noexcept(false);
+  simdjson_inline T&& value() && noexcept(false);
 
   /**
    * Take the result value (move it).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline T&& take_value() && noexcept(false);
+  simdjson_inline T&& take_value() && noexcept(false);
 
   /**
    * Cast to the value (will throw on error).
    *
    * @throw simdjson_error if there was an error.
    */
-  simdjson_really_inline operator T&&() && noexcept(false);
+  simdjson_inline operator T&&() && noexcept(false);
 
 
 #endif // SIMDJSON_EXCEPTIONS
@@ -104,17 +104,17 @@ struct implementation_simdjson_result_base {
    * Get the result value. This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
-  simdjson_really_inline const T& value_unsafe() const& noexcept;
+  simdjson_inline const T& value_unsafe() const& noexcept;
   /**
    * Get the result value. This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
-  simdjson_really_inline T& value_unsafe() & noexcept;
+  simdjson_inline T& value_unsafe() & noexcept;
   /**
    * Take the result value (move it). This function is safe if and only
    * the error() method returns a value that evaluates to false.
    */
-  simdjson_really_inline T&& value_unsafe() && noexcept;
+  simdjson_inline T&& value_unsafe() && noexcept;
 protected:
   /** users should never directly access first and second. **/
   T first{}; /** Users should never directly access 'first'. **/

--- a/include/simdjson/generic/jsoncharutils.h
+++ b/include/simdjson/generic/jsoncharutils.h
@@ -8,11 +8,11 @@ namespace jsoncharutils {
 
 // return non-zero if not a structural or whitespace char
 // zero otherwise
-simdjson_really_inline uint32_t is_not_structural_or_whitespace(uint8_t c) {
+simdjson_inline uint32_t is_not_structural_or_whitespace(uint8_t c) {
   return internal::structural_or_whitespace_negated[c];
 }
 
-simdjson_really_inline uint32_t is_structural_or_whitespace(uint8_t c) {
+simdjson_inline uint32_t is_structural_or_whitespace(uint8_t c) {
   return internal::structural_or_whitespace[c];
 }
 
@@ -43,7 +43,7 @@ static inline uint32_t hex_to_u32_nocheck(
 //
 // Note: we assume that surrogates are treated separately
 //
-simdjson_really_inline size_t codepoint_to_utf8(uint32_t cp, uint8_t *c) {
+simdjson_inline size_t codepoint_to_utf8(uint32_t cp, uint8_t *c) {
   if (cp <= 0x7F) {
     c[0] = uint8_t(cp);
     return 1; // ascii
@@ -75,10 +75,10 @@ simdjson_really_inline size_t codepoint_to_utf8(uint32_t cp, uint8_t *c) {
 #ifdef SIMDJSON_IS_32BITS // _umul128 for x86, arm
 // this is a slow emulation routine for 32-bit
 //
-static simdjson_really_inline uint64_t __emulu(uint32_t x, uint32_t y) {
+static simdjson_inline uint64_t __emulu(uint32_t x, uint32_t y) {
   return x * (uint64_t)y;
 }
-static simdjson_really_inline uint64_t _umul128(uint64_t ab, uint64_t cd, uint64_t *hi) {
+static simdjson_inline uint64_t _umul128(uint64_t ab, uint64_t cd, uint64_t *hi) {
   uint64_t ad = __emulu((uint32_t)(ab >> 32), (uint32_t)cd);
   uint64_t bd = __emulu((uint32_t)ab, (uint32_t)cd);
   uint64_t adbc = ad + __emulu((uint32_t)ab, (uint32_t)(cd >> 32));
@@ -92,7 +92,7 @@ static simdjson_really_inline uint64_t _umul128(uint64_t ab, uint64_t cd, uint64
 
 using internal::value128;
 
-simdjson_really_inline value128 full_multiplication(uint64_t value1, uint64_t value2) {
+simdjson_inline value128 full_multiplication(uint64_t value1, uint64_t value2) {
   value128 answer;
 #if defined(SIMDJSON_REGULAR_VISUAL_STUDIO) || defined(SIMDJSON_IS_32BITS)
 #ifdef _M_ARM64

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -40,45 +40,45 @@ namespace ondemand {
 //   error == SUCCESS.
 //
 
-simdjson_really_inline array::array(const value_iterator &_iter) noexcept
+simdjson_inline array::array(const value_iterator &_iter) noexcept
   : iter{_iter}
 {
 }
 
-simdjson_really_inline simdjson_result<array> array::start(value_iterator &iter) noexcept {
+simdjson_inline simdjson_result<array> array::start(value_iterator &iter) noexcept {
   // We don't need to know if the array is empty to start iteration, but we do want to know if there
   // is an error--thus `simdjson_unused`.
   simdjson_unused bool has_value;
   SIMDJSON_TRY( iter.start_array().get(has_value) );
   return array(iter);
 }
-simdjson_really_inline simdjson_result<array> array::start_root(value_iterator &iter) noexcept {
+simdjson_inline simdjson_result<array> array::start_root(value_iterator &iter) noexcept {
   simdjson_unused bool has_value;
   SIMDJSON_TRY( iter.start_root_array().get(has_value) );
   return array(iter);
 }
-simdjson_really_inline simdjson_result<array> array::started(value_iterator &iter) noexcept {
+simdjson_inline simdjson_result<array> array::started(value_iterator &iter) noexcept {
   bool has_value;
   SIMDJSON_TRY(iter.started_array().get(has_value));
   return array(iter);
 }
 
-simdjson_really_inline simdjson_result<array_iterator> array::begin() noexcept {
+simdjson_inline simdjson_result<array_iterator> array::begin() noexcept {
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
   if (!iter.is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   return array_iterator(iter);
 }
-simdjson_really_inline simdjson_result<array_iterator> array::end() noexcept {
+simdjson_inline simdjson_result<array_iterator> array::end() noexcept {
   return array_iterator(iter);
 }
-simdjson_really_inline error_code array::consume() noexcept {
+simdjson_inline error_code array::consume() noexcept {
   auto error = iter.json_iter().skip_child(iter.depth()-1);
   if(error) { iter.abandon(); }
   return error;
 }
 
-simdjson_really_inline simdjson_result<std::string_view> array::raw_json() noexcept {
+simdjson_inline simdjson_result<std::string_view> array::raw_json() noexcept {
   const uint8_t * starting_point{iter.peek_start()};
   auto error = consume();
   if(error) { return error; }
@@ -91,7 +91,7 @@ simdjson_really_inline simdjson_result<std::string_view> array::raw_json() noexc
 
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
-simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcept {
+simdjson_inline simdjson_result<size_t> array::count_elements() & noexcept {
   size_t count{0};
   // Important: we do not consume any of the values.
   for(simdjson_unused auto v : *this) { count++; }
@@ -104,7 +104,7 @@ simdjson_really_inline simdjson_result<size_t> array::count_elements() & noexcep
 }
 SIMDJSON_POP_DISABLE_WARNINGS
 
-simdjson_really_inline simdjson_result<bool> array::is_empty() & noexcept {
+simdjson_inline simdjson_result<bool> array::is_empty() & noexcept {
   bool is_not_empty;
   auto error = iter.reset_array().get(is_not_empty);
   if(error) { return error; }
@@ -151,7 +151,7 @@ inline simdjson_result<value> array::at_pointer(std::string_view json_pointer) n
   return child;
 }
 
-simdjson_really_inline simdjson_result<value> array::at(size_t index) noexcept {
+simdjson_inline simdjson_result<value> array::at(size_t index) noexcept {
   size_t i = 0;
   for (auto value : *this) {
     if (i == index) { return value; }
@@ -166,7 +166,7 @@ simdjson_really_inline simdjson_result<value> array::at(size_t index) noexcept {
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::simdjson_result(
   SIMDJSON_IMPLEMENTATION::ondemand::array &&value
 ) noexcept
   : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array>(
@@ -174,34 +174,34 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>
     )
 {
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::simdjson_result(
   error_code error
 ) noexcept
   : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array>(error)
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::begin() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::begin() noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::end() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::end() noexcept {
   if (error()) { return error(); }
   return first.end();
 }
-simdjson_really_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::count_elements() & noexcept {
+simdjson_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::count_elements() & noexcept {
   if (error()) { return error(); }
   return first.count_elements();
 }
-simdjson_really_inline  simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::is_empty() & noexcept {
+simdjson_inline  simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::is_empty() & noexcept {
   if (error()) { return error(); }
   return first.is_empty();
 }
-simdjson_really_inline  simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::at(size_t index) noexcept {
+simdjson_inline  simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::at(size_t index) noexcept {
   if (error()) { return error(); }
   return first.at(index);
 }
-simdjson_really_inline  simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::at_pointer(std::string_view json_pointer) noexcept {
+simdjson_inline  simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array>::at_pointer(std::string_view json_pointer) noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
 }

--- a/include/simdjson/generic/ondemand/array.h
+++ b/include/simdjson/generic/ondemand/array.h
@@ -17,20 +17,20 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline array() noexcept = default;
+  simdjson_inline array() noexcept = default;
 
   /**
    * Begin array iteration.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator> begin() noexcept;
+  simdjson_inline simdjson_result<array_iterator> begin() noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator> end() noexcept;
+  simdjson_inline simdjson_result<array_iterator> end() noexcept;
   /**
    * This method scans the array and counts the number of elements.
    * The count_elements method should always be called before you have begun
@@ -45,7 +45,7 @@ public:
    * To check that an array is empty, it is more performant to use
    * the is_empty() method.
    */
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
   /**
    * This method scans the beginning of the array and checks whether the
    * array is empty.
@@ -55,7 +55,7 @@ public:
    * there is a missing comma), then an error is returned and it is no longer
    * safe to continue.
    */
-  simdjson_really_inline simdjson_result<bool> is_empty() & noexcept;
+  simdjson_inline simdjson_result<bool> is_empty() & noexcept;
   /**
    * Reset the iterator so that we are pointing back at the
    * beginning of the array. You should still consume values only once even if you
@@ -100,7 +100,7 @@ public:
    * Consumes the array and returns a string_view instance corresponding to the
    * array as represented in JSON. It points inside the original document.
    */
-  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
+  simdjson_inline simdjson_result<std::string_view> raw_json() noexcept;
 
   /**
    * Get the value at the given index. This function has linear-time complexity.
@@ -109,12 +109,12 @@ public:
    * @return The value at the given index, or:
    *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
    */
-  simdjson_really_inline simdjson_result<value> at(size_t index) noexcept;
+  simdjson_inline simdjson_result<value> at(size_t index) noexcept;
 protected:
   /**
    * Go to the end of the array, no matter where you are right now.
    */
-  simdjson_really_inline error_code consume() noexcept;
+  simdjson_inline error_code consume() noexcept;
 
   /**
    * Begin array iteration.
@@ -123,7 +123,7 @@ protected:
    *        resulting array.
    * @error INCORRECT_TYPE if the iterator is not at [.
    */
-  static simdjson_really_inline simdjson_result<array> start(value_iterator &iter) noexcept;
+  static simdjson_inline simdjson_result<array> start(value_iterator &iter) noexcept;
   /**
    * Begin array iteration from the root.
    *
@@ -132,7 +132,7 @@ protected:
    * @error INCORRECT_TYPE if the iterator is not at [.
    * @error TAPE_ERROR if there is no closing ] at the end of the document.
    */
-  static simdjson_really_inline simdjson_result<array> start_root(value_iterator &iter) noexcept;
+  static simdjson_inline simdjson_result<array> start_root(value_iterator &iter) noexcept;
   /**
    * Begin array iteration.
    *
@@ -141,7 +141,7 @@ protected:
    *
    * @param iter The iterator. Must be after the initial [. Will be *moved* into the resulting array.
    */
-  static simdjson_really_inline simdjson_result<array> started(value_iterator &iter) noexcept;
+  static simdjson_inline simdjson_result<array> started(value_iterator &iter) noexcept;
 
   /**
    * Create an array at the given Internal array creation. Call array::start() or array::started() instead of this.
@@ -150,7 +150,7 @@ protected:
    *        == true, or past the [] with is_alive() == false if the array is empty. Will be *moved*
    *        into the resulting array.
    */
-  simdjson_really_inline array(const value_iterator &iter) noexcept;
+  simdjson_inline array(const value_iterator &iter) noexcept;
 
   /**
    * Iterator marking current position.
@@ -175,17 +175,17 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() noexcept;
   inline simdjson_result<size_t> count_elements() & noexcept;
   inline simdjson_result<bool> is_empty() & noexcept;
   inline simdjson_result<bool> reset() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/array_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/array_iterator-inl.h
@@ -2,21 +2,21 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline array_iterator::array_iterator(const value_iterator &_iter) noexcept
+simdjson_inline array_iterator::array_iterator(const value_iterator &_iter) noexcept
   : iter{_iter}
 {}
 
-simdjson_really_inline simdjson_result<value> array_iterator::operator*() noexcept {
+simdjson_inline simdjson_result<value> array_iterator::operator*() noexcept {
   if (iter.error()) { iter.abandon(); return iter.error(); }
   return value(iter.child());
 }
-simdjson_really_inline bool array_iterator::operator==(const array_iterator &other) const noexcept {
+simdjson_inline bool array_iterator::operator==(const array_iterator &other) const noexcept {
   return !(*this != other);
 }
-simdjson_really_inline bool array_iterator::operator!=(const array_iterator &) const noexcept {
+simdjson_inline bool array_iterator::operator!=(const array_iterator &) const noexcept {
   return iter.is_open();
 }
-simdjson_really_inline array_iterator &array_iterator::operator++() noexcept {
+simdjson_inline array_iterator &array_iterator::operator++() noexcept {
   error_code error;
   // PERF NOTE this is a safety rail ... users should exit loops as soon as they receive an error, so we'll never get here.
   // However, it does not seem to make a perf difference, so we add it out of an abundance of caution.
@@ -32,31 +32,31 @@ simdjson_really_inline array_iterator &array_iterator::operator++() noexcept {
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::simdjson_result(
   SIMDJSON_IMPLEMENTATION::ondemand::array_iterator &&value
 ) noexcept
   : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>(value))
 {
   first.iter.assert_is_valid();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::simdjson_result(error_code error) noexcept
   : SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>({}, error)
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator*() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator*() noexcept {
   if (error()) { return error(); }
   return *first;
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
   if (!first.iter.is_valid()) { return !error(); }
   return first == other.first;
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &other) const noexcept {
   if (!first.iter.is_valid()) { return error(); }
   return first != other.first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator++() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator>::operator++() noexcept {
   // Clear the error if there is one, so we don't yield it twice
   if (error()) { second = SUCCESS; return *this; }
   ++(first);

--- a/include/simdjson/generic/ondemand/array_iterator.h
+++ b/include/simdjson/generic/ondemand/array_iterator.h
@@ -19,7 +19,7 @@ class document;
 class array_iterator {
 public:
   /** Create a new, invalid array iterator. */
-  simdjson_really_inline array_iterator() noexcept = default;
+  simdjson_inline array_iterator() noexcept = default;
 
   //
   // Iterator interface
@@ -30,7 +30,7 @@ public:
    *
    * Part of the std::iterator interface.
    */
-  simdjson_really_inline simdjson_result<value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
+  simdjson_inline simdjson_result<value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
   /**
    * Check if we are at the end of the JSON.
    *
@@ -38,7 +38,7 @@ public:
    *
    * @return true if there are no more elements in the JSON array.
    */
-  simdjson_really_inline bool operator==(const array_iterator &) const noexcept;
+  simdjson_inline bool operator==(const array_iterator &) const noexcept;
   /**
    * Check if there are more elements in the JSON array.
    *
@@ -46,18 +46,18 @@ public:
    *
    * @return true if there are more elements in the JSON array.
    */
-  simdjson_really_inline bool operator!=(const array_iterator &) const noexcept;
+  simdjson_inline bool operator!=(const array_iterator &) const noexcept;
   /**
    * Move to the next element.
    *
    * Part of the std::iterator interface.
    */
-  simdjson_really_inline array_iterator &operator++() noexcept;
+  simdjson_inline array_iterator &operator++() noexcept;
 
 private:
   value_iterator iter{};
 
-  simdjson_really_inline array_iterator(const value_iterator &iter) noexcept;
+  simdjson_inline array_iterator(const value_iterator &iter) noexcept;
 
   friend class array;
   friend class value;
@@ -73,18 +73,18 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array_iterator &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::array_iterator &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 
   //
   // Iterator interface
   //
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
-  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) const noexcept;
-  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) const noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &operator++() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
+  simdjson_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) const noexcept;
+  simdjson_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &) const noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> &operator++() noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -2,13 +2,13 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline document::document(ondemand::json_iterator &&_iter) noexcept
+simdjson_inline document::document(ondemand::json_iterator &&_iter) noexcept
   : iter{std::forward<json_iterator>(_iter)}
 {
   logger::log_start_value(iter, "document");
 }
 
-simdjson_really_inline document document::start(json_iterator &&iter) noexcept {
+simdjson_inline document document::start(json_iterator &&iter) noexcept {
   return document(std::forward<json_iterator>(iter));
 }
 
@@ -31,20 +31,20 @@ inline int32_t document::current_depth() const noexcept {
 inline bool document::is_alive() noexcept {
   return iter.is_alive();
 }
-simdjson_really_inline value_iterator document::resume_value_iterator() noexcept {
+simdjson_inline value_iterator document::resume_value_iterator() noexcept {
   return value_iterator(&iter, 1, iter.root_position());
 }
-simdjson_really_inline value_iterator document::get_root_value_iterator() noexcept {
+simdjson_inline value_iterator document::get_root_value_iterator() noexcept {
   return resume_value_iterator();
 }
-simdjson_really_inline simdjson_result<object> document::start_or_resume_object() noexcept {
+simdjson_inline simdjson_result<object> document::start_or_resume_object() noexcept {
   if (iter.at_root()) {
     return get_object();
   } else {
     return object::resume(resume_value_iterator());
   }
 }
-simdjson_really_inline simdjson_result<value> document::get_value() noexcept {
+simdjson_inline simdjson_result<value> document::get_value() noexcept {
   // Make sure we start any arrays or objects before returning, so that start_root_<object/array>()
   // gets called.
   iter.assert_at_document_depth();
@@ -59,83 +59,83 @@ simdjson_really_inline simdjson_result<value> document::get_value() noexcept {
       // return value(get_root_value_iterator());
   }
 }
-simdjson_really_inline simdjson_result<array> document::get_array() & noexcept {
+simdjson_inline simdjson_result<array> document::get_array() & noexcept {
   auto value = get_root_value_iterator();
   return array::start_root(value);
 }
-simdjson_really_inline simdjson_result<object> document::get_object() & noexcept {
+simdjson_inline simdjson_result<object> document::get_object() & noexcept {
   auto value = get_root_value_iterator();
   return object::start_root(value);
 }
-simdjson_really_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
+simdjson_inline simdjson_result<uint64_t> document::get_uint64() noexcept {
   return get_root_value_iterator().get_root_uint64();
 }
-simdjson_really_inline simdjson_result<uint64_t> document::get_uint64_in_string() noexcept {
+simdjson_inline simdjson_result<uint64_t> document::get_uint64_in_string() noexcept {
   return get_root_value_iterator().get_root_uint64_in_string();
 }
-simdjson_really_inline simdjson_result<int64_t> document::get_int64() noexcept {
+simdjson_inline simdjson_result<int64_t> document::get_int64() noexcept {
   return get_root_value_iterator().get_root_int64();
 }
-simdjson_really_inline simdjson_result<int64_t> document::get_int64_in_string() noexcept {
+simdjson_inline simdjson_result<int64_t> document::get_int64_in_string() noexcept {
   return get_root_value_iterator().get_root_int64_in_string();
 }
-simdjson_really_inline simdjson_result<double> document::get_double() noexcept {
+simdjson_inline simdjson_result<double> document::get_double() noexcept {
   return get_root_value_iterator().get_root_double();
 }
-simdjson_really_inline simdjson_result<double> document::get_double_in_string() noexcept {
+simdjson_inline simdjson_result<double> document::get_double_in_string() noexcept {
   return get_root_value_iterator().get_root_double_in_string();
 }
-simdjson_really_inline simdjson_result<std::string_view> document::get_string() noexcept {
+simdjson_inline simdjson_result<std::string_view> document::get_string() noexcept {
   return get_root_value_iterator().get_root_string();
 }
-simdjson_really_inline simdjson_result<raw_json_string> document::get_raw_json_string() noexcept {
+simdjson_inline simdjson_result<raw_json_string> document::get_raw_json_string() noexcept {
   return get_root_value_iterator().get_root_raw_json_string();
 }
-simdjson_really_inline simdjson_result<bool> document::get_bool() noexcept {
+simdjson_inline simdjson_result<bool> document::get_bool() noexcept {
   return get_root_value_iterator().get_root_bool();
 }
-simdjson_really_inline bool document::is_null() noexcept {
+simdjson_inline bool document::is_null() noexcept {
   return get_root_value_iterator().is_root_null();
 }
 
-template<> simdjson_really_inline simdjson_result<array> document::get() & noexcept { return get_array(); }
-template<> simdjson_really_inline simdjson_result<object> document::get() & noexcept { return get_object(); }
-template<> simdjson_really_inline simdjson_result<raw_json_string> document::get() & noexcept { return get_raw_json_string(); }
-template<> simdjson_really_inline simdjson_result<std::string_view> document::get() & noexcept { return get_string(); }
-template<> simdjson_really_inline simdjson_result<double> document::get() & noexcept { return get_double(); }
-template<> simdjson_really_inline simdjson_result<uint64_t> document::get() & noexcept { return get_uint64(); }
-template<> simdjson_really_inline simdjson_result<int64_t> document::get() & noexcept { return get_int64(); }
-template<> simdjson_really_inline simdjson_result<bool> document::get() & noexcept { return get_bool(); }
-template<> simdjson_really_inline simdjson_result<value> document::get() & noexcept { return get_value(); }
+template<> simdjson_inline simdjson_result<array> document::get() & noexcept { return get_array(); }
+template<> simdjson_inline simdjson_result<object> document::get() & noexcept { return get_object(); }
+template<> simdjson_inline simdjson_result<raw_json_string> document::get() & noexcept { return get_raw_json_string(); }
+template<> simdjson_inline simdjson_result<std::string_view> document::get() & noexcept { return get_string(); }
+template<> simdjson_inline simdjson_result<double> document::get() & noexcept { return get_double(); }
+template<> simdjson_inline simdjson_result<uint64_t> document::get() & noexcept { return get_uint64(); }
+template<> simdjson_inline simdjson_result<int64_t> document::get() & noexcept { return get_int64(); }
+template<> simdjson_inline simdjson_result<bool> document::get() & noexcept { return get_bool(); }
+template<> simdjson_inline simdjson_result<value> document::get() & noexcept { return get_value(); }
 
-template<> simdjson_really_inline simdjson_result<raw_json_string> document::get() && noexcept { return get_raw_json_string(); }
-template<> simdjson_really_inline simdjson_result<std::string_view> document::get() && noexcept { return get_string(); }
-template<> simdjson_really_inline simdjson_result<double> document::get() && noexcept { return std::forward<document>(*this).get_double(); }
-template<> simdjson_really_inline simdjson_result<uint64_t> document::get() && noexcept { return std::forward<document>(*this).get_uint64(); }
-template<> simdjson_really_inline simdjson_result<int64_t> document::get() && noexcept { return std::forward<document>(*this).get_int64(); }
-template<> simdjson_really_inline simdjson_result<bool> document::get() && noexcept { return std::forward<document>(*this).get_bool(); }
-template<> simdjson_really_inline simdjson_result<value> document::get() && noexcept { return get_value(); }
+template<> simdjson_inline simdjson_result<raw_json_string> document::get() && noexcept { return get_raw_json_string(); }
+template<> simdjson_inline simdjson_result<std::string_view> document::get() && noexcept { return get_string(); }
+template<> simdjson_inline simdjson_result<double> document::get() && noexcept { return std::forward<document>(*this).get_double(); }
+template<> simdjson_inline simdjson_result<uint64_t> document::get() && noexcept { return std::forward<document>(*this).get_uint64(); }
+template<> simdjson_inline simdjson_result<int64_t> document::get() && noexcept { return std::forward<document>(*this).get_int64(); }
+template<> simdjson_inline simdjson_result<bool> document::get() && noexcept { return std::forward<document>(*this).get_bool(); }
+template<> simdjson_inline simdjson_result<value> document::get() && noexcept { return get_value(); }
 
-template<typename T> simdjson_really_inline error_code document::get(T &out) & noexcept {
+template<typename T> simdjson_inline error_code document::get(T &out) & noexcept {
   return get<T>().get(out);
 }
-template<typename T> simdjson_really_inline error_code document::get(T &out) && noexcept {
+template<typename T> simdjson_inline error_code document::get(T &out) && noexcept {
   return std::forward<document>(*this).get<T>().get(out);
 }
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline document::operator array() & noexcept(false) { return get_array(); }
-simdjson_really_inline document::operator object() & noexcept(false) { return get_object(); }
-simdjson_really_inline document::operator uint64_t() noexcept(false) { return get_uint64(); }
-simdjson_really_inline document::operator int64_t() noexcept(false) { return get_int64(); }
-simdjson_really_inline document::operator double() noexcept(false) { return get_double(); }
-simdjson_really_inline document::operator std::string_view() noexcept(false) { return get_string(); }
-simdjson_really_inline document::operator raw_json_string() noexcept(false) { return get_raw_json_string(); }
-simdjson_really_inline document::operator bool() noexcept(false) { return get_bool(); }
-simdjson_really_inline document::operator value() noexcept(false) { return get_value(); }
+simdjson_inline document::operator array() & noexcept(false) { return get_array(); }
+simdjson_inline document::operator object() & noexcept(false) { return get_object(); }
+simdjson_inline document::operator uint64_t() noexcept(false) { return get_uint64(); }
+simdjson_inline document::operator int64_t() noexcept(false) { return get_int64(); }
+simdjson_inline document::operator double() noexcept(false) { return get_double(); }
+simdjson_inline document::operator std::string_view() noexcept(false) { return get_string(); }
+simdjson_inline document::operator raw_json_string() noexcept(false) { return get_raw_json_string(); }
+simdjson_inline document::operator bool() noexcept(false) { return get_bool(); }
+simdjson_inline document::operator value() noexcept(false) { return get_value(); }
 
 #endif
-simdjson_really_inline simdjson_result<size_t> document::count_elements() & noexcept {
+simdjson_inline simdjson_result<size_t> document::count_elements() & noexcept {
   auto a = get_array();
   simdjson_result<size_t> answer = a.count_elements();
   /* If there was an array, we are now left pointing at its first element. */
@@ -145,7 +145,7 @@ simdjson_really_inline simdjson_result<size_t> document::count_elements() & noex
   }
   return answer;
 }
-simdjson_really_inline simdjson_result<size_t> document::count_fields() & noexcept {
+simdjson_inline simdjson_result<size_t> document::count_fields() & noexcept {
   auto a = get_object();
   simdjson_result<size_t> answer = a.count_fields();
   /* If there was an array, we are now left pointing at its first element. */
@@ -155,43 +155,43 @@ simdjson_really_inline simdjson_result<size_t> document::count_fields() & noexce
   }
   return answer;
 }
-simdjson_really_inline simdjson_result<value> document::at(size_t index) & noexcept {
+simdjson_inline simdjson_result<value> document::at(size_t index) & noexcept {
   auto a = get_array();
   return a.at(index);
 }
-simdjson_really_inline simdjson_result<array_iterator> document::begin() & noexcept {
+simdjson_inline simdjson_result<array_iterator> document::begin() & noexcept {
   return get_array().begin();
 }
-simdjson_really_inline simdjson_result<array_iterator> document::end() & noexcept {
+simdjson_inline simdjson_result<array_iterator> document::end() & noexcept {
   return {};
 }
 
-simdjson_really_inline simdjson_result<value> document::find_field(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<value> document::find_field(std::string_view key) & noexcept {
   return start_or_resume_object().find_field(key);
 }
-simdjson_really_inline simdjson_result<value> document::find_field(const char *key) & noexcept {
+simdjson_inline simdjson_result<value> document::find_field(const char *key) & noexcept {
   return start_or_resume_object().find_field(key);
 }
-simdjson_really_inline simdjson_result<value> document::find_field_unordered(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<value> document::find_field_unordered(std::string_view key) & noexcept {
   return start_or_resume_object().find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<value> document::find_field_unordered(const char *key) & noexcept {
+simdjson_inline simdjson_result<value> document::find_field_unordered(const char *key) & noexcept {
   return start_or_resume_object().find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<value> document::operator[](std::string_view key) & noexcept {
+simdjson_inline simdjson_result<value> document::operator[](std::string_view key) & noexcept {
   return start_or_resume_object()[key];
 }
-simdjson_really_inline simdjson_result<value> document::operator[](const char *key) & noexcept {
+simdjson_inline simdjson_result<value> document::operator[](const char *key) & noexcept {
   return start_or_resume_object()[key];
 }
 
-simdjson_really_inline error_code document::consume() noexcept {
+simdjson_inline error_code document::consume() noexcept {
   auto error = iter.skip_child(0);
   if(error) { iter.abandon(); }
   return error;
 }
 
-simdjson_really_inline simdjson_result<std::string_view> document::raw_json() noexcept {
+simdjson_inline simdjson_result<std::string_view> document::raw_json() noexcept {
   auto _iter = get_root_value_iterator();
   const uint8_t * starting_point{_iter.peek_start()};
   auto error = consume();
@@ -203,40 +203,40 @@ simdjson_really_inline simdjson_result<std::string_view> document::raw_json() no
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 
-simdjson_really_inline simdjson_result<json_type> document::type() noexcept {
+simdjson_inline simdjson_result<json_type> document::type() noexcept {
   return get_root_value_iterator().type();
 }
 
-simdjson_really_inline simdjson_result<bool> document::is_scalar() noexcept {
+simdjson_inline simdjson_result<bool> document::is_scalar() noexcept {
   json_type this_type;
   auto error = type().get(this_type);
   if(error) { return error; }
   return ! ((this_type == json_type::array) || (this_type == json_type::object));
 }
 
-simdjson_really_inline bool document::is_negative() noexcept {
+simdjson_inline bool document::is_negative() noexcept {
   return get_root_value_iterator().is_root_negative();
 }
 
-simdjson_really_inline simdjson_result<bool> document::is_integer() noexcept {
+simdjson_inline simdjson_result<bool> document::is_integer() noexcept {
   return get_root_value_iterator().is_root_integer();
 }
 
-simdjson_really_inline simdjson_result<number_type> document::get_number_type() noexcept {
+simdjson_inline simdjson_result<number_type> document::get_number_type() noexcept {
   return get_root_value_iterator().get_root_number_type();
 }
 
-simdjson_really_inline simdjson_result<number> document::get_number() noexcept {
+simdjson_inline simdjson_result<number> document::get_number() noexcept {
   return get_root_value_iterator().get_root_number();
 }
 
 
-simdjson_really_inline simdjson_result<std::string_view> document::raw_json_token() noexcept {
+simdjson_inline simdjson_result<std::string_view> document::raw_json_token() noexcept {
   auto _iter = get_root_value_iterator();
   return std::string_view(reinterpret_cast<const char*>(_iter.peek_start()), _iter.peek_start_length());
 }
 
-simdjson_really_inline simdjson_result<value> document::at_pointer(std::string_view json_pointer) noexcept {
+simdjson_inline simdjson_result<value> document::at_pointer(std::string_view json_pointer) noexcept {
   rewind(); // Rewind the document each time at_pointer is called
   if (json_pointer.empty()) {
     return this->get_value();
@@ -260,7 +260,7 @@ simdjson_really_inline simdjson_result<value> document::at_pointer(std::string_v
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::simdjson_result(
   SIMDJSON_IMPLEMENTATION::ondemand::document &&value
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document>(
@@ -268,7 +268,7 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::docume
     )
 {
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::simdjson_result(
   error_code error
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document>(
@@ -276,216 +276,216 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::docume
     )
 {
 }
-simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::count_elements() & noexcept {
+simdjson_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::count_elements() & noexcept {
   if (error()) { return error(); }
   return first.count_elements();
 }
-simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::count_fields() & noexcept {
+simdjson_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::count_fields() & noexcept {
   if (error()) { return error(); }
   return first.count_fields();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::at(size_t index) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::at(size_t index) & noexcept {
   if (error()) { return error(); }
   return first.at(index);
 }
-simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::rewind() noexcept {
+simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::rewind() noexcept {
   if (error()) { return error(); }
   first.rewind();
   return SUCCESS;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::begin() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::end() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::end() & noexcept {
   return {};
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field_unordered(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field_unordered(std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first.find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field_unordered(const char *key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field_unordered(const char *key) & noexcept {
   if (error()) { return error(); }
   return first.find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator[](std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator[](std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator[](const char *key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator[](const char *key) & noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field(std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first.find_field(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field(const char *key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::find_field(const char *key) & noexcept {
   if (error()) { return error(); }
   return first.find_field(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_array() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_array() & noexcept {
   if (error()) { return error(); }
   return first.get_array();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_object() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_object() & noexcept {
   if (error()) { return error(); }
   return first.get_object();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_uint64() noexcept {
+simdjson_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_uint64() noexcept {
   if (error()) { return error(); }
   return first.get_uint64();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_int64() noexcept {
+simdjson_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_int64() noexcept {
   if (error()) { return error(); }
   return first.get_int64();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_double() noexcept {
+simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_double() noexcept {
   if (error()) { return error(); }
   return first.get_double();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_string() noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_string() noexcept {
   if (error()) { return error(); }
   return first.get_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_raw_json_string() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_raw_json_string() noexcept {
   if (error()) { return error(); }
   return first.get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_bool() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_bool() noexcept {
   if (error()) { return error(); }
   return first.get_bool();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_value() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_value() noexcept {
   if (error()) { return error(); }
   return first.get_value();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_null() noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_null() noexcept {
   if (error()) { return error(); }
   return first.is_null();
 }
 
 template<typename T>
-simdjson_really_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get() & noexcept {
+simdjson_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get() & noexcept {
   if (error()) { return error(); }
   return first.get<T>();
 }
 template<typename T>
-simdjson_really_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get() && noexcept {
+simdjson_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document>(first).get<T>();
 }
 template<typename T>
-simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get(T &out) & noexcept {
+simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get(T &out) & noexcept {
   if (error()) { return error(); }
   return first.get<T>(out);
 }
 template<typename T>
-simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get(T &out) && noexcept {
+simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get(T &out) && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document>(first).get<T>(out);
 }
 
-template<> simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>() & noexcept = delete;
-template<> simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>() && noexcept {
+template<> simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>() & noexcept = delete;
+template<> simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document>(first);
 }
-template<> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>(SIMDJSON_IMPLEMENTATION::ondemand::document &out) & noexcept = delete;
-template<> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>(SIMDJSON_IMPLEMENTATION::ondemand::document &out) && noexcept {
+template<> simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>(SIMDJSON_IMPLEMENTATION::ondemand::document &out) & noexcept = delete;
+template<> simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>(SIMDJSON_IMPLEMENTATION::ondemand::document &out) && noexcept {
   if (error()) { return error(); }
   out = std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document>(first);
   return SUCCESS;
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::type() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::type() noexcept {
   if (error()) { return error(); }
   return first.type();
 }
 
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_scalar() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_scalar() noexcept {
   if (error()) { return error(); }
   return first.is_scalar();
 }
 
 
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_negative() noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_negative() noexcept {
   if (error()) { return error(); }
   return first.is_negative();
 }
 
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_integer() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::is_integer() noexcept {
   if (error()) { return error(); }
   return first.is_integer();
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_number_type() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_number_type() noexcept {
   if (error()) { return error(); }
   return first.get_number_type();
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_number() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_number() noexcept {
   if (error()) { return error(); }
   return first.get_number();
 }
 
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator uint64_t() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator uint64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator int64_t() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator int64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator double() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator double() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator std::string_view() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator std::string_view() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator bool() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator bool() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
 #endif
 
 
-simdjson_really_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::current_location() noexcept {
+simdjson_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::current_location() noexcept {
   if (error()) { return error(); }
   return first.current_location();
 }
 
-simdjson_really_inline int32_t simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::current_depth() const noexcept {
+simdjson_inline int32_t simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::current_depth() const noexcept {
   if (error()) { return error(); }
   return first.current_depth();
 }
 
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::raw_json_token() noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::raw_json_token() noexcept {
   if (error()) { return error(); }
   return first.raw_json_token();
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::at_pointer(std::string_view json_pointer) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::at_pointer(std::string_view json_pointer) noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
 }
@@ -498,54 +498,54 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline document_reference::document_reference() noexcept : doc{nullptr} {}
-simdjson_really_inline document_reference::document_reference(document &d) noexcept : doc(&d) {}
-simdjson_really_inline void document_reference::rewind() noexcept { doc->rewind(); }
-simdjson_really_inline simdjson_result<array> document_reference::get_array() & noexcept { return doc->get_array(); }
-simdjson_really_inline simdjson_result<object> document_reference::get_object() & noexcept { return doc->get_object(); }
-simdjson_really_inline simdjson_result<uint64_t> document_reference::get_uint64() noexcept { return doc->get_uint64(); }
-simdjson_really_inline simdjson_result<int64_t> document_reference::get_int64() noexcept { return doc->get_int64(); }
-simdjson_really_inline simdjson_result<double> document_reference::get_double() noexcept { return doc->get_double(); }
-simdjson_really_inline simdjson_result<std::string_view> document_reference::get_string() noexcept { return doc->get_string(); }
-simdjson_really_inline simdjson_result<raw_json_string> document_reference::get_raw_json_string() noexcept { return doc->get_raw_json_string(); }
-simdjson_really_inline simdjson_result<bool> document_reference::get_bool() noexcept { return doc->get_bool(); }
-simdjson_really_inline simdjson_result<value> document_reference::get_value() noexcept { return doc->get_value(); }
-simdjson_really_inline bool document_reference::is_null() noexcept { return doc->is_null(); }
+simdjson_inline document_reference::document_reference() noexcept : doc{nullptr} {}
+simdjson_inline document_reference::document_reference(document &d) noexcept : doc(&d) {}
+simdjson_inline void document_reference::rewind() noexcept { doc->rewind(); }
+simdjson_inline simdjson_result<array> document_reference::get_array() & noexcept { return doc->get_array(); }
+simdjson_inline simdjson_result<object> document_reference::get_object() & noexcept { return doc->get_object(); }
+simdjson_inline simdjson_result<uint64_t> document_reference::get_uint64() noexcept { return doc->get_uint64(); }
+simdjson_inline simdjson_result<int64_t> document_reference::get_int64() noexcept { return doc->get_int64(); }
+simdjson_inline simdjson_result<double> document_reference::get_double() noexcept { return doc->get_double(); }
+simdjson_inline simdjson_result<std::string_view> document_reference::get_string() noexcept { return doc->get_string(); }
+simdjson_inline simdjson_result<raw_json_string> document_reference::get_raw_json_string() noexcept { return doc->get_raw_json_string(); }
+simdjson_inline simdjson_result<bool> document_reference::get_bool() noexcept { return doc->get_bool(); }
+simdjson_inline simdjson_result<value> document_reference::get_value() noexcept { return doc->get_value(); }
+simdjson_inline bool document_reference::is_null() noexcept { return doc->is_null(); }
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline document_reference::operator array() & noexcept(false) { return array(*doc); }
-simdjson_really_inline document_reference::operator object() & noexcept(false) { return object(*doc); }
-simdjson_really_inline document_reference::operator uint64_t() noexcept(false) { return uint64_t(*doc); }
-simdjson_really_inline document_reference::operator int64_t() noexcept(false) { return int64_t(*doc); }
-simdjson_really_inline document_reference::operator double() noexcept(false) { return double(*doc); }
-simdjson_really_inline document_reference::operator std::string_view() noexcept(false) { return std::string_view(*doc); }
-simdjson_really_inline document_reference::operator raw_json_string() noexcept(false) { return raw_json_string(*doc); }
-simdjson_really_inline document_reference::operator bool() noexcept(false) { return bool(*doc); }
-simdjson_really_inline document_reference::operator value() noexcept(false) { return value(*doc); }
+simdjson_inline document_reference::operator array() & noexcept(false) { return array(*doc); }
+simdjson_inline document_reference::operator object() & noexcept(false) { return object(*doc); }
+simdjson_inline document_reference::operator uint64_t() noexcept(false) { return uint64_t(*doc); }
+simdjson_inline document_reference::operator int64_t() noexcept(false) { return int64_t(*doc); }
+simdjson_inline document_reference::operator double() noexcept(false) { return double(*doc); }
+simdjson_inline document_reference::operator std::string_view() noexcept(false) { return std::string_view(*doc); }
+simdjson_inline document_reference::operator raw_json_string() noexcept(false) { return raw_json_string(*doc); }
+simdjson_inline document_reference::operator bool() noexcept(false) { return bool(*doc); }
+simdjson_inline document_reference::operator value() noexcept(false) { return value(*doc); }
 #endif
-simdjson_really_inline simdjson_result<size_t> document_reference::count_elements() & noexcept { return doc->count_elements(); }
-simdjson_really_inline simdjson_result<size_t> document_reference::count_fields() & noexcept { return doc->count_fields(); }
-simdjson_really_inline simdjson_result<value> document_reference::at(size_t index) & noexcept { return doc->at(index); }
-simdjson_really_inline simdjson_result<array_iterator> document_reference::begin() & noexcept { return doc->begin(); }
-simdjson_really_inline simdjson_result<array_iterator> document_reference::end() & noexcept { return doc->end(); }
-simdjson_really_inline simdjson_result<value> document_reference::find_field(std::string_view key) & noexcept { return doc->find_field(key); }
-simdjson_really_inline simdjson_result<value> document_reference::find_field(const char *key) & noexcept { return doc->find_field(key); }
-simdjson_really_inline simdjson_result<value> document_reference::operator[](std::string_view key) & noexcept { return (*doc)[key]; }
-simdjson_really_inline simdjson_result<value> document_reference::operator[](const char *key) & noexcept { return (*doc)[key]; }
-simdjson_really_inline simdjson_result<value> document_reference::find_field_unordered(std::string_view key) & noexcept { return doc->find_field_unordered(key); }
-simdjson_really_inline simdjson_result<value> document_reference::find_field_unordered(const char *key) & noexcept { return doc->find_field_unordered(key); }
-simdjson_really_inline simdjson_result<json_type> document_reference::type() noexcept { return doc->type(); }
-simdjson_really_inline simdjson_result<bool> document_reference::is_scalar() noexcept { return doc->is_scalar(); }
-simdjson_really_inline simdjson_result<const char *> document_reference::current_location() noexcept { return doc->current_location(); }
-simdjson_really_inline int32_t document_reference::current_depth() const noexcept { return doc->current_depth(); }
-simdjson_really_inline bool document_reference::is_negative() noexcept { return doc->is_negative(); }
-simdjson_really_inline simdjson_result<bool> document_reference::is_integer() noexcept { return doc->is_integer(); }
-simdjson_really_inline simdjson_result<number_type> document_reference::get_number_type() noexcept { return doc->get_number_type(); }
-simdjson_really_inline simdjson_result<number> document_reference::get_number() noexcept { return doc->get_number(); }
-simdjson_really_inline simdjson_result<std::string_view> document_reference::raw_json_token() noexcept { return doc->raw_json_token(); }
-simdjson_really_inline simdjson_result<value> document_reference::at_pointer(std::string_view json_pointer) noexcept { return doc->at_pointer(json_pointer); }
-simdjson_really_inline simdjson_result<std::string_view> document_reference::raw_json() noexcept { return doc->raw_json();}
-simdjson_really_inline document_reference::operator document&() const noexcept { return *doc; }
+simdjson_inline simdjson_result<size_t> document_reference::count_elements() & noexcept { return doc->count_elements(); }
+simdjson_inline simdjson_result<size_t> document_reference::count_fields() & noexcept { return doc->count_fields(); }
+simdjson_inline simdjson_result<value> document_reference::at(size_t index) & noexcept { return doc->at(index); }
+simdjson_inline simdjson_result<array_iterator> document_reference::begin() & noexcept { return doc->begin(); }
+simdjson_inline simdjson_result<array_iterator> document_reference::end() & noexcept { return doc->end(); }
+simdjson_inline simdjson_result<value> document_reference::find_field(std::string_view key) & noexcept { return doc->find_field(key); }
+simdjson_inline simdjson_result<value> document_reference::find_field(const char *key) & noexcept { return doc->find_field(key); }
+simdjson_inline simdjson_result<value> document_reference::operator[](std::string_view key) & noexcept { return (*doc)[key]; }
+simdjson_inline simdjson_result<value> document_reference::operator[](const char *key) & noexcept { return (*doc)[key]; }
+simdjson_inline simdjson_result<value> document_reference::find_field_unordered(std::string_view key) & noexcept { return doc->find_field_unordered(key); }
+simdjson_inline simdjson_result<value> document_reference::find_field_unordered(const char *key) & noexcept { return doc->find_field_unordered(key); }
+simdjson_inline simdjson_result<json_type> document_reference::type() noexcept { return doc->type(); }
+simdjson_inline simdjson_result<bool> document_reference::is_scalar() noexcept { return doc->is_scalar(); }
+simdjson_inline simdjson_result<const char *> document_reference::current_location() noexcept { return doc->current_location(); }
+simdjson_inline int32_t document_reference::current_depth() const noexcept { return doc->current_depth(); }
+simdjson_inline bool document_reference::is_negative() noexcept { return doc->is_negative(); }
+simdjson_inline simdjson_result<bool> document_reference::is_integer() noexcept { return doc->is_integer(); }
+simdjson_inline simdjson_result<number_type> document_reference::get_number_type() noexcept { return doc->get_number_type(); }
+simdjson_inline simdjson_result<number> document_reference::get_number() noexcept { return doc->get_number(); }
+simdjson_inline simdjson_result<std::string_view> document_reference::raw_json_token() noexcept { return doc->raw_json_token(); }
+simdjson_inline simdjson_result<value> document_reference::at_pointer(std::string_view json_pointer) noexcept { return doc->at_pointer(json_pointer); }
+simdjson_inline simdjson_result<std::string_view> document_reference::raw_json() noexcept { return doc->raw_json();}
+simdjson_inline document_reference::operator document&() const noexcept { return *doc; }
 
 } // namespace ondemand
 } // namespace SIMDJSON_IMPLEMENTATION
@@ -554,172 +554,172 @@ simdjson_really_inline document_reference::operator document&() const noexcept {
 
 
 namespace simdjson {
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_reference value, error_code error)
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_reference value, error_code error)
   noexcept : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>(value), error) {}
 
 
-simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::count_elements() & noexcept {
+simdjson_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::count_elements() & noexcept {
   if (error()) { return error(); }
   return first.count_elements();
 }
-simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::count_fields() & noexcept {
+simdjson_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::count_fields() & noexcept {
   if (error()) { return error(); }
   return first.count_fields();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::at(size_t index) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::at(size_t index) & noexcept {
   if (error()) { return error(); }
   return first.at(index);
 }
-simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::rewind() noexcept {
+simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::rewind() noexcept {
   if (error()) { return error(); }
   first.rewind();
   return SUCCESS;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::begin() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::end() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::end() & noexcept {
   return {};
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first.find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(const char *key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field_unordered(const char *key) & noexcept {
   if (error()) { return error(); }
   return first.find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator[](std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator[](std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator[](const char *key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator[](const char *key) & noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field(std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first.find_field(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field(const char *key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::find_field(const char *key) & noexcept {
   if (error()) { return error(); }
   return first.find_field(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_array() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_array() & noexcept {
   if (error()) { return error(); }
   return first.get_array();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_object() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_object() & noexcept {
   if (error()) { return error(); }
   return first.get_object();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_uint64() noexcept {
+simdjson_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_uint64() noexcept {
   if (error()) { return error(); }
   return first.get_uint64();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_int64() noexcept {
+simdjson_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_int64() noexcept {
   if (error()) { return error(); }
   return first.get_int64();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_double() noexcept {
+simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_double() noexcept {
   if (error()) { return error(); }
   return first.get_double();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_string() noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_string() noexcept {
   if (error()) { return error(); }
   return first.get_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_raw_json_string() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_raw_json_string() noexcept {
   if (error()) { return error(); }
   return first.get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_bool() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_bool() noexcept {
   if (error()) { return error(); }
   return first.get_bool();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_value() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_value() noexcept {
   if (error()) { return error(); }
   return first.get_value();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_null() noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_null() noexcept {
   if (error()) { return error(); }
   return first.is_null();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::type() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::type() noexcept {
   if (error()) { return error(); }
   return first.type();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_scalar() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_scalar() noexcept {
   if (error()) { return error(); }
   return first.is_scalar();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_negative() noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_negative() noexcept {
   if (error()) { return error(); }
   return first.is_negative();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_integer() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::is_integer() noexcept {
   if (error()) { return error(); }
   return first.is_integer();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_number_type() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_number_type() noexcept {
   if (error()) { return error(); }
   return first.get_number_type();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_number() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_number() noexcept {
   if (error()) { return error(); }
   return first.get_number();
 }
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator uint64_t() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator uint64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator int64_t() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator int64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator double() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator double() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator std::string_view() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator std::string_view() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator bool() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator bool() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
 #endif
 
-simdjson_really_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::current_location() noexcept {
+simdjson_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::current_location() noexcept {
   if (error()) { return error(); }
   return first.current_location();
 }
 
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::raw_json_token() noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::raw_json_token() noexcept {
   if (error()) { return error(); }
   return first.raw_json_token();
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::at_pointer(std::string_view json_pointer) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::at_pointer(std::string_view json_pointer) noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
 }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -26,11 +26,11 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline document() noexcept = default;
-  simdjson_really_inline document(const document &other) noexcept = delete; // pass your documents by reference, not by copy
-  simdjson_really_inline document(document &&other) noexcept = default;
-  simdjson_really_inline document &operator=(const document &other) noexcept = delete;
-  simdjson_really_inline document &operator=(document &&other) noexcept = default;
+  simdjson_inline document() noexcept = default;
+  simdjson_inline document(const document &other) noexcept = delete; // pass your documents by reference, not by copy
+  simdjson_inline document(document &&other) noexcept = default;
+  simdjson_inline document &operator=(const document &other) noexcept = delete;
+  simdjson_inline document &operator=(document &&other) noexcept = default;
 
   /**
    * Cast this JSON value to an array.
@@ -38,49 +38,49 @@ public:
    * @returns An object that can be used to iterate the array.
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array> get_array() & noexcept;
+  simdjson_inline simdjson_result<array> get_array() & noexcept;
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    */
-  simdjson_really_inline simdjson_result<object> get_object() & noexcept;
+  simdjson_inline simdjson_result<object> get_object() & noexcept;
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
   /**
    * Cast this JSON value (inside string) to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64() noexcept;
   /**
    * Cast this JSON value (inside string) to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_inline simdjson_result<double> get_double() noexcept;
 
   /**
    * Cast this JSON value (inside string) to a double.
@@ -88,7 +88,7 @@ public:
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
   /**
    * Cast this JSON value to a string.
    *
@@ -100,7 +100,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_inline simdjson_result<std::string_view> get_string() noexcept;
   /**
    * Cast this JSON value to a raw_json_string.
    *
@@ -109,28 +109,28 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @returns INCORRECT_TYPE if the JSON value is not true or false.
    */
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_inline simdjson_result<bool> get_bool() noexcept;
   /**
    * Cast this JSON value to a value when the document is an object or an array.
    *
    * @returns A value if a JSON array or object cannot be found.
    * @returns SCALAR_DOCUMENT_AS_VALUE error is the document is a scalar (see is_scalar() function).
    */
-  simdjson_really_inline simdjson_result<value> get_value() noexcept;
+  simdjson_inline simdjson_result<value> get_value() noexcept;
 
   /**
    * Checks if this JSON value is null.
    *
    * @returns Whether the value is null.
    */
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_inline bool is_null() noexcept;
 
   /**
    * Get this value as the given type.
@@ -143,13 +143,13 @@ public:
    * @returns A value of the given type, parsed from the JSON.
    * @returns INCORRECT_TYPE If the JSON value is not the given type.
    */
-  template<typename T> simdjson_really_inline simdjson_result<T> get() & noexcept {
+  template<typename T> simdjson_inline simdjson_result<T> get() & noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
   }
   /** @overload template<typename T> simdjson_result<T> get() & noexcept */
-  template<typename T> simdjson_really_inline simdjson_result<T> get() && noexcept {
+  template<typename T> simdjson_inline simdjson_result<T> get() && noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
@@ -166,9 +166,9 @@ public:
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    * @returns SUCCESS If the parse succeeded and the out parameter was set to the value.
    */
-  template<typename T> simdjson_really_inline error_code get(T &out) & noexcept;
+  template<typename T> simdjson_inline error_code get(T &out) & noexcept;
   /** @overload template<typename T> error_code get(T &out) & noexcept */
-  template<typename T> simdjson_really_inline error_code get(T &out) && noexcept;
+  template<typename T> simdjson_inline error_code get(T &out) && noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -177,35 +177,35 @@ public:
    * @returns An object that can be used to iterate the array.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an array.
    */
-  simdjson_really_inline operator array() & noexcept(false);
+  simdjson_inline operator array() & noexcept(false);
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an object.
    */
-  simdjson_really_inline operator object() & noexcept(false);
+  simdjson_inline operator object() & noexcept(false);
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_inline operator uint64_t() noexcept(false);
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_inline operator int64_t() noexcept(false);
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline operator double() noexcept(false);
+  simdjson_inline operator double() noexcept(false);
   /**
    * Cast this JSON value to a string.
    *
@@ -215,7 +215,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_inline operator std::string_view() noexcept(false);
   /**
    * Cast this JSON value to a raw_json_string.
    *
@@ -224,21 +224,21 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator raw_json_string() noexcept(false);
+  simdjson_inline operator raw_json_string() noexcept(false);
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not true or false.
    */
-  simdjson_really_inline operator bool() noexcept(false);
+  simdjson_inline operator bool() noexcept(false);
   /**
    * Cast this JSON value to a value.
    *
    * @returns A value value.
    * @exception if a JSON value cannot be found
    */
-  simdjson_really_inline operator value() noexcept(false);
+  simdjson_inline operator value() noexcept(false);
 #endif
   /**
    * This method scans the array and counts the number of elements.
@@ -251,7 +251,7 @@ public:
    * there is a missing comma), then an error is returned and it is no longer
    * safe to continue.
    */
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
    /**
    * This method scans the object and counts the number of key-value pairs.
    * The count_fields method should always be called before you have begun
@@ -266,7 +266,7 @@ public:
    * To check that an object is empty, it is more performant to use
    * the is_empty() method.
    */
-  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
   /**
    * Get the value at the given index in the array. This function has linear-time complexity.
    * This function should only be called once on an array instance since the array iterator is not reset between each call.
@@ -274,19 +274,19 @@ public:
    * @return The value at the given index, or:
    *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
    */
-  simdjson_really_inline simdjson_result<value> at(size_t index) & noexcept;
+  simdjson_inline simdjson_result<value> at(size_t index) & noexcept;
   /**
    * Begin array iteration.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
+  simdjson_inline simdjson_result<array_iterator> begin() & noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
+  simdjson_inline simdjson_result<array_iterator> end() & noexcept;
 
   /**
    * Look up a field by name on an object (order-sensitive).
@@ -320,9 +320,9 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> find_field(const char *key) & noexcept;
+  simdjson_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> find_field(const char *key) & noexcept;
 
   /**
    * Look up a field by name on an object, without regard to key order.
@@ -354,13 +354,13 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> find_field_unordered(const char *key) & noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
+  simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> find_field_unordered(const char *key) & noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> operator[](const char *key) & noexcept;
 
   /**
    * Get the type of this JSON value.
@@ -371,7 +371,7 @@ public:
    *
    * @error TAPE_ERROR when the JSON value is a bad token like "}" "," or "alse".
    */
-  simdjson_really_inline simdjson_result<json_type> type() noexcept;
+  simdjson_inline simdjson_result<json_type> type() noexcept;
 
   /**
    * Checks whether the document is a scalar (string, number, null, Boolean).
@@ -380,14 +380,14 @@ public:
    * @returns true if the type is string, number, null, Boolean
    * @error TAPE_ERROR when the JSON value is a bad token like "}" "," or "alse".
    */
-  simdjson_really_inline simdjson_result<bool> is_scalar() noexcept;
+  simdjson_inline simdjson_result<bool> is_scalar() noexcept;
 
   /**
    * Checks whether the document is a negative number.
    *
    * @returns true if the number if negative.
    */
-  simdjson_really_inline bool is_negative() noexcept;
+  simdjson_inline bool is_negative() noexcept;
   /**
    * Checks whether the document is an integer number. Note that
    * this requires to partially parse the number string. If
@@ -397,7 +397,7 @@ public:
    *
    * @returns true if the number if negative.
    */
-  simdjson_really_inline simdjson_result<bool> is_integer() noexcept;
+  simdjson_inline simdjson_result<bool> is_integer() noexcept;
   /**
    * Determine the number type (integer or floating-point number) as quickly
    * as possible. This function does not fully validate the input. It is
@@ -420,7 +420,7 @@ public:
    *
    * @returns the type of the number
    */
-  simdjson_really_inline simdjson_result<number_type> get_number_type() noexcept;
+  simdjson_inline simdjson_result<number_type> get_number_type() noexcept;
 
   /**
    * Attempt to parse an ondemand::number. An ondemand::number may
@@ -448,7 +448,7 @@ public:
    * to call "get_int64()" when number.get_number_type() is not
    * number_type::signed_integer and when number.is_int64() is false.
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<number> get_number() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<number> get_number() noexcept;
 
   /**
    * Get the raw JSON for this token.
@@ -472,7 +472,7 @@ public:
    * - false
    * - null
    */
-  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+  simdjson_inline simdjson_result<std::string_view> raw_json_token() noexcept;
 
   /**
    * Reset the iterator inside the document instance so we are pointing back at the
@@ -504,7 +504,7 @@ public:
    *  2 = , or } inside root array/object
    *  3 = key or value inside root array/object.
    */
-  simdjson_really_inline int32_t current_depth() const noexcept;
+  simdjson_inline int32_t current_depth() const noexcept;
 
   /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
@@ -537,26 +537,26 @@ public:
    *         - INVALID_JSON_POINTER if the JSON pointer is invalid and cannot be parsed
    *         - SCALAR_DOCUMENT_AS_VALUE if the json_pointer is empty and the document is not a scalar (see is_scalar() function).
    */
-  simdjson_really_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+  simdjson_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
   /**
    * Consumes the document and returns a string_view instance corresponding to the
    * document as represented in JSON. It points inside the original byte array containing
    * the JSON document.
    */
-  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
+  simdjson_inline simdjson_result<std::string_view> raw_json() noexcept;
 protected:
   /**
    * Consumes the document.
    */
-  simdjson_really_inline error_code consume() noexcept;
+  simdjson_inline error_code consume() noexcept;
 
-  simdjson_really_inline document(ondemand::json_iterator &&iter) noexcept;
-  simdjson_really_inline const uint8_t *text(uint32_t idx) const noexcept;
+  simdjson_inline document(ondemand::json_iterator &&iter) noexcept;
+  simdjson_inline const uint8_t *text(uint32_t idx) const noexcept;
 
-  simdjson_really_inline value_iterator resume_value_iterator() noexcept;
-  simdjson_really_inline value_iterator get_root_value_iterator() noexcept;
-  simdjson_really_inline simdjson_result<object> start_or_resume_object() noexcept;
-  static simdjson_really_inline document start(ondemand::json_iterator &&iter) noexcept;
+  simdjson_inline value_iterator resume_value_iterator() noexcept;
+  simdjson_inline value_iterator get_root_value_iterator() noexcept;
+  simdjson_inline simdjson_result<object> start_or_resume_object() noexcept;
+  static simdjson_inline document start(ondemand::json_iterator &&iter) noexcept;
 
   //
   // Fields
@@ -580,59 +580,59 @@ protected:
  */
 class document_reference {
 public:
-  simdjson_really_inline document_reference() noexcept;
-  simdjson_really_inline document_reference(document &d) noexcept;
-  simdjson_really_inline document_reference(const document_reference &other) noexcept = default;
-  simdjson_really_inline document_reference& operator=(const document_reference &other) noexcept = default;
-  simdjson_really_inline void rewind() noexcept;
-  simdjson_really_inline simdjson_result<array> get_array() & noexcept;
-  simdjson_really_inline simdjson_result<object> get_object() & noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline simdjson_result<value> get_value() noexcept;
+  simdjson_inline document_reference() noexcept;
+  simdjson_inline document_reference(document &d) noexcept;
+  simdjson_inline document_reference(const document_reference &other) noexcept = default;
+  simdjson_inline document_reference& operator=(const document_reference &other) noexcept = default;
+  simdjson_inline void rewind() noexcept;
+  simdjson_inline simdjson_result<array> get_array() & noexcept;
+  simdjson_inline simdjson_result<object> get_object() & noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_inline simdjson_result<double> get_double() noexcept;
+  simdjson_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_inline simdjson_result<value> get_value() noexcept;
 
-  simdjson_really_inline bool is_null() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
-  simdjson_really_inline operator document&() const noexcept;
+  simdjson_inline bool is_null() noexcept;
+  simdjson_inline simdjson_result<std::string_view> raw_json() noexcept;
+  simdjson_inline operator document&() const noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator array() & noexcept(false);
-  simdjson_really_inline operator object() & noexcept(false);
-  simdjson_really_inline operator uint64_t() noexcept(false);
-  simdjson_really_inline operator int64_t() noexcept(false);
-  simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() noexcept(false);
-  simdjson_really_inline operator raw_json_string() noexcept(false);
-  simdjson_really_inline operator bool() noexcept(false);
-  simdjson_really_inline operator value() noexcept(false);
+  simdjson_inline operator array() & noexcept(false);
+  simdjson_inline operator object() & noexcept(false);
+  simdjson_inline operator uint64_t() noexcept(false);
+  simdjson_inline operator int64_t() noexcept(false);
+  simdjson_inline operator double() noexcept(false);
+  simdjson_inline operator std::string_view() noexcept(false);
+  simdjson_inline operator raw_json_string() noexcept(false);
+  simdjson_inline operator bool() noexcept(false);
+  simdjson_inline operator value() noexcept(false);
 #endif
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
-  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
-  simdjson_really_inline simdjson_result<value> at(size_t index) & noexcept;
-  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
-  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
-  simdjson_really_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<value> find_field(const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<value> operator[](const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<value> find_field_unordered(const char *key) & noexcept;
+  simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
+  simdjson_inline simdjson_result<value> at(size_t index) & noexcept;
+  simdjson_inline simdjson_result<array_iterator> begin() & noexcept;
+  simdjson_inline simdjson_result<array_iterator> end() & noexcept;
+  simdjson_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<value> find_field(const char *key) & noexcept;
+  simdjson_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<value> operator[](const char *key) & noexcept;
+  simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<value> find_field_unordered(const char *key) & noexcept;
 
-  simdjson_really_inline simdjson_result<json_type> type() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_scalar() noexcept;
+  simdjson_inline simdjson_result<json_type> type() noexcept;
+  simdjson_inline simdjson_result<bool> is_scalar() noexcept;
 
-  simdjson_really_inline simdjson_result<const char *> current_location() noexcept;
-  simdjson_really_inline int32_t current_depth() const noexcept;
-  simdjson_really_inline bool is_negative() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_integer() noexcept;
-  simdjson_really_inline simdjson_result<number_type> get_number_type() noexcept;
-  simdjson_really_inline simdjson_result<number> get_number() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
-  simdjson_really_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+  simdjson_inline simdjson_result<const char *> current_location() noexcept;
+  simdjson_inline int32_t current_depth() const noexcept;
+  simdjson_inline bool is_negative() noexcept;
+  simdjson_inline simdjson_result<bool> is_integer() noexcept;
+  simdjson_inline simdjson_result<number_type> get_number_type() noexcept;
+  simdjson_inline simdjson_result<number> get_number() noexcept;
+  simdjson_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+  simdjson_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
 private:
   document *doc{nullptr};
 };
@@ -645,63 +645,63 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline error_code rewind() noexcept;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
+  simdjson_inline error_code rewind() noexcept;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double_from_string() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> get_value() noexcept;
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_inline simdjson_result<double> get_double() noexcept;
+  simdjson_inline simdjson_result<double> get_double_from_string() noexcept;
+  simdjson_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> get_value() noexcept;
+  simdjson_inline bool is_null() noexcept;
 
-  template<typename T> simdjson_really_inline simdjson_result<T> get() & noexcept;
-  template<typename T> simdjson_really_inline simdjson_result<T> get() && noexcept;
+  template<typename T> simdjson_inline simdjson_result<T> get() & noexcept;
+  template<typename T> simdjson_inline simdjson_result<T> get() && noexcept;
 
-  template<typename T> simdjson_really_inline error_code get(T &out) & noexcept;
-  template<typename T> simdjson_really_inline error_code get(T &out) && noexcept;
+  template<typename T> simdjson_inline error_code get(T &out) & noexcept;
+  template<typename T> simdjson_inline error_code get(T &out) && noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
-  simdjson_really_inline operator uint64_t() noexcept(false);
-  simdjson_really_inline operator int64_t() noexcept(false);
-  simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
-  simdjson_really_inline operator bool() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
+  simdjson_inline operator uint64_t() noexcept(false);
+  simdjson_inline operator int64_t() noexcept(false);
+  simdjson_inline operator double() noexcept(false);
+  simdjson_inline operator std::string_view() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_inline operator bool() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false);
 #endif
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
-  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> type() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_scalar() noexcept;
-  simdjson_really_inline simdjson_result<const char *> current_location() noexcept;
-  simdjson_really_inline int32_t current_depth() const noexcept;
-  simdjson_really_inline bool is_negative() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_integer() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> get_number_type() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> get_number() noexcept;
-  /** @copydoc simdjson_really_inline std::string_view document::raw_json_token() const noexcept */
-  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+  simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(const char *key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> type() noexcept;
+  simdjson_inline simdjson_result<bool> is_scalar() noexcept;
+  simdjson_inline simdjson_result<const char *> current_location() noexcept;
+  simdjson_inline int32_t current_depth() const noexcept;
+  simdjson_inline bool is_negative() noexcept;
+  simdjson_inline simdjson_result<bool> is_integer() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> get_number_type() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> get_number() noexcept;
+  /** @copydoc simdjson_inline std::string_view document::raw_json_token() const noexcept */
+  simdjson_inline simdjson_result<std::string_view> raw_json_token() noexcept;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
 
 
@@ -714,55 +714,55 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document_reference> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_reference value, error_code error) noexcept;
-  simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline error_code rewind() noexcept;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_reference value, error_code error) noexcept;
+  simdjson_inline simdjson_result() noexcept = default;
+  simdjson_inline error_code rewind() noexcept;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> get_value() noexcept;
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() & noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_inline simdjson_result<double> get_double() noexcept;
+  simdjson_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> get_value() noexcept;
+  simdjson_inline bool is_null() noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
-  simdjson_really_inline operator uint64_t() noexcept(false);
-  simdjson_really_inline operator int64_t() noexcept(false);
-  simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
-  simdjson_really_inline operator bool() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
+  simdjson_inline operator uint64_t() noexcept(false);
+  simdjson_inline operator int64_t() noexcept(false);
+  simdjson_inline operator double() noexcept(false);
+  simdjson_inline operator std::string_view() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_inline operator bool() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::value() noexcept(false);
 #endif
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
-  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> type() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_scalar() noexcept;
-  simdjson_really_inline simdjson_result<const char *> current_location() noexcept;
-  simdjson_really_inline int32_t current_depth() const noexcept;
-  simdjson_really_inline bool is_negative() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_integer() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> get_number_type() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> get_number() noexcept;
-  /** @copydoc simdjson_really_inline std::string_view document_reference::raw_json_token() const noexcept */
-  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+  simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(const char *key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> type() noexcept;
+  simdjson_inline simdjson_result<bool> is_scalar() noexcept;
+  simdjson_inline simdjson_result<const char *> current_location() noexcept;
+  simdjson_inline int32_t current_depth() const noexcept;
+  simdjson_inline bool is_negative() noexcept;
+  simdjson_inline simdjson_result<bool> is_integer() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> get_number_type() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> get_number() noexcept;
+  /** @copydoc simdjson_inline std::string_view document_reference::raw_json_token() const noexcept */
+  simdjson_inline simdjson_result<std::string_view> raw_json_token() noexcept;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
 
 

--- a/include/simdjson/generic/ondemand/document_stream-inl.h
+++ b/include/simdjson/generic/ondemand/document_stream-inl.h
@@ -80,7 +80,7 @@ inline void stage1_worker::run(document_stream * ds, parser * stage1, size_t nex
 
 #endif  // SIMDJSON_THREADS_ENABLED
 
-simdjson_really_inline document_stream::document_stream(
+simdjson_inline document_stream::document_stream(
   ondemand::parser &_parser,
   const uint8_t *_buf,
   size_t _len,
@@ -102,7 +102,7 @@ simdjson_really_inline document_stream::document_stream(
 #endif
 }
 
-simdjson_really_inline document_stream::document_stream() noexcept
+simdjson_inline document_stream::document_stream() noexcept
   : parser{nullptr},
     buf{nullptr},
     len{0},
@@ -114,7 +114,7 @@ simdjson_really_inline document_stream::document_stream() noexcept
 {
 }
 
-simdjson_really_inline document_stream::~document_stream() noexcept
+simdjson_inline document_stream::~document_stream() noexcept
 {
   #ifdef SIMDJSON_THREADS_ENABLED
   worker.reset();
@@ -130,20 +130,20 @@ inline size_t document_stream::truncated_bytes() const noexcept {
   return parser->implementation->structural_indexes[parser->implementation->n_structural_indexes] - parser->implementation->structural_indexes[parser->implementation->n_structural_indexes + 1];
 }
 
-simdjson_really_inline document_stream::iterator::iterator() noexcept
+simdjson_inline document_stream::iterator::iterator() noexcept
   : stream{nullptr}, finished{true} {
 }
 
-simdjson_really_inline document_stream::iterator::iterator(document_stream* _stream, bool is_end) noexcept
+simdjson_inline document_stream::iterator::iterator(document_stream* _stream, bool is_end) noexcept
   : stream{_stream}, finished{is_end} {
 }
 
-simdjson_really_inline simdjson_result<ondemand::document_reference> document_stream::iterator::operator*() noexcept {
+simdjson_inline simdjson_result<ondemand::document_reference> document_stream::iterator::operator*() noexcept {
   //if(stream->error) { return stream->error; }
   return simdjson_result<ondemand::document_reference>(stream->doc, stream->error);
 }
 
-simdjson_really_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
+simdjson_inline document_stream::iterator& document_stream::iterator::operator++() noexcept {
   // If there is an error, then we want the iterator
   // to be finished, no matter what. (E.g., we do not
   // keep generating documents with errors, or go beyond
@@ -170,17 +170,17 @@ simdjson_really_inline document_stream::iterator& document_stream::iterator::ope
   return *this;
 }
 
-simdjson_really_inline bool document_stream::iterator::operator!=(const document_stream::iterator &other) const noexcept {
+simdjson_inline bool document_stream::iterator::operator!=(const document_stream::iterator &other) const noexcept {
   return finished != other.finished;
 }
 
-simdjson_really_inline document_stream::iterator document_stream::begin() noexcept {
+simdjson_inline document_stream::iterator document_stream::begin() noexcept {
   start();
   // If there are no documents, we're finished.
   return iterator(this, error == EMPTY);
 }
 
-simdjson_really_inline document_stream::iterator document_stream::end() noexcept {
+simdjson_inline document_stream::iterator document_stream::end() noexcept {
   return iterator(this, true);
 }
 
@@ -310,11 +310,11 @@ inline error_code document_stream::run_stage1(ondemand::parser &p, size_t _batch
   }
 }
 
-simdjson_really_inline size_t document_stream::iterator::current_index() const noexcept {
+simdjson_inline size_t document_stream::iterator::current_index() const noexcept {
   return stream->doc_index;
 }
 
-simdjson_really_inline std::string_view document_stream::iterator::source() const noexcept {
+simdjson_inline std::string_view document_stream::iterator::source() const noexcept {
   auto depth = stream->doc.iter.depth();
   auto cur_struct_index = stream->doc.iter._root - stream->parser->implementation->structural_indexes.get();
 
@@ -389,13 +389,13 @@ inline void document_stream::start_stage1_thread() noexcept {
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_stream>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_stream>::simdjson_result(
   error_code error
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document_stream>(error)
 {
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_stream>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_stream>::simdjson_result(
   SIMDJSON_IMPLEMENTATION::ondemand::document_stream &&value
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document_stream>(

--- a/include/simdjson/generic/ondemand/document_stream.h
+++ b/include/simdjson/generic/ondemand/document_stream.h
@@ -81,13 +81,13 @@ public:
    *  auto error = parser.iterate_many(json).get(docs);
    *  ```
    */
-  simdjson_really_inline document_stream() noexcept;
+  simdjson_inline document_stream() noexcept;
   /** Move one document_stream to another. */
-  simdjson_really_inline document_stream(document_stream &&other) noexcept = default;
+  simdjson_inline document_stream(document_stream &&other) noexcept = default;
   /** Move one document_stream to another. */
-  simdjson_really_inline document_stream &operator=(document_stream &&other) noexcept = default;
+  simdjson_inline document_stream &operator=(document_stream &&other) noexcept = default;
 
-  simdjson_really_inline ~document_stream() noexcept;
+  simdjson_inline ~document_stream() noexcept;
 
   /**
    * Returns the input size in bytes.
@@ -126,11 +126,11 @@ public:
     /**
      * Default constructor.
      */
-    simdjson_really_inline iterator() noexcept;
+    simdjson_inline iterator() noexcept;
     /**
      * Get the current document (or error).
      */
-    simdjson_really_inline simdjson_result<ondemand::document_reference> operator*() noexcept;
+    simdjson_inline simdjson_result<ondemand::document_reference> operator*() noexcept;
     /**
      * Advance to the next document (prefix).
      */
@@ -139,7 +139,7 @@ public:
      * Check if we're at the end yet.
      * @param other the end iterator to compare to.
      */
-    simdjson_really_inline bool operator!=(const iterator &other) const noexcept;
+    simdjson_inline bool operator!=(const iterator &other) const noexcept;
     /**
      * @private
      *
@@ -155,7 +155,7 @@ public:
      * may change in future versions of simdjson: we find the API somewhat
      * awkward and we would like to offer something friendlier.
      */
-     simdjson_really_inline size_t current_index() const noexcept;
+     simdjson_inline size_t current_index() const noexcept;
 
      /**
      * @private
@@ -176,7 +176,7 @@ public:
      * awkward and we would like to offer something friendlier.
      *
      */
-     simdjson_really_inline std::string_view source() const noexcept;
+     simdjson_inline std::string_view source() const noexcept;
 
     /**
      * Returns error of the stream (if any).
@@ -184,7 +184,7 @@ public:
      inline error_code error() const noexcept;
 
   private:
-    simdjson_really_inline iterator(document_stream *s, bool finished) noexcept;
+    simdjson_inline iterator(document_stream *s, bool finished) noexcept;
     /** The document_stream we're iterating through. */
     document_stream* stream;
     /** Whether we're finished or not. */
@@ -198,11 +198,11 @@ public:
   /**
    * Start iterating the documents in the stream.
    */
-  simdjson_really_inline iterator begin() noexcept;
+  simdjson_inline iterator begin() noexcept;
   /**
    * The end of the stream, for iterator comparison purposes.
    */
-  simdjson_really_inline iterator end() noexcept;
+  simdjson_inline iterator end() noexcept;
 
 private:
 
@@ -218,7 +218,7 @@ private:
    * @param len is the length of the raw byte buffer in bytes
    * @param batch_size is the size of the windows (must be strictly greater or equal to the largest JSON document)
    */
-  simdjson_really_inline document_stream(
+  simdjson_inline document_stream(
     ondemand::parser &parser,
     const uint8_t *buf,
     size_t len,
@@ -322,9 +322,9 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_stream> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::document_stream> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_stream &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::document_stream &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/field-inl.h
+++ b/include/simdjson/generic/ondemand/field-inl.h
@@ -3,41 +3,41 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
 // clang 6 doesn't think the default constructor can be noexcept, so we make it explicit
-simdjson_really_inline field::field() noexcept : std::pair<raw_json_string, ondemand::value>() {}
+simdjson_inline field::field() noexcept : std::pair<raw_json_string, ondemand::value>() {}
 
-simdjson_really_inline field::field(raw_json_string key, ondemand::value &&value) noexcept
+simdjson_inline field::field(raw_json_string key, ondemand::value &&value) noexcept
   : std::pair<raw_json_string, ondemand::value>(key, std::forward<ondemand::value>(value))
 {
 }
 
-simdjson_really_inline simdjson_result<field> field::start(value_iterator &parent_iter) noexcept {
+simdjson_inline simdjson_result<field> field::start(value_iterator &parent_iter) noexcept {
   raw_json_string key;
   SIMDJSON_TRY( parent_iter.field_key().get(key) );
   SIMDJSON_TRY( parent_iter.field_value() );
   return field::start(parent_iter, key);
 }
 
-simdjson_really_inline simdjson_result<field> field::start(const value_iterator &parent_iter, raw_json_string key) noexcept {
+simdjson_inline simdjson_result<field> field::start(const value_iterator &parent_iter, raw_json_string key) noexcept {
     return field(key, parent_iter.child());
 }
 
-simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> field::unescaped_key() noexcept {
+simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> field::unescaped_key() noexcept {
   SIMDJSON_ASSUME(first.buf != nullptr); // We would like to call .alive() but Visual Studio won't let us.
   simdjson_result<std::string_view> answer = first.unescape(second.iter.json_iter());
   first.consume();
   return answer;
 }
 
-simdjson_really_inline raw_json_string field::key() const noexcept {
+simdjson_inline raw_json_string field::key() const noexcept {
   SIMDJSON_ASSUME(first.buf != nullptr); // We would like to call .alive() by Visual Studio won't let us.
   return first;
 }
 
-simdjson_really_inline value &field::value() & noexcept {
+simdjson_inline value &field::value() & noexcept {
   return second;
 }
 
-simdjson_really_inline value field::value() && noexcept {
+simdjson_inline value field::value() && noexcept {
   return std::forward<field>(*this).second;
 }
 
@@ -47,7 +47,7 @@ simdjson_really_inline value field::value() && noexcept {
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::simdjson_result(
   SIMDJSON_IMPLEMENTATION::ondemand::field &&value
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::field>(
@@ -55,22 +55,22 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>
     )
 {
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::simdjson_result(
   error_code error
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::field>(error)
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::key() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::key() noexcept {
   if (error()) { return error(); }
   return first.key();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::unescaped_key() noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::unescaped_key() noexcept {
   if (error()) { return error(); }
   return first.unescaped_key();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::value() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::value() noexcept {
   if (error()) { return error(); }
   return std::move(first.value());
 }

--- a/include/simdjson/generic/ondemand/field.h
+++ b/include/simdjson/generic/ondemand/field.h
@@ -18,7 +18,7 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline field() noexcept;
+  simdjson_inline field() noexcept;
 
   /**
    * Get the key as a string_view (for higher speed, consider raw_key).
@@ -28,25 +28,25 @@ public:
    * This consumes the key: once you have called unescaped_key(), you cannot
    * call it again nor can you call key().
    */
-  simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> unescaped_key() noexcept;
+  simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> unescaped_key() noexcept;
   /**
    * Get the key as a raw_json_string. Can be used for direct comparison with
    * an unescaped C string: e.g., key() == "test".
    */
-  simdjson_really_inline raw_json_string key() const noexcept;
+  simdjson_inline raw_json_string key() const noexcept;
   /**
    * Get the field value.
    */
-  simdjson_really_inline ondemand::value &value() & noexcept;
+  simdjson_inline ondemand::value &value() & noexcept;
   /**
    * @overload ondemand::value &ondemand::value() & noexcept
    */
-  simdjson_really_inline ondemand::value value() && noexcept;
+  simdjson_inline ondemand::value value() && noexcept;
 
 protected:
-  simdjson_really_inline field(raw_json_string key, ondemand::value &&value) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(value_iterator &parent_iter) noexcept;
-  static simdjson_really_inline simdjson_result<field> start(const value_iterator &parent_iter, raw_json_string key) noexcept;
+  simdjson_inline field(raw_json_string key, ondemand::value &&value) noexcept;
+  static simdjson_inline simdjson_result<field> start(value_iterator &parent_iter) noexcept;
+  static simdjson_inline simdjson_result<field> start(const value_iterator &parent_iter, raw_json_string key) noexcept;
   friend struct simdjson_result<field>;
   friend class object_iterator;
 };
@@ -60,13 +60,13 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::field> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::field &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::field &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 
-  simdjson_really_inline simdjson_result<std::string_view> unescaped_key() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> key() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> value() noexcept;
+  simdjson_inline simdjson_result<std::string_view> unescaped_key() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> key() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> value() noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -2,7 +2,7 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline json_iterator::json_iterator(json_iterator &&other) noexcept
+simdjson_inline json_iterator::json_iterator(json_iterator &&other) noexcept
   : token(std::forward<token_iterator>(other.token)),
     parser{other.parser},
     _string_buf_loc{other._string_buf_loc},
@@ -13,7 +13,7 @@ simdjson_really_inline json_iterator::json_iterator(json_iterator &&other) noexc
 {
   other.parser = nullptr;
 }
-simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&other) noexcept {
+simdjson_inline json_iterator &json_iterator::operator=(json_iterator &&other) noexcept {
   token = other.token;
   parser = other.parser;
   _string_buf_loc = other._string_buf_loc;
@@ -25,7 +25,7 @@ simdjson_really_inline json_iterator &json_iterator::operator=(json_iterator &&o
   return *this;
 }
 
-simdjson_really_inline json_iterator::json_iterator(const uint8_t *buf, ondemand::parser *_parser) noexcept
+simdjson_inline json_iterator::json_iterator(const uint8_t *buf, ondemand::parser *_parser) noexcept
   : token(buf, &_parser->implementation->structural_indexes[0]),
     parser{_parser},
     _string_buf_loc{parser->string_buf.get()},
@@ -73,7 +73,7 @@ inline bool json_iterator::balanced() const noexcept {
 // skip_child() function is not marked inline).
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child(depth_t parent_depth) noexcept {
+simdjson_warn_unused simdjson_inline error_code json_iterator::skip_child(depth_t parent_depth) noexcept {
   if (depth() <= parent_depth) { return SUCCESS; }
   switch (*return_current_and_advance()) {
     // TODO consider whether matching braces is a requirement: if non-matching braces indicates
@@ -150,23 +150,23 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::skip_child
 
 SIMDJSON_POP_DISABLE_WARNINGS
 
-simdjson_really_inline bool json_iterator::at_root() const noexcept {
+simdjson_inline bool json_iterator::at_root() const noexcept {
   return position() == root_position();
 }
 
-simdjson_really_inline bool json_iterator::streaming() const noexcept {
+simdjson_inline bool json_iterator::streaming() const noexcept {
   return _streaming;
 }
 
-simdjson_really_inline token_position json_iterator::root_position() const noexcept {
+simdjson_inline token_position json_iterator::root_position() const noexcept {
   return _root;
 }
 
-simdjson_really_inline void json_iterator::assert_at_document_depth() const noexcept {
+simdjson_inline void json_iterator::assert_at_document_depth() const noexcept {
   SIMDJSON_ASSUME( _depth == 1 );
 }
 
-simdjson_really_inline void json_iterator::assert_at_root() const noexcept {
+simdjson_inline void json_iterator::assert_at_root() const noexcept {
   SIMDJSON_ASSUME( _depth == 1 );
 #ifndef SIMDJSON_CLANG_VISUAL_STUDIO
   // Under Visual Studio, the next SIMDJSON_ASSUME fails with: the argument
@@ -175,21 +175,21 @@ simdjson_really_inline void json_iterator::assert_at_root() const noexcept {
 #endif
 }
 
-simdjson_really_inline void json_iterator::assert_more_tokens(uint32_t required_tokens) const noexcept {
+simdjson_inline void json_iterator::assert_more_tokens(uint32_t required_tokens) const noexcept {
   assert_valid_position(token._position + required_tokens - 1);
 }
 
-simdjson_really_inline void json_iterator::assert_valid_position(token_position position) const noexcept {
+simdjson_inline void json_iterator::assert_valid_position(token_position position) const noexcept {
 #ifndef SIMDJSON_CLANG_VISUAL_STUDIO
   SIMDJSON_ASSUME( position >= &parser->implementation->structural_indexes[0] );
   SIMDJSON_ASSUME( position < &parser->implementation->structural_indexes[parser->implementation->n_structural_indexes] );
 #endif
 }
 
-simdjson_really_inline bool json_iterator::at_end() const noexcept {
+simdjson_inline bool json_iterator::at_end() const noexcept {
   return position() == end_position();
 }
-simdjson_really_inline token_position json_iterator::end_position() const noexcept {
+simdjson_inline token_position json_iterator::end_position() const noexcept {
   uint32_t n_structural_indexes{parser->implementation->n_structural_indexes};
   return &parser->implementation->structural_indexes[n_structural_indexes];
 }
@@ -218,42 +218,42 @@ inline simdjson_result<const char *> json_iterator::current_location() noexcept 
   return reinterpret_cast<const char *>(token.peek());
 }
 
-simdjson_really_inline bool json_iterator::is_alive() const noexcept {
+simdjson_inline bool json_iterator::is_alive() const noexcept {
   return parser;
 }
 
-simdjson_really_inline void json_iterator::abandon() noexcept {
+simdjson_inline void json_iterator::abandon() noexcept {
   parser = nullptr;
   _depth = 0;
 }
 
-simdjson_really_inline const uint8_t *json_iterator::return_current_and_advance() noexcept {
+simdjson_inline const uint8_t *json_iterator::return_current_and_advance() noexcept {
 #if SIMDJSON_CHECK_EOF
   assert_more_tokens();
 #endif // SIMDJSON_CHECK_EOF
   return token.return_current_and_advance();
 }
 
-simdjson_really_inline const uint8_t *json_iterator::unsafe_pointer() const noexcept {
+simdjson_inline const uint8_t *json_iterator::unsafe_pointer() const noexcept {
   // deliberately done without safety guard:
   return token.peek(0);
 }
 
-simdjson_really_inline const uint8_t *json_iterator::peek(int32_t delta) const noexcept {
+simdjson_inline const uint8_t *json_iterator::peek(int32_t delta) const noexcept {
 #if SIMDJSON_CHECK_EOF
   assert_more_tokens(delta+1);
 #endif // SIMDJSON_CHECK_EOF
   return token.peek(delta);
 }
 
-simdjson_really_inline uint32_t json_iterator::peek_length(int32_t delta) const noexcept {
+simdjson_inline uint32_t json_iterator::peek_length(int32_t delta) const noexcept {
 #if SIMDJSON_CHECK_EOF
   assert_more_tokens(delta+1);
 #endif // #if SIMDJSON_CHECK_EOF
   return token.peek_length(delta);
 }
 
-simdjson_really_inline const uint8_t *json_iterator::peek(token_position position) const noexcept {
+simdjson_inline const uint8_t *json_iterator::peek(token_position position) const noexcept {
   // todo: currently we require end-of-string buffering, but the following
   // assert_valid_position should be turned on if/when we lift that condition.
   // assert_valid_position(position);
@@ -262,14 +262,14 @@ simdjson_really_inline const uint8_t *json_iterator::peek(token_position positio
   return token.peek(position);
 }
 
-simdjson_really_inline uint32_t json_iterator::peek_length(token_position position) const noexcept {
+simdjson_inline uint32_t json_iterator::peek_length(token_position position) const noexcept {
 #if SIMDJSON_CHECK_EOF
   assert_valid_position(position);
 #endif // SIMDJSON_CHECK_EOF
   return token.peek_length(position);
 }
 
-simdjson_really_inline token_position json_iterator::last_position() const noexcept {
+simdjson_inline token_position json_iterator::last_position() const noexcept {
   // The following line fails under some compilers...
   // SIMDJSON_ASSUME(parser->implementation->n_structural_indexes > 0);
   // since it has side-effects.
@@ -277,46 +277,46 @@ simdjson_really_inline token_position json_iterator::last_position() const noexc
   SIMDJSON_ASSUME(n_structural_indexes > 0);
   return &parser->implementation->structural_indexes[n_structural_indexes - 1];
 }
-simdjson_really_inline const uint8_t *json_iterator::peek_last() const noexcept {
+simdjson_inline const uint8_t *json_iterator::peek_last() const noexcept {
   return token.peek(last_position());
 }
 
-simdjson_really_inline void json_iterator::ascend_to(depth_t parent_depth) noexcept {
+simdjson_inline void json_iterator::ascend_to(depth_t parent_depth) noexcept {
   SIMDJSON_ASSUME(parent_depth >= 0 && parent_depth < INT32_MAX - 1);
   SIMDJSON_ASSUME(_depth == parent_depth + 1);
   _depth = parent_depth;
 }
 
-simdjson_really_inline void json_iterator::descend_to(depth_t child_depth) noexcept {
+simdjson_inline void json_iterator::descend_to(depth_t child_depth) noexcept {
   SIMDJSON_ASSUME(child_depth >= 1 && child_depth < INT32_MAX);
   SIMDJSON_ASSUME(_depth == child_depth - 1);
   _depth = child_depth;
 }
 
-simdjson_really_inline depth_t json_iterator::depth() const noexcept {
+simdjson_inline depth_t json_iterator::depth() const noexcept {
   return _depth;
 }
 
-simdjson_really_inline uint8_t *&json_iterator::string_buf_loc() noexcept {
+simdjson_inline uint8_t *&json_iterator::string_buf_loc() noexcept {
   return _string_buf_loc;
 }
 
-simdjson_really_inline error_code json_iterator::report_error(error_code _error, const char *message) noexcept {
+simdjson_inline error_code json_iterator::report_error(error_code _error, const char *message) noexcept {
   SIMDJSON_ASSUME(_error != SUCCESS && _error != UNINITIALIZED && _error != INCORRECT_TYPE && _error != NO_SUCH_FIELD);
   logger::log_error(*this, message);
   error = _error;
   return error;
 }
 
-simdjson_really_inline token_position json_iterator::position() const noexcept {
+simdjson_inline token_position json_iterator::position() const noexcept {
   return token.position();
 }
 
-simdjson_really_inline simdjson_result<std::string_view> json_iterator::unescape(raw_json_string in) noexcept {
+simdjson_inline simdjson_result<std::string_view> json_iterator::unescape(raw_json_string in) noexcept {
   return parser->unescape(in, _string_buf_loc);
 }
 
-simdjson_really_inline void json_iterator::reenter_child(token_position position, depth_t child_depth) noexcept {
+simdjson_inline void json_iterator::reenter_child(token_position position, depth_t child_depth) noexcept {
   SIMDJSON_ASSUME(child_depth >= 1 && child_depth < INT32_MAX);
   SIMDJSON_ASSUME(_depth == child_depth - 1);
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
@@ -330,25 +330,25 @@ simdjson_really_inline void json_iterator::reenter_child(token_position position
 
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
 
-simdjson_really_inline token_position json_iterator::start_position(depth_t depth) const noexcept {
+simdjson_inline token_position json_iterator::start_position(depth_t depth) const noexcept {
   return parser->start_positions[depth];
 }
 
-simdjson_really_inline void json_iterator::set_start_position(depth_t depth, token_position position) noexcept {
+simdjson_inline void json_iterator::set_start_position(depth_t depth, token_position position) noexcept {
   parser->start_positions[depth] = position;
 }
 
 #endif
 
 
-simdjson_really_inline error_code json_iterator::optional_error(error_code _error, const char *message) noexcept {
+simdjson_inline error_code json_iterator::optional_error(error_code _error, const char *message) noexcept {
   SIMDJSON_ASSUME(_error == INCORRECT_TYPE || _error == NO_SUCH_FIELD);
   logger::log_error(*this, message);
   return _error;
 }
 
 template<int N>
-simdjson_warn_unused simdjson_really_inline bool json_iterator::copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept {
+simdjson_warn_unused simdjson_inline bool json_iterator::copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept {
   // Let us guard against silly cases:
   if((N < max_len) || (N == 0)) { return false; }
   // Truncate whitespace to fit the buffer.
@@ -369,9 +369,9 @@ simdjson_warn_unused simdjson_really_inline bool json_iterator::copy_to_buffer(c
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &&value) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &&value) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator>(error) {}
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -61,20 +61,20 @@ protected:
   bool _streaming{false};
 
 public:
-  simdjson_really_inline json_iterator() noexcept = default;
-  simdjson_really_inline json_iterator(json_iterator &&other) noexcept;
-  simdjson_really_inline json_iterator &operator=(json_iterator &&other) noexcept;
-  simdjson_really_inline explicit json_iterator(const json_iterator &other) noexcept = default;
-  simdjson_really_inline json_iterator &operator=(const json_iterator &other) noexcept = default;
+  simdjson_inline json_iterator() noexcept = default;
+  simdjson_inline json_iterator(json_iterator &&other) noexcept;
+  simdjson_inline json_iterator &operator=(json_iterator &&other) noexcept;
+  simdjson_inline explicit json_iterator(const json_iterator &other) noexcept = default;
+  simdjson_inline json_iterator &operator=(const json_iterator &other) noexcept = default;
   /**
    * Skips a JSON value, whether it is a scalar, array or object.
    */
-  simdjson_warn_unused simdjson_really_inline error_code skip_child(depth_t parent_depth) noexcept;
+  simdjson_warn_unused simdjson_inline error_code skip_child(depth_t parent_depth) noexcept;
 
   /**
    * Tell whether the iterator is still at the start
    */
-  simdjson_really_inline bool at_root() const noexcept;
+  simdjson_inline bool at_root() const noexcept;
 
   /**
    * Tell whether we should be expected to run in streaming
@@ -82,53 +82,53 @@ public:
    * that does not affect how the iterator works. It is used by
    * start_root_array() and start_root_object().
    */
-  simdjson_really_inline bool streaming() const noexcept;
+  simdjson_inline bool streaming() const noexcept;
 
   /**
    * Get the root value iterator
    */
-  simdjson_really_inline token_position root_position() const noexcept;
+  simdjson_inline token_position root_position() const noexcept;
   /**
    * Assert that we are at the document depth (== 1)
    */
-  simdjson_really_inline void assert_at_document_depth() const noexcept;
+  simdjson_inline void assert_at_document_depth() const noexcept;
   /**
    * Assert that we are at the root of the document
    */
-  simdjson_really_inline void assert_at_root() const noexcept;
+  simdjson_inline void assert_at_root() const noexcept;
 
   /**
    * Tell whether the iterator is at the EOF mark
    */
-  simdjson_really_inline bool at_end() const noexcept;
+  simdjson_inline bool at_end() const noexcept;
 
   /**
    * Tell whether the iterator is live (has not been moved).
    */
-  simdjson_really_inline bool is_alive() const noexcept;
+  simdjson_inline bool is_alive() const noexcept;
 
   /**
    * Abandon this iterator, setting depth to 0 (as if the document is finished).
    */
-  simdjson_really_inline void abandon() noexcept;
+  simdjson_inline void abandon() noexcept;
 
   /**
    * Advance the current token without modifying depth.
    */
-  simdjson_really_inline const uint8_t *return_current_and_advance() noexcept;
+  simdjson_inline const uint8_t *return_current_and_advance() noexcept;
 
   /**
    * Assert that there are at least the given number of tokens left.
    *
    * Has no effect in release builds.
    */
-  simdjson_really_inline void assert_more_tokens(uint32_t required_tokens=1) const noexcept;
+  simdjson_inline void assert_more_tokens(uint32_t required_tokens=1) const noexcept;
   /**
    * Assert that the given position addresses an actual token (is within bounds).
    *
    * Has no effect in release builds.
    */
-  simdjson_really_inline void assert_valid_position(token_position position) const noexcept;
+  simdjson_inline void assert_valid_position(token_position position) const noexcept;
   /**
    * Get the JSON text for a given token (relative).
    *
@@ -139,7 +139,7 @@ public:
    * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
    * it isn't used ...
    */
-  simdjson_really_inline const uint8_t *peek(int32_t delta=0) const noexcept;
+  simdjson_inline const uint8_t *peek(int32_t delta=0) const noexcept;
   /**
    * Get the maximum length of the JSON text for the current token (or relative).
    *
@@ -147,7 +147,7 @@ public:
    *
    * @param delta The relative position of the token to retrieve. e.g. 0 = next token, -1 = prev token.
    */
-  simdjson_really_inline uint32_t peek_length(int32_t delta=0) const noexcept;
+  simdjson_inline uint32_t peek_length(int32_t delta=0) const noexcept;
   /**
    * Get a pointer to the current location in the input buffer.
    *
@@ -156,7 +156,7 @@ public:
    * You may be pointing outside of the input buffer: it is not generally
    * safe to dereference this pointer.
    */
-  simdjson_really_inline const uint8_t *unsafe_pointer() const noexcept;
+  simdjson_inline const uint8_t *unsafe_pointer() const noexcept;
   /**
    * Get the JSON text for a given token.
    *
@@ -167,7 +167,7 @@ public:
    * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
    * it isn't used ...
    */
-  simdjson_really_inline const uint8_t *peek(token_position position) const noexcept;
+  simdjson_inline const uint8_t *peek(token_position position) const noexcept;
   /**
    * Get the maximum length of the JSON text for the current token (or relative).
    *
@@ -175,7 +175,7 @@ public:
    *
    * @param position The position of the token to retrieve.
    */
-  simdjson_really_inline uint32_t peek_length(token_position position) const noexcept;
+  simdjson_inline uint32_t peek_length(token_position position) const noexcept;
   /**
    * Get the JSON text for the last token in the document.
    *
@@ -184,7 +184,7 @@ public:
    * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
    * it isn't used ...
    */
-  simdjson_really_inline const uint8_t *peek_last() const noexcept;
+  simdjson_inline const uint8_t *peek_last() const noexcept;
 
   /**
    * Ascend one level.
@@ -193,7 +193,7 @@ public:
    *
    * @param parent_depth the expected parent depth.
    */
-  simdjson_really_inline void ascend_to(depth_t parent_depth) noexcept;
+  simdjson_inline void ascend_to(depth_t parent_depth) noexcept;
 
   /**
    * Descend one level.
@@ -202,18 +202,18 @@ public:
    *
    * @param child_depth the expected child depth.
    */
-  simdjson_really_inline void descend_to(depth_t child_depth) noexcept;
-  simdjson_really_inline void descend_to(depth_t child_depth, int32_t delta) noexcept;
+  simdjson_inline void descend_to(depth_t child_depth) noexcept;
+  simdjson_inline void descend_to(depth_t child_depth, int32_t delta) noexcept;
 
   /**
    * Get current depth.
    */
-  simdjson_really_inline depth_t depth() const noexcept;
+  simdjson_inline depth_t depth() const noexcept;
 
   /**
    * Get current (writeable) location in the string buffer.
    */
-  simdjson_really_inline uint8_t *&string_buf_loc() noexcept;
+  simdjson_inline uint8_t *&string_buf_loc() noexcept;
 
   /**
    * Report an unrecoverable error, preventing further iteration.
@@ -221,29 +221,29 @@ public:
    * @param error The error to report. Must not be SUCCESS, UNINITIALIZED, INCORRECT_TYPE, or NO_SUCH_FIELD.
    * @param message An error message to report with the error.
    */
-  simdjson_really_inline error_code report_error(error_code error, const char *message) noexcept;
+  simdjson_inline error_code report_error(error_code error, const char *message) noexcept;
 
   /**
    * Log error, but don't stop iteration.
    * @param error The error to report. Must be INCORRECT_TYPE, or NO_SUCH_FIELD.
    * @param message An error message to report with the error.
    */
-  simdjson_really_inline error_code optional_error(error_code error, const char *message) noexcept;
+  simdjson_inline error_code optional_error(error_code error, const char *message) noexcept;
 
-  template<int N> simdjson_warn_unused simdjson_really_inline bool copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept;
+  template<int N> simdjson_warn_unused simdjson_inline bool copy_to_buffer(const uint8_t *json, uint32_t max_len, uint8_t (&tmpbuf)[N]) noexcept;
 
-  simdjson_really_inline token_position position() const noexcept;
+  simdjson_inline token_position position() const noexcept;
   /**
    * Write the raw_json_string to the string buffer and return a string_view.
    * Each raw_json_string should be unescaped once, or else the string buffer might
    * overflow.
    */
-  simdjson_really_inline simdjson_result<std::string_view> unescape(raw_json_string in) noexcept;
-  simdjson_really_inline void reenter_child(token_position position, depth_t child_depth) noexcept;
+  simdjson_inline simdjson_result<std::string_view> unescape(raw_json_string in) noexcept;
+  simdjson_inline void reenter_child(token_position position, depth_t child_depth) noexcept;
 
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
-  simdjson_really_inline token_position start_position(depth_t depth) const noexcept;
-  simdjson_really_inline void set_start_position(depth_t depth, token_position position) noexcept;
+  simdjson_inline token_position start_position(depth_t depth) const noexcept;
+  simdjson_inline void set_start_position(depth_t depth, token_position position) noexcept;
 #endif
   /* Useful for debugging and logging purposes. */
   inline std::string to_string() const noexcept;
@@ -266,13 +266,13 @@ public:
    */
   inline bool balanced() const noexcept;
 protected:
-  simdjson_really_inline json_iterator(const uint8_t *buf, ondemand::parser *parser) noexcept;
+  simdjson_inline json_iterator(const uint8_t *buf, ondemand::parser *parser) noexcept;
   /// The last token before the end
-  simdjson_really_inline token_position last_position() const noexcept;
+  simdjson_inline token_position last_position() const noexcept;
   /// The token *at* the end. This points at gibberish and should only be used for comparison.
-  simdjson_really_inline token_position end_position() const noexcept;
+  simdjson_inline token_position end_position() const noexcept;
   /// The end of the buffer.
-  simdjson_really_inline token_position end() const noexcept;
+  simdjson_inline token_position end() const noexcept;
 
   friend class document;
   friend class document_stream;
@@ -282,8 +282,8 @@ protected:
   friend class raw_json_string;
   friend class parser;
   friend class value_iterator;
-  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
-  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
+  friend simdjson_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
+  friend simdjson_inline void logger::log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
 }; // json_iterator
 
 } // namespace ondemand
@@ -295,10 +295,10 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_iterator> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
 
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result() noexcept = default;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/json_type-inl.h
+++ b/include/simdjson/generic/ondemand/json_type-inl.h
@@ -32,48 +32,48 @@ inline std::ostream& operator<<(std::ostream& out, simdjson_result<json_type> &t
 
 
 
-simdjson_really_inline number_type number::get_number_type() const noexcept {
+simdjson_inline number_type number::get_number_type() const noexcept {
   return type;
 }
 
-simdjson_really_inline bool number::is_uint64() const noexcept {
+simdjson_inline bool number::is_uint64() const noexcept {
   return get_number_type() == number_type::unsigned_integer;
 }
 
-simdjson_really_inline uint64_t number::get_uint64() const noexcept {
+simdjson_inline uint64_t number::get_uint64() const noexcept {
   return payload.unsigned_integer;
 }
 
-simdjson_really_inline number::operator uint64_t() const noexcept {
+simdjson_inline number::operator uint64_t() const noexcept {
   return get_uint64();
 }
 
 
-simdjson_really_inline bool number::is_int64() const noexcept {
+simdjson_inline bool number::is_int64() const noexcept {
   return get_number_type() == number_type::signed_integer;
 }
 
-simdjson_really_inline int64_t number::get_int64() const noexcept {
+simdjson_inline int64_t number::get_int64() const noexcept {
   return payload.signed_integer;
 }
 
-simdjson_really_inline number::operator int64_t() const noexcept {
+simdjson_inline number::operator int64_t() const noexcept {
   return get_int64();
 }
 
-simdjson_really_inline bool number::is_double() const noexcept {
+simdjson_inline bool number::is_double() const noexcept {
     return get_number_type() == number_type::floating_point_number;
 }
 
-simdjson_really_inline double number::get_double() const noexcept {
+simdjson_inline double number::get_double() const noexcept {
   return payload.floating_point_number;
 }
 
-simdjson_really_inline number::operator double() const noexcept {
+simdjson_inline number::operator double() const noexcept {
   return get_double();
 }
 
-simdjson_really_inline double number::as_double() const noexcept {
+simdjson_inline double number::as_double() const noexcept {
   if(is_double()) {
     return payload.floating_point_number;
   }
@@ -83,22 +83,22 @@ simdjson_really_inline double number::as_double() const noexcept {
   return double(payload.unsigned_integer);
 }
 
-simdjson_really_inline void number::append_s64(int64_t value) noexcept {
+simdjson_inline void number::append_s64(int64_t value) noexcept {
   payload.signed_integer = value;
   type = number_type::signed_integer;
 }
 
-simdjson_really_inline void number::append_u64(uint64_t value) noexcept {
+simdjson_inline void number::append_u64(uint64_t value) noexcept {
   payload.unsigned_integer = value;
   type = number_type::unsigned_integer;
 }
 
-simdjson_really_inline void number::append_double(double value) noexcept {
+simdjson_inline void number::append_double(double value) noexcept {
   payload.floating_point_number = value;
   type = number_type::floating_point_number;
 }
 
-simdjson_really_inline void number::skip_double() noexcept {
+simdjson_inline void number::skip_double() noexcept {
   type = number_type::floating_point_number;
 }
 
@@ -108,9 +108,9 @@ simdjson_really_inline void number::skip_double() noexcept {
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_type &&value) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_type &&value) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_type>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::json_type>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_type>(error) {}
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/json_type.h
+++ b/include/simdjson/generic/ondemand/json_type.h
@@ -34,46 +34,46 @@ struct number {
    *        unsigned_integer         /// a positive integer larger or equal to 1<<63
    *    };
    */
-  simdjson_really_inline number_type get_number_type() const noexcept;
+  simdjson_inline number_type get_number_type() const noexcept;
   /**
    * return true if the automatically determined type of
    * the number is number_type::unsigned_integer.
    */
-  simdjson_really_inline bool is_uint64() const noexcept;
+  simdjson_inline bool is_uint64() const noexcept;
   /**
    * return the value as a uint64_t, only valid if is_uint64() is true.
    */
-  simdjson_really_inline uint64_t get_uint64() const noexcept;
-  simdjson_really_inline operator uint64_t() const noexcept;
+  simdjson_inline uint64_t get_uint64() const noexcept;
+  simdjson_inline operator uint64_t() const noexcept;
 
   /**
    * return true if the automatically determined type of
    * the number is number_type::signed_integer.
    */
-  simdjson_really_inline bool is_int64() const noexcept;
+  simdjson_inline bool is_int64() const noexcept;
   /**
    * return the value as a int64_t, only valid if is_int64() is true.
    */
-  simdjson_really_inline int64_t get_int64() const noexcept;
-  simdjson_really_inline operator int64_t() const noexcept;
+  simdjson_inline int64_t get_int64() const noexcept;
+  simdjson_inline operator int64_t() const noexcept;
 
 
   /**
    * return true if the automatically determined type of
    * the number is number_type::floating_point_number.
    */
-  simdjson_really_inline bool is_double() const noexcept;
+  simdjson_inline bool is_double() const noexcept;
   /**
    * return the value as a double, only valid if is_double() is true.
    */
-  simdjson_really_inline double get_double() const noexcept;
-  simdjson_really_inline operator double() const noexcept;
+  simdjson_inline double get_double() const noexcept;
+  simdjson_inline operator double() const noexcept;
 
   /**
    * Convert the number to a double. Though it always succeed, the conversion
    * may be lossy if the number cannot be represented exactly.
    */
-  simdjson_really_inline double as_double() const noexcept;
+  simdjson_inline double as_double() const noexcept;
 
 
 protected:
@@ -90,13 +90,13 @@ protected:
   template<typename W>
   friend error_code numberparsing::slow_float_parsing(simdjson_unused const uint8_t * src, W writer);
   /** Store a signed 64-bit value to the number. */
-  simdjson_really_inline void append_s64(int64_t value) noexcept;
+  simdjson_inline void append_s64(int64_t value) noexcept;
   /** Store an unsigned 64-bit value to the number. */
-  simdjson_really_inline void append_u64(uint64_t value) noexcept;
+  simdjson_inline void append_u64(uint64_t value) noexcept;
   /** Store a double value to the number. */
-  simdjson_really_inline void append_double(double value) noexcept;
+  simdjson_inline void append_double(double value) noexcept;
   /** Specifies that the value is a double, but leave it undefined. */
-  simdjson_really_inline void skip_double() noexcept;
+  simdjson_inline void skip_double() noexcept;
   /**
    * End of friend declarations.
    */
@@ -144,10 +144,10 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::json_type> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_type &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::json_type &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
+  simdjson_inline ~simdjson_result() noexcept = default; ///< @private
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -2,46 +2,46 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline simdjson_result<value> object::find_field_unordered(const std::string_view key) & noexcept {
+simdjson_inline simdjson_result<value> object::find_field_unordered(const std::string_view key) & noexcept {
   bool has_value;
   SIMDJSON_TRY( iter.find_field_unordered_raw(key).get(has_value) );
   if (!has_value) { return NO_SUCH_FIELD; }
   return value(iter.child());
 }
-simdjson_really_inline simdjson_result<value> object::find_field_unordered(const std::string_view key) && noexcept {
+simdjson_inline simdjson_result<value> object::find_field_unordered(const std::string_view key) && noexcept {
   bool has_value;
   SIMDJSON_TRY( iter.find_field_unordered_raw(key).get(has_value) );
   if (!has_value) { return NO_SUCH_FIELD; }
   return value(iter.child());
 }
-simdjson_really_inline simdjson_result<value> object::operator[](const std::string_view key) & noexcept {
+simdjson_inline simdjson_result<value> object::operator[](const std::string_view key) & noexcept {
   return find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<value> object::operator[](const std::string_view key) && noexcept {
+simdjson_inline simdjson_result<value> object::operator[](const std::string_view key) && noexcept {
   return std::forward<object>(*this).find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<value> object::find_field(const std::string_view key) & noexcept {
+simdjson_inline simdjson_result<value> object::find_field(const std::string_view key) & noexcept {
   bool has_value;
   SIMDJSON_TRY( iter.find_field_raw(key).get(has_value) );
   if (!has_value) { return NO_SUCH_FIELD; }
   return value(iter.child());
 }
-simdjson_really_inline simdjson_result<value> object::find_field(const std::string_view key) && noexcept {
+simdjson_inline simdjson_result<value> object::find_field(const std::string_view key) && noexcept {
   bool has_value;
   SIMDJSON_TRY( iter.find_field_raw(key).get(has_value) );
   if (!has_value) { return NO_SUCH_FIELD; }
   return value(iter.child());
 }
 
-simdjson_really_inline simdjson_result<object> object::start(value_iterator &iter) noexcept {
+simdjson_inline simdjson_result<object> object::start(value_iterator &iter) noexcept {
   SIMDJSON_TRY( iter.start_object().error() );
   return object(iter);
 }
-simdjson_really_inline simdjson_result<object> object::start_root(value_iterator &iter) noexcept {
+simdjson_inline simdjson_result<object> object::start_root(value_iterator &iter) noexcept {
   SIMDJSON_TRY( iter.start_root_object().error() );
   return object(iter);
 }
-simdjson_really_inline error_code object::consume() noexcept {
+simdjson_inline error_code object::consume() noexcept {
   if(iter.is_at_key()) {
     /**
      * whenever you are pointing at a key, calling skip_child() is
@@ -67,7 +67,7 @@ simdjson_really_inline error_code object::consume() noexcept {
   return error_skip;
 }
 
-simdjson_really_inline simdjson_result<std::string_view> object::raw_json() noexcept {
+simdjson_inline simdjson_result<std::string_view> object::raw_json() noexcept {
   const uint8_t * starting_point{iter.peek_start()};
   auto error = consume();
   if(error) { return error; }
@@ -75,27 +75,27 @@ simdjson_really_inline simdjson_result<std::string_view> object::raw_json() noex
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 
-simdjson_really_inline simdjson_result<object> object::started(value_iterator &iter) noexcept {
+simdjson_inline simdjson_result<object> object::started(value_iterator &iter) noexcept {
   SIMDJSON_TRY( iter.started_object().error() );
   return object(iter);
 }
 
-simdjson_really_inline object object::resume(const value_iterator &iter) noexcept {
+simdjson_inline object object::resume(const value_iterator &iter) noexcept {
   return iter;
 }
 
-simdjson_really_inline object::object(const value_iterator &_iter) noexcept
+simdjson_inline object::object(const value_iterator &_iter) noexcept
   : iter{_iter}
 {
 }
 
-simdjson_really_inline simdjson_result<object_iterator> object::begin() noexcept {
+simdjson_inline simdjson_result<object_iterator> object::begin() noexcept {
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
   if (!iter.is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   return object_iterator(iter);
 }
-simdjson_really_inline simdjson_result<object_iterator> object::end() noexcept {
+simdjson_inline simdjson_result<object_iterator> object::end() noexcept {
   return object_iterator(iter);
 }
 
@@ -139,7 +139,7 @@ inline simdjson_result<value> object::at_pointer(std::string_view json_pointer) 
   return child;
 }
 
-simdjson_really_inline simdjson_result<size_t> object::count_fields() & noexcept {
+simdjson_inline simdjson_result<size_t> object::count_fields() & noexcept {
   size_t count{0};
   // Important: we do not consume any of the values.
   for(simdjson_unused auto v : *this) { count++; }
@@ -151,14 +151,14 @@ simdjson_really_inline simdjson_result<size_t> object::count_fields() & noexcept
   return count;
 }
 
-simdjson_really_inline simdjson_result<bool> object::is_empty() & noexcept {
+simdjson_inline simdjson_result<bool> object::is_empty() & noexcept {
   bool is_not_empty;
   auto error = iter.reset_object().get(is_not_empty);
   if(error) { return error; }
   return !is_not_empty;
 }
 
-simdjson_really_inline simdjson_result<bool> object::reset() & noexcept {
+simdjson_inline simdjson_result<bool> object::reset() & noexcept {
   return iter.reset_object();
 }
 
@@ -168,45 +168,45 @@ simdjson_really_inline simdjson_result<bool> object::reset() & noexcept {
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object &&value) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object &&value) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::object>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object>(error) {}
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::begin() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::begin() noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::end() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::end() noexcept {
   if (error()) { return error(); }
   return first.end();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field_unordered(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field_unordered(std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first.find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field_unordered(std::string_view key) && noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field_unordered(std::string_view key) && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::object>(first).find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::operator[](std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::operator[](std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::operator[](std::string_view key) && noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::operator[](std::string_view key) && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::object>(first)[key];
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field(std::string_view key) & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field(std::string_view key) & noexcept {
   if (error()) { return error(); }
   return first.find_field(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field(std::string_view key) && noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_field(std::string_view key) && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::object>(first).find_field(key);
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::at_pointer(std::string_view json_pointer) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::at_pointer(std::string_view json_pointer) noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
 }
@@ -221,7 +221,7 @@ inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::
   return first.is_empty();
 }
 
-simdjson_really_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::count_fields() & noexcept {
+simdjson_inline  simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::count_fields() & noexcept {
   if (error()) { return error(); }
   return first.count_fields();
 }

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -14,10 +14,10 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline object() noexcept = default;
+  simdjson_inline object() noexcept = default;
 
-  simdjson_really_inline simdjson_result<object_iterator> begin() noexcept;
-  simdjson_really_inline simdjson_result<object_iterator> end() noexcept;
+  simdjson_inline simdjson_result<object_iterator> begin() noexcept;
+  simdjson_inline simdjson_result<object_iterator> end() noexcept;
   /**
    * Look up a field by name on an object (order-sensitive).
    *
@@ -52,9 +52,9 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> find_field(std::string_view key) && noexcept;
+  simdjson_inline simdjson_result<value> find_field(std::string_view key) & noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> find_field(std::string_view key) && noexcept;
 
   /**
    * Look up a field by name on an object, without regard to key order.
@@ -89,13 +89,13 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) && noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
-  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) && noexcept;
+  simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) && noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> operator[](std::string_view key) & noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) & noexcept; */
+  simdjson_inline simdjson_result<value> operator[](std::string_view key) && noexcept;
 
   /**
    * Get the value associated with the given JSON pointer. We use the RFC 6901
@@ -167,26 +167,26 @@ public:
    * To check that an object is empty, it is more performant to use
    * the is_empty() method.
    */
-  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
   /**
    * Consumes the object and returns a string_view instance corresponding to the
    * object as represented in JSON. It points inside the original byte array containing
    * the JSON document.
    */
-  simdjson_really_inline simdjson_result<std::string_view> raw_json() noexcept;
+  simdjson_inline simdjson_result<std::string_view> raw_json() noexcept;
 
 protected:
   /**
    * Go to the end of the object, no matter where you are right now.
    */
-  simdjson_really_inline error_code consume() noexcept;
-  static simdjson_really_inline simdjson_result<object> start(value_iterator &iter) noexcept;
-  static simdjson_really_inline simdjson_result<object> start_root(value_iterator &iter) noexcept;
-  static simdjson_really_inline simdjson_result<object> started(value_iterator &iter) noexcept;
-  static simdjson_really_inline object resume(const value_iterator &iter) noexcept;
-  simdjson_really_inline object(const value_iterator &iter) noexcept;
+  simdjson_inline error_code consume() noexcept;
+  static simdjson_inline simdjson_result<object> start(value_iterator &iter) noexcept;
+  static simdjson_inline simdjson_result<object> start_root(value_iterator &iter) noexcept;
+  static simdjson_inline simdjson_result<object> started(value_iterator &iter) noexcept;
+  static simdjson_inline object resume(const value_iterator &iter) noexcept;
+  simdjson_inline object(const value_iterator &iter) noexcept;
 
-  simdjson_warn_unused simdjson_really_inline error_code find_field_raw(const std::string_view key) noexcept;
+  simdjson_warn_unused simdjson_inline error_code find_field_raw(const std::string_view key) noexcept;
 
   value_iterator iter{};
 
@@ -204,19 +204,19 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> begin() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> end() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> begin() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> end() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) && noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) && noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) && noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
   inline simdjson_result<bool> reset() noexcept;
   inline simdjson_result<bool> is_empty() noexcept;
   inline simdjson_result<size_t> count_fields() & noexcept;

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -6,11 +6,11 @@ namespace ondemand {
 // object_iterator
 //
 
-simdjson_really_inline object_iterator::object_iterator(const value_iterator &_iter) noexcept
+simdjson_inline object_iterator::object_iterator(const value_iterator &_iter) noexcept
   : iter{_iter}
 {}
 
-simdjson_really_inline simdjson_result<field> object_iterator::operator*() noexcept {
+simdjson_inline simdjson_result<field> object_iterator::operator*() noexcept {
   error_code error = iter.error();
   if (error) { iter.abandon(); return error; }
   auto result = field::start(iter);
@@ -19,16 +19,16 @@ simdjson_really_inline simdjson_result<field> object_iterator::operator*() noexc
   if (result.error()) { iter.abandon(); }
   return result;
 }
-simdjson_really_inline bool object_iterator::operator==(const object_iterator &other) const noexcept {
+simdjson_inline bool object_iterator::operator==(const object_iterator &other) const noexcept {
   return !(*this != other);
 }
-simdjson_really_inline bool object_iterator::operator!=(const object_iterator &) const noexcept {
+simdjson_inline bool object_iterator::operator!=(const object_iterator &) const noexcept {
   return iter.is_open();
 }
 
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
-simdjson_really_inline object_iterator &object_iterator::operator++() noexcept {
+simdjson_inline object_iterator &object_iterator::operator++() noexcept {
   // TODO this is a safety rail ... users should exit loops as soon as they receive an error.
   // Nonetheless, let's see if performance is OK with this if statement--the compiler may give it to us for free.
   if (!iter.is_open()) { return *this; } // Iterator will be released if there is an error
@@ -89,34 +89,34 @@ SIMDJSON_POP_DISABLE_WARNINGS
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::simdjson_result(
   SIMDJSON_IMPLEMENTATION::ondemand::object_iterator &&value
 ) noexcept
   : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>(value))
 {
   first.iter.assert_is_valid();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::simdjson_result(error_code error) noexcept
   : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>({}, error)
 {
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator*() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator*() noexcept {
   if (error()) { return error(); }
   return *first;
 }
 // If we're iterating and there is an error, return the error once.
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
   if (!first.iter.is_valid()) { return !error(); }
   return first == other.first;
 }
 // If we're iterating and there is an error, return the error once.
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &other) const noexcept {
   if (!first.iter.is_valid()) { return error(); }
   return first != other.first;
 }
 // Checks for ']' and ','
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator++() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator>::operator++() noexcept {
   // Clear the error if there is one, so we don't yield it twice
   if (error()) { second = SUCCESS; return *this; }
   ++first;

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -13,7 +13,7 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline object_iterator() noexcept = default;
+  simdjson_inline object_iterator() noexcept = default;
 
   //
   // Iterator interface
@@ -21,13 +21,13 @@ public:
 
   // Reads key and value, yielding them to the user.
   // MUST ONLY BE CALLED ONCE PER ITERATION.
-  simdjson_really_inline simdjson_result<field> operator*() noexcept;
+  simdjson_inline simdjson_result<field> operator*() noexcept;
   // Assumes it's being compared with the end. true if depth < iter->depth.
-  simdjson_really_inline bool operator==(const object_iterator &) const noexcept;
+  simdjson_inline bool operator==(const object_iterator &) const noexcept;
   // Assumes it's being compared with the end. true if depth >= iter->depth.
-  simdjson_really_inline bool operator!=(const object_iterator &) const noexcept;
+  simdjson_inline bool operator!=(const object_iterator &) const noexcept;
   // Checks for ']' and ','
-  simdjson_really_inline object_iterator &operator++() noexcept;
+  simdjson_inline object_iterator &operator++() noexcept;
 
 private:
   /**
@@ -38,7 +38,7 @@ private:
    */
   value_iterator iter{};
 
-  simdjson_really_inline object_iterator(const value_iterator &iter) noexcept;
+  simdjson_inline object_iterator(const value_iterator &iter) noexcept;
   friend struct simdjson_result<object_iterator>;
   friend class object;
 };
@@ -52,22 +52,22 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object_iterator &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::object_iterator &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 
   //
   // Iterator interface
   //
 
   // Reads key and value, yielding them to the user.
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field> operator*() noexcept; // MUST ONLY BE CALLED ONCE PER ITERATION.
   // Assumes it's being compared with the end. true if depth < iter->depth.
-  simdjson_really_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) const noexcept;
+  simdjson_inline bool operator==(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) const noexcept;
   // Assumes it's being compared with the end. true if depth >= iter->depth.
-  simdjson_really_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) const noexcept;
+  simdjson_inline bool operator!=(const simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &) const noexcept;
   // Checks for ']' and ','
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &operator++() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object_iterator> &operator++() noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -2,11 +2,11 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline parser::parser(size_t max_capacity) noexcept
+simdjson_inline parser::parser(size_t max_capacity) noexcept
   : _max_capacity{max_capacity} {
 }
 
-simdjson_warn_unused simdjson_really_inline error_code parser::allocate(size_t new_capacity, size_t new_max_depth) noexcept {
+simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capacity, size_t new_max_depth) noexcept {
   if (new_capacity > max_capacity()) { return CAPACITY; }
   if (string_buf && new_capacity == capacity() && new_max_depth == max_depth()) { return SUCCESS; }
 
@@ -28,7 +28,7 @@ simdjson_warn_unused simdjson_really_inline error_code parser::allocate(size_t n
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(padded_string_view json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(padded_string_view json) & noexcept {
   if (json.padding() < SIMDJSON_PADDING) { return INSUFFICIENT_PADDING; }
 
   // Allocate if needed
@@ -41,37 +41,37 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::it
   return document::start({ reinterpret_cast<const uint8_t *>(json.data()), this });
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(const char *json, size_t len, size_t allocated) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const char *json, size_t len, size_t allocated) & noexcept {
   return iterate(padded_string_view(json, len, allocated));
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(const uint8_t *json, size_t len, size_t allocated) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const uint8_t *json, size_t len, size_t allocated) & noexcept {
   return iterate(padded_string_view(json, len, allocated));
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(std::string_view json, size_t allocated) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(std::string_view json, size_t allocated) & noexcept {
   return iterate(padded_string_view(json, allocated));
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(const std::string &json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const std::string &json) & noexcept {
   return iterate(padded_string_view(json));
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string_view> &result) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string_view> &result) & noexcept {
   // We don't presently have a way to temporarily get a const T& from a simdjson_result<T> without throwing an exception
   SIMDJSON_TRY( result.error() );
   padded_string_view json = result.value_unsafe();
   return iterate(json);
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string> &result) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string> &result) & noexcept {
   // We don't presently have a way to temporarily get a const T& from a simdjson_result<T> without throwing an exception
   SIMDJSON_TRY( result.error() );
   const padded_string &json = result.value_unsafe();
   return iterate(json);
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<json_iterator> parser::iterate_raw(padded_string_view json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<json_iterator> parser::iterate_raw(padded_string_view json) & noexcept {
   if (json.padding() < SIMDJSON_PADDING) { return INSUFFICIENT_PADDING; }
 
   // Allocate if needed
@@ -98,17 +98,17 @@ inline simdjson_result<document_stream> parser::iterate_many(const padded_string
   return iterate_many(s.data(), s.length(), batch_size);
 }
 
-simdjson_really_inline size_t parser::capacity() const noexcept {
+simdjson_inline size_t parser::capacity() const noexcept {
   return _capacity;
 }
-simdjson_really_inline size_t parser::max_capacity() const noexcept {
+simdjson_inline size_t parser::max_capacity() const noexcept {
   return _max_capacity;
 }
-simdjson_really_inline size_t parser::max_depth() const noexcept {
+simdjson_inline size_t parser::max_depth() const noexcept {
   return _max_depth;
 }
 
-simdjson_really_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
+simdjson_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
   size_t MINIMAL_DOCUMENT_CAPACITY = 32;
   if(max_capacity < MINIMAL_DOCUMENT_CAPACITY) {
     _max_capacity = max_capacity;
@@ -117,7 +117,7 @@ simdjson_really_inline void parser::set_max_capacity(size_t max_capacity) noexce
   }
 }
 
-simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> parser::unescape(raw_json_string in, uint8_t *&dst) const noexcept {
+simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> parser::unescape(raw_json_string in, uint8_t *&dst) const noexcept {
   uint8_t *end = implementation->parse_string(in.buf, dst);
   if (!end) { return STRING_ERROR; }
   std::string_view result(reinterpret_cast<const char *>(dst), end-dst);
@@ -131,9 +131,9 @@ simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> pa
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::parser>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::parser &&value) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::parser>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::parser &&value) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::parser>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::parser>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::parser>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::parser>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::parser>(error) {}
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -41,9 +41,9 @@ public:
   inline explicit parser(size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
 
   inline parser(parser &&other) noexcept = default;
-  simdjson_really_inline parser(const parser &other) = delete;
-  simdjson_really_inline parser &operator=(const parser &other) = delete;
-  simdjson_really_inline parser &operator=(parser &&other) noexcept = default;
+  simdjson_inline parser(const parser &other) = delete;
+  simdjson_inline parser &operator=(const parser &other) = delete;
+  simdjson_inline parser &operator=(parser &&other) noexcept = default;
 
   /** Deallocate the JSON parser. */
   inline ~parser() noexcept = default;
@@ -226,12 +226,12 @@ public:
   simdjson_result<document_stream> iterate_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
 
   /** The capacity of this parser (the largest document it can process). */
-  simdjson_really_inline size_t capacity() const noexcept;
+  simdjson_inline size_t capacity() const noexcept;
   /** The maximum capacity of this parser (the largest document it is allowed to process). */
-  simdjson_really_inline size_t max_capacity() const noexcept;
-  simdjson_really_inline void set_max_capacity(size_t max_capacity) noexcept;
+  simdjson_inline size_t max_capacity() const noexcept;
+  simdjson_inline void set_max_capacity(size_t max_capacity) noexcept;
   /** The maximum depth of this parser (the most deeply nested objects and arrays it can process). */
-  simdjson_really_inline size_t max_depth() const noexcept;
+  simdjson_inline size_t max_depth() const noexcept;
 
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
@@ -272,7 +272,7 @@ public:
    * @return A string_view pointing at the unescaped string in dst
    * @error STRING_ERROR if escapes are incorrect.
    */
-  simdjson_really_inline simdjson_result<std::string_view> unescape(raw_json_string in, uint8_t *&dst) const noexcept;
+  simdjson_inline simdjson_result<std::string_view> unescape(raw_json_string in, uint8_t *&dst) const noexcept;
 private:
   /** @private [for benchmarking access] The implementation to use */
   std::unique_ptr<internal::dom_parser_implementation> implementation{};
@@ -297,9 +297,9 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::parser> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::parser> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::parser &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::parser &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -3,12 +3,12 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline raw_json_string::raw_json_string(const uint8_t * _buf) noexcept : buf{_buf} {}
+simdjson_inline raw_json_string::raw_json_string(const uint8_t * _buf) noexcept : buf{_buf} {}
 
-simdjson_really_inline const char * raw_json_string::raw() const noexcept { return reinterpret_cast<const char *>(buf); }
+simdjson_inline const char * raw_json_string::raw() const noexcept { return reinterpret_cast<const char *>(buf); }
 
 
-simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(std::string_view target) noexcept {
+simdjson_inline bool raw_json_string::is_free_from_unescaped_quote(std::string_view target) noexcept {
   size_t pos{0};
   // if the content has no escape character, just scan through it quickly!
   for(;pos < target.size() && target[pos] != '\\';pos++) {}
@@ -26,7 +26,7 @@ simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(std::s
   return true;
 }
 
-simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(const char* target) noexcept {
+simdjson_inline bool raw_json_string::is_free_from_unescaped_quote(const char* target) noexcept {
   size_t pos{0};
   // if the content has no escape character, just scan through it quickly!
   for(;target[pos] && target[pos] != '\\';pos++) {}
@@ -45,12 +45,12 @@ simdjson_really_inline bool raw_json_string::is_free_from_unescaped_quote(const 
 }
 
 
-simdjson_really_inline bool raw_json_string::unsafe_is_equal(size_t length, std::string_view target) const noexcept {
+simdjson_inline bool raw_json_string::unsafe_is_equal(size_t length, std::string_view target) const noexcept {
   // If we are going to call memcmp, then we must know something about the length of the raw_json_string.
   return (length >= target.size()) && (raw()[target.size()] == '"') && !memcmp(raw(), target.data(), target.size());
 }
 
-simdjson_really_inline bool raw_json_string::unsafe_is_equal(std::string_view target) const noexcept {
+simdjson_inline bool raw_json_string::unsafe_is_equal(std::string_view target) const noexcept {
   // Assumptions: does not contain unescaped quote characters, and
   // the raw content is quote terminated within a valid JSON string.
   if(target.size() <= SIMDJSON_PADDING) {
@@ -65,7 +65,7 @@ simdjson_really_inline bool raw_json_string::unsafe_is_equal(std::string_view ta
   return true;
 }
 
-simdjson_really_inline bool raw_json_string::is_equal(std::string_view target) const noexcept {
+simdjson_inline bool raw_json_string::is_equal(std::string_view target) const noexcept {
   const char * r{raw()};
   size_t pos{0};
   bool escaping{false};
@@ -89,7 +89,7 @@ simdjson_really_inline bool raw_json_string::is_equal(std::string_view target) c
 }
 
 
-simdjson_really_inline bool raw_json_string::unsafe_is_equal(const char * target) const noexcept {
+simdjson_inline bool raw_json_string::unsafe_is_equal(const char * target) const noexcept {
   // Assumptions: 'target' does not contain unescaped quote characters, is null terminated and
   // the raw content is quote terminated within a valid JSON string.
   const char * r{raw()};
@@ -101,7 +101,7 @@ simdjson_really_inline bool raw_json_string::unsafe_is_equal(const char * target
   return true;
 }
 
-simdjson_really_inline bool raw_json_string::is_equal(const char* target) const noexcept {
+simdjson_inline bool raw_json_string::is_equal(const char* target) const noexcept {
   // Assumptions: does not contain unescaped quote characters, and
   // the raw content is quote terminated within a valid JSON string.
   const char * r{raw()};
@@ -126,29 +126,29 @@ simdjson_really_inline bool raw_json_string::is_equal(const char* target) const 
   return true;
 }
 
-simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, std::string_view c) noexcept {
+simdjson_unused simdjson_inline bool operator==(const raw_json_string &a, std::string_view c) noexcept {
   return a.unsafe_is_equal(c);
 }
 
-simdjson_unused simdjson_really_inline bool operator==(std::string_view c, const raw_json_string &a) noexcept {
+simdjson_unused simdjson_inline bool operator==(std::string_view c, const raw_json_string &a) noexcept {
   return a == c;
 }
 
-simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, std::string_view c) noexcept {
+simdjson_unused simdjson_inline bool operator!=(const raw_json_string &a, std::string_view c) noexcept {
   return !(a == c);
 }
 
-simdjson_unused simdjson_really_inline bool operator!=(std::string_view c, const raw_json_string &a) noexcept {
+simdjson_unused simdjson_inline bool operator!=(std::string_view c, const raw_json_string &a) noexcept {
   return !(a == c);
 }
 
 
-simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> raw_json_string::unescape(json_iterator &iter) const noexcept {
+simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> raw_json_string::unescape(json_iterator &iter) const noexcept {
   return iter.unescape(*this);
 }
 
 
-simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &out, const raw_json_string &str) noexcept {
+simdjson_unused simdjson_inline std::ostream &operator<<(std::ostream &out, const raw_json_string &str) noexcept {
   bool in_escape = false;
   const char *s = str.raw();
   while (true) {
@@ -168,16 +168,16 @@ simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &ou
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string &&value) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string &&value) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>(error) {}
 
-simdjson_really_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::raw() const noexcept {
+simdjson_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::raw() const noexcept {
   if (error()) { return error(); }
   return first.raw();
 }
-simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept {
+simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string>::unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept {
   if (error()) { return error(); }
   return first.unescape(iter);
 }

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -38,7 +38,7 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline raw_json_string() noexcept = default;
+  simdjson_inline raw_json_string() noexcept = default;
 
   /**
    * Create a new invalid raw_json_string pointed at the given location in the JSON.
@@ -47,14 +47,14 @@ public:
    *
    * It *must* be terminated by a ", and be a valid JSON string.
    */
-  simdjson_really_inline raw_json_string(const uint8_t * _buf) noexcept;
+  simdjson_inline raw_json_string(const uint8_t * _buf) noexcept;
   /**
    * Get the raw pointer to the beginning of the string in the JSON (just after the ").
    *
    * It is possible for this function to return a null pointer if the instance
    * has outlived its existence.
    */
-  simdjson_really_inline const char * raw() const noexcept;
+  simdjson_inline const char * raw() const noexcept;
 
   /**
    * This compares the current instance to the std::string_view target: returns true if
@@ -70,7 +70,7 @@ public:
    * Performance: the comparison may be done using memcmp which may be efficient
    * for long strings.
    */
-  simdjson_really_inline bool unsafe_is_equal(size_t length, std::string_view target) const noexcept;
+  simdjson_inline bool unsafe_is_equal(size_t length, std::string_view target) const noexcept;
 
   /**
    * This compares the current instance to the std::string_view target: returns true if
@@ -87,7 +87,7 @@ public:
    *   static_assert(raw_json_string::is_free_from_unescaped_quote(target), "");
    *   s.unsafe_is_equal(target);
    */
-  simdjson_really_inline bool unsafe_is_equal(std::string_view target) const noexcept;
+  simdjson_inline bool unsafe_is_equal(std::string_view target) const noexcept;
 
   /**
    * This compares the current instance to the C string target: returns true if
@@ -101,27 +101,27 @@ public:
    *   static_assert(raw_json_string::is_free_from_unescaped_quote(target), "");
    *   s.unsafe_is_equal(target);
    */
-  simdjson_really_inline bool unsafe_is_equal(const char* target) const noexcept;
+  simdjson_inline bool unsafe_is_equal(const char* target) const noexcept;
 
   /**
    * This compares the current instance to the std::string_view target: returns true if
    * they are byte-by-byte equal (no escaping is done).
    */
-  simdjson_really_inline bool is_equal(std::string_view target) const noexcept;
+  simdjson_inline bool is_equal(std::string_view target) const noexcept;
 
   /**
    * This compares the current instance to the C string target: returns true if
    * they are byte-by-byte equal (no escaping is done).
    */
-  simdjson_really_inline bool is_equal(const char* target) const noexcept;
+  simdjson_inline bool is_equal(const char* target) const noexcept;
 
   /**
    * Returns true if target is free from unescaped quote. If target is known at
    * compile-time, we might expect the computation to happen at compile time with
    * many compilers (not all!).
    */
-  static simdjson_really_inline bool is_free_from_unescaped_quote(std::string_view target) noexcept;
-  static simdjson_really_inline bool is_free_from_unescaped_quote(const char* target) noexcept;
+  static simdjson_inline bool is_free_from_unescaped_quote(std::string_view target) noexcept;
+  static simdjson_inline bool is_free_from_unescaped_quote(const char* target) noexcept;
 
 private:
 
@@ -130,12 +130,12 @@ private:
    * This will set the inner pointer to zero, effectively making
    * this instance unusable.
    */
-  simdjson_really_inline void consume() noexcept { buf = nullptr; }
+  simdjson_inline void consume() noexcept { buf = nullptr; }
 
   /**
    * Checks whether the inner pointer is non-null and thus usable.
    */
-  simdjson_really_inline simdjson_warn_unused bool alive() const noexcept { return buf != nullptr; }
+  simdjson_inline simdjson_warn_unused bool alive() const noexcept { return buf != nullptr; }
 
   /**
    * Unescape this JSON string, replacing \\ with \, \n with newline, etc.
@@ -146,7 +146,7 @@ private:
    *
    * @param iter A json_iterator, which contains a buffer where the string will be written.
    */
-  simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> unescape(json_iterator &iter) const noexcept;
+  simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> unescape(json_iterator &iter) const noexcept;
 
   const uint8_t * buf{};
   friend class object;
@@ -155,16 +155,16 @@ private:
   friend struct simdjson_result<raw_json_string>;
 };
 
-simdjson_unused simdjson_really_inline std::ostream &operator<<(std::ostream &, const raw_json_string &) noexcept;
+simdjson_unused simdjson_inline std::ostream &operator<<(std::ostream &, const raw_json_string &) noexcept;
 
 /**
  * Comparisons between raw_json_string and std::string_view instances are potentially unsafe: the user is responsible
  * for providing a string with no unescaped quote. Note that unescaped quotes cannot be present in valid JSON strings.
  */
-simdjson_unused simdjson_really_inline bool operator==(const raw_json_string &a, std::string_view c) noexcept;
-simdjson_unused simdjson_really_inline bool operator==(std::string_view c, const raw_json_string &a) noexcept;
-simdjson_unused simdjson_really_inline bool operator!=(const raw_json_string &a, std::string_view c) noexcept;
-simdjson_unused simdjson_really_inline bool operator!=(std::string_view c, const raw_json_string &a) noexcept;
+simdjson_unused simdjson_inline bool operator==(const raw_json_string &a, std::string_view c) noexcept;
+simdjson_unused simdjson_inline bool operator==(std::string_view c, const raw_json_string &a) noexcept;
+simdjson_unused simdjson_inline bool operator!=(const raw_json_string &a, std::string_view c) noexcept;
+simdjson_unused simdjson_inline bool operator!=(std::string_view c, const raw_json_string &a) noexcept;
 
 
 } // namespace ondemand
@@ -176,13 +176,13 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
+  simdjson_inline ~simdjson_result() noexcept = default; ///< @private
 
-  simdjson_really_inline simdjson_result<const char *> raw() const noexcept;
-  simdjson_really_inline simdjson_warn_unused simdjson_result<std::string_view> unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept;
+  simdjson_inline simdjson_result<const char *> raw() const noexcept;
+  simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> unescape(SIMDJSON_IMPLEMENTATION::ondemand::json_iterator &iter) const noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/token_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/token_iterator-inl.h
@@ -2,65 +2,65 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline token_iterator::token_iterator(
+simdjson_inline token_iterator::token_iterator(
   const uint8_t *_buf,
   token_position position
 ) noexcept : buf{_buf}, _position{position}
 {
 }
 
-simdjson_really_inline uint32_t token_iterator::current_offset() const noexcept {
+simdjson_inline uint32_t token_iterator::current_offset() const noexcept {
   return *(_position);
 }
 
 
-simdjson_really_inline const uint8_t *token_iterator::return_current_and_advance() noexcept {
+simdjson_inline const uint8_t *token_iterator::return_current_and_advance() noexcept {
   return &buf[*(_position++)];
 }
 
-simdjson_really_inline const uint8_t *token_iterator::peek(token_position position) const noexcept {
+simdjson_inline const uint8_t *token_iterator::peek(token_position position) const noexcept {
   return &buf[*position];
 }
-simdjson_really_inline uint32_t token_iterator::peek_index(token_position position) const noexcept {
+simdjson_inline uint32_t token_iterator::peek_index(token_position position) const noexcept {
   return *position;
 }
-simdjson_really_inline uint32_t token_iterator::peek_length(token_position position) const noexcept {
+simdjson_inline uint32_t token_iterator::peek_length(token_position position) const noexcept {
   return *(position+1) - *position;
 }
 
-simdjson_really_inline const uint8_t *token_iterator::peek(int32_t delta) const noexcept {
+simdjson_inline const uint8_t *token_iterator::peek(int32_t delta) const noexcept {
   return &buf[*(_position+delta)];
 }
-simdjson_really_inline uint32_t token_iterator::peek_index(int32_t delta) const noexcept {
+simdjson_inline uint32_t token_iterator::peek_index(int32_t delta) const noexcept {
   return *(_position+delta);
 }
-simdjson_really_inline uint32_t token_iterator::peek_length(int32_t delta) const noexcept {
+simdjson_inline uint32_t token_iterator::peek_length(int32_t delta) const noexcept {
   return *(_position+delta+1) - *(_position+delta);
 }
 
-simdjson_really_inline token_position token_iterator::position() const noexcept {
+simdjson_inline token_position token_iterator::position() const noexcept {
   return _position;
 }
-simdjson_really_inline void token_iterator::set_position(token_position target_position) noexcept {
+simdjson_inline void token_iterator::set_position(token_position target_position) noexcept {
   _position = target_position;
 }
 
-simdjson_really_inline bool token_iterator::operator==(const token_iterator &other) const noexcept {
+simdjson_inline bool token_iterator::operator==(const token_iterator &other) const noexcept {
   return _position == other._position;
 }
-simdjson_really_inline bool token_iterator::operator!=(const token_iterator &other) const noexcept {
+simdjson_inline bool token_iterator::operator!=(const token_iterator &other) const noexcept {
   return _position != other._position;
 }
-simdjson_really_inline bool token_iterator::operator>(const token_iterator &other) const noexcept {
+simdjson_inline bool token_iterator::operator>(const token_iterator &other) const noexcept {
   return _position > other._position;
 }
-simdjson_really_inline bool token_iterator::operator>=(const token_iterator &other) const noexcept {
+simdjson_inline bool token_iterator::operator>=(const token_iterator &other) const noexcept {
   return _position >= other._position;
 }
-simdjson_really_inline bool token_iterator::operator<(const token_iterator &other) const noexcept {
+simdjson_inline bool token_iterator::operator<(const token_iterator &other) const noexcept {
   return _position < other._position;
 }
-simdjson_really_inline bool token_iterator::operator<=(const token_iterator &other) const noexcept {
+simdjson_inline bool token_iterator::operator<=(const token_iterator &other) const noexcept {
   return _position <= other._position;
 }
 
@@ -70,9 +70,9 @@ simdjson_really_inline bool token_iterator::operator<=(const token_iterator &oth
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::token_iterator &&value) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::token_iterator &&value) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator>(error) {}
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/token_iterator.h
+++ b/include/simdjson/generic/ondemand/token_iterator.h
@@ -15,20 +15,20 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline token_iterator() noexcept = default;
-  simdjson_really_inline token_iterator(token_iterator &&other) noexcept = default;
-  simdjson_really_inline token_iterator &operator=(token_iterator &&other) noexcept = default;
-  simdjson_really_inline token_iterator(const token_iterator &other) noexcept = default;
-  simdjson_really_inline token_iterator &operator=(const token_iterator &other) noexcept = default;
+  simdjson_inline token_iterator() noexcept = default;
+  simdjson_inline token_iterator(token_iterator &&other) noexcept = default;
+  simdjson_inline token_iterator &operator=(token_iterator &&other) noexcept = default;
+  simdjson_inline token_iterator(const token_iterator &other) noexcept = default;
+  simdjson_inline token_iterator &operator=(const token_iterator &other) noexcept = default;
 
   /**
    * Advance to the next token (returning the current one).
    */
-  simdjson_really_inline const uint8_t *return_current_and_advance() noexcept;
+  simdjson_inline const uint8_t *return_current_and_advance() noexcept;
   /**
    * Reports the current offset in bytes from the start of the underlying buffer.
    */
-  simdjson_really_inline uint32_t current_offset() const noexcept;
+  simdjson_inline uint32_t current_offset() const noexcept;
   /**
    * Get the JSON text for a given token (relative).
    *
@@ -40,7 +40,7 @@ public:
    * TODO consider a string_view, assuming the length will get stripped out by the optimizer when
    * it isn't used ...
    */
-  simdjson_really_inline const uint8_t *peek(int32_t delta=0) const noexcept;
+  simdjson_inline const uint8_t *peek(int32_t delta=0) const noexcept;
   /**
    * Get the maximum length of the JSON text for a given token.
    *
@@ -49,7 +49,7 @@ public:
    * @param delta The relative position of the token to retrieve. e.g. 0 = current token,
    *              1 = next token, -1 = prev token.
    */
-  simdjson_really_inline uint32_t peek_length(int32_t delta=0) const noexcept;
+  simdjson_inline uint32_t peek_length(int32_t delta=0) const noexcept;
 
   /**
    * Get the JSON text for a given token.
@@ -59,7 +59,7 @@ public:
    * @param position The position of the token.
    *
    */
-  simdjson_really_inline const uint8_t *peek(token_position position) const noexcept;
+  simdjson_inline const uint8_t *peek(token_position position) const noexcept;
   /**
    * Get the maximum length of the JSON text for a given token.
    *
@@ -67,29 +67,29 @@ public:
    *
    * @param position The position of the token.
    */
-  simdjson_really_inline uint32_t peek_length(token_position position) const noexcept;
+  simdjson_inline uint32_t peek_length(token_position position) const noexcept;
 
   /**
    * Return the current index.
    */
-  simdjson_really_inline token_position position() const noexcept;
+  simdjson_inline token_position position() const noexcept;
   /**
    * Reset to a previously saved index.
    */
-  simdjson_really_inline void set_position(token_position target_position) noexcept;
+  simdjson_inline void set_position(token_position target_position) noexcept;
 
   // NOTE: we don't support a full C++ iterator interface, because we expect people to make
   // different calls to advance the iterator based on *their own* state.
 
-  simdjson_really_inline bool operator==(const token_iterator &other) const noexcept;
-  simdjson_really_inline bool operator!=(const token_iterator &other) const noexcept;
-  simdjson_really_inline bool operator>(const token_iterator &other) const noexcept;
-  simdjson_really_inline bool operator>=(const token_iterator &other) const noexcept;
-  simdjson_really_inline bool operator<(const token_iterator &other) const noexcept;
-  simdjson_really_inline bool operator<=(const token_iterator &other) const noexcept;
+  simdjson_inline bool operator==(const token_iterator &other) const noexcept;
+  simdjson_inline bool operator!=(const token_iterator &other) const noexcept;
+  simdjson_inline bool operator>(const token_iterator &other) const noexcept;
+  simdjson_inline bool operator>=(const token_iterator &other) const noexcept;
+  simdjson_inline bool operator<(const token_iterator &other) const noexcept;
+  simdjson_inline bool operator<=(const token_iterator &other) const noexcept;
 
 protected:
-  simdjson_really_inline token_iterator(const uint8_t *buf, token_position position) noexcept;
+  simdjson_inline token_iterator(const uint8_t *buf, token_position position) noexcept;
 
   /**
    * Get the index of the JSON text for a given token (relative).
@@ -99,7 +99,7 @@ protected:
    * @param delta The relative position of the token to retrieve. e.g. 0 = current token,
    *              1 = next token, -1 = prev token.
    */
-  simdjson_really_inline uint32_t peek_index(int32_t delta=0) const noexcept;
+  simdjson_inline uint32_t peek_index(int32_t delta=0) const noexcept;
   /**
    * Get the index of the JSON text for a given token.
    *
@@ -108,7 +108,7 @@ protected:
    * @param position The position of the token.
    *
    */
-  simdjson_really_inline uint32_t peek_index(token_position position) const noexcept;
+  simdjson_inline uint32_t peek_index(token_position position) const noexcept;
 
   const uint8_t *buf{};
   token_position _position{};
@@ -116,8 +116,8 @@ protected:
   friend class json_iterator;
   friend class value_iterator;
   friend class object;
-  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
-  friend simdjson_really_inline void logger::log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
+  friend simdjson_inline void logger::log_line(const json_iterator &iter, const char *title_prefix, const char *title, std::string_view detail, int delta, int depth_delta) noexcept;
+  friend simdjson_inline void logger::log_line(const json_iterator &iter, token_position index, depth_t depth, const char *title_prefix, const char *title, std::string_view detail) noexcept;
 };
 
 } // namespace ondemand
@@ -129,10 +129,10 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::token_iterator> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::token_iterator &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
-  simdjson_really_inline ~simdjson_result() noexcept = default; ///< @private
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::token_iterator &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
+  simdjson_inline ~simdjson_result() noexcept = default; ///< @private
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -2,24 +2,24 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline value::value(const value_iterator &_iter) noexcept
+simdjson_inline value::value(const value_iterator &_iter) noexcept
   : iter{_iter}
 {
 }
-simdjson_really_inline value value::start(const value_iterator &iter) noexcept {
+simdjson_inline value value::start(const value_iterator &iter) noexcept {
   return iter;
 }
-simdjson_really_inline value value::resume(const value_iterator &iter) noexcept {
+simdjson_inline value value::resume(const value_iterator &iter) noexcept {
   return iter;
 }
 
-simdjson_really_inline simdjson_result<array> value::get_array() noexcept {
+simdjson_inline simdjson_result<array> value::get_array() noexcept {
   return array::start(iter);
 }
-simdjson_really_inline simdjson_result<object> value::get_object() noexcept {
+simdjson_inline simdjson_result<object> value::get_object() noexcept {
   return object::start(iter);
 }
-simdjson_really_inline simdjson_result<object> value::start_or_resume_object() noexcept {
+simdjson_inline simdjson_result<object> value::start_or_resume_object() noexcept {
   if (iter.at_start()) {
     return get_object();
   } else {
@@ -27,85 +27,85 @@ simdjson_really_inline simdjson_result<object> value::start_or_resume_object() n
   }
 }
 
-simdjson_really_inline simdjson_result<raw_json_string> value::get_raw_json_string() noexcept {
+simdjson_inline simdjson_result<raw_json_string> value::get_raw_json_string() noexcept {
   return iter.get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<std::string_view> value::get_string() noexcept {
+simdjson_inline simdjson_result<std::string_view> value::get_string() noexcept {
   return iter.get_string();
 }
-simdjson_really_inline simdjson_result<double> value::get_double() noexcept {
+simdjson_inline simdjson_result<double> value::get_double() noexcept {
   return iter.get_double();
 }
-simdjson_really_inline simdjson_result<double> value::get_double_in_string() noexcept {
+simdjson_inline simdjson_result<double> value::get_double_in_string() noexcept {
   return iter.get_double_in_string();
 }
-simdjson_really_inline simdjson_result<uint64_t> value::get_uint64() noexcept {
+simdjson_inline simdjson_result<uint64_t> value::get_uint64() noexcept {
   return iter.get_uint64();
 }
-simdjson_really_inline simdjson_result<uint64_t> value::get_uint64_in_string() noexcept {
+simdjson_inline simdjson_result<uint64_t> value::get_uint64_in_string() noexcept {
   return iter.get_uint64_in_string();
 }
-simdjson_really_inline simdjson_result<int64_t> value::get_int64() noexcept {
+simdjson_inline simdjson_result<int64_t> value::get_int64() noexcept {
   return iter.get_int64();
 }
-simdjson_really_inline simdjson_result<int64_t> value::get_int64_in_string() noexcept {
+simdjson_inline simdjson_result<int64_t> value::get_int64_in_string() noexcept {
   return iter.get_int64_in_string();
 }
-simdjson_really_inline simdjson_result<bool> value::get_bool() noexcept {
+simdjson_inline simdjson_result<bool> value::get_bool() noexcept {
   return iter.get_bool();
 }
-simdjson_really_inline bool value::is_null() noexcept {
+simdjson_inline bool value::is_null() noexcept {
   return iter.is_null();
 }
 
-template<> simdjson_really_inline simdjson_result<array> value::get() noexcept { return get_array(); }
-template<> simdjson_really_inline simdjson_result<object> value::get() noexcept { return get_object(); }
-template<> simdjson_really_inline simdjson_result<raw_json_string> value::get() noexcept { return get_raw_json_string(); }
-template<> simdjson_really_inline simdjson_result<std::string_view> value::get() noexcept { return get_string(); }
-template<> simdjson_really_inline simdjson_result<number> value::get() noexcept { return get_number(); }
-template<> simdjson_really_inline simdjson_result<double> value::get() noexcept { return get_double(); }
-template<> simdjson_really_inline simdjson_result<uint64_t> value::get() noexcept { return get_uint64(); }
-template<> simdjson_really_inline simdjson_result<int64_t> value::get() noexcept { return get_int64(); }
-template<> simdjson_really_inline simdjson_result<bool> value::get() noexcept { return get_bool(); }
+template<> simdjson_inline simdjson_result<array> value::get() noexcept { return get_array(); }
+template<> simdjson_inline simdjson_result<object> value::get() noexcept { return get_object(); }
+template<> simdjson_inline simdjson_result<raw_json_string> value::get() noexcept { return get_raw_json_string(); }
+template<> simdjson_inline simdjson_result<std::string_view> value::get() noexcept { return get_string(); }
+template<> simdjson_inline simdjson_result<number> value::get() noexcept { return get_number(); }
+template<> simdjson_inline simdjson_result<double> value::get() noexcept { return get_double(); }
+template<> simdjson_inline simdjson_result<uint64_t> value::get() noexcept { return get_uint64(); }
+template<> simdjson_inline simdjson_result<int64_t> value::get() noexcept { return get_int64(); }
+template<> simdjson_inline simdjson_result<bool> value::get() noexcept { return get_bool(); }
 
-template<typename T> simdjson_really_inline error_code value::get(T &out) noexcept {
+template<typename T> simdjson_inline error_code value::get(T &out) noexcept {
   return get<T>().get(out);
 }
 
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline value::operator array() noexcept(false) {
+simdjson_inline value::operator array() noexcept(false) {
   return get_array();
 }
-simdjson_really_inline value::operator object() noexcept(false) {
+simdjson_inline value::operator object() noexcept(false) {
   return get_object();
 }
-simdjson_really_inline value::operator uint64_t() noexcept(false) {
+simdjson_inline value::operator uint64_t() noexcept(false) {
   return get_uint64();
 }
-simdjson_really_inline value::operator int64_t() noexcept(false) {
+simdjson_inline value::operator int64_t() noexcept(false) {
   return get_int64();
 }
-simdjson_really_inline value::operator double() noexcept(false) {
+simdjson_inline value::operator double() noexcept(false) {
   return get_double();
 }
-simdjson_really_inline value::operator std::string_view() noexcept(false) {
+simdjson_inline value::operator std::string_view() noexcept(false) {
   return get_string();
 }
-simdjson_really_inline value::operator raw_json_string() noexcept(false) {
+simdjson_inline value::operator raw_json_string() noexcept(false) {
   return get_raw_json_string();
 }
-simdjson_really_inline value::operator bool() noexcept(false) {
+simdjson_inline value::operator bool() noexcept(false) {
   return get_bool();
 }
 #endif
 
-simdjson_really_inline simdjson_result<array_iterator> value::begin() & noexcept {
+simdjson_inline simdjson_result<array_iterator> value::begin() & noexcept {
   return get_array().begin();
 }
-simdjson_really_inline simdjson_result<array_iterator> value::end() & noexcept {
+simdjson_inline simdjson_result<array_iterator> value::end() & noexcept {
   return {};
 }
-simdjson_really_inline simdjson_result<size_t> value::count_elements() & noexcept {
+simdjson_inline simdjson_result<size_t> value::count_elements() & noexcept {
   simdjson_result<size_t> answer;
   auto a = get_array();
   answer = a.count_elements();
@@ -115,77 +115,77 @@ simdjson_really_inline simdjson_result<size_t> value::count_elements() & noexcep
   iter.move_at_start();
   return answer;
 }
-simdjson_really_inline simdjson_result<size_t> value::count_fields() & noexcept {
+simdjson_inline simdjson_result<size_t> value::count_fields() & noexcept {
   simdjson_result<size_t> answer;
   auto a = get_object();
   answer = a.count_fields();
   iter.move_at_start();
   return answer;
 }
-simdjson_really_inline simdjson_result<value> value::at(size_t index) noexcept {
+simdjson_inline simdjson_result<value> value::at(size_t index) noexcept {
   auto a = get_array();
   return a.at(index);
 }
 
-simdjson_really_inline simdjson_result<value> value::find_field(std::string_view key) noexcept {
+simdjson_inline simdjson_result<value> value::find_field(std::string_view key) noexcept {
   return start_or_resume_object().find_field(key);
 }
-simdjson_really_inline simdjson_result<value> value::find_field(const char *key) noexcept {
+simdjson_inline simdjson_result<value> value::find_field(const char *key) noexcept {
   return start_or_resume_object().find_field(key);
 }
 
-simdjson_really_inline simdjson_result<value> value::find_field_unordered(std::string_view key) noexcept {
+simdjson_inline simdjson_result<value> value::find_field_unordered(std::string_view key) noexcept {
   return start_or_resume_object().find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<value> value::find_field_unordered(const char *key) noexcept {
+simdjson_inline simdjson_result<value> value::find_field_unordered(const char *key) noexcept {
   return start_or_resume_object().find_field_unordered(key);
 }
 
-simdjson_really_inline simdjson_result<value> value::operator[](std::string_view key) noexcept {
+simdjson_inline simdjson_result<value> value::operator[](std::string_view key) noexcept {
   return start_or_resume_object()[key];
 }
-simdjson_really_inline simdjson_result<value> value::operator[](const char *key) noexcept {
+simdjson_inline simdjson_result<value> value::operator[](const char *key) noexcept {
   return start_or_resume_object()[key];
 }
 
-simdjson_really_inline simdjson_result<json_type> value::type() noexcept {
+simdjson_inline simdjson_result<json_type> value::type() noexcept {
   return iter.type();
 }
 
-simdjson_really_inline simdjson_result<bool> value::is_scalar() noexcept {
+simdjson_inline simdjson_result<bool> value::is_scalar() noexcept {
   json_type this_type;
   auto error = type().get(this_type);
   if(error) { return error; }
   return ! ((this_type == json_type::array) || (this_type == json_type::object));
 }
 
-simdjson_really_inline bool value::is_negative() noexcept {
+simdjson_inline bool value::is_negative() noexcept {
   return iter.is_negative();
 }
 
-simdjson_really_inline simdjson_result<bool> value::is_integer() noexcept {
+simdjson_inline simdjson_result<bool> value::is_integer() noexcept {
   return iter.is_integer();
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<number_type> value::get_number_type() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<number_type> value::get_number_type() noexcept {
   return iter.get_number_type();
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<number> value::get_number() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<number> value::get_number() noexcept {
   return iter.get_number();
 }
 
-simdjson_really_inline std::string_view value::raw_json_token() noexcept {
+simdjson_inline std::string_view value::raw_json_token() noexcept {
   return std::string_view(reinterpret_cast<const char*>(iter.peek_start()), iter.peek_start_length());
 }
 
-simdjson_really_inline simdjson_result<const char *> value::current_location() noexcept {
+simdjson_inline simdjson_result<const char *> value::current_location() noexcept {
   return iter.json_iter().current_location();
 }
 
-simdjson_really_inline int32_t value::current_depth() const noexcept{
+simdjson_inline int32_t value::current_depth() const noexcept{
   return iter.json_iter().depth();
 }
 
-simdjson_really_inline simdjson_result<value> value::at_pointer(std::string_view json_pointer) noexcept {
+simdjson_inline simdjson_result<value> value::at_pointer(std::string_view json_pointer) noexcept {
   json_type t;
   SIMDJSON_TRY(type().get(t));
   switch (t)
@@ -205,7 +205,7 @@ simdjson_really_inline simdjson_result<value> value::at_pointer(std::string_view
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::simdjson_result(
   SIMDJSON_IMPLEMENTATION::ondemand::value &&value
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value>(
@@ -213,203 +213,203 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>
     )
 {
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::simdjson_result(
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::simdjson_result(
   error_code error
 ) noexcept :
     implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value>(error)
 {
 }
-simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::count_elements() & noexcept {
+simdjson_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::count_elements() & noexcept {
   if (error()) { return error(); }
   return first.count_elements();
 }
-simdjson_really_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::count_fields() & noexcept {
+simdjson_inline simdjson_result<size_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::count_fields() & noexcept {
   if (error()) { return error(); }
   return first.count_fields();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::at(size_t index) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::at(size_t index) noexcept {
   if (error()) { return error(); }
   return first.at(index);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::begin() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::begin() & noexcept {
   if (error()) { return error(); }
   return first.begin();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::end() & noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::end() & noexcept {
   if (error()) { return error(); }
   return {};
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field(std::string_view key) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field(std::string_view key) noexcept {
   if (error()) { return error(); }
   return first.find_field(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field(const char *key) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field(const char *key) noexcept {
   if (error()) { return error(); }
   return first.find_field(key);
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field_unordered(std::string_view key) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field_unordered(std::string_view key) noexcept {
   if (error()) { return error(); }
   return first.find_field_unordered(key);
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field_unordered(const char *key) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::find_field_unordered(const char *key) noexcept {
   if (error()) { return error(); }
   return first.find_field_unordered(key);
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](std::string_view key) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](std::string_view key) noexcept {
   if (error()) { return error(); }
   return first[key];
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](const char *key) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator[](const char *key) noexcept {
   if (error()) { return error(); }
   return first[key];
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_array() noexcept {
   if (error()) { return error(); }
   return first.get_array();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_object() noexcept {
   if (error()) { return error(); }
   return first.get_object();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() noexcept {
+simdjson_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64() noexcept {
   if (error()) { return error(); }
   return first.get_uint64();
 }
-simdjson_really_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64_in_string() noexcept {
+simdjson_inline simdjson_result<uint64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_uint64_in_string() noexcept {
   if (error()) { return error(); }
   return first.get_uint64_in_string();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() noexcept {
+simdjson_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64() noexcept {
   if (error()) { return error(); }
   return first.get_int64();
 }
-simdjson_really_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64_in_string() noexcept {
+simdjson_inline simdjson_result<int64_t> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_int64_in_string() noexcept {
   if (error()) { return error(); }
   return first.get_int64_in_string();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() noexcept {
+simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double() noexcept {
   if (error()) { return error(); }
   return first.get_double();
 }
-simdjson_really_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double_in_string() noexcept {
+simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double_in_string() noexcept {
   if (error()) { return error(); }
   return first.get_double_in_string();
 }
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string() noexcept {
   if (error()) { return error(); }
   return first.get_string();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_raw_json_string() noexcept {
   if (error()) { return error(); }
   return first.get_raw_json_string();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_bool() noexcept {
   if (error()) { return error(); }
   return first.get_bool();
 }
-simdjson_really_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() noexcept {
+simdjson_inline bool simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_null() noexcept {
   if (error()) { return false; }
   return first.is_null();
 }
 
-template<typename T> simdjson_really_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get() noexcept {
+template<typename T> simdjson_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get() noexcept {
   if (error()) { return error(); }
   return first.get<T>();
 }
-template<typename T> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get(T &out) noexcept {
+template<typename T> simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get(T &out) noexcept {
   if (error()) { return error(); }
   return first.get<T>(out);
 }
 
-template<> simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>() noexcept  {
+template<> simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>() noexcept  {
   if (error()) { return error(); }
   return std::move(first);
 }
-template<> simdjson_really_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>(SIMDJSON_IMPLEMENTATION::ondemand::value &out) noexcept {
+template<> simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get<SIMDJSON_IMPLEMENTATION::ondemand::value>(SIMDJSON_IMPLEMENTATION::ondemand::value &out) noexcept {
   if (error()) { return error(); }
   out = first;
   return SUCCESS;
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::type() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::type() noexcept {
   if (error()) { return error(); }
   return first.type();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_scalar() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_scalar() noexcept {
   if (error()) { return error(); }
   return first.is_scalar();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_negative() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_negative() noexcept {
   if (error()) { return error(); }
   return first.is_negative();
 }
-simdjson_really_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_integer() noexcept {
+simdjson_inline simdjson_result<bool> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::is_integer() noexcept {
   if (error()) { return error(); }
   return first.is_integer();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_number_type() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_number_type() noexcept {
   if (error()) { return error(); }
   return first.get_number_type();
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_number() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_number() noexcept {
   if (error()) { return error(); }
   return first.get_number();
 }
 #if SIMDJSON_EXCEPTIONS
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator uint64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator int64_t() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator double() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator std::string_view() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() noexcept(false) {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator bool() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
 }
 #endif
 
-simdjson_really_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::raw_json_token() noexcept {
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::raw_json_token() noexcept {
   if (error()) { return error(); }
   return first.raw_json_token();
 }
 
-simdjson_really_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::current_location() noexcept {
+simdjson_inline simdjson_result<const char *> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::current_location() noexcept {
   if (error()) { return error(); }
   return first.current_location();
 }
 
-simdjson_really_inline int32_t simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::current_depth() const noexcept {
+simdjson_inline int32_t simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::current_depth() const noexcept {
   if (error()) { return error(); }
   return first.current_depth();
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::at_pointer(std::string_view json_pointer) noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::at_pointer(std::string_view json_pointer) noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
 }

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -21,7 +21,7 @@ public:
    *
    * Exists so you can declare a variable and later assign to it before use.
    */
-  simdjson_really_inline value() noexcept = default;
+  simdjson_inline value() noexcept = default;
 
   /**
    * Get this value as the given type.
@@ -34,7 +34,7 @@ public:
    * @returns A value of the given type, parsed from the JSON.
    * @returns INCORRECT_TYPE If the JSON value is not the given type.
    */
-  template<typename T> simdjson_really_inline simdjson_result<T> get() noexcept {
+  template<typename T> simdjson_inline simdjson_result<T> get() noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
@@ -49,7 +49,7 @@ public:
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    * @returns SUCCESS If the parse succeeded and the out parameter was set to the value.
    */
-  template<typename T> simdjson_really_inline error_code get(T &out) noexcept;
+  template<typename T> simdjson_inline error_code get(T &out) noexcept;
 
   /**
    * Cast this JSON value to an array.
@@ -57,7 +57,7 @@ public:
    * @returns An object that can be used to iterate the array.
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array> get_array() noexcept;
+  simdjson_inline simdjson_result<array> get_array() noexcept;
 
   /**
    * Cast this JSON value to an object.
@@ -65,7 +65,7 @@ public:
    * @returns An object that can be used to look up or iterate fields.
    * @returns INCORRECT_TYPE If the JSON value is not an object.
    */
-  simdjson_really_inline simdjson_result<object> get_object() noexcept;
+  simdjson_inline simdjson_result<object> get_object() noexcept;
 
   /**
    * Cast this JSON value to an unsigned integer.
@@ -73,7 +73,7 @@ public:
    * @returns A unsigned 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
 
   /**
    * Cast this JSON value (inside string) to a unsigned integer.
@@ -81,7 +81,7 @@ public:
    * @returns A unsigned 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
 
   /**
    * Cast this JSON value to a signed integer.
@@ -89,7 +89,7 @@ public:
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64() noexcept;
 
   /**
    * Cast this JSON value (inside string) to a signed integer.
@@ -97,7 +97,7 @@ public:
    * @returns A signed 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
 
   /**
    * Cast this JSON value to a double.
@@ -105,7 +105,7 @@ public:
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
+  simdjson_inline simdjson_result<double> get_double() noexcept;
 
   /**
    * Cast this JSON value (inside string) to a double
@@ -113,7 +113,7 @@ public:
    * @returns A double.
    * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
 
   /**
    * Cast this JSON value to a string.
@@ -129,7 +129,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_inline simdjson_result<std::string_view> get_string() noexcept;
 
   /**
    * Cast this JSON value to a raw_json_string.
@@ -139,7 +139,7 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
-  simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
 
   /**
    * Cast this JSON value to a bool.
@@ -147,14 +147,14 @@ public:
    * @returns A bool value.
    * @returns INCORRECT_TYPE if the JSON value is not true or false.
    */
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_inline simdjson_result<bool> get_bool() noexcept;
 
   /**
    * Checks if this JSON value is null.
    *
    * @returns Whether the value is null.
    */
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_inline bool is_null() noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -163,35 +163,35 @@ public:
    * @returns An object that can be used to iterate the array.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an array.
    */
-  simdjson_really_inline operator array() noexcept(false);
+  simdjson_inline operator array() noexcept(false);
   /**
    * Cast this JSON value to an object.
    *
    * @returns An object that can be used to look up or iterate fields.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not an object.
    */
-  simdjson_really_inline operator object() noexcept(false);
+  simdjson_inline operator object() noexcept(false);
   /**
    * Cast this JSON value to an unsigned integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
-  simdjson_really_inline operator uint64_t() noexcept(false);
+  simdjson_inline operator uint64_t() noexcept(false);
   /**
    * Cast this JSON value to a signed integer.
    *
    * @returns A signed 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit integer.
    */
-  simdjson_really_inline operator int64_t() noexcept(false);
+  simdjson_inline operator int64_t() noexcept(false);
   /**
    * Cast this JSON value to a double.
    *
    * @returns A double.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a valid floating-point number.
    */
-  simdjson_really_inline operator double() noexcept(false);
+  simdjson_inline operator double() noexcept(false);
   /**
    * Cast this JSON value to a string.
    *
@@ -203,7 +203,7 @@ public:
    *          time it parses a document or when it is destroyed.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator std::string_view() noexcept(false);
+  simdjson_inline operator std::string_view() noexcept(false);
   /**
    * Cast this JSON value to a raw_json_string.
    *
@@ -212,14 +212,14 @@ public:
    * @returns A pointer to the raw JSON for the given string.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not a string.
    */
-  simdjson_really_inline operator raw_json_string() noexcept(false);
+  simdjson_inline operator raw_json_string() noexcept(false);
   /**
    * Cast this JSON value to a bool.
    *
    * @returns A bool value.
    * @exception simdjson_error(INCORRECT_TYPE) if the JSON value is not true or false.
    */
-  simdjson_really_inline operator bool() noexcept(false);
+  simdjson_inline operator bool() noexcept(false);
 #endif
 
   /**
@@ -229,13 +229,13 @@ public:
    *
    * @returns INCORRECT_TYPE If the JSON value is not an array.
    */
-  simdjson_really_inline simdjson_result<array_iterator> begin() & noexcept;
+  simdjson_inline simdjson_result<array_iterator> begin() & noexcept;
   /**
    * Sentinel representing the end of the array.
    *
    * Part of the std::iterable interface.
    */
-  simdjson_really_inline simdjson_result<array_iterator> end() & noexcept;
+  simdjson_inline simdjson_result<array_iterator> end() & noexcept;
   /**
    * This method scans the array and counts the number of elements.
    * The count_elements method should always be called before you have begun
@@ -247,7 +247,7 @@ public:
    * there is a missing comma), then an error is returned and it is no longer
    * safe to continue.
    */
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
   /**
    * This method scans the object and counts the number of key-value pairs.
    * The count_fields method should always be called before you have begun
@@ -262,7 +262,7 @@ public:
    * To check that an object is empty, it is more performant to use
    * the is_empty() method on the object instance.
    */
-  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
   /**
    * Get the value at the given index in the array. This function has linear-time complexity.
    * This function should only be called once on an array instance since the array iterator is not reset between each call.
@@ -270,7 +270,7 @@ public:
    * @return The value at the given index, or:
    *         - INDEX_OUT_OF_BOUNDS if the array index is larger than an array length
    */
-  simdjson_really_inline simdjson_result<value> at(size_t index) noexcept;
+  simdjson_inline simdjson_result<value> at(size_t index) noexcept;
   /**
    * Look up a field by name on an object (order-sensitive).
    *
@@ -293,9 +293,9 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<value> find_field(std::string_view key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<value> find_field(const char *key) noexcept;
+  simdjson_inline simdjson_result<value> find_field(std::string_view key) noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<value> find_field(const char *key) noexcept;
 
   /**
    * Look up a field by name on an object, without regard to key order.
@@ -319,13 +319,13 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<value> find_field_unordered(const char *key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<value> operator[](std::string_view key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<value> operator[](const char *key) noexcept;
+  simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<value> find_field_unordered(const char *key) noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<value> operator[](std::string_view key) noexcept;
+  /** @overload simdjson_inline simdjson_result<value> find_field_unordered(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<value> operator[](const char *key) noexcept;
 
   /**
    * Get the type of this JSON value.
@@ -338,7 +338,7 @@ public:
    *     json_type::number, json_type::boolean, or json_type::null).
    * @error TAPE_ERROR when the JSON value is a bad token like "}" "," or "alse".
    */
-  simdjson_really_inline simdjson_result<json_type> type() noexcept;
+  simdjson_inline simdjson_result<json_type> type() noexcept;
 
   /**
    * Checks whether the value is a scalar (string, number, null, Boolean).
@@ -347,14 +347,14 @@ public:
    * @returns true if the type is string, number, null, Boolean
    * @error TAPE_ERROR when the JSON value is a bad token like "}" "," or "alse".
    */
-  simdjson_really_inline simdjson_result<bool> is_scalar() noexcept;
+  simdjson_inline simdjson_result<bool> is_scalar() noexcept;
 
   /**
    * Checks whether the value is a negative number.
    *
    * @returns true if the number if negative.
    */
-  simdjson_really_inline bool is_negative() noexcept;
+  simdjson_inline bool is_negative() noexcept;
   /**
    * Checks whether the value is an integer number. Note that
    * this requires to partially parse the number string. If
@@ -368,7 +368,7 @@ public:
    *
    * @returns true if the number if negative.
    */
-  simdjson_really_inline simdjson_result<bool> is_integer() noexcept;
+  simdjson_inline simdjson_result<bool> is_integer() noexcept;
   /**
    * Determine the number type (integer or floating-point number) as quickly
    * as possible. This function does not fully validate the input. It is
@@ -391,7 +391,7 @@ public:
    *
    * @returns the type of the number
    */
-  simdjson_really_inline simdjson_result<number_type> get_number_type() noexcept;
+  simdjson_inline simdjson_result<number_type> get_number_type() noexcept;
 
   /**
    * Attempt to parse an ondemand::number. An ondemand::number may
@@ -423,7 +423,7 @@ public:
    * calling 'get_number()', you scan the number string only once, determining
    * efficiently the type and storing it in an efficient manner.
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<number> get_number() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<number> get_number() noexcept;
 
 
   /**
@@ -449,12 +449,12 @@ public:
    * - false
    * - null
    */
-  simdjson_really_inline std::string_view raw_json_token() noexcept;
+  simdjson_inline std::string_view raw_json_token() noexcept;
 
   /**
    * Returns the current location in the document if in bounds.
    */
-  simdjson_really_inline simdjson_result<const char *> current_location() noexcept;
+  simdjson_inline simdjson_result<const char *> current_location() noexcept;
 
   /**
    * Returns the current depth in the document if in bounds.
@@ -465,7 +465,7 @@ public:
    *  2 = , or } inside root array/object
    *  3 = key or value inside root array/object.
    */
-  simdjson_really_inline int32_t current_depth() const noexcept;
+  simdjson_inline int32_t current_depth() const noexcept;
 
   /**
    * Get the value associated with the given JSON pointer.  We use the RFC 6901
@@ -509,38 +509,38 @@ public:
    *         - INCORRECT_TYPE if a non-integer is used to access an array
    *         - INVALID_JSON_POINTER if the JSON pointer is invalid and cannot be parsed
    */
-  simdjson_really_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
+  simdjson_inline simdjson_result<value> at_pointer(std::string_view json_pointer) noexcept;
 
 protected:
   /**
    * Create a value.
    */
-  simdjson_really_inline value(const value_iterator &iter) noexcept;
+  simdjson_inline value(const value_iterator &iter) noexcept;
 
   /**
    * Skip this value, allowing iteration to continue.
    */
-  simdjson_really_inline void skip() noexcept;
+  simdjson_inline void skip() noexcept;
 
   /**
    * Start a value at the current position.
    *
    * (It should already be started; this is just a self-documentation method.)
    */
-  static simdjson_really_inline value start(const value_iterator &iter) noexcept;
+  static simdjson_inline value start(const value_iterator &iter) noexcept;
 
   /**
    * Resume a value.
    */
-  static simdjson_really_inline value resume(const value_iterator &iter) noexcept;
+  static simdjson_inline value resume(const value_iterator &iter) noexcept;
 
   /**
    * Get the object, starting or resuming it as necessary
    */
-  simdjson_really_inline simdjson_result<object> start_or_resume_object() noexcept;
+  simdjson_inline simdjson_result<object> start_or_resume_object() noexcept;
 
-  // simdjson_really_inline void log_value(const char *type) const noexcept;
-  // simdjson_really_inline void log_error(const char *message) const noexcept;
+  // simdjson_inline void log_value(const char *type) const noexcept;
+  // simdjson_inline void log_error(const char *message) const noexcept;
 
   value_iterator iter{};
 
@@ -561,43 +561,43 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array> get_array() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object> get_object() noexcept;
 
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
-  simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
-  simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline bool is_null() noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
+  simdjson_inline simdjson_result<double> get_double() noexcept;
+  simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> get_raw_json_string() noexcept;
+  simdjson_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_inline bool is_null() noexcept;
 
-  template<typename T> simdjson_really_inline simdjson_result<T> get() noexcept;
+  template<typename T> simdjson_inline simdjson_result<T> get() noexcept;
 
-  template<typename T> simdjson_really_inline error_code get(T &out) noexcept;
+  template<typename T> simdjson_inline error_code get(T &out) noexcept;
 
 #if SIMDJSON_EXCEPTIONS
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false);
-  simdjson_really_inline operator uint64_t() noexcept(false);
-  simdjson_really_inline operator int64_t() noexcept(false);
-  simdjson_really_inline operator double() noexcept(false);
-  simdjson_really_inline operator std::string_view() noexcept(false);
-  simdjson_really_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
-  simdjson_really_inline operator bool() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() noexcept(false);
+  simdjson_inline operator uint64_t() noexcept(false);
+  simdjson_inline operator int64_t() noexcept(false);
+  simdjson_inline operator double() noexcept(false);
+  simdjson_inline operator std::string_view() noexcept(false);
+  simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string() noexcept(false);
+  simdjson_inline operator bool() noexcept(false);
 #endif
-  simdjson_really_inline simdjson_result<size_t> count_elements() & noexcept;
-  simdjson_really_inline simdjson_result<size_t> count_fields() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
+  simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at(size_t index) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> begin() & noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::array_iterator> end() & noexcept;
 
   /**
    * Look up a field by name on an object (order-sensitive).
@@ -619,9 +619,9 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(const char *key) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) noexcept;
+  /** @overload simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field(const char *key) noexcept;
 
   /**
    * Look up a field by name on an object, without regard to key order.
@@ -642,13 +642,13 @@ public:
    * @param key The key to look up.
    * @returns The value of the field, or NO_SUCH_FIELD if the field is not in the object.
    */
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) noexcept;
-  /** @overload simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept; */
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept;
+  /** @overload simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(const char *key) noexcept;
+  /** @overload simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](std::string_view key) noexcept;
+  /** @overload simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> find_field_unordered(std::string_view key) noexcept; */
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> operator[](const char *key) noexcept;
 
   /**
    * Get the type of this JSON value.
@@ -657,21 +657,21 @@ public:
    * better to just call .get_double, .get_string, etc. and check for INCORRECT_TYPE (or just
    * let it throw an exception).
    */
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> type() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_scalar() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_negative() noexcept;
-  simdjson_really_inline simdjson_result<bool> is_integer() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> get_number_type() noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> get_number() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::json_type> type() noexcept;
+  simdjson_inline simdjson_result<bool> is_scalar() noexcept;
+  simdjson_inline simdjson_result<bool> is_negative() noexcept;
+  simdjson_inline simdjson_result<bool> is_integer() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> get_number_type() noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> get_number() noexcept;
 
-  /** @copydoc simdjson_really_inline std::string_view value::raw_json_token() const noexcept */
-  simdjson_really_inline simdjson_result<std::string_view> raw_json_token() noexcept;
+  /** @copydoc simdjson_inline std::string_view value::raw_json_token() const noexcept */
+  simdjson_inline simdjson_result<std::string_view> raw_json_token() noexcept;
 
-  /** @copydoc simdjson_really_inline simdjson_result<const char *> current_location() noexcept */
-  simdjson_really_inline simdjson_result<const char *> current_location() noexcept;
-  /** @copydoc simdjson_really_inline int32_t current_depth() const noexcept */
-  simdjson_really_inline int32_t current_depth() const noexcept;
-  simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
+  /** @copydoc simdjson_inline simdjson_result<const char *> current_location() noexcept */
+  simdjson_inline simdjson_result<const char *> current_location() noexcept;
+  /** @copydoc simdjson_inline int32_t current_depth() const noexcept */
+  simdjson_inline int32_t current_depth() const noexcept;
+  simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> at_pointer(std::string_view json_pointer) noexcept;
 };
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -2,7 +2,7 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
-simdjson_really_inline value_iterator::value_iterator(
+simdjson_inline value_iterator::value_iterator(
   json_iterator *json_iter,
   depth_t depth,
   token_position start_position
@@ -10,17 +10,17 @@ simdjson_really_inline value_iterator::value_iterator(
 {
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_object() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::start_object() noexcept {
   SIMDJSON_TRY( start_container('{', "Not an object", "object") );
   return started_object();
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_root_object() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::start_root_object() noexcept {
   SIMDJSON_TRY( start_container('{', "Not an object", "object") );
   return started_root_object();
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_object() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::started_object() noexcept {
   assert_at_container_start();
 #ifdef SIMDJSON_DEVELOPMENT_CHECKS
   _json_iter->set_start_position(_depth, start_position());
@@ -34,7 +34,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return true;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_root_object() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::started_root_object() noexcept {
   // When in streaming mode, we cannot expect peek_last() to be the last structural element of the
   // current document. It only works in the normal mode where we have indexed a single document.
   // Note that adding a check for 'streaming' is not expensive since we only have at most
@@ -59,7 +59,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return started_object();
 }
 
-simdjson_warn_unused simdjson_really_inline error_code value_iterator::end_container() noexcept {
+simdjson_warn_unused simdjson_inline error_code value_iterator::end_container() noexcept {
 #if SIMDJSON_CHECK_EOF
     if (depth() > 1 && at_end()) { return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing parent ] or }"); }
     // if (depth() <= 1 && !at_end()) { return report_error(INCOMPLETE_ARRAY_OR_OBJECT, "missing [ or { at start"); }
@@ -68,7 +68,7 @@ simdjson_warn_unused simdjson_really_inline error_code value_iterator::end_conta
     return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_field() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::has_next_field() noexcept {
   assert_at_next();
 
   // It's illegal to call this unless there are more tokens: anything that ends in } or ] is
@@ -85,7 +85,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   }
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_raw(const std::string_view key) noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::find_field_raw(const std::string_view key) noexcept {
   error_code error;
   bool has_value;
   //
@@ -182,7 +182,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::find_field_unordered_raw(const std::string_view key) noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::find_field_unordered_raw(const std::string_view key) noexcept {
   /**
    * When find_field_unordered_raw is called, we can either be pointing at the
    * first key, pointing outside (at the closing brace) or if a key was matched
@@ -371,7 +371,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 }
 SIMDJSON_POP_DISABLE_WARNINGS
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::field_key() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<raw_json_string> value_iterator::field_key() noexcept {
   assert_at_next();
 
   const uint8_t *key = _json_iter->return_current_and_advance();
@@ -379,7 +379,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> val
   return raw_json_string(key);
 }
 
-simdjson_warn_unused simdjson_really_inline error_code value_iterator::field_value() noexcept {
+simdjson_warn_unused simdjson_inline error_code value_iterator::field_value() noexcept {
   assert_at_next();
 
   if (*_json_iter->return_current_and_advance() != ':') { return report_error(TAPE_ERROR, "Missing colon in object field"); }
@@ -387,12 +387,12 @@ simdjson_warn_unused simdjson_really_inline error_code value_iterator::field_val
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_array() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::start_array() noexcept {
   SIMDJSON_TRY( start_container('[', "Not an array", "array") );
   return started_array();
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::start_root_array() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::start_root_array() noexcept {
   SIMDJSON_TRY( start_container('[', "Not an array", "array") );
   return started_root_array();
 }
@@ -404,7 +404,7 @@ inline std::string value_iterator::to_string() const noexcept {
   return answer;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_array() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::started_array() noexcept {
   assert_at_container_start();
   if (*_json_iter->peek() == ']') {
     logger::log_value(*_json_iter, "empty array");
@@ -419,7 +419,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return true;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_root_array() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::started_root_array() noexcept {
   // When in streaming mode, we cannot expect peek_last() to be the last structural element of the
   // current document. It only works in the normal mode where we have indexed a single document.
   // Note that adding a check for 'streaming' is not expensive since we only have at most
@@ -444,7 +444,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   return started_array();
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::has_next_element() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::has_next_element() noexcept {
   assert_at_next();
 
   logger::log_event(*this, "has_next_element");
@@ -461,86 +461,86 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   }
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::parse_bool(const uint8_t *json) const noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::parse_bool(const uint8_t *json) const noexcept {
   auto not_true = atomparsing::str4ncmp(json, "true");
   auto not_false = atomparsing::str4ncmp(json, "fals") | (json[4] ^ 'e');
   bool error = (not_true && not_false) || jsoncharutils::is_not_structural_or_whitespace(json[not_true ? 5 : 4]);
   if (error) { return incorrect_type_error("Not a boolean"); }
   return simdjson_result<bool>(!not_true);
 }
-simdjson_really_inline bool value_iterator::parse_null(const uint8_t *json) const noexcept {
+simdjson_inline bool value_iterator::parse_null(const uint8_t *json) const noexcept {
   return !atomparsing::str4ncmp(json, "null") && jsoncharutils::is_structural_or_whitespace(json[4]);
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> value_iterator::get_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> value_iterator::get_string() noexcept {
   return get_raw_json_string().unescape(json_iter());
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::get_raw_json_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<raw_json_string> value_iterator::get_raw_json_string() noexcept {
   auto json = peek_scalar("string");
   if (*json != '"') { return incorrect_type_error("Not a string"); }
   advance_scalar("string");
   return raw_json_string(json+1);
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_uint64() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> value_iterator::get_uint64() noexcept {
   auto result = numberparsing::parse_unsigned(peek_non_root_scalar("uint64"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("uint64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_uint64_in_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> value_iterator::get_uint64_in_string() noexcept {
   auto result = numberparsing::parse_unsigned_in_string(peek_non_root_scalar("uint64"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("uint64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_int64() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<int64_t> value_iterator::get_int64() noexcept {
   auto result = numberparsing::parse_integer(peek_non_root_scalar("int64"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("int64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_int64_in_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<int64_t> value_iterator::get_int64_in_string() noexcept {
   auto result = numberparsing::parse_integer_in_string(peek_non_root_scalar("int64"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("int64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_double() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<double> value_iterator::get_double() noexcept {
   auto result = numberparsing::parse_double(peek_non_root_scalar("double"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("double"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_double_in_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<double> value_iterator::get_double_in_string() noexcept {
   auto result = numberparsing::parse_double_in_string(peek_non_root_scalar("double"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("double"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::get_bool() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::get_bool() noexcept {
   auto result = parse_bool(peek_non_root_scalar("bool"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("bool"); }
   return result;
 }
-simdjson_really_inline bool value_iterator::is_null() noexcept {
+simdjson_inline bool value_iterator::is_null() noexcept {
   auto result = parse_null(peek_non_root_scalar("null"));
   if(result) { advance_non_root_scalar("null"); }
   return result;
 }
-simdjson_really_inline bool value_iterator::is_negative() noexcept {
+simdjson_inline bool value_iterator::is_negative() noexcept {
   return numberparsing::is_negative(peek_non_root_scalar("numbersign"));
 }
-simdjson_really_inline bool value_iterator::is_root_negative() noexcept {
+simdjson_inline bool value_iterator::is_root_negative() noexcept {
   return numberparsing::is_negative(peek_root_scalar("numbersign"));
 }
-simdjson_really_inline simdjson_result<bool> value_iterator::is_integer() noexcept {
+simdjson_inline simdjson_result<bool> value_iterator::is_integer() noexcept {
   return numberparsing::is_integer(peek_non_root_scalar("integer"));
 }
-simdjson_really_inline simdjson_result<number_type> value_iterator::get_number_type() noexcept {
+simdjson_inline simdjson_result<number_type> value_iterator::get_number_type() noexcept {
   return numberparsing::get_number_type(peek_non_root_scalar("integer"));
 }
-simdjson_really_inline simdjson_result<number> value_iterator::get_number() noexcept {
+simdjson_inline simdjson_result<number> value_iterator::get_number() noexcept {
   number num;
   error_code error =  numberparsing::parse_number(peek_non_root_scalar("number"), num);
   if(error) { return error; }
   return num;
 }
 
-simdjson_really_inline simdjson_result<bool> value_iterator::is_root_integer() noexcept {
+simdjson_inline simdjson_result<bool> value_iterator::is_root_integer() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("is_root_integer");
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
@@ -550,7 +550,7 @@ simdjson_really_inline simdjson_result<bool> value_iterator::is_root_integer() n
   return numberparsing::is_integer(tmpbuf);
 }
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> value_iterator::get_root_number_type() noexcept {
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number_type> value_iterator::get_root_number_type() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("number");
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/,
@@ -563,7 +563,7 @@ simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number
   }
   return numberparsing::get_number_type(tmpbuf);
 }
-simdjson_really_inline simdjson_result<number> value_iterator::get_root_number() noexcept {
+simdjson_inline simdjson_result<number> value_iterator::get_root_number() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("number");
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/,
@@ -581,13 +581,13 @@ simdjson_really_inline simdjson_result<number> value_iterator::get_root_number()
   return num;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> value_iterator::get_root_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> value_iterator::get_root_string() noexcept {
   return get_string();
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> value_iterator::get_root_raw_json_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<raw_json_string> value_iterator::get_root_raw_json_string() noexcept {
   return get_raw_json_string();
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_root_uint64() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> value_iterator::get_root_uint64() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("uint64");
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
@@ -599,7 +599,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   if(result.error() == SUCCESS) { advance_root_scalar("uint64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iterator::get_root_uint64_in_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> value_iterator::get_root_uint64_in_string() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("uint64");
   uint8_t tmpbuf[20+1]; // <20 digits> is the longest possible unsigned integer
@@ -611,7 +611,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> value_iter
   if(result.error() == SUCCESS) { advance_root_scalar("uint64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_root_int64() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<int64_t> value_iterator::get_root_int64() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("int64");
   uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
@@ -624,7 +624,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   if(result.error() == SUCCESS) { advance_root_scalar("int64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_iterator::get_root_int64_in_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<int64_t> value_iterator::get_root_int64_in_string() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("int64");
   uint8_t tmpbuf[20+1]; // -<19 digits> is the longest possible integer
@@ -637,7 +637,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> value_itera
   if(result.error() == SUCCESS) { advance_root_scalar("int64"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_root_double() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<double> value_iterator::get_root_double() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("double");
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/,
@@ -653,7 +653,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   return result;
 }
 
-simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterator::get_root_double_in_string() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<double> value_iterator::get_root_double_in_string() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("double");
   // Per https://www.exploringbinary.com/maximum-number-of-decimal-digits-in-binary-floating-point-numbers/,
@@ -668,7 +668,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<double> value_iterat
   if(result.error() == SUCCESS) { advance_root_scalar("double"); }
   return result;
 }
-simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::get_root_bool() noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::get_root_bool() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("bool");
   uint8_t tmpbuf[5+1];
@@ -677,7 +677,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   if(result.error() == SUCCESS) { advance_root_scalar("bool"); }
   return result;
 }
-simdjson_really_inline bool value_iterator::is_root_null() noexcept {
+simdjson_inline bool value_iterator::is_root_null() noexcept {
   auto max_len = peek_start_length();
   auto json = peek_root_scalar("null");
   bool result = (max_len >= 4 && !atomparsing::str4ncmp(json, "null") &&
@@ -686,14 +686,14 @@ simdjson_really_inline bool value_iterator::is_root_null() noexcept {
   return result;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code value_iterator::skip_child() noexcept {
+simdjson_warn_unused simdjson_inline error_code value_iterator::skip_child() noexcept {
   SIMDJSON_ASSUME( _json_iter->token._position > _start_position );
   SIMDJSON_ASSUME( _json_iter->_depth >= _depth );
 
   return _json_iter->skip_child(depth());
 }
 
-simdjson_really_inline value_iterator value_iterator::child() const noexcept {
+simdjson_inline value_iterator value_iterator::child() const noexcept {
   assert_at_child();
   return { _json_iter, depth()+1, _json_iter->token.position() };
 }
@@ -703,52 +703,52 @@ simdjson_really_inline value_iterator value_iterator::child() const noexcept {
 // marked non-inline.
 SIMDJSON_PUSH_DISABLE_WARNINGS
 SIMDJSON_DISABLE_STRICT_OVERFLOW_WARNING
-simdjson_really_inline bool value_iterator::is_open() const noexcept {
+simdjson_inline bool value_iterator::is_open() const noexcept {
   return _json_iter->depth() >= depth();
 }
 SIMDJSON_POP_DISABLE_WARNINGS
 
-simdjson_really_inline bool value_iterator::at_end() const noexcept {
+simdjson_inline bool value_iterator::at_end() const noexcept {
   return _json_iter->at_end();
 }
 
-simdjson_really_inline bool value_iterator::at_start() const noexcept {
+simdjson_inline bool value_iterator::at_start() const noexcept {
   return _json_iter->token.position() == start_position();
 }
 
-simdjson_really_inline bool value_iterator::at_first_field() const noexcept {
+simdjson_inline bool value_iterator::at_first_field() const noexcept {
   SIMDJSON_ASSUME( _json_iter->token._position > _start_position );
   return _json_iter->token.position() == start_position() + 1;
 }
 
-simdjson_really_inline void value_iterator::abandon() noexcept {
+simdjson_inline void value_iterator::abandon() noexcept {
   _json_iter->abandon();
 }
 
-simdjson_warn_unused simdjson_really_inline depth_t value_iterator::depth() const noexcept {
+simdjson_warn_unused simdjson_inline depth_t value_iterator::depth() const noexcept {
   return _depth;
 }
-simdjson_warn_unused simdjson_really_inline error_code value_iterator::error() const noexcept {
+simdjson_warn_unused simdjson_inline error_code value_iterator::error() const noexcept {
   return _json_iter->error;
 }
-simdjson_warn_unused simdjson_really_inline uint8_t *&value_iterator::string_buf_loc() noexcept {
+simdjson_warn_unused simdjson_inline uint8_t *&value_iterator::string_buf_loc() noexcept {
   return _json_iter->string_buf_loc();
 }
-simdjson_warn_unused simdjson_really_inline const json_iterator &value_iterator::json_iter() const noexcept {
+simdjson_warn_unused simdjson_inline const json_iterator &value_iterator::json_iter() const noexcept {
   return *_json_iter;
 }
-simdjson_warn_unused simdjson_really_inline json_iterator &value_iterator::json_iter() noexcept {
+simdjson_warn_unused simdjson_inline json_iterator &value_iterator::json_iter() noexcept {
   return *_json_iter;
 }
 
-simdjson_really_inline const uint8_t *value_iterator::peek_start() const noexcept {
+simdjson_inline const uint8_t *value_iterator::peek_start() const noexcept {
   return _json_iter->peek(start_position());
 }
-simdjson_really_inline uint32_t value_iterator::peek_start_length() const noexcept {
+simdjson_inline uint32_t value_iterator::peek_start_length() const noexcept {
   return _json_iter->peek_length(start_position());
 }
 
-simdjson_really_inline const uint8_t *value_iterator::peek_scalar(const char *type) noexcept {
+simdjson_inline const uint8_t *value_iterator::peek_scalar(const char *type) noexcept {
   logger::log_value(*_json_iter, start_position(), depth(), type);
   // If we're not at the position anymore, we don't want to advance the cursor.
   if (!is_at_start()) { return peek_start(); }
@@ -758,7 +758,7 @@ simdjson_really_inline const uint8_t *value_iterator::peek_scalar(const char *ty
   return _json_iter->peek();
 }
 
-simdjson_really_inline void value_iterator::advance_scalar(const char *type) noexcept {
+simdjson_inline void value_iterator::advance_scalar(const char *type) noexcept {
   logger::log_value(*_json_iter, start_position(), depth(), type);
   // If we're not at the position anymore, we don't want to advance the cursor.
   if (!is_at_start()) { return; }
@@ -769,7 +769,7 @@ simdjson_really_inline void value_iterator::advance_scalar(const char *type) noe
   _json_iter->ascend_to(depth()-1);
 }
 
-simdjson_really_inline error_code value_iterator::start_container(uint8_t start_char, const char *incorrect_type_message, const char *type) noexcept {
+simdjson_inline error_code value_iterator::start_container(uint8_t start_char, const char *incorrect_type_message, const char *type) noexcept {
   logger::log_start_value(*_json_iter, start_position(), depth(), type);
   // If we're not at the position anymore, we don't want to advance the cursor.
   const uint8_t *json;
@@ -796,14 +796,14 @@ simdjson_really_inline error_code value_iterator::start_container(uint8_t start_
 }
 
 
-simdjson_really_inline const uint8_t *value_iterator::peek_root_scalar(const char *type) noexcept {
+simdjson_inline const uint8_t *value_iterator::peek_root_scalar(const char *type) noexcept {
   logger::log_value(*_json_iter, start_position(), depth(), type);
   if (!is_at_start()) { return peek_start(); }
 
   assert_at_root();
   return _json_iter->peek();
 }
-simdjson_really_inline const uint8_t *value_iterator::peek_non_root_scalar(const char *type) noexcept {
+simdjson_inline const uint8_t *value_iterator::peek_non_root_scalar(const char *type) noexcept {
   logger::log_value(*_json_iter, start_position(), depth(), type);
   if (!is_at_start()) { return peek_start(); }
 
@@ -811,7 +811,7 @@ simdjson_really_inline const uint8_t *value_iterator::peek_non_root_scalar(const
   return _json_iter->peek();
 }
 
-simdjson_really_inline void value_iterator::advance_root_scalar(const char *type) noexcept {
+simdjson_inline void value_iterator::advance_root_scalar(const char *type) noexcept {
   logger::log_value(*_json_iter, start_position(), depth(), type);
   if (!is_at_start()) { return; }
 
@@ -819,7 +819,7 @@ simdjson_really_inline void value_iterator::advance_root_scalar(const char *type
   _json_iter->return_current_and_advance();
   _json_iter->ascend_to(depth()-1);
 }
-simdjson_really_inline void value_iterator::advance_non_root_scalar(const char *type) noexcept {
+simdjson_inline void value_iterator::advance_non_root_scalar(const char *type) noexcept {
   logger::log_value(*_json_iter, start_position(), depth(), type);
   if (!is_at_start()) { return; }
 
@@ -828,23 +828,23 @@ simdjson_really_inline void value_iterator::advance_non_root_scalar(const char *
   _json_iter->ascend_to(depth()-1);
 }
 
-simdjson_really_inline error_code value_iterator::incorrect_type_error(const char *message) const noexcept {
+simdjson_inline error_code value_iterator::incorrect_type_error(const char *message) const noexcept {
   logger::log_error(*_json_iter, start_position(), depth(), message);
   return INCORRECT_TYPE;
 }
 
-simdjson_really_inline bool value_iterator::is_at_start() const noexcept {
+simdjson_inline bool value_iterator::is_at_start() const noexcept {
   return position() == start_position();
 }
 
-simdjson_really_inline bool value_iterator::is_at_key() const noexcept {
+simdjson_inline bool value_iterator::is_at_key() const noexcept {
   // Keys are at the same depth as the object.
   // Note here that we could be safer and check that we are within an object,
   // but we do not.
   return _depth == _json_iter->_depth && *_json_iter->peek() == '"';
 }
 
-simdjson_really_inline bool value_iterator::is_at_iterator_start() const noexcept {
+simdjson_inline bool value_iterator::is_at_iterator_start() const noexcept {
   // We can legitimately be either at the first value ([1]), or after the array if it's empty ([]).
   auto delta = position() - start_position();
   return delta == 1 || delta == 2;
@@ -868,22 +868,22 @@ inline void value_iterator::assert_at_next() const noexcept {
   SIMDJSON_ASSUME( _depth > 0 );
 }
 
-simdjson_really_inline void value_iterator::move_at_start() noexcept {
+simdjson_inline void value_iterator::move_at_start() noexcept {
   _json_iter->_depth = _depth;
   _json_iter->token.set_position(_start_position);
 }
 
-simdjson_really_inline void value_iterator::move_at_container_start() noexcept {
+simdjson_inline void value_iterator::move_at_container_start() noexcept {
   _json_iter->_depth = _depth;
   _json_iter->token.set_position(_start_position + 1);
 }
 
-simdjson_really_inline simdjson_result<bool> value_iterator::reset_array() noexcept {
+simdjson_inline simdjson_result<bool> value_iterator::reset_array() noexcept {
   move_at_container_start();
   return started_array();
 }
 
-simdjson_really_inline simdjson_result<bool> value_iterator::reset_object() noexcept {
+simdjson_inline simdjson_result<bool> value_iterator::reset_object() noexcept {
   move_at_container_start();
   return started_object();
 }
@@ -908,11 +908,11 @@ inline void value_iterator::assert_is_valid() const noexcept {
   SIMDJSON_ASSUME( _json_iter != nullptr );
 }
 
-simdjson_really_inline bool value_iterator::is_valid() const noexcept {
+simdjson_inline bool value_iterator::is_valid() const noexcept {
   return _json_iter != nullptr;
 }
 
-simdjson_really_inline simdjson_result<json_type> value_iterator::type() const noexcept {
+simdjson_inline simdjson_result<json_type> value_iterator::type() const noexcept {
   switch (*peek_start()) {
     case '{':
       return json_type::object;
@@ -933,23 +933,23 @@ simdjson_really_inline simdjson_result<json_type> value_iterator::type() const n
   }
 }
 
-simdjson_really_inline token_position value_iterator::start_position() const noexcept {
+simdjson_inline token_position value_iterator::start_position() const noexcept {
   return _start_position;
 }
 
-simdjson_really_inline token_position value_iterator::position() const noexcept {
+simdjson_inline token_position value_iterator::position() const noexcept {
   return _json_iter->position();
 }
 
-simdjson_really_inline token_position value_iterator::end_position() const noexcept {
+simdjson_inline token_position value_iterator::end_position() const noexcept {
   return _json_iter->end_position();
 }
 
-simdjson_really_inline token_position value_iterator::last_position() const noexcept {
+simdjson_inline token_position value_iterator::last_position() const noexcept {
   return _json_iter->last_position();
 }
 
-simdjson_really_inline error_code value_iterator::report_error(error_code error, const char *message) noexcept {
+simdjson_inline error_code value_iterator::report_error(error_code error, const char *message) noexcept {
   return _json_iter->report_error(error, message);
 }
 
@@ -959,9 +959,9 @@ simdjson_really_inline error_code value_iterator::report_error(error_code error,
 
 namespace simdjson {
 
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value_iterator &&value) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>::simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value_iterator &&value) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>(std::forward<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>(value)) {}
-simdjson_really_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>::simdjson_result(error_code error) noexcept
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>::simdjson_result(error_code error) noexcept
     : implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator>(error) {}
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -29,61 +29,61 @@ protected:
   token_position _start_position{};
 
 public:
-  simdjson_really_inline value_iterator() noexcept = default;
+  simdjson_inline value_iterator() noexcept = default;
 
   /**
    * Denote that we're starting a document.
    */
-  simdjson_really_inline void start_document() noexcept;
+  simdjson_inline void start_document() noexcept;
 
   /**
    * Skips a non-iterated or partially-iterated JSON value, whether it is a scalar, array or object.
    *
    * Optimized for scalars.
    */
-  simdjson_warn_unused simdjson_really_inline error_code skip_child() noexcept;
+  simdjson_warn_unused simdjson_inline error_code skip_child() noexcept;
 
   /**
    * Tell whether the iterator is at the EOF mark
    */
-  simdjson_really_inline bool at_end() const noexcept;
+  simdjson_inline bool at_end() const noexcept;
 
   /**
    * Tell whether the iterator is at the start of the value
    */
-  simdjson_really_inline bool at_start() const noexcept;
+  simdjson_inline bool at_start() const noexcept;
 
   /**
    * Tell whether the value is open--if the value has not been used, or the array/object is still open.
    */
-  simdjson_really_inline bool is_open() const noexcept;
+  simdjson_inline bool is_open() const noexcept;
 
   /**
    * Tell whether the value is at an object's first field (just after the {).
    */
-  simdjson_really_inline bool at_first_field() const noexcept;
+  simdjson_inline bool at_first_field() const noexcept;
 
   /**
    * Abandon all iteration.
    */
-  simdjson_really_inline void abandon() noexcept;
+  simdjson_inline void abandon() noexcept;
 
   /**
    * Get the child value as a value_iterator.
    */
-  simdjson_really_inline value_iterator child_value() const noexcept;
+  simdjson_inline value_iterator child_value() const noexcept;
 
   /**
    * Get the depth of this value.
    */
-  simdjson_really_inline int32_t depth() const noexcept;
+  simdjson_inline int32_t depth() const noexcept;
 
   /**
    * Get the JSON type of this value.
    *
    * @error TAPE_ERROR when the JSON value is a bad token like "}" "," or "alse".
    */
-  simdjson_really_inline simdjson_result<json_type> type() const noexcept;
+  simdjson_inline simdjson_result<json_type> type() const noexcept;
 
   /**
    * @addtogroup object Object iteration
@@ -100,7 +100,7 @@ public:
    * @returns Whether the object had any fields (returns false for empty).
    * @error INCORRECT_TYPE if there is no opening {
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_object() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> start_object() noexcept;
   /**
    * Start an object iteration from the root.
    *
@@ -108,7 +108,7 @@ public:
    * @error INCORRECT_TYPE if there is no opening {
    * @error TAPE_ERROR if there is no matching } at end of document
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_root_object() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> start_root_object() noexcept;
 
   /**
    * Start an object iteration after the user has already checked and moved past the {.
@@ -119,7 +119,7 @@ public:
    * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
    *        array or object is incomplete).
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_object() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> started_object() noexcept;
   /**
    * Start an object iteration from the root, after the user has already checked and moved past the {.
    *
@@ -129,7 +129,7 @@ public:
    * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
    *        array or object is incomplete).
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_root_object() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> started_root_object() noexcept;
 
   /**
    * Moves to the next field in an object.
@@ -141,17 +141,17 @@ public:
    * @error TAPE_ERROR If there is a comma missing between fields.
    * @error TAPE_ERROR If there is a comma, but not enough tokens remaining to have a key, :, and value.
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> has_next_field() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> has_next_field() noexcept;
 
   /**
    * Get the current field's key.
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> field_key() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<raw_json_string> field_key() noexcept;
 
   /**
    * Pass the : in the field and move to its value.
    */
-  simdjson_warn_unused simdjson_really_inline error_code field_value() noexcept;
+  simdjson_warn_unused simdjson_inline error_code field_value() noexcept;
 
   /**
    * Find the next field with the given key.
@@ -169,7 +169,7 @@ public:
    * unescape it. This works well for typical ASCII and UTF-8 keys (almost all of them), but may
    * fail to match some keys with escapes (\u, \n, etc.).
    */
-  simdjson_warn_unused simdjson_really_inline error_code find_field(const std::string_view key) noexcept;
+  simdjson_warn_unused simdjson_inline error_code find_field(const std::string_view key) noexcept;
 
   /**
    * Find the next field with the given key, *without* unescaping. This assumes object order: it
@@ -188,7 +188,7 @@ public:
    * unescape it. This works well for typical ASCII and UTF-8 keys (almost all of them), but may
    * fail to match some keys with escapes (\u, \n, etc.).
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> find_field_raw(const std::string_view key) noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> find_field_raw(const std::string_view key) noexcept;
 
   /**
    * Find the field with the given key without regard to order, and *without* unescaping.
@@ -208,7 +208,7 @@ public:
    * unescape it. This works well for typical ASCII and UTF-8 keys (almost all of them), but may
    * fail to match some keys with escapes (\u, \n, etc.).
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> find_field_unordered_raw(const std::string_view key) noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> find_field_unordered_raw(const std::string_view key) noexcept;
 
   /** @} */
 
@@ -225,7 +225,7 @@ public:
    * @returns Whether the array had any elements (returns false for empty).
    * @error INCORRECT_TYPE If there is no [.
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_array() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> start_array() noexcept;
   /**
    * Check for an opening [ and start an array iteration while at the root.
    *
@@ -233,7 +233,7 @@ public:
    * @error INCORRECT_TYPE If there is no [.
    * @error TAPE_ERROR if there is no matching ] at end of document
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> start_root_array() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> start_root_array() noexcept;
 
   /**
    * Start an array iteration, after the user has already checked and moved past the [.
@@ -244,7 +244,7 @@ public:
    * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
    *        array or object is incomplete).
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_array() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> started_array() noexcept;
   /**
    * Start an array iteration from the root, after the user has already checked and moved past the [.
    *
@@ -254,7 +254,7 @@ public:
    * @error INCOMPLETE_ARRAY_OR_OBJECT If there are no more tokens (implying the *parent*
    *        array or object is incomplete).
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> started_root_array() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> started_root_array() noexcept;
 
   /**
    * Moves to the next element in an array.
@@ -265,12 +265,12 @@ public:
    * @return Whether there is another element in the array.
    * @error TAPE_ERROR If there is a comma missing between elements.
    */
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> has_next_element() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> has_next_element() noexcept;
 
   /**
    * Get a child value iterator.
    */
-  simdjson_warn_unused simdjson_really_inline value_iterator child() const noexcept;
+  simdjson_warn_unused simdjson_inline value_iterator child() const noexcept;
 
   /** @} */
 
@@ -280,43 +280,43 @@ public:
    * @{
    */
 
-  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> get_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_double_in_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> get_bool() noexcept;
-  simdjson_really_inline bool is_null() noexcept;
-  simdjson_warn_unused simdjson_really_inline bool is_negative() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> is_integer() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<number_type> get_number_type() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<number> get_number() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> get_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<raw_json_string> get_raw_json_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<int64_t> get_int64() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<int64_t> get_int64_in_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<double> get_double() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> get_bool() noexcept;
+  simdjson_inline bool is_null() noexcept;
+  simdjson_warn_unused simdjson_inline bool is_negative() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> is_integer() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<number_type> get_number_type() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<number> get_number() noexcept;
 
-  simdjson_warn_unused simdjson_really_inline simdjson_result<std::string_view> get_root_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<raw_json_string> get_root_raw_json_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_root_uint64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<uint64_t> get_root_uint64_in_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_root_int64() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<int64_t> get_root_int64_in_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_root_double() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<double> get_root_double_in_string() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> get_root_bool() noexcept;
-  simdjson_warn_unused simdjson_really_inline bool is_root_negative() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<bool> is_root_integer() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<number_type> get_root_number_type() noexcept;
-  simdjson_warn_unused simdjson_really_inline simdjson_result<number> get_root_number() noexcept;
-  simdjson_really_inline bool is_root_null() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> get_root_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<raw_json_string> get_root_raw_json_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> get_root_uint64() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> get_root_uint64_in_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<int64_t> get_root_int64() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<int64_t> get_root_int64_in_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<double> get_root_double() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<double> get_root_double_in_string() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> get_root_bool() noexcept;
+  simdjson_warn_unused simdjson_inline bool is_root_negative() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<bool> is_root_integer() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<number_type> get_root_number_type() noexcept;
+  simdjson_warn_unused simdjson_inline simdjson_result<number> get_root_number() noexcept;
+  simdjson_inline bool is_root_null() noexcept;
 
-  simdjson_really_inline error_code error() const noexcept;
-  simdjson_really_inline uint8_t *&string_buf_loc() noexcept;
-  simdjson_really_inline const json_iterator &json_iter() const noexcept;
-  simdjson_really_inline json_iterator &json_iter() noexcept;
+  simdjson_inline error_code error() const noexcept;
+  simdjson_inline uint8_t *&string_buf_loc() noexcept;
+  simdjson_inline const json_iterator &json_iter() const noexcept;
+  simdjson_inline json_iterator &json_iter() noexcept;
 
-  simdjson_really_inline void assert_is_valid() const noexcept;
-  simdjson_really_inline bool is_valid() const noexcept;
+  simdjson_inline void assert_is_valid() const noexcept;
+  simdjson_inline bool is_valid() const noexcept;
 
   /** @} */
 protected:
@@ -324,12 +324,12 @@ protected:
    * Restarts an array iteration.
    * @returns Whether the array has any elements (returns false for empty).
    */
-  simdjson_really_inline simdjson_result<bool> reset_array() noexcept;
+  simdjson_inline simdjson_result<bool> reset_array() noexcept;
   /**
    * Restarts an object iteration.
    * @returns Whether the object has any fields (returns false for empty).
    */
-  simdjson_really_inline simdjson_result<bool> reset_object() noexcept;
+  simdjson_inline simdjson_result<bool> reset_object() noexcept;
   /**
    * move_at_start(): moves us so that we are pointing at the beginning of
    * the container. It updates the index so that at_start() is true and it
@@ -337,7 +337,7 @@ protected:
    *
    * Usage: used with value::count_elements().
    **/
-  simdjson_really_inline void move_at_start() noexcept;
+  simdjson_inline void move_at_start() noexcept;
 
   /**
    * move_at_container_start(): moves us so that we are pointing at the beginning of
@@ -345,15 +345,15 @@ protected:
    *
    * Usage: used with reset_array() and reset_object().
    **/
-   simdjson_really_inline void move_at_container_start() noexcept;
+   simdjson_inline void move_at_container_start() noexcept;
   /* Useful for debugging and logging purposes. */
   inline std::string to_string() const noexcept;
-  simdjson_really_inline value_iterator(json_iterator *json_iter, depth_t depth, token_position start_index) noexcept;
+  simdjson_inline value_iterator(json_iterator *json_iter, depth_t depth, token_position start_index) noexcept;
 
-  simdjson_really_inline bool parse_null(const uint8_t *json) const noexcept;
-  simdjson_really_inline simdjson_result<bool> parse_bool(const uint8_t *json) const noexcept;
-  simdjson_really_inline const uint8_t *peek_start() const noexcept;
-  simdjson_really_inline uint32_t peek_start_length() const noexcept;
+  simdjson_inline bool parse_null(const uint8_t *json) const noexcept;
+  simdjson_inline simdjson_result<bool> parse_bool(const uint8_t *json) const noexcept;
+  simdjson_inline const uint8_t *peek_start() const noexcept;
+  simdjson_inline uint32_t peek_start_length() const noexcept;
 
   /**
    * The general idea of the advance_... methods and the peek_* methods
@@ -384,17 +384,17 @@ protected:
    * Unfortunately, it makes the code more verbose, longer and maybe more error prone.
    */
 
-  simdjson_really_inline void advance_scalar(const char *type) noexcept;
-  simdjson_really_inline void advance_root_scalar(const char *type) noexcept;
-  simdjson_really_inline void advance_non_root_scalar(const char *type) noexcept;
+  simdjson_inline void advance_scalar(const char *type) noexcept;
+  simdjson_inline void advance_root_scalar(const char *type) noexcept;
+  simdjson_inline void advance_non_root_scalar(const char *type) noexcept;
 
-  simdjson_really_inline const uint8_t *peek_scalar(const char *type) noexcept;
-  simdjson_really_inline const uint8_t *peek_root_scalar(const char *type) noexcept;
-  simdjson_really_inline const uint8_t *peek_non_root_scalar(const char *type) noexcept;
+  simdjson_inline const uint8_t *peek_scalar(const char *type) noexcept;
+  simdjson_inline const uint8_t *peek_root_scalar(const char *type) noexcept;
+  simdjson_inline const uint8_t *peek_non_root_scalar(const char *type) noexcept;
 
 
-  simdjson_really_inline error_code start_container(uint8_t start_char, const char *incorrect_type_message, const char *type) noexcept;
-  simdjson_really_inline error_code end_container() noexcept;
+  simdjson_inline error_code start_container(uint8_t start_char, const char *incorrect_type_message, const char *type) noexcept;
+  simdjson_inline error_code end_container() noexcept;
 
   /**
    * Advance to a place expecting a value (increasing depth).
@@ -402,19 +402,19 @@ protected:
    * @return The current token (the one left behind).
    * @error TAPE_ERROR If the document ended early.
    */
-  simdjson_really_inline simdjson_result<const uint8_t *> advance_to_value() noexcept;
+  simdjson_inline simdjson_result<const uint8_t *> advance_to_value() noexcept;
 
-  simdjson_really_inline error_code incorrect_type_error(const char *message) const noexcept;
-  simdjson_really_inline error_code error_unless_more_tokens(uint32_t tokens=1) const noexcept;
+  simdjson_inline error_code incorrect_type_error(const char *message) const noexcept;
+  simdjson_inline error_code error_unless_more_tokens(uint32_t tokens=1) const noexcept;
 
-  simdjson_really_inline bool is_at_start() const noexcept;
+  simdjson_inline bool is_at_start() const noexcept;
   /**
    * is_at_iterator_start() returns true on an array or object after it has just been
    * created, whether the instance is empty or not.
    *
    * Usage: used by array::begin() in debug mode (SIMDJSON_DEVELOPMENT_CHECKS)
    */
-  simdjson_really_inline bool is_at_iterator_start() const noexcept;
+  simdjson_inline bool is_at_iterator_start() const noexcept;
 
   /**
    * Assuming that we are within an object, this returns true if we
@@ -423,7 +423,7 @@ protected:
    * Usage: the skip_child() method should never be used while we are pointing
    * at a key inside an object.
    */
-  simdjson_really_inline bool is_at_key() const noexcept;
+  simdjson_inline bool is_at_key() const noexcept;
 
   inline void assert_at_start() const noexcept;
   inline void assert_at_container_start() const noexcept;
@@ -433,16 +433,16 @@ protected:
   inline void assert_at_non_root_start() const noexcept;
 
   /** Get the starting position of this value */
-  simdjson_really_inline token_position start_position() const noexcept;
+  simdjson_inline token_position start_position() const noexcept;
 
   /** @copydoc error_code json_iterator::position() const noexcept; */
-  simdjson_really_inline token_position position() const noexcept;
+  simdjson_inline token_position position() const noexcept;
   /** @copydoc error_code json_iterator::end_position() const noexcept; */
-  simdjson_really_inline token_position last_position() const noexcept;
+  simdjson_inline token_position last_position() const noexcept;
   /** @copydoc error_code json_iterator::end_position() const noexcept; */
-  simdjson_really_inline token_position end_position() const noexcept;
+  simdjson_inline token_position end_position() const noexcept;
   /** @copydoc error_code json_iterator::report_error(error_code error, const char *message) noexcept; */
-  simdjson_really_inline error_code report_error(error_code error, const char *message) noexcept;
+  simdjson_inline error_code report_error(error_code error, const char *message) noexcept;
 
   friend class document;
   friend class object;
@@ -459,9 +459,9 @@ namespace simdjson {
 template<>
 struct simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator> : public SIMDJSON_IMPLEMENTATION::implementation_simdjson_result_base<SIMDJSON_IMPLEMENTATION::ondemand::value_iterator> {
 public:
-  simdjson_really_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value_iterator &&value) noexcept; ///< @private
-  simdjson_really_inline simdjson_result(error_code error) noexcept; ///< @private
-  simdjson_really_inline simdjson_result() noexcept = default;
+  simdjson_inline simdjson_result(SIMDJSON_IMPLEMENTATION::ondemand::value_iterator &&value) noexcept; ///< @private
+  simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
+  simdjson_inline simdjson_result() noexcept = default;
 };
 
 } // namespace simdjson

--- a/include/simdjson/haswell/bitmanipulation.h
+++ b/include/simdjson/haswell/bitmanipulation.h
@@ -9,7 +9,7 @@ namespace {
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
 SIMDJSON_NO_SANITIZE_UNDEFINED
-simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
+simdjson_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   return (int)_tzcnt_u64(input_num);
 #else // SIMDJSON_REGULAR_VISUAL_STUDIO
@@ -23,27 +23,27 @@ simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline uint64_t clear_lowest_bit(uint64_t input_num) {
+simdjson_inline uint64_t clear_lowest_bit(uint64_t input_num) {
   return _blsr_u64(input_num);
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline int leading_zeroes(uint64_t input_num) {
+simdjson_inline int leading_zeroes(uint64_t input_num) {
   return int(_lzcnt_u64(input_num));
 }
 
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-simdjson_really_inline unsigned __int64 count_ones(uint64_t input_num) {
+simdjson_inline unsigned __int64 count_ones(uint64_t input_num) {
   // note: we do not support legacy 32-bit Windows
   return __popcnt64(input_num);// Visual Studio wants two underscores
 }
 #else
-simdjson_really_inline long long int count_ones(uint64_t input_num) {
+simdjson_inline long long int count_ones(uint64_t input_num) {
   return _popcnt64(input_num);
 }
 #endif
 
-simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
+simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                 uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   return _addcarry_u64(0, value1, value2,

--- a/include/simdjson/haswell/bitmask.h
+++ b/include/simdjson/haswell/bitmask.h
@@ -10,7 +10,7 @@ namespace {
 //
 // For example, prefix_xor(00100100) == 00011100
 //
-simdjson_really_inline uint64_t prefix_xor(const uint64_t bitmask) {
+simdjson_inline uint64_t prefix_xor(const uint64_t bitmask) {
   // There should be no such thing with a processor supporting avx2
   // but not clmul.
   __m128i all_ones = _mm_set1_epi8('\xFF');

--- a/include/simdjson/haswell/implementation.h
+++ b/include/simdjson/haswell/implementation.h
@@ -11,7 +11,7 @@ using namespace simdjson;
 
 class implementation final : public simdjson::implementation {
 public:
-  simdjson_really_inline implementation() : simdjson::implementation(
+  simdjson_inline implementation() : simdjson::implementation(
       "haswell",
       "Intel/AMD AVX2",
       internal::instruction_set::AVX2 | internal::instruction_set::PCLMULQDQ | internal::instruction_set::BMI1 | internal::instruction_set::BMI2

--- a/include/simdjson/haswell/numberparsing.h
+++ b/include/simdjson/haswell/numberparsing.h
@@ -5,7 +5,7 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 
-static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
+static simdjson_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   // this actually computes *16* values so we are being wasteful.
   const __m128i ascii0 = _mm_set1_epi8('0');
   const __m128i mul_1_10 =

--- a/include/simdjson/haswell/simd.h
+++ b/include/simdjson/haswell/simd.h
@@ -14,23 +14,23 @@ namespace simd {
     __m256i value;
 
     // Zero constructor
-    simdjson_really_inline base() : value{__m256i()} {}
+    simdjson_inline base() : value{__m256i()} {}
 
     // Conversion from SIMD register
-    simdjson_really_inline base(const __m256i _value) : value(_value) {}
+    simdjson_inline base(const __m256i _value) : value(_value) {}
 
     // Conversion to SIMD register
-    simdjson_really_inline operator const __m256i&() const { return this->value; }
-    simdjson_really_inline operator __m256i&() { return this->value; }
+    simdjson_inline operator const __m256i&() const { return this->value; }
+    simdjson_inline operator __m256i&() { return this->value; }
 
     // Bit operations
-    simdjson_really_inline Child operator|(const Child other) const { return _mm256_or_si256(*this, other); }
-    simdjson_really_inline Child operator&(const Child other) const { return _mm256_and_si256(*this, other); }
-    simdjson_really_inline Child operator^(const Child other) const { return _mm256_xor_si256(*this, other); }
-    simdjson_really_inline Child bit_andnot(const Child other) const { return _mm256_andnot_si256(other, *this); }
-    simdjson_really_inline Child& operator|=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast | other; return *this_cast; }
-    simdjson_really_inline Child& operator&=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast & other; return *this_cast; }
-    simdjson_really_inline Child& operator^=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
+    simdjson_inline Child operator|(const Child other) const { return _mm256_or_si256(*this, other); }
+    simdjson_inline Child operator&(const Child other) const { return _mm256_and_si256(*this, other); }
+    simdjson_inline Child operator^(const Child other) const { return _mm256_xor_si256(*this, other); }
+    simdjson_inline Child bit_andnot(const Child other) const { return _mm256_andnot_si256(other, *this); }
+    simdjson_inline Child& operator|=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast | other; return *this_cast; }
+    simdjson_inline Child& operator&=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast & other; return *this_cast; }
+    simdjson_inline Child& operator^=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
   };
 
   // Forward-declared so they can be used by splat and friends.
@@ -42,15 +42,15 @@ namespace simd {
     typedef uint32_t bitmask_t;
     typedef uint64_t bitmask2_t;
 
-    simdjson_really_inline base8() : base<simd8<T>>() {}
-    simdjson_really_inline base8(const __m256i _value) : base<simd8<T>>(_value) {}
+    simdjson_inline base8() : base<simd8<T>>() {}
+    simdjson_inline base8(const __m256i _value) : base<simd8<T>>(_value) {}
 
     friend simdjson_really_inline Mask operator==(const simd8<T> lhs, const simd8<T> rhs) { return _mm256_cmpeq_epi8(lhs, rhs); }
 
     static const int SIZE = sizeof(base<T>::value);
 
     template<int N=1>
-    simdjson_really_inline simd8<T> prev(const simd8<T> prev_chunk) const {
+    simdjson_inline simd8<T> prev(const simd8<T> prev_chunk) const {
       return _mm256_alignr_epi8(*this, _mm256_permute2x128_si256(prev_chunk, *this, 0x21), 16 - N);
     }
   };
@@ -58,27 +58,27 @@ namespace simd {
   // SIMD byte mask type (returned by things like eq and gt)
   template<>
   struct simd8<bool>: base8<bool> {
-    static simdjson_really_inline simd8<bool> splat(bool _value) { return _mm256_set1_epi8(uint8_t(-(!!_value))); }
+    static simdjson_inline simd8<bool> splat(bool _value) { return _mm256_set1_epi8(uint8_t(-(!!_value))); }
 
-    simdjson_really_inline simd8<bool>() : base8() {}
-    simdjson_really_inline simd8<bool>(const __m256i _value) : base8<bool>(_value) {}
+    simdjson_inline simd8<bool>() : base8() {}
+    simdjson_inline simd8<bool>(const __m256i _value) : base8<bool>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
+    simdjson_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
 
-    simdjson_really_inline int to_bitmask() const { return _mm256_movemask_epi8(*this); }
-    simdjson_really_inline bool any() const { return !_mm256_testz_si256(*this, *this); }
-    simdjson_really_inline simd8<bool> operator~() const { return *this ^ true; }
+    simdjson_inline int to_bitmask() const { return _mm256_movemask_epi8(*this); }
+    simdjson_inline bool any() const { return !_mm256_testz_si256(*this, *this); }
+    simdjson_inline simd8<bool> operator~() const { return *this ^ true; }
   };
 
   template<typename T>
   struct base8_numeric: base8<T> {
-    static simdjson_really_inline simd8<T> splat(T _value) { return _mm256_set1_epi8(_value); }
-    static simdjson_really_inline simd8<T> zero() { return _mm256_setzero_si256(); }
-    static simdjson_really_inline simd8<T> load(const T values[32]) {
+    static simdjson_inline simd8<T> splat(T _value) { return _mm256_set1_epi8(_value); }
+    static simdjson_inline simd8<T> zero() { return _mm256_setzero_si256(); }
+    static simdjson_inline simd8<T> load(const T values[32]) {
       return _mm256_loadu_si256(reinterpret_cast<const __m256i *>(values));
     }
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    static simdjson_really_inline simd8<T> repeat_16(
+    static simdjson_inline simd8<T> repeat_16(
       T v0,  T v1,  T v2,  T v3,  T v4,  T v5,  T v6,  T v7,
       T v8,  T v9,  T v10, T v11, T v12, T v13, T v14, T v15
     ) {
@@ -90,24 +90,24 @@ namespace simd {
       );
     }
 
-    simdjson_really_inline base8_numeric() : base8<T>() {}
-    simdjson_really_inline base8_numeric(const __m256i _value) : base8<T>(_value) {}
+    simdjson_inline base8_numeric() : base8<T>() {}
+    simdjson_inline base8_numeric(const __m256i _value) : base8<T>(_value) {}
 
     // Store to array
-    simdjson_really_inline void store(T dst[32]) const { return _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst), *this); }
+    simdjson_inline void store(T dst[32]) const { return _mm256_storeu_si256(reinterpret_cast<__m256i *>(dst), *this); }
 
     // Addition/subtraction are the same for signed and unsigned
-    simdjson_really_inline simd8<T> operator+(const simd8<T> other) const { return _mm256_add_epi8(*this, other); }
-    simdjson_really_inline simd8<T> operator-(const simd8<T> other) const { return _mm256_sub_epi8(*this, other); }
-    simdjson_really_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *static_cast<simd8<T>*>(this); }
-    simdjson_really_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *static_cast<simd8<T>*>(this); }
+    simdjson_inline simd8<T> operator+(const simd8<T> other) const { return _mm256_add_epi8(*this, other); }
+    simdjson_inline simd8<T> operator-(const simd8<T> other) const { return _mm256_sub_epi8(*this, other); }
+    simdjson_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *static_cast<simd8<T>*>(this); }
+    simdjson_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *static_cast<simd8<T>*>(this); }
 
     // Override to distinguish from bool version
-    simdjson_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
+    simdjson_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
 
     // Perform a lookup assuming the value is between 0 and 16 (undefined behavior for out of range values)
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
+    simdjson_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
       return _mm256_shuffle_epi8(lookup_table, *this);
     }
 
@@ -119,7 +119,7 @@ namespace simd {
     // signature simd8<L> compress(uint32_t mask) would be
     // sensible, but the AVX ISA makes this kind of approach difficult.
     template<typename L>
-    simdjson_really_inline void compress(uint32_t mask, L * output) const {
+    simdjson_inline void compress(uint32_t mask, L * output) const {
       using internal::thintable_epi8;
       using internal::BitsSetTable256mul2;
       using internal::pshufb_combine_table;
@@ -165,7 +165,7 @@ namespace simd {
     }
 
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(
+    simdjson_inline simd8<L> lookup_16(
         L replace0,  L replace1,  L replace2,  L replace3,
         L replace4,  L replace5,  L replace6,  L replace7,
         L replace8,  L replace9,  L replace10, L replace11,
@@ -182,14 +182,14 @@ namespace simd {
   // Signed bytes
   template<>
   struct simd8<int8_t> : base8_numeric<int8_t> {
-    simdjson_really_inline simd8() : base8_numeric<int8_t>() {}
-    simdjson_really_inline simd8(const __m256i _value) : base8_numeric<int8_t>(_value) {}
+    simdjson_inline simd8() : base8_numeric<int8_t>() {}
+    simdjson_inline simd8(const __m256i _value) : base8_numeric<int8_t>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8(int8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(int8_t _value) : simd8(splat(_value)) {}
     // Array constructor
-    simdjson_really_inline simd8(const int8_t values[32]) : simd8(load(values)) {}
+    simdjson_inline simd8(const int8_t values[32]) : simd8(load(values)) {}
     // Member-by-member initialization
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3,  int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15,
       int8_t v16, int8_t v17, int8_t v18, int8_t v19, int8_t v20, int8_t v21, int8_t v22, int8_t v23,
@@ -201,7 +201,7 @@ namespace simd {
       v24,v25,v26,v27,v28,v29,v30,v31
     )) {}
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<int8_t> repeat_16(
+    simdjson_inline static simd8<int8_t> repeat_16(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3,  int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15
     ) {
@@ -214,23 +214,23 @@ namespace simd {
     }
 
     // Order-sensitive comparisons
-    simdjson_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return _mm256_max_epi8(*this, other); }
-    simdjson_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return _mm256_min_epi8(*this, other); }
-    simdjson_really_inline simd8<bool> operator>(const simd8<int8_t> other) const { return _mm256_cmpgt_epi8(*this, other); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<int8_t> other) const { return _mm256_cmpgt_epi8(other, *this); }
+    simdjson_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return _mm256_max_epi8(*this, other); }
+    simdjson_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return _mm256_min_epi8(*this, other); }
+    simdjson_inline simd8<bool> operator>(const simd8<int8_t> other) const { return _mm256_cmpgt_epi8(*this, other); }
+    simdjson_inline simd8<bool> operator<(const simd8<int8_t> other) const { return _mm256_cmpgt_epi8(other, *this); }
   };
 
   // Unsigned bytes
   template<>
   struct simd8<uint8_t>: base8_numeric<uint8_t> {
-    simdjson_really_inline simd8() : base8_numeric<uint8_t>() {}
-    simdjson_really_inline simd8(const __m256i _value) : base8_numeric<uint8_t>(_value) {}
+    simdjson_inline simd8() : base8_numeric<uint8_t>() {}
+    simdjson_inline simd8(const __m256i _value) : base8_numeric<uint8_t>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
     // Array constructor
-    simdjson_really_inline simd8(const uint8_t values[32]) : simd8(load(values)) {}
+    simdjson_inline simd8(const uint8_t values[32]) : simd8(load(values)) {}
     // Member-by-member initialization
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15,
       uint8_t v16, uint8_t v17, uint8_t v18, uint8_t v19, uint8_t v20, uint8_t v21, uint8_t v22, uint8_t v23,
@@ -242,7 +242,7 @@ namespace simd {
       v24,v25,v26,v27,v28,v29,v30,v31
     )) {}
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<uint8_t> repeat_16(
+    simdjson_inline static simd8<uint8_t> repeat_16(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15
     ) {
@@ -255,39 +255,39 @@ namespace simd {
     }
 
     // Saturated math
-    simdjson_really_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return _mm256_adds_epu8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return _mm256_subs_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return _mm256_adds_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return _mm256_subs_epu8(*this, other); }
 
     // Order-specific operations
-    simdjson_really_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return _mm256_max_epu8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return _mm256_min_epu8(other, *this); }
+    simdjson_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return _mm256_max_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return _mm256_min_epu8(other, *this); }
     // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-    simdjson_really_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return this->saturating_sub(other); }
+    simdjson_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return this->saturating_sub(other); }
     // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-    simdjson_really_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return other.saturating_sub(*this); }
-    simdjson_really_inline simd8<bool> operator<=(const simd8<uint8_t> other) const { return other.max_val(*this) == other; }
-    simdjson_really_inline simd8<bool> operator>=(const simd8<uint8_t> other) const { return other.min_val(*this) == other; }
-    simdjson_really_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return this->lt_bits(other).any_bits_set(); }
+    simdjson_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return other.saturating_sub(*this); }
+    simdjson_inline simd8<bool> operator<=(const simd8<uint8_t> other) const { return other.max_val(*this) == other; }
+    simdjson_inline simd8<bool> operator>=(const simd8<uint8_t> other) const { return other.min_val(*this) == other; }
+    simdjson_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
+    simdjson_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return this->lt_bits(other).any_bits_set(); }
 
     // Bit-specific operations
-    simdjson_really_inline simd8<bool> bits_not_set() const { return *this == uint8_t(0); }
-    simdjson_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const { return (*this & bits).bits_not_set(); }
-    simdjson_really_inline simd8<bool> any_bits_set() const { return ~this->bits_not_set(); }
-    simdjson_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return ~this->bits_not_set(bits); }
-    simdjson_really_inline bool is_ascii() const { return _mm256_movemask_epi8(*this) == 0; }
-    simdjson_really_inline bool bits_not_set_anywhere() const { return _mm256_testz_si256(*this, *this); }
-    simdjson_really_inline bool any_bits_set_anywhere() const { return !bits_not_set_anywhere(); }
-    simdjson_really_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const { return _mm256_testz_si256(*this, bits); }
-    simdjson_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return !bits_not_set_anywhere(bits); }
+    simdjson_inline simd8<bool> bits_not_set() const { return *this == uint8_t(0); }
+    simdjson_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const { return (*this & bits).bits_not_set(); }
+    simdjson_inline simd8<bool> any_bits_set() const { return ~this->bits_not_set(); }
+    simdjson_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return ~this->bits_not_set(bits); }
+    simdjson_inline bool is_ascii() const { return _mm256_movemask_epi8(*this) == 0; }
+    simdjson_inline bool bits_not_set_anywhere() const { return _mm256_testz_si256(*this, *this); }
+    simdjson_inline bool any_bits_set_anywhere() const { return !bits_not_set_anywhere(); }
+    simdjson_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const { return _mm256_testz_si256(*this, bits); }
+    simdjson_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return !bits_not_set_anywhere(bits); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shr() const { return simd8<uint8_t>(_mm256_srli_epi16(*this, N)) & uint8_t(0xFFu >> N); }
+    simdjson_inline simd8<uint8_t> shr() const { return simd8<uint8_t>(_mm256_srli_epi16(*this, N)) & uint8_t(0xFFu >> N); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shl() const { return simd8<uint8_t>(_mm256_slli_epi16(*this, N)) & uint8_t(0xFFu << N); }
+    simdjson_inline simd8<uint8_t> shl() const { return simd8<uint8_t>(_mm256_slli_epi16(*this, N)) & uint8_t(0xFFu << N); }
     // Get one of the bits and make a bitmask out of it.
     // e.g. value.get_bit<7>() gets the high bit
     template<int N>
-    simdjson_really_inline int get_bit() const { return _mm256_movemask_epi8(_mm256_slli_epi16(*this, 7-N)); }
+    simdjson_inline int get_bit() const { return _mm256_movemask_epi8(_mm256_slli_epi16(*this, 7-N)); }
   };
 
   template<typename T>
@@ -300,10 +300,10 @@ namespace simd {
     simd8x64<T>& operator=(const simd8<T>& other) = delete; // no assignment allowed
     simd8x64() = delete; // no default constructor allowed
 
-    simdjson_really_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1) : chunks{chunk0, chunk1} {}
-    simdjson_really_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+32)} {}
+    simdjson_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1) : chunks{chunk0, chunk1} {}
+    simdjson_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+32)} {}
 
-    simdjson_really_inline uint64_t compress(uint64_t mask, T * output) const {
+    simdjson_inline uint64_t compress(uint64_t mask, T * output) const {
       uint32_t mask1 = uint32_t(mask);
       uint32_t mask2 = uint32_t(mask >> 32);
       this->chunks[0].compress(mask1, output);
@@ -311,22 +311,22 @@ namespace simd {
       return 64 - count_ones(mask);
     }
 
-    simdjson_really_inline void store(T ptr[64]) const {
+    simdjson_inline void store(T ptr[64]) const {
       this->chunks[0].store(ptr+sizeof(simd8<T>)*0);
       this->chunks[1].store(ptr+sizeof(simd8<T>)*1);
     }
 
-    simdjson_really_inline uint64_t to_bitmask() const {
+    simdjson_inline uint64_t to_bitmask() const {
       uint64_t r_lo = uint32_t(this->chunks[0].to_bitmask());
       uint64_t r_hi =                       this->chunks[1].to_bitmask();
       return r_lo | (r_hi << 32);
     }
 
-    simdjson_really_inline simd8<T> reduce_or() const {
+    simdjson_inline simd8<T> reduce_or() const {
       return this->chunks[0] | this->chunks[1];
     }
 
-    simdjson_really_inline simd8x64<T> bit_or(const T m) const {
+    simdjson_inline simd8x64<T> bit_or(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return simd8x64<T>(
         this->chunks[0] | mask,
@@ -334,7 +334,7 @@ namespace simd {
       );
     }
 
-    simdjson_really_inline uint64_t eq(const T m) const {
+    simdjson_inline uint64_t eq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(
         this->chunks[0] == mask,
@@ -342,14 +342,14 @@ namespace simd {
       ).to_bitmask();
     }
 
-    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
+    simdjson_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
       return  simd8x64<bool>(
         this->chunks[0] == other.chunks[0],
         this->chunks[1] == other.chunks[1]
       ).to_bitmask();
     }
 
-    simdjson_really_inline uint64_t lteq(const T m) const {
+    simdjson_inline uint64_t lteq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(
         this->chunks[0] <= mask,

--- a/include/simdjson/haswell/stringparsing.h
+++ b/include/simdjson/haswell/stringparsing.h
@@ -15,18 +15,18 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_really_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_really_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_really_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }
-  simdjson_really_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_really_inline int backslash_index() { return trailing_zeroes(bs_bits); }
+  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
+  simdjson_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }
+  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
+  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
 
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote
 
-simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
+simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // this can read up to 15 bytes beyond the buffer size, but we require
   // SIMDJSON_PADDING of padding
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");

--- a/include/simdjson/icelake/bitmanipulation.h
+++ b/include/simdjson/icelake/bitmanipulation.h
@@ -9,7 +9,7 @@ namespace {
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
 SIMDJSON_NO_SANITIZE_UNDEFINED
-simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
+simdjson_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   return (int)_tzcnt_u64(input_num);
 #else // SIMDJSON_REGULAR_VISUAL_STUDIO
@@ -23,27 +23,27 @@ simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline uint64_t clear_lowest_bit(uint64_t input_num) {
+simdjson_inline uint64_t clear_lowest_bit(uint64_t input_num) {
   return _blsr_u64(input_num);
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline int leading_zeroes(uint64_t input_num) {
+simdjson_inline int leading_zeroes(uint64_t input_num) {
   return int(_lzcnt_u64(input_num));
 }
 
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-simdjson_really_inline unsigned __int64 count_ones(uint64_t input_num) {
+simdjson_inline unsigned __int64 count_ones(uint64_t input_num) {
   // note: we do not support legacy 32-bit Windows
   return __popcnt64(input_num);// Visual Studio wants two underscores
 }
 #else
-simdjson_really_inline long long int count_ones(uint64_t input_num) {
+simdjson_inline long long int count_ones(uint64_t input_num) {
   return _popcnt64(input_num);
 }
 #endif
 
-simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
+simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                 uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   return _addcarry_u64(0, value1, value2,

--- a/include/simdjson/icelake/bitmask.h
+++ b/include/simdjson/icelake/bitmask.h
@@ -10,7 +10,7 @@ namespace {
 //
 // For example, prefix_xor(00100100) == 00011100
 //
-simdjson_really_inline uint64_t prefix_xor(const uint64_t bitmask) {
+simdjson_inline uint64_t prefix_xor(const uint64_t bitmask) {
   // There should be no such thing with a processor supporting avx2
   // but not clmul.
   __m128i all_ones = _mm_set1_epi8('\xFF');

--- a/include/simdjson/icelake/implementation.h
+++ b/include/simdjson/icelake/implementation.h
@@ -11,7 +11,7 @@ using namespace simdjson;
 
 class implementation final : public simdjson::implementation {
 public:
-  simdjson_really_inline implementation() : simdjson::implementation(
+  simdjson_inline implementation() : simdjson::implementation(
       "icelake",
       "Intel/AMD AVX512",
       internal::instruction_set::AVX2 | internal::instruction_set::PCLMULQDQ | internal::instruction_set::BMI1 | internal::instruction_set::BMI2 | internal::instruction_set::AVX512F | internal::instruction_set::AVX512DQ | internal::instruction_set::AVX512CD | internal::instruction_set::AVX512BW | internal::instruction_set::AVX512VL | internal::instruction_set::AVX512VBMI2

--- a/include/simdjson/icelake/numberparsing.h
+++ b/include/simdjson/icelake/numberparsing.h
@@ -5,7 +5,7 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 
-static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
+static simdjson_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   // this actually computes *16* values so we are being wasteful.
   const __m128i ascii0 = _mm_set1_epi8('0');
   const __m128i mul_1_10 =

--- a/include/simdjson/icelake/simd.h
+++ b/include/simdjson/icelake/simd.h
@@ -40,23 +40,23 @@ namespace simd {
     __m512i value;
 
     // Zero constructor
-    simdjson_really_inline base() : value{__m512i()} {}
+    simdjson_inline base() : value{__m512i()} {}
 
     // Conversion from SIMD register
-    simdjson_really_inline base(const __m512i _value) : value(_value) {}
+    simdjson_inline base(const __m512i _value) : value(_value) {}
 
     // Conversion to SIMD register
-    simdjson_really_inline operator const __m512i&() const { return this->value; }
-    simdjson_really_inline operator __m512i&() { return this->value; }
+    simdjson_inline operator const __m512i&() const { return this->value; }
+    simdjson_inline operator __m512i&() { return this->value; }
 
     // Bit operations
-    simdjson_really_inline Child operator|(const Child other) const { return _mm512_or_si512(*this, other); }
-    simdjson_really_inline Child operator&(const Child other) const { return _mm512_and_si512(*this, other); }
-    simdjson_really_inline Child operator^(const Child other) const { return _mm512_xor_si512(*this, other); }
-    simdjson_really_inline Child bit_andnot(const Child other) const { return _mm512_andnot_si512(other, *this); }
-    simdjson_really_inline Child& operator|=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast | other; return *this_cast; }
-    simdjson_really_inline Child& operator&=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast & other; return *this_cast; }
-    simdjson_really_inline Child& operator^=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
+    simdjson_inline Child operator|(const Child other) const { return _mm512_or_si512(*this, other); }
+    simdjson_inline Child operator&(const Child other) const { return _mm512_and_si512(*this, other); }
+    simdjson_inline Child operator^(const Child other) const { return _mm512_xor_si512(*this, other); }
+    simdjson_inline Child bit_andnot(const Child other) const { return _mm512_andnot_si512(other, *this); }
+    simdjson_inline Child& operator|=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast | other; return *this_cast; }
+    simdjson_inline Child& operator&=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast & other; return *this_cast; }
+    simdjson_inline Child& operator^=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
   };
 
   // Forward-declared so they can be used by splat and friends.
@@ -68,8 +68,8 @@ namespace simd {
     typedef uint32_t bitmask_t;
     typedef uint64_t bitmask2_t;
 
-    simdjson_really_inline base8() : base<simd8<T>>() {}
-    simdjson_really_inline base8(const __m512i _value) : base<simd8<T>>(_value) {}
+    simdjson_inline base8() : base<simd8<T>>() {}
+    simdjson_inline base8(const __m512i _value) : base<simd8<T>>(_value) {}
 
     friend simdjson_really_inline uint64_t operator==(const simd8<T> lhs, const simd8<T> rhs) {
       return _mm512_cmpeq_epi8_mask(lhs, rhs);
@@ -78,7 +78,7 @@ namespace simd {
     static const int SIZE = sizeof(base<T>::value);
 
     template<int N=1>
-    simdjson_really_inline simd8<T> prev(const simd8<T> prev_chunk) const {
+    simdjson_inline simd8<T> prev(const simd8<T> prev_chunk) const {
 #if SIMDJSON_GCC8
      // workaround for compilers unable to figure out that 16 - N is a constant (GCC 8)
       constexpr int shift = 16 - N;
@@ -92,25 +92,25 @@ namespace simd {
   // SIMD byte mask type (returned by things like eq and gt)
   template<>
   struct simd8<bool>: base8<bool> {
-    static simdjson_really_inline simd8<bool> splat(bool _value) { return _mm512_set1_epi8(uint8_t(-(!!_value))); }
+    static simdjson_inline simd8<bool> splat(bool _value) { return _mm512_set1_epi8(uint8_t(-(!!_value))); }
 
-    simdjson_really_inline simd8<bool>() : base8() {}
-    simdjson_really_inline simd8<bool>(const __m512i _value) : base8<bool>(_value) {}
+    simdjson_inline simd8<bool>() : base8() {}
+    simdjson_inline simd8<bool>(const __m512i _value) : base8<bool>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
-    simdjson_really_inline bool any() const { return !!_mm512_test_epi8_mask (*this, *this); }
-    simdjson_really_inline simd8<bool> operator~() const { return *this ^ true; }
+    simdjson_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
+    simdjson_inline bool any() const { return !!_mm512_test_epi8_mask (*this, *this); }
+    simdjson_inline simd8<bool> operator~() const { return *this ^ true; }
   };
 
   template<typename T>
   struct base8_numeric: base8<T> {
-    static simdjson_really_inline simd8<T> splat(T _value) { return _mm512_set1_epi8(_value); }
-    static simdjson_really_inline simd8<T> zero() { return _mm512_setzero_si512(); }
-    static simdjson_really_inline simd8<T> load(const T values[64]) {
+    static simdjson_inline simd8<T> splat(T _value) { return _mm512_set1_epi8(_value); }
+    static simdjson_inline simd8<T> zero() { return _mm512_setzero_si512(); }
+    static simdjson_inline simd8<T> load(const T values[64]) {
       return _mm512_loadu_si512(reinterpret_cast<const __m512i *>(values));
     }
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    static simdjson_really_inline simd8<T> repeat_16(
+    static simdjson_inline simd8<T> repeat_16(
       T v0,  T v1,  T v2,  T v3,  T v4,  T v5,  T v6,  T v7,
       T v8,  T v9,  T v10, T v11, T v12, T v13, T v14, T v15
     ) {
@@ -126,24 +126,24 @@ namespace simd {
       );
     }
 
-    simdjson_really_inline base8_numeric() : base8<T>() {}
-    simdjson_really_inline base8_numeric(const __m512i _value) : base8<T>(_value) {}
+    simdjson_inline base8_numeric() : base8<T>() {}
+    simdjson_inline base8_numeric(const __m512i _value) : base8<T>(_value) {}
 
     // Store to array
-    simdjson_really_inline void store(T dst[64]) const { return _mm512_storeu_si512(reinterpret_cast<__m512i *>(dst), *this); }
+    simdjson_inline void store(T dst[64]) const { return _mm512_storeu_si512(reinterpret_cast<__m512i *>(dst), *this); }
 
     // Addition/subtraction are the same for signed and unsigned
-    simdjson_really_inline simd8<T> operator+(const simd8<T> other) const { return _mm512_add_epi8(*this, other); }
-    simdjson_really_inline simd8<T> operator-(const simd8<T> other) const { return _mm512_sub_epi8(*this, other); }
-    simdjson_really_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *static_cast<simd8<T>*>(this); }
-    simdjson_really_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *static_cast<simd8<T>*>(this); }
+    simdjson_inline simd8<T> operator+(const simd8<T> other) const { return _mm512_add_epi8(*this, other); }
+    simdjson_inline simd8<T> operator-(const simd8<T> other) const { return _mm512_sub_epi8(*this, other); }
+    simdjson_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *static_cast<simd8<T>*>(this); }
+    simdjson_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *static_cast<simd8<T>*>(this); }
 
     // Override to distinguish from bool version
-    simdjson_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
+    simdjson_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
 
     // Perform a lookup assuming the value is between 0 and 16 (undefined behavior for out of range values)
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
+    simdjson_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
       return _mm512_shuffle_epi8(lookup_table, *this);
     }
 
@@ -155,12 +155,12 @@ namespace simd {
     // signature simd8<L> compress(uint32_t mask) would be
     // sensible, but the AVX ISA makes this kind of approach difficult.
     template<typename L>
-    simdjson_really_inline void compress(uint64_t mask, L * output) const {
+    simdjson_inline void compress(uint64_t mask, L * output) const {
       _mm512_mask_compressstoreu_epi8 (output,~mask,*this);
     }
 
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(
+    simdjson_inline simd8<L> lookup_16(
         L replace0,  L replace1,  L replace2,  L replace3,
         L replace4,  L replace5,  L replace6,  L replace7,
         L replace8,  L replace9,  L replace10, L replace11,
@@ -177,14 +177,14 @@ namespace simd {
   // Signed bytes
   template<>
   struct simd8<int8_t> : base8_numeric<int8_t> {
-    simdjson_really_inline simd8() : base8_numeric<int8_t>() {}
-    simdjson_really_inline simd8(const __m512i _value) : base8_numeric<int8_t>(_value) {}
+    simdjson_inline simd8() : base8_numeric<int8_t>() {}
+    simdjson_inline simd8(const __m512i _value) : base8_numeric<int8_t>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8(int8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(int8_t _value) : simd8(splat(_value)) {}
     // Array constructor
-    simdjson_really_inline simd8(const int8_t values[64]) : simd8(load(values)) {}
+    simdjson_inline simd8(const int8_t values[64]) : simd8(load(values)) {}
     // Member-by-member initialization
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3,  int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15,
       int8_t v16, int8_t v17, int8_t v18, int8_t v19, int8_t v20, int8_t v21, int8_t v22, int8_t v23,
@@ -205,7 +205,7 @@ namespace simd {
     )) {}
 
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<int8_t> repeat_16(
+    simdjson_inline static simd8<int8_t> repeat_16(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3,  int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15
     ) {
@@ -222,24 +222,24 @@ namespace simd {
     }
 
     // Order-sensitive comparisons
-    simdjson_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return _mm512_max_epi8(*this, other); }
-    simdjson_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return _mm512_min_epi8(*this, other); }
+    simdjson_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return _mm512_max_epi8(*this, other); }
+    simdjson_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return _mm512_min_epi8(*this, other); }
 
-    simdjson_really_inline simd8<bool> operator>(const simd8<int8_t> other) const { return _mm512_maskz_abs_epi8(_mm512_cmpgt_epi8_mask(*this, other),_mm512_set1_epi8(uint8_t(0x80))); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<int8_t> other) const { return _mm512_maskz_abs_epi8(_mm512_cmpgt_epi8_mask(other, *this),_mm512_set1_epi8(uint8_t(0x80))); }
+    simdjson_inline simd8<bool> operator>(const simd8<int8_t> other) const { return _mm512_maskz_abs_epi8(_mm512_cmpgt_epi8_mask(*this, other),_mm512_set1_epi8(uint8_t(0x80))); }
+    simdjson_inline simd8<bool> operator<(const simd8<int8_t> other) const { return _mm512_maskz_abs_epi8(_mm512_cmpgt_epi8_mask(other, *this),_mm512_set1_epi8(uint8_t(0x80))); }
   };
 
   // Unsigned bytes
   template<>
   struct simd8<uint8_t>: base8_numeric<uint8_t> {
-    simdjson_really_inline simd8() : base8_numeric<uint8_t>() {}
-    simdjson_really_inline simd8(const __m512i _value) : base8_numeric<uint8_t>(_value) {}
+    simdjson_inline simd8() : base8_numeric<uint8_t>() {}
+    simdjson_inline simd8(const __m512i _value) : base8_numeric<uint8_t>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
     // Array constructor
-    simdjson_really_inline simd8(const uint8_t values[64]) : simd8(load(values)) {}
+    simdjson_inline simd8(const uint8_t values[64]) : simd8(load(values)) {}
     // Member-by-member initialization
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15,
       uint8_t v16, uint8_t v17, uint8_t v18, uint8_t v19, uint8_t v20, uint8_t v21, uint8_t v22, uint8_t v23,
@@ -260,7 +260,7 @@ namespace simd {
     )) {}
 
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<uint8_t> repeat_16(
+    simdjson_inline static simd8<uint8_t> repeat_16(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15
     ) {
@@ -277,42 +277,42 @@ namespace simd {
     }
 
     // Saturated math
-    simdjson_really_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return _mm512_adds_epu8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return _mm512_subs_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return _mm512_adds_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return _mm512_subs_epu8(*this, other); }
 
     // Order-specific operations
-    simdjson_really_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return _mm512_max_epu8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return _mm512_min_epu8(other, *this); }
+    simdjson_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return _mm512_max_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return _mm512_min_epu8(other, *this); }
     // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-    simdjson_really_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return this->saturating_sub(other); }
+    simdjson_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return this->saturating_sub(other); }
     // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-    simdjson_really_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return other.saturating_sub(*this); }
-    simdjson_really_inline uint64_t operator<=(const simd8<uint8_t> other) const { return other.max_val(*this) == other; }
-    simdjson_really_inline uint64_t operator>=(const simd8<uint8_t> other) const { return other.min_val(*this) == other; }
-    simdjson_really_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return this->lt_bits(other).any_bits_set(); }
+    simdjson_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return other.saturating_sub(*this); }
+    simdjson_inline uint64_t operator<=(const simd8<uint8_t> other) const { return other.max_val(*this) == other; }
+    simdjson_inline uint64_t operator>=(const simd8<uint8_t> other) const { return other.min_val(*this) == other; }
+    simdjson_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
+    simdjson_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return this->lt_bits(other).any_bits_set(); }
 
     // Bit-specific operations
-    simdjson_really_inline simd8<bool> bits_not_set() const { return _mm512_mask_blend_epi8(*this == uint8_t(0), _mm512_set1_epi8(0), _mm512_set1_epi8(-1)); }
-    simdjson_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const { return (*this & bits).bits_not_set(); }
-    simdjson_really_inline simd8<bool> any_bits_set() const { return ~this->bits_not_set(); }
-    simdjson_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return ~this->bits_not_set(bits); }
+    simdjson_inline simd8<bool> bits_not_set() const { return _mm512_mask_blend_epi8(*this == uint8_t(0), _mm512_set1_epi8(0), _mm512_set1_epi8(-1)); }
+    simdjson_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const { return (*this & bits).bits_not_set(); }
+    simdjson_inline simd8<bool> any_bits_set() const { return ~this->bits_not_set(); }
+    simdjson_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return ~this->bits_not_set(bits); }
 
-    simdjson_really_inline bool is_ascii() const { return _mm512_movepi8_mask(*this) == 0; }
-    simdjson_really_inline bool bits_not_set_anywhere() const {
+    simdjson_inline bool is_ascii() const { return _mm512_movepi8_mask(*this) == 0; }
+    simdjson_inline bool bits_not_set_anywhere() const {
       return !_mm512_test_epi8_mask(*this, *this);
     }
-    simdjson_really_inline bool any_bits_set_anywhere() const { return !bits_not_set_anywhere(); }
-    simdjson_really_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const { return !_mm512_test_epi8_mask(*this, bits); }
-    simdjson_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return !bits_not_set_anywhere(bits); }
+    simdjson_inline bool any_bits_set_anywhere() const { return !bits_not_set_anywhere(); }
+    simdjson_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const { return !_mm512_test_epi8_mask(*this, bits); }
+    simdjson_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return !bits_not_set_anywhere(bits); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shr() const { return simd8<uint8_t>(_mm512_srli_epi16(*this, N)) & uint8_t(0xFFu >> N); }
+    simdjson_inline simd8<uint8_t> shr() const { return simd8<uint8_t>(_mm512_srli_epi16(*this, N)) & uint8_t(0xFFu >> N); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shl() const { return simd8<uint8_t>(_mm512_slli_epi16(*this, N)) & uint8_t(0xFFu << N); }
+    simdjson_inline simd8<uint8_t> shl() const { return simd8<uint8_t>(_mm512_slli_epi16(*this, N)) & uint8_t(0xFFu << N); }
     // Get one of the bits and make a bitmask out of it.
     // e.g. value.get_bit<7>() gets the high bit
     template<int N>
-    simdjson_really_inline uint64_t get_bit() const { return _mm512_movepi8_mask(_mm512_slli_epi16(*this, 7-N)); }
+    simdjson_inline uint64_t get_bit() const { return _mm512_movepi8_mask(_mm512_slli_epi16(*this, 7-N)); }
   };
 
   template<typename T>
@@ -325,40 +325,40 @@ namespace simd {
     simd8x64<T>& operator=(const simd8<T>& other) = delete; // no assignment allowed
     simd8x64() = delete; // no default constructor allowed
 
-    simdjson_really_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1) : chunks{chunk0, chunk1} {}
-    simdjson_really_inline simd8x64(const simd8<T> chunk0) : chunks{chunk0} {}
-    simdjson_really_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr)} {}
+    simdjson_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1) : chunks{chunk0, chunk1} {}
+    simdjson_inline simd8x64(const simd8<T> chunk0) : chunks{chunk0} {}
+    simdjson_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr)} {}
 
-    simdjson_really_inline uint64_t compress(uint64_t mask, T * output) const {
+    simdjson_inline uint64_t compress(uint64_t mask, T * output) const {
       this->chunks[0].compress(mask, output);
       return 64 - count_ones(mask);
     }
 
-    simdjson_really_inline void store(T ptr[64]) const {
+    simdjson_inline void store(T ptr[64]) const {
       this->chunks[0].store(ptr+sizeof(simd8<T>)*0);
     }
 
-    simdjson_really_inline simd8<T> reduce_or() const {
+    simdjson_inline simd8<T> reduce_or() const {
       return this->chunks[0];
     }
 
-    simdjson_really_inline simd8x64<T> bit_or(const T m) const {
+    simdjson_inline simd8x64<T> bit_or(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return simd8x64<T>(
         this->chunks[0] | mask
       );
     }
 
-    simdjson_really_inline uint64_t eq(const T m) const {
+    simdjson_inline uint64_t eq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return this->chunks[0] == mask;
     }
 
-    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
+    simdjson_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
       return this->chunks[0] == other.chunks[0];
     }
 
-    simdjson_really_inline uint64_t lteq(const T m) const {
+    simdjson_inline uint64_t lteq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return this->chunks[0] <= mask;
     }

--- a/include/simdjson/icelake/stringparsing.h
+++ b/include/simdjson/icelake/stringparsing.h
@@ -15,18 +15,18 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_really_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_really_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_really_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }
-  simdjson_really_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_really_inline int backslash_index() { return trailing_zeroes(bs_bits); }
+  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
+  simdjson_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }
+  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
+  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
 
   uint64_t bs_bits;
   uint64_t quote_bits;
 }; // struct backslash_and_quote
 
-simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
+simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // this can read up to 15 bytes beyond the buffer size, but we require
   // SIMDJSON_PADDING of padding
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");

--- a/include/simdjson/implementation.h
+++ b/include/simdjson/implementation.h
@@ -24,7 +24,7 @@ simdjson_warn_unused bool validate_utf8(const char * buf, size_t len) noexcept;
  * @param sv the string_view to validate.
  * @return true if the string is valid UTF-8.
  */
-simdjson_really_inline simdjson_warn_unused bool validate_utf8(const std::string_view sv) noexcept {
+simdjson_inline simdjson_warn_unused bool validate_utf8(const std::string_view sv) noexcept {
   return validate_utf8(sv.data(), sv.size());
 }
 
@@ -34,7 +34,7 @@ simdjson_really_inline simdjson_warn_unused bool validate_utf8(const std::string
  * @param p the string to validate.
  * @return true if the string is valid UTF-8.
  */
-simdjson_really_inline simdjson_warn_unused bool validate_utf8(const std::string& s) noexcept {
+simdjson_inline simdjson_warn_unused bool validate_utf8(const std::string& s) noexcept {
   return validate_utf8(s.data(), s.size());
 }
 
@@ -136,7 +136,7 @@ public:
 
 protected:
   /** @private Construct an implementation with the given name and description. For subclasses. */
-  simdjson_really_inline implementation(
+  simdjson_inline implementation(
     std::string_view name,
     std::string_view description,
     uint32_t required_instruction_sets
@@ -174,7 +174,7 @@ namespace internal {
 class available_implementation_list {
 public:
   /** Get the list of available implementations compiled into simdjson */
-  simdjson_really_inline available_implementation_list() {}
+  simdjson_inline available_implementation_list() {}
   /** Number of implementations */
   size_t size() const noexcept;
   /** STL const begin() iterator */

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -160,14 +160,14 @@ public:
    *
    * @return Current capacity, in bytes.
    */
-  simdjson_really_inline size_t capacity() const noexcept;
+  simdjson_inline size_t capacity() const noexcept;
 
   /**
    * The maximum level of nested object and arrays supported by this parser.
    *
    * @return Maximum depth, in bytes.
    */
-  simdjson_really_inline size_t max_depth() const noexcept;
+  simdjson_inline size_t max_depth() const noexcept;
 
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
@@ -196,23 +196,23 @@ protected:
   size_t _max_depth{0};
 
   // Declaring these so that subclasses can use them to implement their constructors.
-  simdjson_really_inline dom_parser_implementation() noexcept;
-  simdjson_really_inline dom_parser_implementation(dom_parser_implementation &&other) noexcept;
-  simdjson_really_inline dom_parser_implementation &operator=(dom_parser_implementation &&other) noexcept;
+  simdjson_inline dom_parser_implementation() noexcept;
+  simdjson_inline dom_parser_implementation(dom_parser_implementation &&other) noexcept;
+  simdjson_inline dom_parser_implementation &operator=(dom_parser_implementation &&other) noexcept;
 
-  simdjson_really_inline dom_parser_implementation(const dom_parser_implementation &) noexcept = delete;
-  simdjson_really_inline dom_parser_implementation &operator=(const dom_parser_implementation &other) noexcept = delete;
+  simdjson_inline dom_parser_implementation(const dom_parser_implementation &) noexcept = delete;
+  simdjson_inline dom_parser_implementation &operator=(const dom_parser_implementation &other) noexcept = delete;
 }; // class dom_parser_implementation
 
-simdjson_really_inline dom_parser_implementation::dom_parser_implementation() noexcept = default;
-simdjson_really_inline dom_parser_implementation::dom_parser_implementation(dom_parser_implementation &&other) noexcept = default;
-simdjson_really_inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parser_implementation &&other) noexcept = default;
+simdjson_inline dom_parser_implementation::dom_parser_implementation() noexcept = default;
+simdjson_inline dom_parser_implementation::dom_parser_implementation(dom_parser_implementation &&other) noexcept = default;
+simdjson_inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parser_implementation &&other) noexcept = default;
 
-simdjson_really_inline size_t dom_parser_implementation::capacity() const noexcept {
+simdjson_inline size_t dom_parser_implementation::capacity() const noexcept {
   return _capacity;
 }
 
-simdjson_really_inline size_t dom_parser_implementation::max_depth() const noexcept {
+simdjson_inline size_t dom_parser_implementation::max_depth() const noexcept {
   return _max_depth;
 }
 

--- a/include/simdjson/internal/tape_ref-inl.h
+++ b/include/simdjson/internal/tape_ref-inl.h
@@ -10,11 +10,11 @@ namespace internal {
 //
 // tape_ref inline implementation
 //
-simdjson_really_inline tape_ref::tape_ref() noexcept : doc{nullptr}, json_index{0} {}
-simdjson_really_inline tape_ref::tape_ref(const dom::document *_doc, size_t _json_index) noexcept : doc{_doc}, json_index{_json_index} {}
+simdjson_inline tape_ref::tape_ref() noexcept : doc{nullptr}, json_index{0} {}
+simdjson_inline tape_ref::tape_ref(const dom::document *_doc, size_t _json_index) noexcept : doc{_doc}, json_index{_json_index} {}
 
 
-simdjson_really_inline bool tape_ref::is_document_root() const noexcept {
+simdjson_inline bool tape_ref::is_document_root() const noexcept {
   return json_index == 1; // should we ever change the structure of the tape, this should get updated.
 }
 
@@ -22,27 +22,27 @@ simdjson_really_inline bool tape_ref::is_document_root() const noexcept {
 // to check the type by doing a word-to-word comparison instead of extracting the
 // most significant 8 bits.
 
-simdjson_really_inline bool tape_ref::is_double() const noexcept {
+simdjson_inline bool tape_ref::is_double() const noexcept {
   constexpr uint64_t tape_double = uint64_t(tape_type::DOUBLE)<<56;
   return doc->tape[json_index] == tape_double;
 }
-simdjson_really_inline bool tape_ref::is_int64() const noexcept {
+simdjson_inline bool tape_ref::is_int64() const noexcept {
   constexpr uint64_t tape_int64 = uint64_t(tape_type::INT64)<<56;
   return doc->tape[json_index] == tape_int64;
 }
-simdjson_really_inline bool tape_ref::is_uint64() const noexcept {
+simdjson_inline bool tape_ref::is_uint64() const noexcept {
   constexpr uint64_t tape_uint64 = uint64_t(tape_type::UINT64)<<56;
   return doc->tape[json_index] == tape_uint64;
 }
-simdjson_really_inline bool tape_ref::is_false() const noexcept {
+simdjson_inline bool tape_ref::is_false() const noexcept {
   constexpr uint64_t tape_false = uint64_t(tape_type::FALSE_VALUE)<<56;
   return doc->tape[json_index] == tape_false;
 }
-simdjson_really_inline bool tape_ref::is_true() const noexcept {
+simdjson_inline bool tape_ref::is_true() const noexcept {
   constexpr uint64_t tape_true = uint64_t(tape_type::TRUE_VALUE)<<56;
   return doc->tape[json_index] == tape_true;
 }
-simdjson_really_inline bool tape_ref::is_null_on_tape() const noexcept {
+simdjson_inline bool tape_ref::is_null_on_tape() const noexcept {
   constexpr uint64_t tape_null = uint64_t(tape_type::NULL_VALUE)<<56;
   return doc->tape[json_index] == tape_null;
 }
@@ -60,21 +60,21 @@ inline size_t tape_ref::after_element() const noexcept {
       return json_index + 1;
   }
 }
-simdjson_really_inline tape_type tape_ref::tape_ref_type() const noexcept {
+simdjson_inline tape_type tape_ref::tape_ref_type() const noexcept {
   return static_cast<tape_type>(doc->tape[json_index] >> 56);
 }
-simdjson_really_inline uint64_t internal::tape_ref::tape_value() const noexcept {
+simdjson_inline uint64_t internal::tape_ref::tape_value() const noexcept {
   return doc->tape[json_index] & internal::JSON_VALUE_MASK;
 }
-simdjson_really_inline uint32_t internal::tape_ref::matching_brace_index() const noexcept {
+simdjson_inline uint32_t internal::tape_ref::matching_brace_index() const noexcept {
   return uint32_t(doc->tape[json_index]);
 }
-simdjson_really_inline uint32_t internal::tape_ref::scope_count() const noexcept {
+simdjson_inline uint32_t internal::tape_ref::scope_count() const noexcept {
   return uint32_t((doc->tape[json_index] >> 32) & internal::JSON_COUNT_MASK);
 }
 
 template<typename T>
-simdjson_really_inline T tape_ref::next_tape_value() const noexcept {
+simdjson_inline T tape_ref::next_tape_value() const noexcept {
   static_assert(sizeof(T) == sizeof(uint64_t), "next_tape_value() template parameter must be 64-bit");
   // Though the following is tempting...
   //  return *reinterpret_cast<const T*>(&doc->tape[json_index + 1]);
@@ -85,14 +85,14 @@ simdjson_really_inline T tape_ref::next_tape_value() const noexcept {
   return x;
 }
 
-simdjson_really_inline uint32_t internal::tape_ref::get_string_length() const noexcept {
+simdjson_inline uint32_t internal::tape_ref::get_string_length() const noexcept {
   size_t string_buf_index = size_t(tape_value());
   uint32_t len;
   std::memcpy(&len, &doc->string_buf[string_buf_index], sizeof(len));
   return len;
 }
 
-simdjson_really_inline const char * internal::tape_ref::get_c_str() const noexcept {
+simdjson_inline const char * internal::tape_ref::get_c_str() const noexcept {
   size_t string_buf_index = size_t(tape_value());
   return reinterpret_cast<const char *>(&doc->string_buf[string_buf_index + sizeof(uint32_t)]);
 }

--- a/include/simdjson/internal/tape_ref.h
+++ b/include/simdjson/internal/tape_ref.h
@@ -19,25 +19,25 @@ constexpr const uint32_t JSON_COUNT_MASK = 0xFFFFFF;
  */
 class tape_ref {
 public:
-  simdjson_really_inline tape_ref() noexcept;
-  simdjson_really_inline tape_ref(const dom::document *doc, size_t json_index) noexcept;
+  simdjson_inline tape_ref() noexcept;
+  simdjson_inline tape_ref(const dom::document *doc, size_t json_index) noexcept;
   inline size_t after_element() const noexcept;
-  simdjson_really_inline tape_type tape_ref_type() const noexcept;
-  simdjson_really_inline uint64_t tape_value() const noexcept;
-  simdjson_really_inline bool is_double() const noexcept;
-  simdjson_really_inline bool is_int64() const noexcept;
-  simdjson_really_inline bool is_uint64() const noexcept;
-  simdjson_really_inline bool is_false() const noexcept;
-  simdjson_really_inline bool is_true() const noexcept;
-  simdjson_really_inline bool is_null_on_tape() const noexcept;// different name to avoid clash with is_null.
-  simdjson_really_inline uint32_t matching_brace_index() const noexcept;
-  simdjson_really_inline uint32_t scope_count() const noexcept;
+  simdjson_inline tape_type tape_ref_type() const noexcept;
+  simdjson_inline uint64_t tape_value() const noexcept;
+  simdjson_inline bool is_double() const noexcept;
+  simdjson_inline bool is_int64() const noexcept;
+  simdjson_inline bool is_uint64() const noexcept;
+  simdjson_inline bool is_false() const noexcept;
+  simdjson_inline bool is_true() const noexcept;
+  simdjson_inline bool is_null_on_tape() const noexcept;// different name to avoid clash with is_null.
+  simdjson_inline uint32_t matching_brace_index() const noexcept;
+  simdjson_inline uint32_t scope_count() const noexcept;
   template<typename T>
-  simdjson_really_inline T next_tape_value() const noexcept;
-  simdjson_really_inline uint32_t get_string_length() const noexcept;
-  simdjson_really_inline const char * get_c_str() const noexcept;
+  simdjson_inline T next_tape_value() const noexcept;
+  simdjson_inline uint32_t get_string_length() const noexcept;
+  simdjson_inline const char * get_c_str() const noexcept;
   inline std::string_view get_string_view() const noexcept;
-  simdjson_really_inline bool is_document_root() const noexcept;
+  simdjson_inline bool is_document_root() const noexcept;
 
   /** The document this element references. */
   const dom::document *doc;

--- a/include/simdjson/ppc64/bitmanipulation.h
+++ b/include/simdjson/ppc64/bitmanipulation.h
@@ -9,7 +9,7 @@ namespace {
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
 SIMDJSON_NO_SANITIZE_UNDEFINED
-simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
+simdjson_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long ret;
   // Search the mask data from least significant bit (LSB)
@@ -22,12 +22,12 @@ simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline uint64_t clear_lowest_bit(uint64_t input_num) {
+simdjson_inline uint64_t clear_lowest_bit(uint64_t input_num) {
   return input_num & (input_num - 1);
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline int leading_zeroes(uint64_t input_num) {
+simdjson_inline int leading_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)
@@ -42,17 +42,17 @@ simdjson_really_inline int leading_zeroes(uint64_t input_num) {
 }
 
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-simdjson_really_inline int count_ones(uint64_t input_num) {
+simdjson_inline int count_ones(uint64_t input_num) {
   // note: we do not support legacy 32-bit Windows
   return __popcnt64(input_num); // Visual Studio wants two underscores
 }
 #else
-simdjson_really_inline int count_ones(uint64_t input_num) {
+simdjson_inline int count_ones(uint64_t input_num) {
   return __builtin_popcountll(input_num);
 }
 #endif
 
-simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
+simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                          uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   *result = value1 + value2;

--- a/include/simdjson/ppc64/bitmask.h
+++ b/include/simdjson/ppc64/bitmask.h
@@ -11,7 +11,7 @@ namespace {
 //
 // For example, prefix_xor(00100100) == 00011100
 //
-simdjson_really_inline uint64_t prefix_xor(uint64_t bitmask) {
+simdjson_inline uint64_t prefix_xor(uint64_t bitmask) {
   // You can use the version below, however gcc sometimes miscompiles
   // vec_pmsum_be, it happens somewhere around between 8 and 9th version.
   // The performance boost was not noticeable, falling back to a usual

--- a/include/simdjson/ppc64/implementation.h
+++ b/include/simdjson/ppc64/implementation.h
@@ -14,7 +14,7 @@ using namespace simdjson::dom;
 
 class implementation final : public simdjson::implementation {
 public:
-  simdjson_really_inline implementation()
+  simdjson_inline implementation()
       : simdjson::implementation("ppc64", "PPC64 ALTIVEC",
                                  internal::instruction_set::ALTIVEC) {}
   simdjson_warn_unused error_code create_dom_parser_implementation(

--- a/include/simdjson/ppc64/numberparsing.h
+++ b/include/simdjson/ppc64/numberparsing.h
@@ -13,7 +13,7 @@ namespace {
 
 // we don't have appropriate instructions, so let us use a scalar function
 // credit: https://johnnylee-sde.github.io/Fast-numeric-string-to-int/
-static simdjson_really_inline uint32_t
+static simdjson_inline uint32_t
 parse_eight_digits_unrolled(const uint8_t *chars) {
   uint64_t val;
   std::memcpy(&val, chars, sizeof(uint64_t));

--- a/include/simdjson/ppc64/simd.h
+++ b/include/simdjson/ppc64/simd.h
@@ -17,41 +17,41 @@ template <typename Child> struct base {
   __m128i value;
 
   // Zero constructor
-  simdjson_really_inline base() : value{__m128i()} {}
+  simdjson_inline base() : value{__m128i()} {}
 
   // Conversion from SIMD register
-  simdjson_really_inline base(const __m128i _value) : value(_value) {}
+  simdjson_inline base(const __m128i _value) : value(_value) {}
 
   // Conversion to SIMD register
-  simdjson_really_inline operator const __m128i &() const {
+  simdjson_inline operator const __m128i &() const {
     return this->value;
   }
-  simdjson_really_inline operator __m128i &() { return this->value; }
+  simdjson_inline operator __m128i &() { return this->value; }
 
   // Bit operations
-  simdjson_really_inline Child operator|(const Child other) const {
+  simdjson_inline Child operator|(const Child other) const {
     return vec_or(this->value, (__m128i)other);
   }
-  simdjson_really_inline Child operator&(const Child other) const {
+  simdjson_inline Child operator&(const Child other) const {
     return vec_and(this->value, (__m128i)other);
   }
-  simdjson_really_inline Child operator^(const Child other) const {
+  simdjson_inline Child operator^(const Child other) const {
     return vec_xor(this->value, (__m128i)other);
   }
-  simdjson_really_inline Child bit_andnot(const Child other) const {
+  simdjson_inline Child bit_andnot(const Child other) const {
     return vec_andc(this->value, (__m128i)other);
   }
-  simdjson_really_inline Child &operator|=(const Child other) {
+  simdjson_inline Child &operator|=(const Child other) {
     auto this_cast = static_cast<Child*>(this);
     *this_cast = *this_cast | other;
     return *this_cast;
   }
-  simdjson_really_inline Child &operator&=(const Child other) {
+  simdjson_inline Child &operator&=(const Child other) {
     auto this_cast = static_cast<Child*>(this);
     *this_cast = *this_cast & other;
     return *this_cast;
   }
-  simdjson_really_inline Child &operator^=(const Child other) {
+  simdjson_inline Child &operator^=(const Child other) {
     auto this_cast = static_cast<Child*>(this);
     *this_cast = *this_cast ^ other;
     return *this_cast;
@@ -66,17 +66,17 @@ struct base8 : base<simd8<T>> {
   typedef uint16_t bitmask_t;
   typedef uint32_t bitmask2_t;
 
-  simdjson_really_inline base8() : base<simd8<T>>() {}
-  simdjson_really_inline base8(const __m128i _value) : base<simd8<T>>(_value) {}
+  simdjson_inline base8() : base<simd8<T>>() {}
+  simdjson_inline base8(const __m128i _value) : base<simd8<T>>(_value) {}
 
-  friend simdjson_really_inline Mask operator==(const simd8<T> lhs, const simd8<T> rhs) {
+  friend simdjson_inline Mask operator==(const simd8<T> lhs, const simd8<T> rhs) {
     return (__m128i)vec_cmpeq(lhs.value, (__m128i)rhs);
   }
 
   static const int SIZE = sizeof(base<simd8<T>>::value);
 
   template <int N = 1>
-  simdjson_really_inline simd8<T> prev(simd8<T> prev_chunk) const {
+  simdjson_inline simd8<T> prev(simd8<T> prev_chunk) const {
     __m128i chunk = this->value;
 #ifdef __LITTLE_ENDIAN__
     chunk = (__m128i)vec_reve(this->value);
@@ -92,18 +92,18 @@ struct base8 : base<simd8<T>> {
 
 // SIMD byte mask type (returned by things like eq and gt)
 template <> struct simd8<bool> : base8<bool> {
-  static simdjson_really_inline simd8<bool> splat(bool _value) {
+  static simdjson_inline simd8<bool> splat(bool _value) {
     return (__m128i)vec_splats((unsigned char)(-(!!_value)));
   }
 
-  simdjson_really_inline simd8<bool>() : base8() {}
-  simdjson_really_inline simd8<bool>(const __m128i _value)
+  simdjson_inline simd8<bool>() : base8() {}
+  simdjson_inline simd8<bool>(const __m128i _value)
       : base8<bool>(_value) {}
   // Splat constructor
-  simdjson_really_inline simd8<bool>(bool _value)
+  simdjson_inline simd8<bool>(bool _value)
       : base8<bool>(splat(_value)) {}
 
-  simdjson_really_inline int to_bitmask() const {
+  simdjson_inline int to_bitmask() const {
     __vector unsigned long long result;
     const __m128i perm_mask = {0x78, 0x70, 0x68, 0x60, 0x58, 0x50, 0x48, 0x40,
                                0x38, 0x30, 0x28, 0x20, 0x18, 0x10, 0x08, 0x00};
@@ -116,25 +116,25 @@ template <> struct simd8<bool> : base8<bool> {
     return static_cast<int>(result[0]);
 #endif
   }
-  simdjson_really_inline bool any() const {
+  simdjson_inline bool any() const {
     return !vec_all_eq(this->value, (__m128i)vec_splats(0));
   }
-  simdjson_really_inline simd8<bool> operator~() const {
+  simdjson_inline simd8<bool> operator~() const {
     return this->value ^ (__m128i)splat(true);
   }
 };
 
 template <typename T> struct base8_numeric : base8<T> {
-  static simdjson_really_inline simd8<T> splat(T value) {
+  static simdjson_inline simd8<T> splat(T value) {
     (void)value;
     return (__m128i)vec_splats(value);
   }
-  static simdjson_really_inline simd8<T> zero() { return splat(0); }
-  static simdjson_really_inline simd8<T> load(const T values[16]) {
+  static simdjson_inline simd8<T> zero() { return splat(0); }
+  static simdjson_inline simd8<T> load(const T values[16]) {
     return (__m128i)(vec_vsx_ld(0, reinterpret_cast<const uint8_t *>(values)));
   }
   // Repeat 16 values as many times as necessary (usually for lookup tables)
-  static simdjson_really_inline simd8<T> repeat_16(T v0, T v1, T v2, T v3, T v4,
+  static simdjson_inline simd8<T> repeat_16(T v0, T v1, T v2, T v3, T v4,
                                                    T v5, T v6, T v7, T v8, T v9,
                                                    T v10, T v11, T v12, T v13,
                                                    T v14, T v15) {
@@ -142,30 +142,30 @@ template <typename T> struct base8_numeric : base8<T> {
                     v14, v15);
   }
 
-  simdjson_really_inline base8_numeric() : base8<T>() {}
-  simdjson_really_inline base8_numeric(const __m128i _value)
+  simdjson_inline base8_numeric() : base8<T>() {}
+  simdjson_inline base8_numeric(const __m128i _value)
       : base8<T>(_value) {}
 
   // Store to array
-  simdjson_really_inline void store(T dst[16]) const {
+  simdjson_inline void store(T dst[16]) const {
     vec_vsx_st(this->value, 0, reinterpret_cast<__m128i *>(dst));
   }
 
   // Override to distinguish from bool version
-  simdjson_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
+  simdjson_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
 
   // Addition/subtraction are the same for signed and unsigned
-  simdjson_really_inline simd8<T> operator+(const simd8<T> other) const {
+  simdjson_inline simd8<T> operator+(const simd8<T> other) const {
     return (__m128i)((__m128i)this->value + (__m128i)other);
   }
-  simdjson_really_inline simd8<T> operator-(const simd8<T> other) const {
+  simdjson_inline simd8<T> operator-(const simd8<T> other) const {
     return (__m128i)((__m128i)this->value - (__m128i)other);
   }
-  simdjson_really_inline simd8<T> &operator+=(const simd8<T> other) {
+  simdjson_inline simd8<T> &operator+=(const simd8<T> other) {
     *this = *this + other;
     return *static_cast<simd8<T> *>(this);
   }
-  simdjson_really_inline simd8<T> &operator-=(const simd8<T> other) {
+  simdjson_inline simd8<T> &operator-=(const simd8<T> other) {
     *this = *this - other;
     return *static_cast<simd8<T> *>(this);
   }
@@ -173,7 +173,7 @@ template <typename T> struct base8_numeric : base8<T> {
   // Perform a lookup assuming the value is between 0 and 16 (undefined behavior
   // for out of range values)
   template <typename L>
-  simdjson_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
+  simdjson_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
     return (__m128i)vec_perm((__m128i)lookup_table, (__m128i)lookup_table, this->value);
   }
 
@@ -184,7 +184,7 @@ template <typename T> struct base8_numeric : base8<T> {
   // seems like a function with the signature simd8<L> compress(uint32_t mask)
   // would be sensible, but the AVX ISA makes this kind of approach difficult.
   template <typename L>
-  simdjson_really_inline void compress(uint16_t mask, L *output) const {
+  simdjson_inline void compress(uint16_t mask, L *output) const {
     using internal::BitsSetTable256mul2;
     using internal::pshufb_combine_table;
     using internal::thintable_epi8;
@@ -223,7 +223,7 @@ template <typename T> struct base8_numeric : base8<T> {
   }
 
   template <typename L>
-  simdjson_really_inline simd8<L>
+  simdjson_inline simd8<L>
   lookup_16(L replace0, L replace1, L replace2, L replace3, L replace4,
             L replace5, L replace6, L replace7, L replace8, L replace9,
             L replace10, L replace11, L replace12, L replace13, L replace14,
@@ -237,15 +237,15 @@ template <typename T> struct base8_numeric : base8<T> {
 
 // Signed bytes
 template <> struct simd8<int8_t> : base8_numeric<int8_t> {
-  simdjson_really_inline simd8() : base8_numeric<int8_t>() {}
-  simdjson_really_inline simd8(const __m128i _value)
+  simdjson_inline simd8() : base8_numeric<int8_t>() {}
+  simdjson_inline simd8(const __m128i _value)
       : base8_numeric<int8_t>(_value) {}
   // Splat constructor
-  simdjson_really_inline simd8(int8_t _value) : simd8(splat(_value)) {}
+  simdjson_inline simd8(int8_t _value) : simd8(splat(_value)) {}
   // Array constructor
-  simdjson_really_inline simd8(const int8_t *values) : simd8(load(values)) {}
+  simdjson_inline simd8(const int8_t *values) : simd8(load(values)) {}
   // Member-by-member initialization
-  simdjson_really_inline simd8(int8_t v0, int8_t v1, int8_t v2, int8_t v3,
+  simdjson_inline simd8(int8_t v0, int8_t v1, int8_t v2, int8_t v3,
                                int8_t v4, int8_t v5, int8_t v6, int8_t v7,
                                int8_t v8, int8_t v9, int8_t v10, int8_t v11,
                                int8_t v12, int8_t v13, int8_t v14, int8_t v15)
@@ -253,7 +253,7 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
                                               v8, v9, v10, v11, v12, v13, v14,
                                               v15}) {}
   // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdjson_really_inline static simd8<int8_t>
+  simdjson_inline static simd8<int8_t>
   repeat_16(int8_t v0, int8_t v1, int8_t v2, int8_t v3, int8_t v4, int8_t v5,
             int8_t v6, int8_t v7, int8_t v8, int8_t v9, int8_t v10, int8_t v11,
             int8_t v12, int8_t v13, int8_t v14, int8_t v15) {
@@ -262,22 +262,22 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
   }
 
   // Order-sensitive comparisons
-  simdjson_really_inline simd8<int8_t>
+  simdjson_inline simd8<int8_t>
   max_val(const simd8<int8_t> other) const {
     return (__m128i)vec_max((__vector signed char)this->value,
                             (__vector signed char)(__m128i)other);
   }
-  simdjson_really_inline simd8<int8_t>
+  simdjson_inline simd8<int8_t>
   min_val(const simd8<int8_t> other) const {
     return (__m128i)vec_min((__vector signed char)this->value,
                             (__vector signed char)(__m128i)other);
   }
-  simdjson_really_inline simd8<bool>
+  simdjson_inline simd8<bool>
   operator>(const simd8<int8_t> other) const {
     return (__m128i)vec_cmpgt((__vector signed char)this->value,
                               (__vector signed char)(__m128i)other);
   }
-  simdjson_really_inline simd8<bool>
+  simdjson_inline simd8<bool>
   operator<(const simd8<int8_t> other) const {
     return (__m128i)vec_cmplt((__vector signed char)this->value,
                               (__vector signed char)(__m128i)other);
@@ -286,22 +286,22 @@ template <> struct simd8<int8_t> : base8_numeric<int8_t> {
 
 // Unsigned bytes
 template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
-  simdjson_really_inline simd8() : base8_numeric<uint8_t>() {}
-  simdjson_really_inline simd8(const __m128i _value)
+  simdjson_inline simd8() : base8_numeric<uint8_t>() {}
+  simdjson_inline simd8(const __m128i _value)
       : base8_numeric<uint8_t>(_value) {}
   // Splat constructor
-  simdjson_really_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
+  simdjson_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
   // Array constructor
-  simdjson_really_inline simd8(const uint8_t *values) : simd8(load(values)) {}
+  simdjson_inline simd8(const uint8_t *values) : simd8(load(values)) {}
   // Member-by-member initialization
-  simdjson_really_inline
+  simdjson_inline
   simd8(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3, uint8_t v4, uint8_t v5,
         uint8_t v6, uint8_t v7, uint8_t v8, uint8_t v9, uint8_t v10,
         uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15)
       : simd8((__m128i){v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12,
                         v13, v14, v15}) {}
   // Repeat 16 values as many times as necessary (usually for lookup tables)
-  simdjson_really_inline static simd8<uint8_t>
+  simdjson_inline static simd8<uint8_t>
   repeat_16(uint8_t v0, uint8_t v1, uint8_t v2, uint8_t v3, uint8_t v4,
             uint8_t v5, uint8_t v6, uint8_t v7, uint8_t v8, uint8_t v9,
             uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14,
@@ -311,82 +311,82 @@ template <> struct simd8<uint8_t> : base8_numeric<uint8_t> {
   }
 
   // Saturated math
-  simdjson_really_inline simd8<uint8_t>
+  simdjson_inline simd8<uint8_t>
   saturating_add(const simd8<uint8_t> other) const {
     return (__m128i)vec_adds(this->value, (__m128i)other);
   }
-  simdjson_really_inline simd8<uint8_t>
+  simdjson_inline simd8<uint8_t>
   saturating_sub(const simd8<uint8_t> other) const {
     return (__m128i)vec_subs(this->value, (__m128i)other);
   }
 
   // Order-specific operations
-  simdjson_really_inline simd8<uint8_t>
+  simdjson_inline simd8<uint8_t>
   max_val(const simd8<uint8_t> other) const {
     return (__m128i)vec_max(this->value, (__m128i)other);
   }
-  simdjson_really_inline simd8<uint8_t>
+  simdjson_inline simd8<uint8_t>
   min_val(const simd8<uint8_t> other) const {
     return (__m128i)vec_min(this->value, (__m128i)other);
   }
   // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-  simdjson_really_inline simd8<uint8_t>
+  simdjson_inline simd8<uint8_t>
   gt_bits(const simd8<uint8_t> other) const {
     return this->saturating_sub(other);
   }
   // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-  simdjson_really_inline simd8<uint8_t>
+  simdjson_inline simd8<uint8_t>
   lt_bits(const simd8<uint8_t> other) const {
     return other.saturating_sub(*this);
   }
-  simdjson_really_inline simd8<bool>
+  simdjson_inline simd8<bool>
   operator<=(const simd8<uint8_t> other) const {
     return other.max_val(*this) == other;
   }
-  simdjson_really_inline simd8<bool>
+  simdjson_inline simd8<bool>
   operator>=(const simd8<uint8_t> other) const {
     return other.min_val(*this) == other;
   }
-  simdjson_really_inline simd8<bool>
+  simdjson_inline simd8<bool>
   operator>(const simd8<uint8_t> other) const {
     return this->gt_bits(other).any_bits_set();
   }
-  simdjson_really_inline simd8<bool>
+  simdjson_inline simd8<bool>
   operator<(const simd8<uint8_t> other) const {
     return this->gt_bits(other).any_bits_set();
   }
 
   // Bit-specific operations
-  simdjson_really_inline simd8<bool> bits_not_set() const {
+  simdjson_inline simd8<bool> bits_not_set() const {
     return (__m128i)vec_cmpeq(this->value, (__m128i)vec_splats(uint8_t(0)));
   }
-  simdjson_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const {
+  simdjson_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const {
     return (*this & bits).bits_not_set();
   }
-  simdjson_really_inline simd8<bool> any_bits_set() const {
+  simdjson_inline simd8<bool> any_bits_set() const {
     return ~this->bits_not_set();
   }
-  simdjson_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const {
+  simdjson_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const {
     return ~this->bits_not_set(bits);
   }
-  simdjson_really_inline bool bits_not_set_anywhere() const {
+  simdjson_inline bool bits_not_set_anywhere() const {
     return vec_all_eq(this->value, (__m128i)vec_splats(0));
   }
-  simdjson_really_inline bool any_bits_set_anywhere() const {
+  simdjson_inline bool any_bits_set_anywhere() const {
     return !bits_not_set_anywhere();
   }
-  simdjson_really_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const {
+  simdjson_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const {
     return vec_all_eq(vec_and(this->value, (__m128i)bits),
                       (__m128i)vec_splats(0));
   }
-  simdjson_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
+  simdjson_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const {
     return !bits_not_set_anywhere(bits);
   }
-  template <int N> simdjson_really_inline simd8<uint8_t> shr() const {
+  template <int N> simdjson_inline simd8<uint8_t> shr() const {
     return simd8<uint8_t>(
         (__m128i)vec_sr(this->value, (__m128i)vec_splat_u8(N)));
   }
-  template <int N> simdjson_really_inline simd8<uint8_t> shl() const {
+  template <int N> simdjson_inline simd8<uint8_t> shl() const {
     return simd8<uint8_t>(
         (__m128i)vec_sl(this->value, (__m128i)vec_splat_u8(N)));
   }
@@ -403,26 +403,26 @@ template <typename T> struct simd8x64 {
   operator=(const simd8<T>& other) = delete; // no assignment allowed
   simd8x64() = delete;                      // no default constructor allowed
 
-  simdjson_really_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1,
+  simdjson_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1,
                                   const simd8<T> chunk2, const simd8<T> chunk3)
       : chunks{chunk0, chunk1, chunk2, chunk3} {}
-  simdjson_really_inline simd8x64(const T ptr[64])
+  simdjson_inline simd8x64(const T ptr[64])
       : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr + 16),
                simd8<T>::load(ptr + 32), simd8<T>::load(ptr + 48)} {}
 
-  simdjson_really_inline void store(T ptr[64]) const {
+  simdjson_inline void store(T ptr[64]) const {
     this->chunks[0].store(ptr + sizeof(simd8<T>) * 0);
     this->chunks[1].store(ptr + sizeof(simd8<T>) * 1);
     this->chunks[2].store(ptr + sizeof(simd8<T>) * 2);
     this->chunks[3].store(ptr + sizeof(simd8<T>) * 3);
   }
 
-  simdjson_really_inline simd8<T> reduce_or() const {
+  simdjson_inline simd8<T> reduce_or() const {
     return (this->chunks[0] | this->chunks[1]) |
            (this->chunks[2] | this->chunks[3]);
   }
 
-  simdjson_really_inline uint64_t compress(uint64_t mask, T *output) const {
+  simdjson_inline uint64_t compress(uint64_t mask, T *output) const {
     this->chunks[0].compress(uint16_t(mask), output);
     this->chunks[1].compress(uint16_t(mask >> 16),
                              output + 16 - count_ones(mask & 0xFFFF));
@@ -433,7 +433,7 @@ template <typename T> struct simd8x64 {
     return 64 - count_ones(mask);
   }
 
-  simdjson_really_inline uint64_t to_bitmask() const {
+  simdjson_inline uint64_t to_bitmask() const {
     uint64_t r0 = uint32_t(this->chunks[0].to_bitmask());
     uint64_t r1 = this->chunks[1].to_bitmask();
     uint64_t r2 = this->chunks[2].to_bitmask();
@@ -441,14 +441,14 @@ template <typename T> struct simd8x64 {
     return r0 | (r1 << 16) | (r2 << 32) | (r3 << 48);
   }
 
-  simdjson_really_inline uint64_t eq(const T m) const {
+  simdjson_inline uint64_t eq(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] == mask, this->chunks[1] == mask,
                           this->chunks[2] == mask, this->chunks[3] == mask)
         .to_bitmask();
   }
 
-  simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
+  simdjson_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
     return simd8x64<bool>(this->chunks[0] == other.chunks[0],
                           this->chunks[1] == other.chunks[1],
                           this->chunks[2] == other.chunks[2],
@@ -456,7 +456,7 @@ template <typename T> struct simd8x64 {
         .to_bitmask();
   }
 
-  simdjson_really_inline uint64_t lteq(const T m) const {
+  simdjson_inline uint64_t lteq(const T m) const {
     const simd8<T> mask = simd8<T>::splat(m);
     return simd8x64<bool>(this->chunks[0] <= mask, this->chunks[1] <= mask,
                           this->chunks[2] <= mask, this->chunks[3] <= mask)

--- a/include/simdjson/ppc64/stringparsing.h
+++ b/include/simdjson/ppc64/stringparsing.h
@@ -15,17 +15,17 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_really_inline static backslash_and_quote
+  simdjson_inline static backslash_and_quote
   copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_really_inline bool has_quote_first() {
+  simdjson_inline bool has_quote_first() {
     return ((bs_bits - 1) & quote_bits) != 0;
   }
-  simdjson_really_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_really_inline int quote_index() {
+  simdjson_inline bool has_backslash() { return bs_bits != 0; }
+  simdjson_inline int quote_index() {
     return trailing_zeroes(quote_bits);
   }
-  simdjson_really_inline int backslash_index() {
+  simdjson_inline int backslash_index() {
     return trailing_zeroes(bs_bits);
   }
 
@@ -33,7 +33,7 @@ public:
   uint32_t quote_bits;
 }; // struct backslash_and_quote
 
-simdjson_really_inline backslash_and_quote
+simdjson_inline backslash_and_quote
 backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // this can read up to 31 bytes beyond the buffer size, but we require
   // SIMDJSON_PADDING of padding

--- a/include/simdjson/westmere/bitmanipulation.h
+++ b/include/simdjson/westmere/bitmanipulation.h
@@ -9,7 +9,7 @@ namespace {
 // but the algorithms do not end up using the returned value.
 // Sadly, sanitizers are not smart enough to figure it out.
 SIMDJSON_NO_SANITIZE_UNDEFINED
-simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
+simdjson_inline int trailing_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long ret;
   // Search the mask data from least significant bit (LSB)
@@ -22,12 +22,12 @@ simdjson_really_inline int trailing_zeroes(uint64_t input_num) {
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline uint64_t clear_lowest_bit(uint64_t input_num) {
+simdjson_inline uint64_t clear_lowest_bit(uint64_t input_num) {
   return input_num & (input_num-1);
 }
 
 /* result might be undefined when input_num is zero */
-simdjson_really_inline int leading_zeroes(uint64_t input_num) {
+simdjson_inline int leading_zeroes(uint64_t input_num) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)
@@ -42,17 +42,17 @@ simdjson_really_inline int leading_zeroes(uint64_t input_num) {
 }
 
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
-simdjson_really_inline unsigned __int64 count_ones(uint64_t input_num) {
+simdjson_inline unsigned __int64 count_ones(uint64_t input_num) {
   // note: we do not support legacy 32-bit Windows
   return __popcnt64(input_num);// Visual Studio wants two underscores
 }
 #else
-simdjson_really_inline long long int count_ones(uint64_t input_num) {
+simdjson_inline long long int count_ones(uint64_t input_num) {
   return _popcnt64(input_num);
 }
 #endif
 
-simdjson_really_inline bool add_overflow(uint64_t value1, uint64_t value2,
+simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
                                 uint64_t *result) {
 #ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   return _addcarry_u64(0, value1, value2,

--- a/include/simdjson/westmere/bitmask.h
+++ b/include/simdjson/westmere/bitmask.h
@@ -10,7 +10,7 @@ namespace {
 //
 // For example, prefix_xor(00100100) == 00011100
 //
-simdjson_really_inline uint64_t prefix_xor(const uint64_t bitmask) {
+simdjson_inline uint64_t prefix_xor(const uint64_t bitmask) {
   // There should be no such thing with a processing supporting avx2
   // but not clmul.
   __m128i all_ones = _mm_set1_epi8('\xFF');

--- a/include/simdjson/westmere/implementation.h
+++ b/include/simdjson/westmere/implementation.h
@@ -14,7 +14,7 @@ using namespace simdjson::dom;
 
 class implementation final : public simdjson::implementation {
 public:
-  simdjson_really_inline implementation() : simdjson::implementation("westmere", "Intel/AMD SSE4.2", internal::instruction_set::SSE42 | internal::instruction_set::PCLMULQDQ) {}
+  simdjson_inline implementation() : simdjson::implementation("westmere", "Intel/AMD SSE4.2", internal::instruction_set::SSE42 | internal::instruction_set::PCLMULQDQ) {}
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,

--- a/include/simdjson/westmere/numberparsing.h
+++ b/include/simdjson/westmere/numberparsing.h
@@ -5,7 +5,7 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 
-static simdjson_really_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
+static simdjson_inline uint32_t parse_eight_digits_unrolled(const uint8_t *chars) {
   // this actually computes *16* values so we are being wasteful.
   const __m128i ascii0 = _mm_set1_epi8('0');
   const __m128i mul_1_10 =

--- a/include/simdjson/westmere/simd.h
+++ b/include/simdjson/westmere/simd.h
@@ -13,23 +13,23 @@ namespace simd {
     __m128i value;
 
     // Zero constructor
-    simdjson_really_inline base() : value{__m128i()} {}
+    simdjson_inline base() : value{__m128i()} {}
 
     // Conversion from SIMD register
-    simdjson_really_inline base(const __m128i _value) : value(_value) {}
+    simdjson_inline base(const __m128i _value) : value(_value) {}
 
     // Conversion to SIMD register
-    simdjson_really_inline operator const __m128i&() const { return this->value; }
-    simdjson_really_inline operator __m128i&() { return this->value; }
+    simdjson_inline operator const __m128i&() const { return this->value; }
+    simdjson_inline operator __m128i&() { return this->value; }
 
     // Bit operations
-    simdjson_really_inline Child operator|(const Child other) const { return _mm_or_si128(*this, other); }
-    simdjson_really_inline Child operator&(const Child other) const { return _mm_and_si128(*this, other); }
-    simdjson_really_inline Child operator^(const Child other) const { return _mm_xor_si128(*this, other); }
-    simdjson_really_inline Child bit_andnot(const Child other) const { return _mm_andnot_si128(other, *this); }
-    simdjson_really_inline Child& operator|=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast | other; return *this_cast; }
-    simdjson_really_inline Child& operator&=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast & other; return *this_cast; }
-    simdjson_really_inline Child& operator^=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
+    simdjson_inline Child operator|(const Child other) const { return _mm_or_si128(*this, other); }
+    simdjson_inline Child operator&(const Child other) const { return _mm_and_si128(*this, other); }
+    simdjson_inline Child operator^(const Child other) const { return _mm_xor_si128(*this, other); }
+    simdjson_inline Child bit_andnot(const Child other) const { return _mm_andnot_si128(other, *this); }
+    simdjson_inline Child& operator|=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast | other; return *this_cast; }
+    simdjson_inline Child& operator&=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast & other; return *this_cast; }
+    simdjson_inline Child& operator^=(const Child other) { auto this_cast = static_cast<Child*>(this); *this_cast = *this_cast ^ other; return *this_cast; }
   };
 
   // Forward-declared so they can be used by splat and friends.
@@ -41,15 +41,15 @@ namespace simd {
     typedef uint16_t bitmask_t;
     typedef uint32_t bitmask2_t;
 
-    simdjson_really_inline base8() : base<simd8<T>>() {}
-    simdjson_really_inline base8(const __m128i _value) : base<simd8<T>>(_value) {}
+    simdjson_inline base8() : base<simd8<T>>() {}
+    simdjson_inline base8(const __m128i _value) : base<simd8<T>>(_value) {}
 
-    friend simdjson_really_inline Mask operator==(const simd8<T> lhs, const simd8<T> rhs) { return _mm_cmpeq_epi8(lhs, rhs); }
+    friend simdjson_inline Mask operator==(const simd8<T> lhs, const simd8<T> rhs) { return _mm_cmpeq_epi8(lhs, rhs); }
 
     static const int SIZE = sizeof(base<simd8<T>>::value);
 
     template<int N=1>
-    simdjson_really_inline simd8<T> prev(const simd8<T> prev_chunk) const {
+    simdjson_inline simd8<T> prev(const simd8<T> prev_chunk) const {
       return _mm_alignr_epi8(*this, prev_chunk, 16 - N);
     }
   };
@@ -57,27 +57,27 @@ namespace simd {
   // SIMD byte mask type (returned by things like eq and gt)
   template<>
   struct simd8<bool>: base8<bool> {
-    static simdjson_really_inline simd8<bool> splat(bool _value) { return _mm_set1_epi8(uint8_t(-(!!_value))); }
+    static simdjson_inline simd8<bool> splat(bool _value) { return _mm_set1_epi8(uint8_t(-(!!_value))); }
 
-    simdjson_really_inline simd8<bool>() : base8() {}
-    simdjson_really_inline simd8<bool>(const __m128i _value) : base8<bool>(_value) {}
+    simdjson_inline simd8<bool>() : base8() {}
+    simdjson_inline simd8<bool>(const __m128i _value) : base8<bool>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
+    simdjson_inline simd8<bool>(bool _value) : base8<bool>(splat(_value)) {}
 
-    simdjson_really_inline int to_bitmask() const { return _mm_movemask_epi8(*this); }
-    simdjson_really_inline bool any() const { return !_mm_testz_si128(*this, *this); }
-    simdjson_really_inline simd8<bool> operator~() const { return *this ^ true; }
+    simdjson_inline int to_bitmask() const { return _mm_movemask_epi8(*this); }
+    simdjson_inline bool any() const { return !_mm_testz_si128(*this, *this); }
+    simdjson_inline simd8<bool> operator~() const { return *this ^ true; }
   };
 
   template<typename T>
   struct base8_numeric: base8<T> {
-    static simdjson_really_inline simd8<T> splat(T _value) { return _mm_set1_epi8(_value); }
-    static simdjson_really_inline simd8<T> zero() { return _mm_setzero_si128(); }
-    static simdjson_really_inline simd8<T> load(const T values[16]) {
+    static simdjson_inline simd8<T> splat(T _value) { return _mm_set1_epi8(_value); }
+    static simdjson_inline simd8<T> zero() { return _mm_setzero_si128(); }
+    static simdjson_inline simd8<T> load(const T values[16]) {
       return _mm_loadu_si128(reinterpret_cast<const __m128i *>(values));
     }
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    static simdjson_really_inline simd8<T> repeat_16(
+    static simdjson_inline simd8<T> repeat_16(
       T v0,  T v1,  T v2,  T v3,  T v4,  T v5,  T v6,  T v7,
       T v8,  T v9,  T v10, T v11, T v12, T v13, T v14, T v15
     ) {
@@ -87,24 +87,24 @@ namespace simd {
       );
     }
 
-    simdjson_really_inline base8_numeric() : base8<T>() {}
-    simdjson_really_inline base8_numeric(const __m128i _value) : base8<T>(_value) {}
+    simdjson_inline base8_numeric() : base8<T>() {}
+    simdjson_inline base8_numeric(const __m128i _value) : base8<T>(_value) {}
 
     // Store to array
-    simdjson_really_inline void store(T dst[16]) const { return _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), *this); }
+    simdjson_inline void store(T dst[16]) const { return _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), *this); }
 
     // Override to distinguish from bool version
-    simdjson_really_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
+    simdjson_inline simd8<T> operator~() const { return *this ^ 0xFFu; }
 
     // Addition/subtraction are the same for signed and unsigned
-    simdjson_really_inline simd8<T> operator+(const simd8<T> other) const { return _mm_add_epi8(*this, other); }
-    simdjson_really_inline simd8<T> operator-(const simd8<T> other) const { return _mm_sub_epi8(*this, other); }
-    simdjson_really_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *static_cast<simd8<T>*>(this); }
-    simdjson_really_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *static_cast<simd8<T>*>(this); }
+    simdjson_inline simd8<T> operator+(const simd8<T> other) const { return _mm_add_epi8(*this, other); }
+    simdjson_inline simd8<T> operator-(const simd8<T> other) const { return _mm_sub_epi8(*this, other); }
+    simdjson_inline simd8<T>& operator+=(const simd8<T> other) { *this = *this + other; return *static_cast<simd8<T>*>(this); }
+    simdjson_inline simd8<T>& operator-=(const simd8<T> other) { *this = *this - other; return *static_cast<simd8<T>*>(this); }
 
     // Perform a lookup assuming the value is between 0 and 16 (undefined behavior for out of range values)
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
+    simdjson_inline simd8<L> lookup_16(simd8<L> lookup_table) const {
       return _mm_shuffle_epi8(lookup_table, *this);
     }
 
@@ -116,7 +116,7 @@ namespace simd {
     // signature simd8<L> compress(uint32_t mask) would be
     // sensible, but the AVX ISA makes this kind of approach difficult.
     template<typename L>
-    simdjson_really_inline void compress(uint16_t mask, L * output) const {
+    simdjson_inline void compress(uint16_t mask, L * output) const {
       using internal::thintable_epi8;
       using internal::BitsSetTable256mul2;
       using internal::pshufb_combine_table;
@@ -147,7 +147,7 @@ namespace simd {
     }
 
     template<typename L>
-    simdjson_really_inline simd8<L> lookup_16(
+    simdjson_inline simd8<L> lookup_16(
         L replace0,  L replace1,  L replace2,  L replace3,
         L replace4,  L replace5,  L replace6,  L replace7,
         L replace8,  L replace9,  L replace10, L replace11,
@@ -164,14 +164,14 @@ namespace simd {
   // Signed bytes
   template<>
   struct simd8<int8_t> : base8_numeric<int8_t> {
-    simdjson_really_inline simd8() : base8_numeric<int8_t>() {}
-    simdjson_really_inline simd8(const __m128i _value) : base8_numeric<int8_t>(_value) {}
+    simdjson_inline simd8() : base8_numeric<int8_t>() {}
+    simdjson_inline simd8(const __m128i _value) : base8_numeric<int8_t>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8(int8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(int8_t _value) : simd8(splat(_value)) {}
     // Array constructor
-    simdjson_really_inline simd8(const int8_t* values) : simd8(load(values)) {}
+    simdjson_inline simd8(const int8_t* values) : simd8(load(values)) {}
     // Member-by-member initialization
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3,  int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15
     ) : simd8(_mm_setr_epi8(
@@ -179,7 +179,7 @@ namespace simd {
       v8, v9, v10,v11,v12,v13,v14,v15
     )) {}
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<int8_t> repeat_16(
+    simdjson_inline static simd8<int8_t> repeat_16(
       int8_t v0,  int8_t v1,  int8_t v2,  int8_t v3,  int8_t v4,  int8_t v5,  int8_t v6,  int8_t v7,
       int8_t v8,  int8_t v9,  int8_t v10, int8_t v11, int8_t v12, int8_t v13, int8_t v14, int8_t v15
     ) {
@@ -190,23 +190,23 @@ namespace simd {
     }
 
     // Order-sensitive comparisons
-    simdjson_really_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return _mm_max_epi8(*this, other); }
-    simdjson_really_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return _mm_min_epi8(*this, other); }
-    simdjson_really_inline simd8<bool> operator>(const simd8<int8_t> other) const { return _mm_cmpgt_epi8(*this, other); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<int8_t> other) const { return _mm_cmpgt_epi8(other, *this); }
+    simdjson_inline simd8<int8_t> max_val(const simd8<int8_t> other) const { return _mm_max_epi8(*this, other); }
+    simdjson_inline simd8<int8_t> min_val(const simd8<int8_t> other) const { return _mm_min_epi8(*this, other); }
+    simdjson_inline simd8<bool> operator>(const simd8<int8_t> other) const { return _mm_cmpgt_epi8(*this, other); }
+    simdjson_inline simd8<bool> operator<(const simd8<int8_t> other) const { return _mm_cmpgt_epi8(other, *this); }
   };
 
   // Unsigned bytes
   template<>
   struct simd8<uint8_t>: base8_numeric<uint8_t> {
-    simdjson_really_inline simd8() : base8_numeric<uint8_t>() {}
-    simdjson_really_inline simd8(const __m128i _value) : base8_numeric<uint8_t>(_value) {}
+    simdjson_inline simd8() : base8_numeric<uint8_t>() {}
+    simdjson_inline simd8(const __m128i _value) : base8_numeric<uint8_t>(_value) {}
     // Splat constructor
-    simdjson_really_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
+    simdjson_inline simd8(uint8_t _value) : simd8(splat(_value)) {}
     // Array constructor
-    simdjson_really_inline simd8(const uint8_t* values) : simd8(load(values)) {}
+    simdjson_inline simd8(const uint8_t* values) : simd8(load(values)) {}
     // Member-by-member initialization
-    simdjson_really_inline simd8(
+    simdjson_inline simd8(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15
     ) : simd8(_mm_setr_epi8(
@@ -214,7 +214,7 @@ namespace simd {
       v8, v9, v10,v11,v12,v13,v14,v15
     )) {}
     // Repeat 16 values as many times as necessary (usually for lookup tables)
-    simdjson_really_inline static simd8<uint8_t> repeat_16(
+    simdjson_inline static simd8<uint8_t> repeat_16(
       uint8_t v0,  uint8_t v1,  uint8_t v2,  uint8_t v3,  uint8_t v4,  uint8_t v5,  uint8_t v6,  uint8_t v7,
       uint8_t v8,  uint8_t v9,  uint8_t v10, uint8_t v11, uint8_t v12, uint8_t v13, uint8_t v14, uint8_t v15
     ) {
@@ -225,39 +225,39 @@ namespace simd {
     }
 
     // Saturated math
-    simdjson_really_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return _mm_adds_epu8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return _mm_subs_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_add(const simd8<uint8_t> other) const { return _mm_adds_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> saturating_sub(const simd8<uint8_t> other) const { return _mm_subs_epu8(*this, other); }
 
     // Order-specific operations
-    simdjson_really_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return _mm_max_epu8(*this, other); }
-    simdjson_really_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return _mm_min_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> max_val(const simd8<uint8_t> other) const { return _mm_max_epu8(*this, other); }
+    simdjson_inline simd8<uint8_t> min_val(const simd8<uint8_t> other) const { return _mm_min_epu8(*this, other); }
     // Same as >, but only guarantees true is nonzero (< guarantees true = -1)
-    simdjson_really_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return this->saturating_sub(other); }
+    simdjson_inline simd8<uint8_t> gt_bits(const simd8<uint8_t> other) const { return this->saturating_sub(other); }
     // Same as <, but only guarantees true is nonzero (< guarantees true = -1)
-    simdjson_really_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return other.saturating_sub(*this); }
-    simdjson_really_inline simd8<bool> operator<=(const simd8<uint8_t> other) const { return other.max_val(*this) == other; }
-    simdjson_really_inline simd8<bool> operator>=(const simd8<uint8_t> other) const { return other.min_val(*this) == other; }
-    simdjson_really_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
-    simdjson_really_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
+    simdjson_inline simd8<uint8_t> lt_bits(const simd8<uint8_t> other) const { return other.saturating_sub(*this); }
+    simdjson_inline simd8<bool> operator<=(const simd8<uint8_t> other) const { return other.max_val(*this) == other; }
+    simdjson_inline simd8<bool> operator>=(const simd8<uint8_t> other) const { return other.min_val(*this) == other; }
+    simdjson_inline simd8<bool> operator>(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
+    simdjson_inline simd8<bool> operator<(const simd8<uint8_t> other) const { return this->gt_bits(other).any_bits_set(); }
 
     // Bit-specific operations
-    simdjson_really_inline simd8<bool> bits_not_set() const { return *this == uint8_t(0); }
-    simdjson_really_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const { return (*this & bits).bits_not_set(); }
-    simdjson_really_inline simd8<bool> any_bits_set() const { return ~this->bits_not_set(); }
-    simdjson_really_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return ~this->bits_not_set(bits); }
-    simdjson_really_inline bool is_ascii() const { return _mm_movemask_epi8(*this) == 0; }
-    simdjson_really_inline bool bits_not_set_anywhere() const { return _mm_testz_si128(*this, *this); }
-    simdjson_really_inline bool any_bits_set_anywhere() const { return !bits_not_set_anywhere(); }
-    simdjson_really_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const { return _mm_testz_si128(*this, bits); }
-    simdjson_really_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return !bits_not_set_anywhere(bits); }
+    simdjson_inline simd8<bool> bits_not_set() const { return *this == uint8_t(0); }
+    simdjson_inline simd8<bool> bits_not_set(simd8<uint8_t> bits) const { return (*this & bits).bits_not_set(); }
+    simdjson_inline simd8<bool> any_bits_set() const { return ~this->bits_not_set(); }
+    simdjson_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return ~this->bits_not_set(bits); }
+    simdjson_inline bool is_ascii() const { return _mm_movemask_epi8(*this) == 0; }
+    simdjson_inline bool bits_not_set_anywhere() const { return _mm_testz_si128(*this, *this); }
+    simdjson_inline bool any_bits_set_anywhere() const { return !bits_not_set_anywhere(); }
+    simdjson_inline bool bits_not_set_anywhere(simd8<uint8_t> bits) const { return _mm_testz_si128(*this, bits); }
+    simdjson_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return !bits_not_set_anywhere(bits); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shr() const { return simd8<uint8_t>(_mm_srli_epi16(*this, N)) & uint8_t(0xFFu >> N); }
+    simdjson_inline simd8<uint8_t> shr() const { return simd8<uint8_t>(_mm_srli_epi16(*this, N)) & uint8_t(0xFFu >> N); }
     template<int N>
-    simdjson_really_inline simd8<uint8_t> shl() const { return simd8<uint8_t>(_mm_slli_epi16(*this, N)) & uint8_t(0xFFu << N); }
+    simdjson_inline simd8<uint8_t> shl() const { return simd8<uint8_t>(_mm_slli_epi16(*this, N)) & uint8_t(0xFFu << N); }
     // Get one of the bits and make a bitmask out of it.
     // e.g. value.get_bit<7>() gets the high bit
     template<int N>
-    simdjson_really_inline int get_bit() const { return _mm_movemask_epi8(_mm_slli_epi16(*this, 7-N)); }
+    simdjson_inline int get_bit() const { return _mm_movemask_epi8(_mm_slli_epi16(*this, 7-N)); }
   };
 
   template<typename T>
@@ -270,21 +270,21 @@ namespace simd {
     simd8x64<T>& operator=(const simd8<T>& other) = delete; // no assignment allowed
     simd8x64() = delete; // no default constructor allowed
 
-    simdjson_really_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1, const simd8<T> chunk2, const simd8<T> chunk3) : chunks{chunk0, chunk1, chunk2, chunk3} {}
-    simdjson_really_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+16), simd8<T>::load(ptr+32), simd8<T>::load(ptr+48)} {}
+    simdjson_inline simd8x64(const simd8<T> chunk0, const simd8<T> chunk1, const simd8<T> chunk2, const simd8<T> chunk3) : chunks{chunk0, chunk1, chunk2, chunk3} {}
+    simdjson_inline simd8x64(const T ptr[64]) : chunks{simd8<T>::load(ptr), simd8<T>::load(ptr+16), simd8<T>::load(ptr+32), simd8<T>::load(ptr+48)} {}
 
-    simdjson_really_inline void store(T ptr[64]) const {
+    simdjson_inline void store(T ptr[64]) const {
       this->chunks[0].store(ptr+sizeof(simd8<T>)*0);
       this->chunks[1].store(ptr+sizeof(simd8<T>)*1);
       this->chunks[2].store(ptr+sizeof(simd8<T>)*2);
       this->chunks[3].store(ptr+sizeof(simd8<T>)*3);
     }
 
-    simdjson_really_inline simd8<T> reduce_or() const {
+    simdjson_inline simd8<T> reduce_or() const {
       return (this->chunks[0] | this->chunks[1]) | (this->chunks[2] | this->chunks[3]);
     }
 
-    simdjson_really_inline uint64_t compress(uint64_t mask, T * output) const {
+    simdjson_inline uint64_t compress(uint64_t mask, T * output) const {
       this->chunks[0].compress(uint16_t(mask), output);
       this->chunks[1].compress(uint16_t(mask >> 16), output + 16 - count_ones(mask & 0xFFFF));
       this->chunks[2].compress(uint16_t(mask >> 32), output + 32 - count_ones(mask & 0xFFFFFFFF));
@@ -292,7 +292,7 @@ namespace simd {
       return 64 - count_ones(mask);
     }
 
-    simdjson_really_inline uint64_t to_bitmask() const {
+    simdjson_inline uint64_t to_bitmask() const {
       uint64_t r0 = uint32_t(this->chunks[0].to_bitmask() );
       uint64_t r1 =          this->chunks[1].to_bitmask() ;
       uint64_t r2 =          this->chunks[2].to_bitmask() ;
@@ -300,7 +300,7 @@ namespace simd {
       return r0 | (r1 << 16) | (r2 << 32) | (r3 << 48);
     }
 
-    simdjson_really_inline uint64_t eq(const T m) const {
+    simdjson_inline uint64_t eq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(
         this->chunks[0] == mask,
@@ -310,7 +310,7 @@ namespace simd {
       ).to_bitmask();
     }
 
-    simdjson_really_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
+    simdjson_inline uint64_t eq(const simd8x64<uint8_t> &other) const {
       return  simd8x64<bool>(
         this->chunks[0] == other.chunks[0],
         this->chunks[1] == other.chunks[1],
@@ -319,7 +319,7 @@ namespace simd {
       ).to_bitmask();
     }
 
-    simdjson_really_inline uint64_t lteq(const T m) const {
+    simdjson_inline uint64_t lteq(const T m) const {
       const simd8<T> mask = simd8<T>::splat(m);
       return  simd8x64<bool>(
         this->chunks[0] <= mask,

--- a/include/simdjson/westmere/stringparsing.h
+++ b/include/simdjson/westmere/stringparsing.h
@@ -11,18 +11,18 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_really_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_really_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_really_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_really_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_really_inline int backslash_index() { return trailing_zeroes(bs_bits); }
+  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
+  simdjson_inline bool has_backslash() { return bs_bits != 0; }
+  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
+  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
 
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote
 
-simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
+simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // this can read up to 31 bytes beyond the buffer size, but we require
   // SIMDJSON_PADDING of padding
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");

--- a/src/arm64/dom_parser_implementation.cpp
+++ b/src/arm64/dom_parser_implementation.cpp
@@ -10,17 +10,17 @@ namespace {
 using namespace simd;
 
 struct json_character_block {
-  static simdjson_really_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
+  static simdjson_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
 
-  simdjson_really_inline uint64_t whitespace() const noexcept { return _whitespace; }
-  simdjson_really_inline uint64_t op() const noexcept { return _op; }
-  simdjson_really_inline uint64_t scalar() const noexcept { return ~(op() | whitespace()); }
+  simdjson_inline uint64_t whitespace() const noexcept { return _whitespace; }
+  simdjson_inline uint64_t op() const noexcept { return _op; }
+  simdjson_inline uint64_t scalar() const noexcept { return ~(op() | whitespace()); }
 
   uint64_t _whitespace;
   uint64_t _op;
 };
 
-simdjson_really_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
+simdjson_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
   // Functional programming causes trouble with Visual Studio.
   // Keeping this version in comments since it is much nicer:
   // auto v = in.map<uint8_t>([&](simd8<uint8_t> chunk) {
@@ -74,12 +74,12 @@ simdjson_really_inline json_character_block json_character_block::classify(const
   return { whitespace, op };
 }
 
-simdjson_really_inline bool is_ascii(const simd8x64<uint8_t>& input) {
+simdjson_inline bool is_ascii(const simd8x64<uint8_t>& input) {
     simd8<uint8_t> bits = input.reduce_or();
     return bits.max_val() < 0x80u;
 }
 
-simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_unused simdjson_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
     simd8<bool> is_second_byte = prev1 >= uint8_t(0xc0u);
     simd8<bool> is_third_byte  = prev2 >= uint8_t(0xe0u);
     simd8<bool> is_fourth_byte = prev3 >= uint8_t(0xf0u);
@@ -91,7 +91,7 @@ simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const si
     return is_second_byte ^ is_third_byte ^ is_fourth_byte;
 }
 
-simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
     simd8<bool> is_third_byte  = prev2 >= uint8_t(0xe0u);
     simd8<bool> is_fourth_byte = prev3 >= uint8_t(0xf0u);
     return is_third_byte ^ is_fourth_byte;
@@ -120,7 +120,7 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 namespace stage1 {
 
-simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+simdjson_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
   // On ARM, we don't short-circuit this if there are no backslashes, because the branch gives us no
   // benefit and therefore makes things worse.
   // if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }

--- a/src/fallback/dom_parser_implementation.cpp
+++ b/src/fallback/dom_parser_implementation.cpp
@@ -13,7 +13,7 @@ namespace stage1 {
 class structural_scanner {
 public:
 
-simdjson_really_inline structural_scanner(dom_parser_implementation &_parser, stage1_mode _partial)
+simdjson_inline structural_scanner(dom_parser_implementation &_parser, stage1_mode _partial)
   : buf{_parser.buf},
     next_structural_index{_parser.structural_indexes.get()},
     parser{_parser},
@@ -21,16 +21,16 @@ simdjson_really_inline structural_scanner(dom_parser_implementation &_parser, st
     partial{_partial} {
 }
 
-simdjson_really_inline void add_structural() {
+simdjson_inline void add_structural() {
   *next_structural_index = idx;
   next_structural_index++;
 }
 
-simdjson_really_inline bool is_continuation(uint8_t c) {
+simdjson_inline bool is_continuation(uint8_t c) {
   return (c & 0xc0) == 0x80;
 }
 
-simdjson_really_inline void validate_utf8_character() {
+simdjson_inline void validate_utf8_character() {
   // Continuation
   if (simdjson_unlikely((buf[idx] & 0x40) == 0)) {
     // extra continuation
@@ -92,7 +92,7 @@ simdjson_really_inline void validate_utf8_character() {
 }
 
 // Returns true if the string is unclosed.
-simdjson_really_inline bool validate_string() {
+simdjson_inline bool validate_string() {
   idx++; // skip first quote
   while (idx < len && buf[idx] != '"') {
     if (buf[idx] == '\\') {
@@ -108,7 +108,7 @@ simdjson_really_inline bool validate_string() {
   return false;
 }
 
-simdjson_really_inline bool is_whitespace_or_operator(uint8_t c) {
+simdjson_inline bool is_whitespace_or_operator(uint8_t c) {
   switch (c) {
     case '{': case '}': case '[': case ']': case ',': case ':':
     case ' ': case '\r': case '\n': case '\t':
@@ -121,7 +121,7 @@ simdjson_really_inline bool is_whitespace_or_operator(uint8_t c) {
 //
 // Parse the entire input in STEP_SIZE-byte chunks.
 //
-simdjson_really_inline error_code scan() {
+simdjson_inline error_code scan() {
   bool unclosed_string = false;
   for (;idx<len;idx++) {
     switch (buf[idx]) {

--- a/src/generic/stage1/buf_block_reader.h
+++ b/src/generic/stage1/buf_block_reader.h
@@ -6,10 +6,10 @@ namespace {
 template<size_t STEP_SIZE>
 struct buf_block_reader {
 public:
-  simdjson_really_inline buf_block_reader(const uint8_t *_buf, size_t _len);
-  simdjson_really_inline size_t block_index();
-  simdjson_really_inline bool has_full_block() const;
-  simdjson_really_inline const uint8_t *full_block() const;
+  simdjson_inline buf_block_reader(const uint8_t *_buf, size_t _len);
+  simdjson_inline size_t block_index();
+  simdjson_inline bool has_full_block() const;
+  simdjson_inline const uint8_t *full_block() const;
   /**
    * Get the last block, padded with spaces.
    *
@@ -19,8 +19,8 @@ public:
    *
    * @return the number of effective characters in the last block.
    */
-  simdjson_really_inline size_t get_remainder(uint8_t *dst) const;
-  simdjson_really_inline void advance();
+  simdjson_inline size_t get_remainder(uint8_t *dst) const;
+  simdjson_inline void advance();
 private:
   const uint8_t *buf;
   const size_t len;
@@ -59,23 +59,23 @@ simdjson_unused static char * format_mask(uint64_t mask) {
 }
 
 template<size_t STEP_SIZE>
-simdjson_really_inline buf_block_reader<STEP_SIZE>::buf_block_reader(const uint8_t *_buf, size_t _len) : buf{_buf}, len{_len}, lenminusstep{len < STEP_SIZE ? 0 : len - STEP_SIZE}, idx{0} {}
+simdjson_inline buf_block_reader<STEP_SIZE>::buf_block_reader(const uint8_t *_buf, size_t _len) : buf{_buf}, len{_len}, lenminusstep{len < STEP_SIZE ? 0 : len - STEP_SIZE}, idx{0} {}
 
 template<size_t STEP_SIZE>
-simdjson_really_inline size_t buf_block_reader<STEP_SIZE>::block_index() { return idx; }
+simdjson_inline size_t buf_block_reader<STEP_SIZE>::block_index() { return idx; }
 
 template<size_t STEP_SIZE>
-simdjson_really_inline bool buf_block_reader<STEP_SIZE>::has_full_block() const {
+simdjson_inline bool buf_block_reader<STEP_SIZE>::has_full_block() const {
   return idx < lenminusstep;
 }
 
 template<size_t STEP_SIZE>
-simdjson_really_inline const uint8_t *buf_block_reader<STEP_SIZE>::full_block() const {
+simdjson_inline const uint8_t *buf_block_reader<STEP_SIZE>::full_block() const {
   return &buf[idx];
 }
 
 template<size_t STEP_SIZE>
-simdjson_really_inline size_t buf_block_reader<STEP_SIZE>::get_remainder(uint8_t *dst) const {
+simdjson_inline size_t buf_block_reader<STEP_SIZE>::get_remainder(uint8_t *dst) const {
   if(len == idx) { return 0; } // memcpy(dst, null, 0) will trigger an error with some sanitizers
   std::memset(dst, 0x20, STEP_SIZE); // std::memset STEP_SIZE because it's more efficient to write out 8 or 16 bytes at once.
   std::memcpy(dst, buf + idx, len - idx);
@@ -83,7 +83,7 @@ simdjson_really_inline size_t buf_block_reader<STEP_SIZE>::get_remainder(uint8_t
 }
 
 template<size_t STEP_SIZE>
-simdjson_really_inline void buf_block_reader<STEP_SIZE>::advance() {
+simdjson_inline void buf_block_reader<STEP_SIZE>::advance() {
   idx += STEP_SIZE;
 }
 

--- a/src/generic/stage1/find_next_document_index.h
+++ b/src/generic/stage1/find_next_document_index.h
@@ -27,7 +27,7 @@ namespace {
   * complete document, therefore the last json buffer location is the end of the
   * batch.
   */
-simdjson_really_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
+simdjson_inline uint32_t find_next_document_index(dom_parser_implementation &parser) {
   // Variant: do not count separately, just figure out depth
   if(parser.n_structural_indexes == 0) { return 0; }
   auto arr_cnt = 0;

--- a/src/generic/stage1/json_minifier.h
+++ b/src/generic/stage1/json_minifier.h
@@ -14,23 +14,23 @@ public:
   static error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) noexcept;
 
 private:
-  simdjson_really_inline json_minifier(uint8_t *_dst)
+  simdjson_inline json_minifier(uint8_t *_dst)
   : dst{_dst}
   {}
   template<size_t STEP_SIZE>
-  simdjson_really_inline void step(const uint8_t *block_buf, buf_block_reader<STEP_SIZE> &reader) noexcept;
-  simdjson_really_inline void next(const simd::simd8x64<uint8_t>& in, const json_block& block);
-  simdjson_really_inline error_code finish(uint8_t *dst_start, size_t &dst_len);
+  simdjson_inline void step(const uint8_t *block_buf, buf_block_reader<STEP_SIZE> &reader) noexcept;
+  simdjson_inline void next(const simd::simd8x64<uint8_t>& in, const json_block& block);
+  simdjson_inline error_code finish(uint8_t *dst_start, size_t &dst_len);
   json_scanner scanner{};
   uint8_t *dst;
 };
 
-simdjson_really_inline void json_minifier::next(const simd::simd8x64<uint8_t>& in, const json_block& block) {
+simdjson_inline void json_minifier::next(const simd::simd8x64<uint8_t>& in, const json_block& block) {
   uint64_t mask = block.whitespace();
   dst += in.compress(mask, dst);
 }
 
-simdjson_really_inline error_code json_minifier::finish(uint8_t *dst_start, size_t &dst_len) {
+simdjson_inline error_code json_minifier::finish(uint8_t *dst_start, size_t &dst_len) {
   error_code error = scanner.finish();
   if (error) { dst_len = 0; return error; }
   dst_len = dst - dst_start;
@@ -38,7 +38,7 @@ simdjson_really_inline error_code json_minifier::finish(uint8_t *dst_start, size
 }
 
 template<>
-simdjson_really_inline void json_minifier::step<128>(const uint8_t *block_buf, buf_block_reader<128> &reader) noexcept {
+simdjson_inline void json_minifier::step<128>(const uint8_t *block_buf, buf_block_reader<128> &reader) noexcept {
   simd::simd8x64<uint8_t> in_1(block_buf);
   simd::simd8x64<uint8_t> in_2(block_buf+64);
   json_block block_1 = scanner.next(in_1);
@@ -49,7 +49,7 @@ simdjson_really_inline void json_minifier::step<128>(const uint8_t *block_buf, b
 }
 
 template<>
-simdjson_really_inline void json_minifier::step<64>(const uint8_t *block_buf, buf_block_reader<64> &reader) noexcept {
+simdjson_inline void json_minifier::step<64>(const uint8_t *block_buf, buf_block_reader<64> &reader) noexcept {
   simd::simd8x64<uint8_t> in_1(block_buf);
   json_block block_1 = scanner.next(in_1);
   this->next(block_buf, block_1);

--- a/src/generic/stage1/json_scanner.h
+++ b/src/generic/stage1/json_scanner.h
@@ -23,25 +23,25 @@ namespace stage1 {
 struct json_block {
 public:
   // We spell out the constructors in the hope of resolving inlining issues with Visual Studio 2017
-  simdjson_really_inline json_block(json_string_block&& string, json_character_block characters, uint64_t follows_potential_nonquote_scalar) :
+  simdjson_inline json_block(json_string_block&& string, json_character_block characters, uint64_t follows_potential_nonquote_scalar) :
   _string(std::move(string)), _characters(characters), _follows_potential_nonquote_scalar(follows_potential_nonquote_scalar) {}
-  simdjson_really_inline json_block(json_string_block string, json_character_block characters, uint64_t follows_potential_nonquote_scalar) :
+  simdjson_inline json_block(json_string_block string, json_character_block characters, uint64_t follows_potential_nonquote_scalar) :
   _string(string), _characters(characters), _follows_potential_nonquote_scalar(follows_potential_nonquote_scalar) {}
 
   /**
    * The start of structurals.
    * In simdjson prior to v0.3, these were called the pseudo-structural characters.
    **/
-  simdjson_really_inline uint64_t structural_start() const noexcept { return potential_structural_start() & ~_string.string_tail(); }
+  simdjson_inline uint64_t structural_start() const noexcept { return potential_structural_start() & ~_string.string_tail(); }
   /** All JSON whitespace (i.e. not in a string) */
-  simdjson_really_inline uint64_t whitespace() const noexcept { return non_quote_outside_string(_characters.whitespace()); }
+  simdjson_inline uint64_t whitespace() const noexcept { return non_quote_outside_string(_characters.whitespace()); }
 
   // Helpers
 
   /** Whether the given characters are inside a string (only works on non-quotes) */
-  simdjson_really_inline uint64_t non_quote_inside_string(uint64_t mask) const noexcept { return _string.non_quote_inside_string(mask); }
+  simdjson_inline uint64_t non_quote_inside_string(uint64_t mask) const noexcept { return _string.non_quote_inside_string(mask); }
   /** Whether the given characters are outside a string (only works on non-quotes) */
-  simdjson_really_inline uint64_t non_quote_outside_string(uint64_t mask) const noexcept { return _string.non_quote_outside_string(mask); }
+  simdjson_inline uint64_t non_quote_outside_string(uint64_t mask) const noexcept { return _string.non_quote_outside_string(mask); }
 
   // string and escape characters
   json_string_block _string;
@@ -56,12 +56,12 @@ private:
    * structural elements ([,],{,},:, comma) plus scalar starts like 123, true and "abc".
    * They may reside inside a string.
    **/
-  simdjson_really_inline uint64_t potential_structural_start() const noexcept { return _characters.op() | potential_scalar_start(); }
+  simdjson_inline uint64_t potential_structural_start() const noexcept { return _characters.op() | potential_scalar_start(); }
   /**
    * The start of non-operator runs, like 123, true and "abc".
    * It main reside inside a string.
    **/
-  simdjson_really_inline uint64_t potential_scalar_start() const noexcept {
+  simdjson_inline uint64_t potential_scalar_start() const noexcept {
     // The term "scalar" refers to anything except structural characters and white space
     // (so letters, numbers, quotes).
     // Whenever it is preceded by something that is not a structural element ({,},[,],:, ") nor a white-space
@@ -72,7 +72,7 @@ private:
    * Whether the given character is immediately after a non-operator like 123, true.
    * The characters following a quote are not included.
    */
-  simdjson_really_inline uint64_t follows_potential_scalar() const noexcept {
+  simdjson_inline uint64_t follows_potential_scalar() const noexcept {
     // _follows_potential_nonquote_scalar: is defined as marking any character that follows a character
     // that is not a structural element ({,},[,],:, comma) nor a quote (") and that is not a
     // white space.
@@ -97,9 +97,9 @@ private:
 class json_scanner {
 public:
   json_scanner() {}
-  simdjson_really_inline json_block next(const simd::simd8x64<uint8_t>& in);
+  simdjson_inline json_block next(const simd::simd8x64<uint8_t>& in);
   // Returns either UNCLOSED_STRING or SUCCESS
-  simdjson_really_inline error_code finish();
+  simdjson_inline error_code finish();
 
 private:
   // Whether the last character of the previous iteration is part of a scalar token
@@ -116,13 +116,13 @@ private:
 //
 //     const uint64_t backslashed_quote = in.eq('"') & immediately_follows(in.eq('\'), prev_backslash);
 //
-simdjson_really_inline uint64_t follows(const uint64_t match, uint64_t &overflow) {
+simdjson_inline uint64_t follows(const uint64_t match, uint64_t &overflow) {
   const uint64_t result = match << 1 | overflow;
   overflow = match >> 63;
   return result;
 }
 
-simdjson_really_inline json_block json_scanner::next(const simd::simd8x64<uint8_t>& in) {
+simdjson_inline json_block json_scanner::next(const simd::simd8x64<uint8_t>& in) {
   json_string_block strings = string_scanner.next(in);
   // identifies the white-space and the structural characters
   json_character_block characters = json_character_block::classify(in);
@@ -147,7 +147,7 @@ simdjson_really_inline json_block json_scanner::next(const simd::simd8x64<uint8_
   );
 }
 
-simdjson_really_inline error_code json_scanner::finish() {
+simdjson_inline error_code json_scanner::finish() {
   return string_scanner.finish();
 }
 

--- a/src/generic/stage1/utf8_lookup4_algorithm.h
+++ b/src/generic/stage1/utf8_lookup4_algorithm.h
@@ -5,7 +5,7 @@ namespace utf8_validation {
 
 using namespace simd;
 
-  simdjson_really_inline simd8<uint8_t> check_special_cases(const simd8<uint8_t> input, const simd8<uint8_t> prev1) {
+  simdjson_inline simd8<uint8_t> check_special_cases(const simd8<uint8_t> input, const simd8<uint8_t> prev1) {
 // Bit 0 = Too Short (lead byte/ASCII followed by lead byte/ASCII)
 // Bit 1 = Too Long (ASCII followed by continuation)
 // Bit 2 = Overlong 3-byte
@@ -95,7 +95,7 @@ using namespace simd;
     );
     return (byte_1_high & byte_1_low & byte_2_high);
   }
-  simdjson_really_inline simd8<uint8_t> check_multibyte_lengths(const simd8<uint8_t> input,
+  simdjson_inline simd8<uint8_t> check_multibyte_lengths(const simd8<uint8_t> input,
       const simd8<uint8_t> prev_input, const simd8<uint8_t> sc) {
     simd8<uint8_t> prev2 = input.prev<2>(prev_input);
     simd8<uint8_t> prev3 = input.prev<3>(prev_input);
@@ -108,7 +108,7 @@ using namespace simd;
   // Return nonzero if there are incomplete multibyte characters at the end of the block:
   // e.g. if there is a 4-byte character, but it's 3 bytes from the end.
   //
-  simdjson_really_inline simd8<uint8_t> is_incomplete(const simd8<uint8_t> input) {
+  simdjson_inline simd8<uint8_t> is_incomplete(const simd8<uint8_t> input) {
     // If the previous input's last 3 bytes match this, they're too short (they ended at EOF):
     // ... 1111____ 111_____ 11______
 #if SIMDJSON_IMPLEMENTATION_ICELAKE
@@ -145,7 +145,7 @@ using namespace simd;
     //
     // Check whether the current bytes are valid UTF-8.
     //
-    simdjson_really_inline void check_utf8_bytes(const simd8<uint8_t> input, const simd8<uint8_t> prev_input) {
+    simdjson_inline void check_utf8_bytes(const simd8<uint8_t> input, const simd8<uint8_t> prev_input) {
       // Flip prev1...prev3 so we can easily determine if they are 2+, 3+ or 4+ lead bytes
       // (2, 3, 4-byte leads become large positive numbers instead of small negative numbers)
       simd8<uint8_t> prev1 = input.prev<1>(prev_input);
@@ -156,13 +156,13 @@ using namespace simd;
     // The only problem that can happen at EOF is that a multibyte character is too short
     // or a byte value too large in the last bytes: check_special_cases only checks for bytes
     // too large in the first of two bytes.
-    simdjson_really_inline void check_eof() {
+    simdjson_inline void check_eof() {
       // If the previous block had incomplete UTF-8 characters at the end, an ASCII block can't
       // possibly finish them.
       this->error |= this->prev_incomplete;
     }
 
-    simdjson_really_inline void check_next_input(const simd8x64<uint8_t>& input) {
+    simdjson_inline void check_next_input(const simd8x64<uint8_t>& input) {
       if(simdjson_likely(is_ascii(input))) {
         this->error |= this->prev_incomplete;
       } else {
@@ -187,7 +187,7 @@ using namespace simd;
       }
     }
     // do not forget to call check_eof!
-    simdjson_really_inline error_code errors() {
+    simdjson_inline error_code errors() {
       return this->error.any_bits_set_anywhere() ? error_code::UTF8_ERROR : error_code::SUCCESS;
     }
 

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -36,14 +36,14 @@ public:
    * - increment_count(iter) - each time a value is found in an array or object.
    */
   template<bool STREAMING, typename V>
-  simdjson_warn_unused simdjson_really_inline error_code walk_document(V &visitor) noexcept;
+  simdjson_warn_unused simdjson_inline error_code walk_document(V &visitor) noexcept;
 
   /**
    * Create an iterator capable of walking a JSON document.
    *
    * The document must have already passed through stage 1.
    */
-  simdjson_really_inline json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index);
+  simdjson_inline json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index);
 
   /**
    * Look at the next token.
@@ -52,7 +52,7 @@ public:
    *
    * They may include invalid JSON as well (such as `1.2.3` or `ture`).
    */
-  simdjson_really_inline const uint8_t *peek() const noexcept;
+  simdjson_inline const uint8_t *peek() const noexcept;
   /**
    * Advance to the next token.
    *
@@ -60,56 +60,56 @@ public:
    *
    * They may include invalid JSON as well (such as `1.2.3` or `ture`).
    */
-  simdjson_really_inline const uint8_t *advance() noexcept;
+  simdjson_inline const uint8_t *advance() noexcept;
   /**
    * Get the remaining length of the document, from the start of the current token.
    */
-  simdjson_really_inline size_t remaining_len() const noexcept;
+  simdjson_inline size_t remaining_len() const noexcept;
   /**
    * Check if we are at the end of the document.
    *
    * If this is true, there are no more tokens.
    */
-  simdjson_really_inline bool at_eof() const noexcept;
+  simdjson_inline bool at_eof() const noexcept;
   /**
    * Check if we are at the beginning of the document.
    */
-  simdjson_really_inline bool at_beginning() const noexcept;
-  simdjson_really_inline uint8_t last_structural() const noexcept;
+  simdjson_inline bool at_beginning() const noexcept;
+  simdjson_inline uint8_t last_structural() const noexcept;
 
   /**
    * Log that a value has been found.
    *
    * Set LOG_ENABLED=true in logger.h to see logging.
    */
-  simdjson_really_inline void log_value(const char *type) const noexcept;
+  simdjson_inline void log_value(const char *type) const noexcept;
   /**
    * Log the start of a multipart value.
    *
    * Set LOG_ENABLED=true in logger.h to see logging.
    */
-  simdjson_really_inline void log_start_value(const char *type) const noexcept;
+  simdjson_inline void log_start_value(const char *type) const noexcept;
   /**
    * Log the end of a multipart value.
    *
    * Set LOG_ENABLED=true in logger.h to see logging.
    */
-  simdjson_really_inline void log_end_value(const char *type) const noexcept;
+  simdjson_inline void log_end_value(const char *type) const noexcept;
   /**
    * Log an error.
    *
    * Set LOG_ENABLED=true in logger.h to see logging.
    */
-  simdjson_really_inline void log_error(const char *error) const noexcept;
+  simdjson_inline void log_error(const char *error) const noexcept;
 
   template<typename V>
-  simdjson_warn_unused simdjson_really_inline error_code visit_root_primitive(V &visitor, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_root_primitive(V &visitor, const uint8_t *value) noexcept;
   template<typename V>
-  simdjson_warn_unused simdjson_really_inline error_code visit_primitive(V &visitor, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_primitive(V &visitor, const uint8_t *value) noexcept;
 };
 
 template<bool STREAMING, typename V>
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::walk_document(V &visitor) noexcept {
+simdjson_warn_unused simdjson_inline error_code json_iterator::walk_document(V &visitor) noexcept {
   logger::log_start();
 
   //
@@ -234,52 +234,52 @@ document_end:
 
 } // walk_document()
 
-simdjson_really_inline json_iterator::json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
+simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
   : buf{_dom_parser.buf},
     next_structural{&_dom_parser.structural_indexes[start_structural_index]},
     dom_parser{_dom_parser} {
 }
 
-simdjson_really_inline const uint8_t *json_iterator::peek() const noexcept {
+simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
   return &buf[*(next_structural)];
 }
-simdjson_really_inline const uint8_t *json_iterator::advance() noexcept {
+simdjson_inline const uint8_t *json_iterator::advance() noexcept {
   return &buf[*(next_structural++)];
 }
-simdjson_really_inline size_t json_iterator::remaining_len() const noexcept {
+simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
 }
 
-simdjson_really_inline bool json_iterator::at_eof() const noexcept {
+simdjson_inline bool json_iterator::at_eof() const noexcept {
   return next_structural == &dom_parser.structural_indexes[dom_parser.n_structural_indexes];
 }
-simdjson_really_inline bool json_iterator::at_beginning() const noexcept {
+simdjson_inline bool json_iterator::at_beginning() const noexcept {
   return next_structural == dom_parser.structural_indexes.get();
 }
-simdjson_really_inline uint8_t json_iterator::last_structural() const noexcept {
+simdjson_inline uint8_t json_iterator::last_structural() const noexcept {
   return buf[dom_parser.structural_indexes[dom_parser.n_structural_indexes - 1]];
 }
 
-simdjson_really_inline void json_iterator::log_value(const char *type) const noexcept {
+simdjson_inline void json_iterator::log_value(const char *type) const noexcept {
   logger::log_line(*this, "", type, "");
 }
 
-simdjson_really_inline void json_iterator::log_start_value(const char *type) const noexcept {
+simdjson_inline void json_iterator::log_start_value(const char *type) const noexcept {
   logger::log_line(*this, "+", type, "");
   if (logger::LOG_ENABLED) { logger::log_depth++; }
 }
 
-simdjson_really_inline void json_iterator::log_end_value(const char *type) const noexcept {
+simdjson_inline void json_iterator::log_end_value(const char *type) const noexcept {
   if (logger::LOG_ENABLED) { logger::log_depth--; }
   logger::log_line(*this, "-", type, "");
 }
 
-simdjson_really_inline void json_iterator::log_error(const char *error) const noexcept {
+simdjson_inline void json_iterator::log_error(const char *error) const noexcept {
   logger::log_line(*this, "", "ERROR", error);
 }
 
 template<typename V>
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::visit_root_primitive(V &visitor, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code json_iterator::visit_root_primitive(V &visitor, const uint8_t *value) noexcept {
   switch (*value) {
     case '"': return visitor.visit_root_string(*this, value);
     case 't': return visitor.visit_root_true_atom(*this, value);
@@ -295,7 +295,7 @@ simdjson_warn_unused simdjson_really_inline error_code json_iterator::visit_root
   }
 }
 template<typename V>
-simdjson_warn_unused simdjson_really_inline error_code json_iterator::visit_primitive(V &visitor, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code json_iterator::visit_primitive(V &visitor, const uint8_t *value) noexcept {
   switch (*value) {
     case '"': return visitor.visit_string(*this, value);
     case 't': return visitor.visit_true_atom(*this, value);

--- a/src/generic/stage2/logger.h
+++ b/src/generic/stage2/logger.h
@@ -20,7 +20,7 @@ namespace logger {
   static int log_depth; // Not threadsafe. Log only.
 
   // Helper to turn unprintable or newline characters into spaces
-  static simdjson_really_inline char printable_char(char c) {
+  static simdjson_inline char printable_char(char c) {
     if (c >= 0x20) {
       return c;
     } else {
@@ -29,7 +29,7 @@ namespace logger {
   }
 
   // Print the header and set up log_start
-  static simdjson_really_inline void log_start() {
+  static simdjson_inline void log_start() {
     if (LOG_ENABLED) {
       log_depth = 0;
       printf("\n");
@@ -38,7 +38,7 @@ namespace logger {
     }
   }
 
-  simdjson_unused static simdjson_really_inline void log_string(const char *message) {
+  simdjson_unused static simdjson_inline void log_string(const char *message) {
     if (LOG_ENABLED) {
       printf("%s\n", message);
     }
@@ -46,7 +46,7 @@ namespace logger {
 
   // Logs a single line from the stage 2 DOM parser
   template<typename S>
-  static simdjson_really_inline void log_line(S &structurals, const char *title_prefix, const char *title, const char *detail) {
+  static simdjson_inline void log_line(S &structurals, const char *title_prefix, const char *title, const char *detail) {
     if (LOG_ENABLED) {
       printf("| %*s%s%-*s ", log_depth*2, "", title_prefix, LOG_EVENT_LEN - log_depth*2 - int(strlen(title_prefix)), title);
       auto current_index = structurals.at_beginning() ? nullptr : structurals.next_structural-1;

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -40,7 +40,7 @@ static const uint8_t escape_map[256] = {
 // return true if the unicode codepoint was valid
 // We work in little-endian then swap at write time
 simdjson_warn_unused
-simdjson_really_inline bool handle_unicode_codepoint(const uint8_t **src_ptr,
+simdjson_inline bool handle_unicode_codepoint(const uint8_t **src_ptr,
                                             uint8_t **dst_ptr) {
   // jsoncharutils::hex_to_u32_nocheck fills high 16 bits of the return value with 1s if the
   // conversion isn't valid; we defer the check for this to inside the
@@ -81,7 +81,7 @@ simdjson_really_inline bool handle_unicode_codepoint(const uint8_t **src_ptr,
  * enough. E.g., if src points at 'joe"', then dst needs to have four free bytes +
  * SIMDJSON_PADDING bytes.
  */
-simdjson_warn_unused simdjson_really_inline uint8_t *parse_string(const uint8_t *src, uint8_t *dst) {
+simdjson_warn_unused simdjson_inline uint8_t *parse_string(const uint8_t *src, uint8_t *dst) {
   while (1) {
     // Copy the next n bytes, and find the backslash and quote in them.
     auto bs_quote = backslash_and_quote::copy_and_find(src, dst);

--- a/src/generic/stage2/structural_iterator.h
+++ b/src/generic/stage2/structural_iterator.h
@@ -10,40 +10,40 @@ public:
   dom_parser_implementation &dom_parser;
 
   // Start a structural
-  simdjson_really_inline structural_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
+  simdjson_inline structural_iterator(dom_parser_implementation &_dom_parser, size_t start_structural_index)
     : buf{_dom_parser.buf},
       next_structural{&_dom_parser.structural_indexes[start_structural_index]},
       dom_parser{_dom_parser} {
   }
   // Get the buffer position of the current structural character
-  simdjson_really_inline const uint8_t* current() {
+  simdjson_inline const uint8_t* current() {
     return &buf[*(next_structural-1)];
   }
   // Get the current structural character
-  simdjson_really_inline char current_char() {
+  simdjson_inline char current_char() {
     return buf[*(next_structural-1)];
   }
   // Get the next structural character without advancing
-  simdjson_really_inline char peek_next_char() {
+  simdjson_inline char peek_next_char() {
     return buf[*next_structural];
   }
-  simdjson_really_inline const uint8_t* peek() {
+  simdjson_inline const uint8_t* peek() {
     return &buf[*next_structural];
   }
-  simdjson_really_inline const uint8_t* advance() {
+  simdjson_inline const uint8_t* advance() {
     return &buf[*(next_structural++)];
   }
-  simdjson_really_inline char advance_char() {
+  simdjson_inline char advance_char() {
     return buf[*(next_structural++)];
   }
-  simdjson_really_inline size_t remaining_len() {
+  simdjson_inline size_t remaining_len() {
     return dom_parser.len - *(next_structural-1);
   }
 
-  simdjson_really_inline bool at_end() {
+  simdjson_inline bool at_end() {
     return next_structural == &dom_parser.structural_indexes[dom_parser.n_structural_indexes];
   }
-  simdjson_really_inline bool at_beginning() {
+  simdjson_inline bool at_beginning() {
     return next_structural == dom_parser.structural_indexes.get();
   }
 };

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -8,40 +8,40 @@ namespace stage2 {
 
 struct tape_builder {
   template<bool STREAMING>
-  simdjson_warn_unused static simdjson_really_inline error_code parse_document(
+  simdjson_warn_unused static simdjson_inline error_code parse_document(
     dom_parser_implementation &dom_parser,
     dom::document &doc) noexcept;
 
   /** Called when a non-empty document starts. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_document_start(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_document_start(json_iterator &iter) noexcept;
   /** Called when a non-empty document ends without error. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_document_end(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_document_end(json_iterator &iter) noexcept;
 
   /** Called when a non-empty array starts. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_array_start(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_array_start(json_iterator &iter) noexcept;
   /** Called when a non-empty array ends. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_array_end(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_array_end(json_iterator &iter) noexcept;
   /** Called when an empty array is found. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_empty_array(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_empty_array(json_iterator &iter) noexcept;
 
   /** Called when a non-empty object starts. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_object_start(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_object_start(json_iterator &iter) noexcept;
   /**
    * Called when a key in a field is encountered.
    *
    * primitive, visit_object_start, visit_empty_object, visit_array_start, or visit_empty_array
    * will be called after this with the field value.
    */
-  simdjson_warn_unused simdjson_really_inline error_code visit_key(json_iterator &iter, const uint8_t *key) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_key(json_iterator &iter, const uint8_t *key) noexcept;
   /** Called when a non-empty object ends. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_object_end(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_object_end(json_iterator &iter) noexcept;
   /** Called when an empty object is found. */
-  simdjson_warn_unused simdjson_really_inline error_code visit_empty_object(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_empty_object(json_iterator &iter) noexcept;
 
   /**
    * Called when a string, number, boolean or null is found.
    */
-  simdjson_warn_unused simdjson_really_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_primitive(json_iterator &iter, const uint8_t *value) noexcept;
   /**
    * Called when a string, number, boolean or null is found at the top level of a document (i.e.
    * when there is no array or object and the entire document is a single string, number, boolean or
@@ -50,22 +50,22 @@ struct tape_builder {
    * This is separate from primitive() because simdjson's normal primitive parsing routines assume
    * there is at least one more token after the value, which is only true in an array or object.
    */
-  simdjson_warn_unused simdjson_really_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept;
 
-  simdjson_warn_unused simdjson_really_inline error_code visit_string(json_iterator &iter, const uint8_t *value, bool key = false) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_number(json_iterator &iter, const uint8_t *value) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_string(json_iterator &iter, const uint8_t *value, bool key = false) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_number(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
 
-  simdjson_warn_unused simdjson_really_inline error_code visit_root_string(json_iterator &iter, const uint8_t *value) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_root_number(json_iterator &iter, const uint8_t *value) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_root_string(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_root_number(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept;
+  simdjson_warn_unused simdjson_inline error_code visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept;
 
   /** Called each time a new field or element in an array or object is found. */
-  simdjson_warn_unused simdjson_really_inline error_code increment_count(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code increment_count(json_iterator &iter) noexcept;
 
   /** Next location to write to tape */
   tape_writer tape;
@@ -73,18 +73,18 @@ private:
   /** Next write location in the string buf for stage 2 parsing */
   uint8_t *current_string_buf_loc;
 
-  simdjson_really_inline tape_builder(dom::document &doc) noexcept;
+  simdjson_inline tape_builder(dom::document &doc) noexcept;
 
-  simdjson_really_inline uint32_t next_tape_index(json_iterator &iter) const noexcept;
-  simdjson_really_inline void start_container(json_iterator &iter) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept;
-  simdjson_warn_unused simdjson_really_inline error_code empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept;
-  simdjson_really_inline uint8_t *on_start_string(json_iterator &iter) noexcept;
-  simdjson_really_inline void on_end_string(uint8_t *dst) noexcept;
+  simdjson_inline uint32_t next_tape_index(json_iterator &iter) const noexcept;
+  simdjson_inline void start_container(json_iterator &iter) noexcept;
+  simdjson_warn_unused simdjson_inline error_code end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept;
+  simdjson_warn_unused simdjson_inline error_code empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept;
+  simdjson_inline uint8_t *on_start_string(json_iterator &iter) noexcept;
+  simdjson_inline void on_end_string(uint8_t *dst) noexcept;
 }; // class tape_builder
 
 template<bool STREAMING>
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::parse_document(
+simdjson_warn_unused simdjson_inline error_code tape_builder::parse_document(
     dom_parser_implementation &dom_parser,
     dom::document &doc) noexcept {
   dom_parser.doc = &doc;
@@ -93,56 +93,56 @@ simdjson_warn_unused simdjson_really_inline error_code tape_builder::parse_docum
   return iter.walk_document<STREAMING>(builder);
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept {
   return iter.visit_root_primitive(*this, value);
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_primitive(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_primitive(json_iterator &iter, const uint8_t *value) noexcept {
   return iter.visit_primitive(*this, value);
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_empty_object(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_empty_object(json_iterator &iter) noexcept {
   return empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_empty_array(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_empty_array(json_iterator &iter) noexcept {
   return empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_document_start(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_document_start(json_iterator &iter) noexcept {
   start_container(iter);
   return SUCCESS;
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_object_start(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_object_start(json_iterator &iter) noexcept {
   start_container(iter);
   return SUCCESS;
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_array_start(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_array_start(json_iterator &iter) noexcept {
   start_container(iter);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_object_end(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_object_end(json_iterator &iter) noexcept {
   return end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_array_end(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_array_end(json_iterator &iter) noexcept {
   return end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_document_end(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_document_end(json_iterator &iter) noexcept {
   constexpr uint32_t start_tape_index = 0;
   tape.append(start_tape_index, internal::tape_type::ROOT);
   tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
   return SUCCESS;
 }
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_key(json_iterator &iter, const uint8_t *key) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_key(json_iterator &iter, const uint8_t *key) noexcept {
   return visit_string(iter, key, true);
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::increment_count(json_iterator &iter) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::increment_count(json_iterator &iter) noexcept {
   iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
   return SUCCESS;
 }
 
-simdjson_really_inline tape_builder::tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
+simdjson_inline tape_builder::tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_string(json_iterator &iter, const uint8_t *value, bool key) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_string(json_iterator &iter, const uint8_t *value, bool key) noexcept {
   iter.log_value(key ? "key" : "string");
   uint8_t *dst = on_start_string(iter);
   dst = stringparsing::parse_string(value+1, dst);
@@ -154,16 +154,16 @@ simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_strin
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_string(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_string(json_iterator &iter, const uint8_t *value) noexcept {
   return visit_string(iter, value);
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("number");
   return numberparsing::parse_number(value, tape);
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {
   //
   // We need to make a copy to make sure that the string is space terminated.
   // This is not about padding the input, which should already padded up
@@ -185,42 +185,42 @@ simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_
   return error;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("true");
   if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
   tape.append(0, internal::tape_type::TRUE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("true");
   if (!atomparsing::is_valid_true_atom(value, iter.remaining_len())) { return T_ATOM_ERROR; }
   tape.append(0, internal::tape_type::TRUE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("false");
   if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
   tape.append(0, internal::tape_type::FALSE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("false");
   if (!atomparsing::is_valid_false_atom(value, iter.remaining_len())) { return F_ATOM_ERROR; }
   tape.append(0, internal::tape_type::FALSE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("null");
   if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
   tape.append(0, internal::tape_type::NULL_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("null");
   if (!atomparsing::is_valid_null_atom(value, iter.remaining_len())) { return N_ATOM_ERROR; }
   tape.append(0, internal::tape_type::NULL_VALUE);
@@ -229,24 +229,24 @@ simdjson_warn_unused simdjson_really_inline error_code tape_builder::visit_root_
 
 // private:
 
-simdjson_really_inline uint32_t tape_builder::next_tape_index(json_iterator &iter) const noexcept {
+simdjson_inline uint32_t tape_builder::next_tape_index(json_iterator &iter) const noexcept {
   return uint32_t(tape.next_tape_loc - iter.dom_parser.doc->tape.get());
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
   auto start_index = next_tape_index(iter);
   tape.append(start_index+2, start);
   tape.append(start_index, end);
   return SUCCESS;
 }
 
-simdjson_really_inline void tape_builder::start_container(json_iterator &iter) noexcept {
+simdjson_inline void tape_builder::start_container(json_iterator &iter) noexcept {
   iter.dom_parser.open_containers[iter.depth].tape_index = next_tape_index(iter);
   iter.dom_parser.open_containers[iter.depth].count = 0;
   tape.skip(); // We don't actually *write* the start element until the end.
 }
 
-simdjson_warn_unused simdjson_really_inline error_code tape_builder::end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
+simdjson_warn_unused simdjson_inline error_code tape_builder::end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
   // Write the ending tape element, pointing at the start location
   const uint32_t start_tape_index = iter.dom_parser.open_containers[iter.depth].tape_index;
   tape.append(start_tape_index, end);
@@ -259,13 +259,13 @@ simdjson_warn_unused simdjson_really_inline error_code tape_builder::end_contain
   return SUCCESS;
 }
 
-simdjson_really_inline uint8_t *tape_builder::on_start_string(json_iterator &iter) noexcept {
+simdjson_inline uint8_t *tape_builder::on_start_string(json_iterator &iter) noexcept {
   // we advance the point, accounting for the fact that we have a NULL termination
   tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::STRING);
   return current_string_buf_loc + sizeof(uint32_t);
 }
 
-simdjson_really_inline void tape_builder::on_end_string(uint8_t *dst) noexcept {
+simdjson_inline void tape_builder::on_end_string(uint8_t *dst) noexcept {
   uint32_t str_length = uint32_t(dst - (current_string_buf_loc + sizeof(uint32_t)));
   // TODO check for overflow in case someone has a crazy string (>=4GB?)
   // But only add the overflow check when the document itself exceeds 4GB

--- a/src/generic/stage2/tape_writer.h
+++ b/src/generic/stage2/tape_writer.h
@@ -8,18 +8,18 @@ struct tape_writer {
   uint64_t *next_tape_loc;
 
   /** Write a signed 64-bit value to tape. */
-  simdjson_really_inline void append_s64(int64_t value) noexcept;
+  simdjson_inline void append_s64(int64_t value) noexcept;
 
   /** Write an unsigned 64-bit value to tape. */
-  simdjson_really_inline void append_u64(uint64_t value) noexcept;
+  simdjson_inline void append_u64(uint64_t value) noexcept;
 
   /** Write a double value to tape. */
-  simdjson_really_inline void append_double(double value) noexcept;
+  simdjson_inline void append_double(double value) noexcept;
 
   /**
    * Append a tape entry (an 8-bit type,and 56 bits worth of value).
    */
-  simdjson_really_inline void append(uint64_t val, internal::tape_type t) noexcept;
+  simdjson_inline void append(uint64_t val, internal::tape_type t) noexcept;
 
   /**
    * Skip the current tape entry without writing.
@@ -27,24 +27,24 @@ struct tape_writer {
    * Used to skip the start of the container, since we'll come back later to fill it in when the
    * container ends.
    */
-  simdjson_really_inline void skip() noexcept;
+  simdjson_inline void skip() noexcept;
 
   /**
    * Skip the number of tape entries necessary to write a large u64 or i64.
    */
-  simdjson_really_inline void skip_large_integer() noexcept;
+  simdjson_inline void skip_large_integer() noexcept;
 
   /**
    * Skip the number of tape entries necessary to write a double.
    */
-  simdjson_really_inline void skip_double() noexcept;
+  simdjson_inline void skip_double() noexcept;
 
   /**
    * Write a value to a known location on tape.
    *
    * Used to go back and write out the start of a container after the container ends.
    */
-  simdjson_really_inline static void write(uint64_t &tape_loc, uint64_t val, internal::tape_type t) noexcept;
+  simdjson_inline static void write(uint64_t &tape_loc, uint64_t val, internal::tape_type t) noexcept;
 
 private:
   /**
@@ -52,50 +52,50 @@ private:
    * all 64 bits, such as double and uint64_t.
    */
   template<typename T>
-  simdjson_really_inline void append2(uint64_t val, T val2, internal::tape_type t) noexcept;
+  simdjson_inline void append2(uint64_t val, T val2, internal::tape_type t) noexcept;
 }; // struct number_writer
 
-simdjson_really_inline void tape_writer::append_s64(int64_t value) noexcept {
+simdjson_inline void tape_writer::append_s64(int64_t value) noexcept {
   append2(0, value, internal::tape_type::INT64);
 }
 
-simdjson_really_inline void tape_writer::append_u64(uint64_t value) noexcept {
+simdjson_inline void tape_writer::append_u64(uint64_t value) noexcept {
   append(0, internal::tape_type::UINT64);
   *next_tape_loc = value;
   next_tape_loc++;
 }
 
 /** Write a double value to tape. */
-simdjson_really_inline void tape_writer::append_double(double value) noexcept {
+simdjson_inline void tape_writer::append_double(double value) noexcept {
   append2(0, value, internal::tape_type::DOUBLE);
 }
 
-simdjson_really_inline void tape_writer::skip() noexcept {
+simdjson_inline void tape_writer::skip() noexcept {
   next_tape_loc++;
 }
 
-simdjson_really_inline void tape_writer::skip_large_integer() noexcept {
+simdjson_inline void tape_writer::skip_large_integer() noexcept {
   next_tape_loc += 2;
 }
 
-simdjson_really_inline void tape_writer::skip_double() noexcept {
+simdjson_inline void tape_writer::skip_double() noexcept {
   next_tape_loc += 2;
 }
 
-simdjson_really_inline void tape_writer::append(uint64_t val, internal::tape_type t) noexcept {
+simdjson_inline void tape_writer::append(uint64_t val, internal::tape_type t) noexcept {
   *next_tape_loc = val | ((uint64_t(char(t))) << 56);
   next_tape_loc++;
 }
 
 template<typename T>
-simdjson_really_inline void tape_writer::append2(uint64_t val, T val2, internal::tape_type t) noexcept {
+simdjson_inline void tape_writer::append2(uint64_t val, T val2, internal::tape_type t) noexcept {
   append(val, t);
   static_assert(sizeof(val2) == sizeof(*next_tape_loc), "Type is not 64 bits!");
   memcpy(next_tape_loc, &val2, sizeof(val2));
   next_tape_loc++;
 }
 
-simdjson_really_inline void tape_writer::write(uint64_t &tape_loc, uint64_t val, internal::tape_type t) noexcept {
+simdjson_inline void tape_writer::write(uint64_t &tape_loc, uint64_t val, internal::tape_type t) noexcept {
   tape_loc = val | ((uint64_t(char(t))) << 56);
 }
 

--- a/src/haswell/dom_parser_implementation.cpp
+++ b/src/haswell/dom_parser_implementation.cpp
@@ -11,25 +11,25 @@ namespace {
 using namespace simd;
 
 struct json_character_block {
-  static simdjson_really_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
+  static simdjson_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
   //  ASCII white-space ('\r','\n','\t',' ')
-  simdjson_really_inline uint64_t whitespace() const noexcept;
+  simdjson_inline uint64_t whitespace() const noexcept;
   // non-quote structural characters (comma, colon, braces, brackets)
-  simdjson_really_inline uint64_t op() const noexcept;
+  simdjson_inline uint64_t op() const noexcept;
   // neither a structural character nor a white-space, so letters, numbers and quotes
-  simdjson_really_inline uint64_t scalar() const noexcept;
+  simdjson_inline uint64_t scalar() const noexcept;
 
   uint64_t _whitespace; // ASCII white-space ('\r','\n','\t',' ')
   uint64_t _op; // structural characters (comma, colon, braces, brackets but not quotes)
 };
 
-simdjson_really_inline uint64_t json_character_block::whitespace() const noexcept { return _whitespace; }
-simdjson_really_inline uint64_t json_character_block::op() const noexcept { return _op; }
-simdjson_really_inline uint64_t json_character_block::scalar() const noexcept { return ~(op() | whitespace()); }
+simdjson_inline uint64_t json_character_block::whitespace() const noexcept { return _whitespace; }
+simdjson_inline uint64_t json_character_block::op() const noexcept { return _op; }
+simdjson_inline uint64_t json_character_block::scalar() const noexcept { return ~(op() | whitespace()); }
 
 // This identifies structural characters (comma, colon, braces, brackets),
 // and ASCII white-space ('\r','\n','\t',' ').
-simdjson_really_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
+simdjson_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
   // These lookups rely on the fact that anything < 127 will match the lower 4 bits, which is why
   // we can't use the generic lookup_16.
   const auto whitespace_table = simd8<uint8_t>::repeat_16(' ', 100, 100, 100, 17, 100, 113, 2, 100, '\t', '\n', 112, 100, '\r', 100, 100);
@@ -82,11 +82,11 @@ simdjson_really_inline json_character_block json_character_block::classify(const
   return { whitespace, op };
 }
 
-simdjson_really_inline bool is_ascii(const simd8x64<uint8_t>& input) {
+simdjson_inline bool is_ascii(const simd8x64<uint8_t>& input) {
   return input.reduce_or().is_ascii();
 }
 
-simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_unused simdjson_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
   simd8<uint8_t> is_second_byte = prev1.saturating_sub(0xc0u-1); // Only 11______ will be > 0
   simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-1); // Only 111_____ will be > 0
   simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-1); // Only 1111____ will be > 0
@@ -94,7 +94,7 @@ simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const si
   return simd8<int8_t>(is_second_byte | is_third_byte | is_fourth_byte) > int8_t(0);
 }
 
-simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
   simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-1); // Only 111_____ will be > 0
   simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-1); // Only 1111____ will be > 0
   // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
@@ -123,7 +123,7 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 namespace stage1 {
 
-simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+simdjson_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
   if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
   return find_escaped_branchless(backslash);
 }

--- a/src/icelake/dom_parser_implementation.cpp
+++ b/src/icelake/dom_parser_implementation.cpp
@@ -11,25 +11,25 @@ namespace {
 using namespace simd;
 
 struct json_character_block {
-  static simdjson_really_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
+  static simdjson_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
   //  ASCII white-space ('\r','\n','\t',' ')
-  simdjson_really_inline uint64_t whitespace() const noexcept;
+  simdjson_inline uint64_t whitespace() const noexcept;
   // non-quote structural characters (comma, colon, braces, brackets)
-  simdjson_really_inline uint64_t op() const noexcept;
+  simdjson_inline uint64_t op() const noexcept;
   // neither a structural character nor a white-space, so letters, numbers and quotes
-  simdjson_really_inline uint64_t scalar() const noexcept;
+  simdjson_inline uint64_t scalar() const noexcept;
 
   uint64_t _whitespace; // ASCII white-space ('\r','\n','\t',' ')
   uint64_t _op; // structural characters (comma, colon, braces, brackets but not quotes)
 };
 
-simdjson_really_inline uint64_t json_character_block::whitespace() const noexcept { return _whitespace; }
-simdjson_really_inline uint64_t json_character_block::op() const noexcept { return _op; }
-simdjson_really_inline uint64_t json_character_block::scalar() const noexcept { return ~(op() | whitespace()); }
+simdjson_inline uint64_t json_character_block::whitespace() const noexcept { return _whitespace; }
+simdjson_inline uint64_t json_character_block::op() const noexcept { return _op; }
+simdjson_inline uint64_t json_character_block::scalar() const noexcept { return ~(op() | whitespace()); }
 
 // This identifies structural characters (comma, colon, braces, brackets),
 // and ASCII white-space ('\r','\n','\t',' ').
-simdjson_really_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
+simdjson_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
   // These lookups rely on the fact that anything < 127 will match the lower 4 bits, which is why
   // we can't use the generic lookup_16.
   const auto whitespace_table = simd8<uint8_t>::repeat_16(' ', 100, 100, 100, 17, 100, 113, 2, 100, '\t', '\n', 112, 100, '\r', 100, 100);
@@ -79,11 +79,11 @@ simdjson_really_inline json_character_block json_character_block::classify(const
   return { whitespace, op };
 }
 
-simdjson_really_inline bool is_ascii(const simd8x64<uint8_t>& input) {
+simdjson_inline bool is_ascii(const simd8x64<uint8_t>& input) {
   return input.reduce_or().is_ascii();
 }
 
-simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_unused simdjson_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
   simd8<uint8_t> is_second_byte = prev1.saturating_sub(0xc0u-1); // Only 11______ will be > 0
   simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-1); // Only 111_____ will be > 0
   simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-1); // Only 1111____ will be > 0
@@ -91,7 +91,7 @@ simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const si
   return simd8<int8_t>(is_second_byte | is_third_byte | is_fourth_byte) > int8_t(0);
 }
 
-simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
   simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-1); // Only 111_____ will be > 0
   simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-1); // Only 1111____ will be > 0
   // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
@@ -118,7 +118,7 @@ simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t>
 // as a workaround, we disable warnings within the following function.
 SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 namespace simdjson { namespace SIMDJSON_IMPLEMENTATION { namespace { namespace stage1 {
-simdjson_really_inline void bit_indexer::write(uint32_t idx, uint64_t bits) {
+simdjson_inline void bit_indexer::write(uint32_t idx, uint64_t bits) {
     // In some instances, the next branch is expensive because it is mispredicted.
     // Unfortunately, in other cases,
     // it helps tremendously.
@@ -169,7 +169,7 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 namespace stage1 {
 
-simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+simdjson_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
   if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
   return find_escaped_branchless(backslash);
 }

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -72,7 +72,7 @@ public:
   simdjson_warn_unused bool validate_utf8(const char * buf, size_t len) const noexcept final override {
     return set_best()->validate_utf8(buf, len);
   }
-  simdjson_really_inline detect_best_supported_implementation_on_first_use() noexcept : implementation("best_supported_detector", "Detects the best supported implementation and sets it", 0) {}
+  simdjson_inline detect_best_supported_implementation_on_first_use() noexcept : implementation("best_supported_detector", "Detects the best supported implementation and sets it", 0) {}
 private:
   const implementation *set_best() const noexcept;
 };

--- a/src/westmere/dom_parser_implementation.cpp
+++ b/src/westmere/dom_parser_implementation.cpp
@@ -11,17 +11,17 @@ namespace {
 using namespace simd;
 
 struct json_character_block {
-  static simdjson_really_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
+  static simdjson_inline json_character_block classify(const simd::simd8x64<uint8_t>& in);
 
-  simdjson_really_inline uint64_t whitespace() const noexcept { return _whitespace; }
-  simdjson_really_inline uint64_t op() const noexcept { return _op; }
-  simdjson_really_inline uint64_t scalar() const noexcept { return ~(op() | whitespace()); }
+  simdjson_inline uint64_t whitespace() const noexcept { return _whitespace; }
+  simdjson_inline uint64_t op() const noexcept { return _op; }
+  simdjson_inline uint64_t scalar() const noexcept { return ~(op() | whitespace()); }
 
   uint64_t _whitespace;
   uint64_t _op;
 };
 
-simdjson_really_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
+simdjson_inline json_character_block json_character_block::classify(const simd::simd8x64<uint8_t>& in) {
   // These lookups rely on the fact that anything < 127 will match the lower 4 bits, which is why
   // we can't use the generic lookup_16.
   auto whitespace_table = simd8<uint8_t>::repeat_16(' ', 100, 100, 100, 17, 100, 113, 2, 100, '\t', '\n', 112, 100, '\r', 100, 100);
@@ -80,11 +80,11 @@ simdjson_really_inline json_character_block json_character_block::classify(const
     return { whitespace, op };
 }
 
-simdjson_really_inline bool is_ascii(const simd8x64<uint8_t>& input) {
+simdjson_inline bool is_ascii(const simd8x64<uint8_t>& input) {
   return input.reduce_or().is_ascii();
 }
 
-simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_unused simdjson_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
   simd8<uint8_t> is_second_byte = prev1.saturating_sub(0xc0u-1); // Only 11______ will be > 0
   simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-1); // Only 111_____ will be > 0
   simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-1); // Only 1111____ will be > 0
@@ -92,7 +92,7 @@ simdjson_unused simdjson_really_inline simd8<bool> must_be_continuation(const si
   return simd8<int8_t>(is_second_byte | is_third_byte | is_fourth_byte) > int8_t(0);
 }
 
-simdjson_really_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
+simdjson_inline simd8<bool> must_be_2_3_continuation(const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
   simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-1); // Only 111_____ will be > 0
   simd8<uint8_t> is_fourth_byte = prev3.saturating_sub(0xf0u-1); // Only 1111____ will be > 0
   // Caller requires a bool (all 1's). All values resulting from the subtraction will be <= 64, so signed comparison is fine.
@@ -122,7 +122,7 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 namespace stage1 {
 
-simdjson_really_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
+simdjson_inline uint64_t json_string_scanner::find_escaped(uint64_t backslash) {
   if (!backslash) { uint64_t escaped = prev_escaped; prev_escaped = 0; return escaped; }
   return find_escaped_branchless(backslash);
 }

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -26,28 +26,28 @@ const char *TRUENULL_JSON = SIMDJSON_BENCHMARK_SMALLDATA_DIR  "truenull.json";
 
 // For the ASSERT_EQUAL macro
 template<typename A, typename E>
-simdjson_really_inline bool equals_expected(A actual, E expected) {
+simdjson_inline bool equals_expected(A actual, E expected) {
   return actual == A(expected);
 }
 template<>
-simdjson_really_inline bool equals_expected<const char *, const char *>(const char *actual, const char *expected) {
+simdjson_inline bool equals_expected<const char *, const char *>(const char *actual, const char *expected) {
   return !strcmp(actual, expected);
 }
 template<>
-simdjson_really_inline bool equals_expected<simdjson::ondemand::raw_json_string, const char *>(simdjson::ondemand::raw_json_string actual, const char * expected) {
+simdjson_inline bool equals_expected<simdjson::ondemand::raw_json_string, const char *>(simdjson::ondemand::raw_json_string actual, const char * expected) {
   return actual == expected;
 }
 
-simdjson_really_inline simdjson::error_code to_error_code(simdjson::error_code error) {
+simdjson_inline simdjson::error_code to_error_code(simdjson::error_code error) {
   return error;
 }
 template<typename T>
-simdjson_really_inline simdjson::error_code to_error_code(const simdjson::simdjson_result<T> &result) {
+simdjson_inline simdjson::error_code to_error_code(const simdjson::simdjson_result<T> &result) {
   return result.error();
 }
 
 template<typename T>
-simdjson_really_inline bool assert_success(const T &actual, const char *operation = "result") {
+simdjson_inline bool assert_success(const T &actual, const char *operation = "result") {
   simdjson::error_code error = to_error_code(actual);
   if (error) {
     std::cerr << "FAIL: " << operation << " returned error: " << error << " (" << int(error) << ")" << std::endl;
@@ -56,7 +56,7 @@ simdjson_really_inline bool assert_success(const T &actual, const char *operatio
   return true;
 }
 template<typename A, typename E=A>
-simdjson_really_inline bool assert_equal(const A &actual, const E &expected, const char *operation = "result") {
+simdjson_inline bool assert_equal(const A &actual, const E &expected, const char *operation = "result") {
   if (!equals_expected(actual, expected)) {
     std::cerr << "FAIL: " << operation << " returned '" << actual << "' (expected '" << expected << "')" << std::flush;
     std::cerr << std::endl;
@@ -65,7 +65,7 @@ simdjson_really_inline bool assert_equal(const A &actual, const E &expected, con
   return true;
 }
 template<typename T>
-simdjson_really_inline bool assert_error(const T &actual_result, simdjson::error_code expected, const char *operation = "result") {
+simdjson_inline bool assert_error(const T &actual_result, simdjson::error_code expected, const char *operation = "result") {
   simdjson::error_code actual = to_error_code(actual_result);
   if (actual != expected) {
     if (actual) {
@@ -79,19 +79,19 @@ simdjson_really_inline bool assert_error(const T &actual_result, simdjson::error
   return true;
 }
 template<typename A, typename E>
-simdjson_really_inline bool assert_result(simdjson::simdjson_result<A> &&actual_result, const E &expected, const char *operation = "result") {
+simdjson_inline bool assert_result(simdjson::simdjson_result<A> &&actual_result, const E &expected, const char *operation = "result") {
   E actual;
   return assert_success(std::forward<simdjson::simdjson_result<A>>(actual_result).get(actual))
       && assert_equal(actual, expected, operation);
 }
-simdjson_really_inline bool assert_true(bool value, const char *operation = "result") {
+simdjson_inline bool assert_true(bool value, const char *operation = "result") {
   if (!value) {
     std::cerr << "FAIL: " << operation << " was false!" << std::endl;
     return false;
   }
   return true;
 }
-simdjson_really_inline bool assert_false(bool value, const char *operation = "result") {
+simdjson_inline bool assert_false(bool value, const char *operation = "result") {
   if (value) {
     std::cerr << "FAIL: " << operation << " was true!" << std::endl;
     return false;
@@ -99,7 +99,7 @@ simdjson_really_inline bool assert_false(bool value, const char *operation = "re
   return true;
 }
 template<typename T>
-simdjson_really_inline bool assert_iterate_error(T &arr, simdjson::error_code expected, const char *operation = "result") {
+simdjson_inline bool assert_iterate_error(T &arr, simdjson::error_code expected, const char *operation = "result") {
   int count = 0;
   for (auto element : arr) {
     count++;


### PR DESCRIPTION
simdjson_inline is used for most simdjson functions. It forces inlining.
In unoptimized/debug builds, this can lead to a lot of machine code
being generated (especially with Address Sanitizer), causing slow
compilation.

Change simdjson_inline to force inlining only for optimized builds.

Sometimes, the programmer might want a slightly-optimized build and want
fast compilation (e.g. GCC's -Og mode). Allow simdjson users to define
the simdjson_inline macro themselves (e.g. on the command line:
-Dsimdjson_inline=inline) in cases where the default behavior is
undesired.

This patch reduced build times by over 75% for ondemand_object_tests.cpp
with GCC 9.4.0 and CMAKE_BUILD_TYPE=Debug on my AMD 5950X:

Before: 6.885 6.683 6.971 6.957 6.949 seconds (5 samples)
After:  1.492 1.551 1.494 1.490 1.531 seconds (5 samples)

