### PR TITLE
We change slightly on development checks are enabled.

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -245,16 +245,19 @@ transcode the UTF-8 strings produced by the simdjson library to other formats. S
 Using the Parsed JSON
 ---------------------
 
-
-
-We recommend that you first compile and run your code in Debug mode (with `NDEBUG`
-undefined). When you do so, the simdjson library runs additional sanity tests on
-your code to help ensure that you are using the library in a safe manner. Once
-your code has been tested, you can then run it in Release mode (with `NDEBUG`
-defined) for best performance. Alternatively, you can set the macro
-`SIMDJSON_DEVELOPMENT_CHECKS` to 1 prior to including the `simdjson.h` header
-to enable these additional checks: just make sure you remove the definition once your
-code has been tested.
+We recommend that you first compile and run your code in Debug mode: under Visual Studio,
+it means having the `_DEBUG` macro defined, and, for other compilers, it means leaving
+the `__OPTIMIZE__` macro undefined. The simdjson code will set `SIMDJSON_DEVELOPMENT_CHECKS=1`.
+Alternatively, you can set the macro `SIMDJSON_DEVELOPMENT_CHECKS` to 1 prior to including
+the `simdjson.h` header to enable these additional checks: just make sure you remove the
+definition once your code has been tested. When `SIMDJSON_DEVELOPMENT_CHECKS` is set to 1, the
+simdjson library runs additional (expensive) tests on your code to help ensure that you are
+using the library in a safe manner. Once your code has been tested, you can then run it in
+Release mode: under Visual Studio, it means having the `_DEBUG` macro undefined, and, for other
+compilers, it means setting `__OPTIMIZE__` to a positive integer. You can also forcefully
+disable these checks by setting `SIMDJSON_DEVELOPMENT_CHECKS` to 0. Once your code is tested, we
+further encourage you to define `NDEBUG` in your Release builds to disable additional runtime
+testing and get the best performance.
 
 Once you have a document (`simdjson::ondemand::document`), you can navigate it with
 idiomatic C++ iterators, operators and casts. Besides the document instances and

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -266,10 +266,35 @@ namespace std {
 /// If EXPR is an error, returns it.
 #define SIMDJSON_TRY(EXPR) { auto _err = (EXPR); if (_err) { return _err; } }
 
+// Unless the programmer has already set SIMDJSON_DEVELOPMENT_CHECKS,
+// we want to set it under debug builds. We detect a debug build
+// under Visual Studio when the _DEBUG macro is set. Under the other
+// compilers, we use the fact that they define __OPTIMIZE__ whenever
+// they allow optimizations.
+// It is possible that this could miss some cases where SIMDJSON_DEVELOPMENT_CHECKS
+// is helpful, but the programmer can set the macro SIMDJSON_DEVELOPMENT_CHECKS.
+// It could also wrongly set SIMDJSON_DEVELOPMENT_CHECKS (e.g., if the programmer
+// sets _DEBUG in a release build under Visual Studio, or if some compiler fails to
+// set the __OPTIMIZE__ macro).
 #ifndef SIMDJSON_DEVELOPMENT_CHECKS
-#ifndef NDEBUG
-#define SIMDJSON_DEVELOPMENT_CHECKS
-#endif
+#ifdef _MSC_VER
+// Visual Studio seems to set _DEBUG for debug builds.
+#ifdef _DEBUG
+#define SIMDJSON_DEVELOPMENT_CHECKS 1
+#endif // _DEBUG
+#else // _MSC_VER
+// All other compilers appear to set __OPTIMIZE__ to a positive integer
+// when the compiler is optimizing.
+#ifndef __OPTIMIZE__
+#define SIMDJSON_DEVELOPMENT_CHECKS 1
+#endif // __OPTIMIZE__
+#endif // _MSC_VER
+#endif // SIMDJSON_DEVELOPMENT_CHECKS
+
+#ifdef _DEBUG
+#define SIMDJSON_DEVELOPMENT_CHECKS 1
+#else
+    std::cout << "release build\n";
 #endif
 
 // The SIMDJSON_CHECK_EOF macro is a feature flag for the "don't require padding"

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -64,7 +64,7 @@ simdjson_really_inline simdjson_result<array> array::started(value_iterator &ite
 }
 
 simdjson_really_inline simdjson_result<array_iterator> array::begin() noexcept {
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
   if (!iter.is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   return array_iterator(iter);

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -319,7 +319,7 @@ simdjson_really_inline simdjson_result<std::string_view> json_iterator::unescape
 simdjson_really_inline void json_iterator::reenter_child(token_position position, depth_t child_depth) noexcept {
   SIMDJSON_ASSUME(child_depth >= 1 && child_depth < INT32_MAX);
   SIMDJSON_ASSUME(_depth == child_depth - 1);
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
 #ifndef SIMDJSON_CLANG_VISUAL_STUDIO
   SIMDJSON_ASSUME(position >= parser->start_positions[child_depth]);
 #endif
@@ -328,7 +328,7 @@ simdjson_really_inline void json_iterator::reenter_child(token_position position
   _depth = child_depth;
 }
 
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
 
 simdjson_really_inline token_position json_iterator::start_position(depth_t depth) const noexcept {
   return parser->start_positions[depth];

--- a/include/simdjson/generic/ondemand/json_iterator.h
+++ b/include/simdjson/generic/ondemand/json_iterator.h
@@ -241,7 +241,7 @@ public:
   simdjson_really_inline simdjson_result<std::string_view> unescape(raw_json_string in) noexcept;
   simdjson_really_inline void reenter_child(token_position position, depth_t child_depth) noexcept;
 
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
   simdjson_really_inline token_position start_position(depth_t depth) const noexcept;
   simdjson_really_inline void set_start_position(depth_t depth, token_position position) noexcept;
 #endif

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -90,7 +90,7 @@ simdjson_really_inline object::object(const value_iterator &_iter) noexcept
 }
 
 simdjson_really_inline simdjson_result<object_iterator> object::begin() noexcept {
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
   if (!iter.is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   return object_iterator(iter);

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -14,7 +14,7 @@ simdjson_warn_unused simdjson_really_inline error_code parser::allocate(size_t n
   _capacity = 0;
   size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * new_capacity / 3 + SIMDJSON_PADDING, 64);
   string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
   start_positions.reset(new (std::nothrow) token_position[new_max_depth]);
 #endif
   if (implementation) {

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -280,7 +280,7 @@ private:
   size_t _max_capacity;
   size_t _max_depth{DEFAULT_MAX_DEPTH};
   std::unique_ptr<uint8_t[]> string_buf{};
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
   std::unique_ptr<token_position[]> start_positions{};
 #endif
 

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -22,7 +22,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
 
 simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator::started_object() noexcept {
   assert_at_container_start();
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
   _json_iter->set_start_position(_depth, start_position());
 #endif
   if (*_json_iter->peek() == '}') {
@@ -111,7 +111,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //    ```
   //
   } else if (!is_open()) {
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
     // If we're past the end of the object, we're being iterated out of order.
     // Note: this isn't perfect detection. It's possible the user is inside some other object; if so,
     // this object iterator will blithely scan that object for fields.
@@ -136,7 +136,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   } else {
     if ((error = skip_child() )) { abandon(); return error; }
     if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
     if (_json_iter->start_position(_depth) != start_position()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   }
@@ -223,7 +223,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
   //
   } else if (!is_open()) {
 
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
     // If we're past the end of the object, we're being iterated out of order.
     // Note: this isn't perfect detection. It's possible the user is inside some other object; if so,
     // this object iterator will blithely scan that object for fields.
@@ -252,7 +252,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     if ((error = skip_child() )) { abandon(); return error; }
     search_start = _json_iter->position();
     if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
     if (_json_iter->start_position(_depth) != start_position()) { return OUT_OF_ORDER_ITERATION; }
 #endif
   }
@@ -413,7 +413,7 @@ simdjson_warn_unused simdjson_really_inline simdjson_result<bool> value_iterator
     return false;
   }
   _json_iter->descend_to(depth()+1);
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
   _json_iter->set_start_position(_depth, start_position());
 #endif
   return true;
@@ -774,7 +774,7 @@ simdjson_really_inline error_code value_iterator::start_container(uint8_t start_
   // If we're not at the position anymore, we don't want to advance the cursor.
   const uint8_t *json;
   if (!is_at_start()) {
-#ifdef SIMDJSON_DEVELOPMENT_CHECKS
+#if SIMDJSON_DEVELOPMENT_CHECKS
     if (!is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
 #endif
     json = peek_start();


### PR DESCRIPTION
Currently, we enable the expensive development checks *unless* NDEBUG is set. Though it is true that CMake will often set NDEBUG, it is not set by default by C++ compilers. This means that some folks are getting development checks even in their release builds. This was never reported to us, but it might happen.

We still rely on NDEBUG, but for our asserts... So the users should still want to set NDEBUG, but it is a different purpose. (The development checks are much more than mere asserts, they allocate buffers and so forth.)