### PR TITLE
Fixing issue 1870

### DIFF
--- a/include/simdjson/arm64/stringparsing.h
+++ b/include/simdjson/arm64/stringparsing.h
@@ -48,6 +48,4 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
 
-#include "simdjson/generic/stringparsing.h"
-
 #endif // SIMDJSON_ARM64_STRINGPARSING_H

--- a/include/simdjson/fallback/stringparsing.h
+++ b/include/simdjson/fallback/stringparsing.h
@@ -31,6 +31,4 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
 
-#include "simdjson/generic/stringparsing.h"
-
 #endif // SIMDJSON_FALLBACK_STRINGPARSING_H

--- a/include/simdjson/haswell/stringparsing.h
+++ b/include/simdjson/haswell/stringparsing.h
@@ -43,6 +43,4 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
 
-#include "simdjson/generic/stringparsing.h"
-
 #endif // SIMDJSON_HASWELL_STRINGPARSING_H

--- a/include/simdjson/icelake/stringparsing.h
+++ b/include/simdjson/icelake/stringparsing.h
@@ -43,6 +43,4 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
 
-#include "simdjson/generic/stringparsing.h"
-
 #endif // SIMDJSON_ICELAKE_STRINGPARSING_H

--- a/include/simdjson/ppc64/stringparsing.h
+++ b/include/simdjson/ppc64/stringparsing.h
@@ -60,6 +60,4 @@ backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
 
-#include "simdjson/generic/stringparsing.h"
-
 #endif // SIMDJSON_PPC64_STRINGPARSING_H

--- a/include/simdjson/westmere/stringparsing.h
+++ b/include/simdjson/westmere/stringparsing.h
@@ -41,6 +41,4 @@ simdjson_really_inline backslash_and_quote backslash_and_quote::copy_and_find(co
 } // namespace SIMDJSON_IMPLEMENTATION
 } // namespace simdjson
 
-#include "simdjson/generic/stringparsing.h"
-
 #endif // SIMDJSON_WESTMERE_STRINGPARSING_H

--- a/tests/ondemand/ondemand_misc_tests.cpp
+++ b/tests/ondemand/ondemand_misc_tests.cpp
@@ -52,6 +52,17 @@ namespace misc_tests {
     TEST_SUCCEED();
   }
 
+  bool issue1870() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("\uDC00")"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    std::string_view view;
+    ASSERT_ERROR( doc.get_string().get(view), STRING_ERROR );
+    TEST_SUCCEED();
+  }
+
   bool issue1660() {
     TEST_START();
     ondemand::parser parser;
@@ -447,6 +458,7 @@ namespace misc_tests {
 
   bool run() {
     return
+           issue1870() &&
            is_alive_root_array() &&
            is_alive_root_object() &&
            is_alive_array() &&


### PR DESCRIPTION
@MashPlant has identified a very interesting bug where it is possible, in the simdjson, to get back UTF-8 invalid strings, if you use the right escape sequences.

This PR also deletes an empty file that is no longer needed.

Fixes https://github.com/simdjson/simdjson/issues/1870