### PR TITLE
cleaning on-demand benchmarks

### DIFF
--- a/benchmark/bench_ondemand.cpp
+++ b/benchmark/bench_ondemand.cpp
@@ -25,74 +25,116 @@ SIMDJSON_PUSH_DISABLE_ALL_WARNINGS
 #include <benchmark/benchmark.h>
 
 SIMDJSON_POP_DISABLE_WARNINGS
-#include "json2msgpack/simdjson_dom.h"
 #include "json2msgpack/simdjson_ondemand.h"
-#include "json2msgpack/rapidjson.h"
+#include "json2msgpack/simdjson_dom.h"
 #include "json2msgpack/yyjson.h"
+#include "json2msgpack/rapidjson.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_SAJSON
 #include "json2msgpack/sajson.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_SAJSON
 #include "json2msgpack/nlohmann_json.h"
+
+#include "partial_tweets/simdjson_ondemand.h"
+#include "partial_tweets/simdjson_dom.h"
+#include "partial_tweets/yyjson.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "partial_tweets/sajson.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "partial_tweets/rapidjson.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "partial_tweets/rapidjson_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+#include "partial_tweets/nlohmann_json.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "partial_tweets/nlohmann_json_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+
+
+#include "distinct_user_id/simdjson_ondemand.h"
+#include "distinct_user_id/simdjson_ondemand_json_pointer.h"
+#include "distinct_user_id/simdjson_dom.h"
+#include "distinct_user_id/simdjson_dom_json_pointer.h"
+#include "distinct_user_id/yyjson.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "distinct_user_id/sajson.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "distinct_user_id/rapidjson.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "distinct_user_id/rapidjson_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+#include "distinct_user_id/nlohmann_json.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "distinct_user_id/nlohmann_json_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+
+#include "find_tweet/simdjson_ondemand.h"
+#include "find_tweet/simdjson_dom.h"
+#include "find_tweet/yyjson.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "find_tweet/sajson.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "find_tweet/rapidjson.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "find_tweet/rapidjson_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+#include "find_tweet/nlohmann_json.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "find_tweet/nlohmann_json_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+
+#include "top_tweet/simdjson_ondemand.h"
+#include "top_tweet/simdjson_dom.h"
+#include "top_tweet/yyjson.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "top_tweet/sajson.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "top_tweet/rapidjson.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "top_tweet/rapidjson_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+#include "top_tweet/nlohmann_json.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "top_tweet/nlohmann_json_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+
+
+#include "kostya/simdjson_ondemand.h"
+#include "kostya/simdjson_dom.h"
+#include "kostya/yyjson.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "kostya/sajson.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "kostya/rapidjson.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "kostya/rapidjson_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+#include "kostya/nlohmann_json.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "kostya/nlohmann_json_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+
+#include "large_random/simdjson_ondemand.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_UNORDERED
+#include "large_random/simdjson_ondemand_unordered.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_UNORDERED
+#include "large_random/simdjson_dom.h"
+#include "large_random/yyjson.h"
+#if SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "large_random/sajson.h"
+#endif // SIMDJSON_COMPETITION_ONDEMAND_SAJSON
+#include "large_random/rapidjson.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "large_random/rapidjson_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
+#include "large_random/nlohmann_json.h"
+#if SIMDJSON_COMPETITION_SAX
+#include "large_random/nlohmann_json_sax.h"
+#endif // SIMDJSON_COMPETITION_SAX
 
 #include "amazon_cellphones/simdjson_dom.h"
 #include "amazon_cellphones/simdjson_ondemand.h"
 
 #include "large_amazon_cellphones/simdjson_dom.h"
 #include "large_amazon_cellphones/simdjson_ondemand.h"
-
-#include "partial_tweets/simdjson_dom.h"
-#include "partial_tweets/simdjson_ondemand.h"
-#include "partial_tweets/yyjson.h"
-#include "partial_tweets/sajson.h"
-#include "partial_tweets/rapidjson.h"
-#include "partial_tweets/rapidjson_sax.h"
-#include "partial_tweets/nlohmann_json.h"
-#include "partial_tweets/nlohmann_json_sax.h"
-
-#include "large_random/simdjson_dom.h"
-#include "large_random/simdjson_ondemand.h"
-#include "large_random/simdjson_ondemand_unordered.h"
-#include "large_random/yyjson.h"
-#include "large_random/sajson.h"
-#include "large_random/rapidjson.h"
-#include "large_random/rapidjson_sax.h"
-#include "large_random/nlohmann_json.h"
-#include "large_random/nlohmann_json_sax.h"
-
-#include "kostya/simdjson_dom.h"
-#include "kostya/simdjson_ondemand.h"
-#include "kostya/yyjson.h"
-#include "kostya/sajson.h"
-#include "kostya/rapidjson.h"
-#include "kostya/rapidjson_sax.h"
-#include "kostya/nlohmann_json.h"
-#include "kostya/nlohmann_json_sax.h"
-
-#include "distinct_user_id/simdjson_dom.h"
-#include "distinct_user_id/simdjson_dom_json_pointer.h"
-#include "distinct_user_id/simdjson_ondemand.h"
-#include "distinct_user_id/simdjson_ondemand_json_pointer.h"
-#include "distinct_user_id/yyjson.h"
-#include "distinct_user_id/sajson.h"
-#include "distinct_user_id/rapidjson.h"
-#include "distinct_user_id/rapidjson_sax.h"
-#include "distinct_user_id/nlohmann_json.h"
-#include "distinct_user_id/nlohmann_json_sax.h"
-
-#include "find_tweet/simdjson_dom.h"
-#include "find_tweet/simdjson_ondemand.h"
-#include "find_tweet/yyjson.h"
-#include "find_tweet/sajson.h"
-#include "find_tweet/rapidjson.h"
-#include "find_tweet/rapidjson_sax.h"
-#include "find_tweet/nlohmann_json.h"
-#include "find_tweet/nlohmann_json_sax.h"
-
-#include "top_tweet/simdjson_dom.h"
-#include "top_tweet/simdjson_ondemand.h"
-#include "top_tweet/yyjson.h"
-#include "top_tweet/sajson.h"
-#include "top_tweet/rapidjson.h"
-#include "top_tweet/rapidjson_sax.h"
-#include "top_tweet/nlohmann_json.h"
-#include "top_tweet/nlohmann_json_sax.h"
 
 BENCHMARK_MAIN();

--- a/benchmark/distinct_user_id/rapidjson.h
+++ b/benchmark/distinct_user_id/rapidjson.h
@@ -46,13 +46,14 @@ struct rapidjson : rapidjson_base {
 };
 BENCHMARK_TEMPLATE(distinct_user_id, rapidjson)->UseManualTime();
 
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, rapidjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace partial_tweets
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/distinct_user_id/yyjson.h
+++ b/benchmark/distinct_user_id/yyjson.h
@@ -49,13 +49,14 @@ struct yyjson : yyjson_base {
 };
 BENCHMARK_TEMPLATE(distinct_user_id, yyjson)->UseManualTime();
 
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
     return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, yyjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace distinct_user_id
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/find_tweet/rapidjson.h
+++ b/benchmark/find_tweet/rapidjson.h
@@ -40,13 +40,14 @@ struct rapidjson : rapidjson_base {
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson)->UseManualTime();
 
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), find_id, result);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, rapidjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace find_tweet
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/find_tweet/yyjson.h
+++ b/benchmark/find_tweet/yyjson.h
@@ -40,14 +40,14 @@ struct yyjson : yyjson_base {
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, yyjson)->UseManualTime();
-
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
     return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), find_id, result);
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, yyjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace find_tweet
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/json2msgpack/rapidjson.h
+++ b/benchmark/json2msgpack/rapidjson.h
@@ -122,19 +122,21 @@ struct rapidjson_base {
 };
 
 
-using rapidjson_lossless = rapidjson_base<kParseValidateEncodingFlag|kParseFullPrecisionFlag>;
-
-BENCHMARK_TEMPLATE(json2msgpack, rapidjson_lossless)->UseManualTime();
-
-
-using rapidjson = rapidjson_base<kParseValidateEncodingFlag>;
+using rapidjson = rapidjson_base<kParseValidateEncodingFlag|kParseFullPrecisionFlag>;
 
 BENCHMARK_TEMPLATE(json2msgpack, rapidjson)->UseManualTime();
 
+#if SIMDJSON_COMPETITION_ONDEMAND_APPROX
+using rapidjson_approx = rapidjson_base<kParseValidateEncodingFlag>;
+
+BENCHMARK_TEMPLATE(json2msgpack, rapidjson_approx)->UseManualTime();
+#endif // SIMDJSON_COMPETITION_ONDEMAND_APPROX
+
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 using rapidjson_insitu = rapidjson_base<kParseValidateEncodingFlag|kParseInsituFlag>;
 
 BENCHMARK_TEMPLATE(json2msgpack, rapidjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace json2msgpack
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/json2msgpack/yyjson.h
+++ b/benchmark/json2msgpack/yyjson.h
@@ -106,6 +106,7 @@ struct yyjson : yyjson2msgpack {
 
 BENCHMARK_TEMPLATE(json2msgpack, yyjson)->UseManualTime();
 
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson2msgpack {
   bool run(simdjson::padded_string &json, char *buffer,
            std::string_view &result) {
@@ -116,7 +117,7 @@ struct yyjson_insitu : yyjson2msgpack {
   }
 };
 BENCHMARK_TEMPLATE(json2msgpack, yyjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace json2msgpack
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/kostya/rapidjson.h
+++ b/benchmark/kostya/rapidjson.h
@@ -34,28 +34,29 @@ struct rapidjson_base {
     return true;
   }
 };
-
-struct rapidjson : rapidjson_base {
+#if SIMDJSON_COMPETITION_ONDEMAND_APPROX
+struct rapidjson_approx : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
-BENCHMARK_TEMPLATE(kostya, rapidjson)->UseManualTime();
+BENCHMARK_TEMPLATE(kostya, rapidjson_approx)->UseManualTime();
+#endif // SIMDJSON_COMPETITION_ONDEMAND_APPROX
 
-struct rapidjson_lossless : rapidjson_base {
+struct rapidjson : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), result);
   }
 };
-BENCHMARK_TEMPLATE(kostya, rapidjson_lossless)->UseManualTime();
-
+BENCHMARK_TEMPLATE(kostya, rapidjson)->UseManualTime();
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, rapidjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace kostya
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/kostya/yyjson.h
+++ b/benchmark/kostya/yyjson.h
@@ -53,14 +53,14 @@ struct yyjson : yyjson_base {
   }
 };
 BENCHMARK_TEMPLATE(kostya, yyjson)->UseManualTime();
-
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
   }
 };
 BENCHMARK_TEMPLATE(kostya, yyjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace kostya
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/large_random/rapidjson.h
+++ b/benchmark/large_random/rapidjson.h
@@ -31,28 +31,30 @@ struct rapidjson_base {
     return true;
   }
 };
-
-struct rapidjson : rapidjson_base {
+#if SIMDJSON_COMPETITION_ONDEMAND_APPROX
+struct rapidjson_approx : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag>(json.data()), result);
   }
 };
-BENCHMARK_TEMPLATE(large_random, rapidjson)->UseManualTime();
+BENCHMARK_TEMPLATE(large_random, rapidjson_approx)->UseManualTime();
+#endif // SIMDJSON_COMPETITION_ONDEMAND_APPROX
 
-struct rapidjson_lossless : rapidjson_base {
+struct rapidjson : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.Parse<kParseValidateEncodingFlag | kParseFullPrecisionFlag>(json.data()), result);
   }
 };
-BENCHMARK_TEMPLATE(large_random, rapidjson_lossless)->UseManualTime();
+BENCHMARK_TEMPLATE(large_random, rapidjson)->UseManualTime();
 
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, rapidjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 
 } // namespace large_random
 

--- a/benchmark/large_random/yyjson.h
+++ b/benchmark/large_random/yyjson.h
@@ -51,14 +51,14 @@ struct yyjson : yyjson_base {
   }
 };
 BENCHMARK_TEMPLATE(large_random, yyjson)->UseManualTime();
-
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
     return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
   }
 };
 BENCHMARK_TEMPLATE(large_random, yyjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace large_random
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/partial_tweets/rapidjson.h
+++ b/benchmark/partial_tweets/rapidjson.h
@@ -67,14 +67,14 @@ struct rapidjson : rapidjson_base {
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, rapidjson)->UseManualTime();
-
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), result);
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, rapidjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace partial_tweets
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -66,14 +66,14 @@ struct yyjson : yyjson_base {
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, yyjson)->UseManualTime();
-
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
     return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, yyjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace partial_tweets
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/top_tweet/rapidjson.h
+++ b/benchmark/top_tweet/rapidjson.h
@@ -56,14 +56,14 @@ struct rapidjson : rapidjson_base {
   }
 };
 BENCHMARK_TEMPLATE(top_tweet, rapidjson)->UseManualTime();
-
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct rapidjson_insitu : rapidjson_base {
   bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
     return rapidjson_base::run(doc.ParseInsitu<kParseValidateEncodingFlag|kParseInsituFlag>(json.data()), max_retweet_count, result);
   }
 };
 BENCHMARK_TEMPLATE(top_tweet, rapidjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace top_tweet
 
 #endif // SIMDJSON_COMPETITION_RAPIDJSON

--- a/benchmark/top_tweet/yyjson.h
+++ b/benchmark/top_tweet/yyjson.h
@@ -55,14 +55,14 @@ struct yyjson : yyjson_base {
   }
 };
 BENCHMARK_TEMPLATE(top_tweet, yyjson)->UseManualTime();
-
+#if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
     return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), max_retweet_count, result);
   }
 };
 BENCHMARK_TEMPLATE(top_tweet, yyjson_insitu)->UseManualTime();
-
+#endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
 } // namespace top_tweet
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -91,7 +91,7 @@ int main() {}
   target_include_directories(jsoncpp SYSTEM PUBLIC "${jsoncpp_SOURCE_DIR}")
   target_compile_definitions(jsoncpp INTERFACE SIMDJSON_COMPETITION_JSONCPP)
 
-  import_dependency(rapidjson Tencent/rapidjson b32cd94)
+  import_dependency(rapidjson Tencent/rapidjson f54b0e4)
   add_library(rapidjson INTERFACE)
   target_compile_definitions(rapidjson INTERFACE RAPIDJSON_HAS_STDSTRING)
   target_include_directories(rapidjson SYSTEM INTERFACE
@@ -114,7 +114,7 @@ int main() {}
           "${ujson4c_SOURCE_DIR}/3rdparty")
   target_compile_definitions(ujson4c INTERFACE SIMDJSON_COMPETITION_UJSON4C)
 
-  import_dependency(yyjson ibireme/yyjson aa33ec5)
+  import_dependency(yyjson ibireme/yyjson c385651)
   add_library(yyjson STATIC "${yyjson_SOURCE_DIR}/src/yyjson.c")
   target_include_directories(yyjson SYSTEM PUBLIC "${yyjson_SOURCE_DIR}/src")
   target_compile_definitions(yyjson INTERFACE SIMDJSON_COMPETITION_YYJSON)


### PR DESCRIPTION
This sets yyjson and rapidjson their latest releases and it disables by default several competitors.
