### PR TITLE
Verifying and fixing issue 1876

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -433,7 +433,8 @@ support for users who avoid exceptions. See [the simdjson error handling documen
 * **Counting elements in arrays:** Sometimes it is useful to scan an array to determine its length prior to parsing it.
   For this purpose, `array` instances have a `count_elements` method. Users should be
   aware that the `count_elements` method can be costly since it requires scanning the
-  whole array. You may use it as follows if your document is itself an array:
+  whole array. You should only call `count_elements` as a last resort as it may
+  require scanning the document twice or more. You may use it as follows if your document is itself an array:
 
   ```C++
   auto cars_json = R"( [ 40.1, 39.9, 37.7, 40.4 ] )"_padded;
@@ -460,7 +461,8 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   parsing it.
   For this purpose, `object` instances have a `count_fields` method. Again, users should be
   aware that the `count_fields` method can be costly since it requires scanning the
-  whole objects. You may use it as follows if your document is itself an object:
+  whole objects. You should only call `count_fields` as a last resort as it may
+  require scanning the document twice or more.  You may use it as follows if your document is itself an object:
 
   ```C++
   ondemand::parser parser;

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -139,20 +139,14 @@ simdjson_inline simdjson_result<size_t> document::count_elements() & noexcept {
   auto a = get_array();
   simdjson_result<size_t> answer = a.count_elements();
   /* If there was an array, we are now left pointing at its first element. */
-  if(answer.error() == SUCCESS) {
-    iter._depth = 1 ; /* undoing the increment so we go back at the doc depth.*/
-    iter.assert_at_document_depth();
-  }
+  if(answer.error() == SUCCESS) { rewind(); }
   return answer;
 }
 simdjson_inline simdjson_result<size_t> document::count_fields() & noexcept {
   auto a = get_object();
   simdjson_result<size_t> answer = a.count_fields();
-  /* If there was an array, we are now left pointing at its first element. */
-  if(answer.error() == SUCCESS) {
-    iter._depth = 1 ; /* undoing the increment so we go back at the doc depth.*/
-    iter.assert_at_document_depth();
-  }
+  /* If there was an object, we are now left pointing at its first element. */
+  if(answer.error() == SUCCESS) { rewind(); }
   return answer;
 }
 simdjson_inline simdjson_result<value> document::at(size_t index) & noexcept {

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -166,6 +166,9 @@ public:
    *
    * To check that an object is empty, it is more performant to use
    * the is_empty() method.
+   *
+   * Performance hint: You should only call count_fields() as a last
+   * resort as it may require scanning the document twice or more.
    */
   simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
   /**

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -246,6 +246,9 @@ public:
    * beginning as if it had never been accessed. If the JSON is malformed (e.g.,
    * there is a missing comma), then an error is returned and it is no longer
    * safe to continue.
+   *
+   * Performance hint: You should only call count_elements() as a last
+   * resort as it may require scanning the document twice or more.
    */
   simdjson_inline simdjson_result<size_t> count_elements() & noexcept;
   /**
@@ -261,6 +264,9 @@ public:
    *
    * To check that an object is empty, it is more performant to use
    * the is_empty() method on the object instance.
+   *
+   * Performance hint: You should only call count_fields() as a last
+   * resort as it may require scanning the document twice or more.
    */
   simdjson_inline simdjson_result<size_t> count_fields() & noexcept;
   /**

--- a/tests/ondemand/ondemand_array_tests.cpp
+++ b/tests/ondemand/ondemand_array_tests.cpp
@@ -142,7 +142,7 @@ namespace array_tests {
     ASSERT_EQUAL(count, 0);
     for (auto element : arr) {
       double value;
-      ASSERT_SUCCESS(element.value().get_double().get(value));
+      ASSERT_SUCCESS(element.get_double().get(value));
       std::cout << value << std::endl;
     }
     TEST_SUCCEED();

--- a/tests/ondemand/ondemand_array_tests.cpp
+++ b/tests/ondemand/ondemand_array_tests.cpp
@@ -128,6 +128,26 @@ namespace array_tests {
     TEST_SUCCEED();
   }
 
+  bool issue1876() {
+    TEST_START();
+    auto json = R"( [] )"_padded;
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    size_t count;
+    ASSERT_SUCCESS(doc.count_elements().get(count));
+    ondemand::array arr;
+    ASSERT_SUCCESS(doc.get_array().get(arr));
+
+    ASSERT_EQUAL(count, 0);
+    for (auto element : arr) {
+      double value;
+      ASSERT_SUCCESS(element.value().get_double().get(value));
+      std::cout << value << std::endl;
+    }
+    TEST_SUCCEED();
+  }
+
   bool iterate_complex_array_count() {
     TEST_START();
     ondemand::parser parser;
@@ -810,6 +830,7 @@ namespace array_tests {
 
   bool run() {
     return
+           issue1876() &&
            issue1742() &&
            empty_rewind_convoluted() &&
            empty_rewind() &&

--- a/tests/ondemand/ondemand_object_tests.cpp
+++ b/tests/ondemand/ondemand_object_tests.cpp
@@ -896,6 +896,49 @@ namespace object_tests {
     TEST_SUCCEED();
   }
 
+  bool issue1876a() {
+    TEST_START();
+    auto json = R"( {} )"_padded;
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    ondemand::object obj;
+    ASSERT_SUCCESS(doc.get_object().get(obj));
+    size_t count;
+    ASSERT_SUCCESS(obj.count_fields().get(count));
+    ASSERT_EQUAL(count, 0);
+    for (auto field : obj) {
+      std::string_view key;
+      ASSERT_SUCCESS(field.unescaped_key().get(key));
+      double value;
+      ASSERT_SUCCESS(field.value().get_double().get(value));
+      std::cout << key << " " << value << std::endl;
+    }
+    TEST_SUCCEED();
+  }
+
+  bool issue1876() {
+    TEST_START();
+    auto json = R"( {} )"_padded;
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    size_t count;
+    ASSERT_SUCCESS(doc.count_fields().get(count));
+    ondemand::object obj;
+    ASSERT_SUCCESS(doc.get_object().get(obj));
+
+    ASSERT_EQUAL(count, 0);
+    for (auto field : obj) {
+      std::string_view key;
+      ASSERT_SUCCESS(field.unescaped_key().get(key));
+      double value;
+      ASSERT_SUCCESS(field.value().get_double().get(value));
+      std::cout << key << " " << value << std::endl;
+    }
+    TEST_SUCCEED();
+  }
+
   bool issue1742() {
     TEST_START();
     auto json = R"( {
@@ -1178,6 +1221,8 @@ namespace object_tests {
 
   bool run() {
     return
+           issue1876a() &&
+           issue1876() &&
            test_strager() &&
            issue1745() &&
            issue1742() &&


### PR DESCRIPTION
Calling `count_fields` on an empty document, and then instantiating an object over the document might currently be unsafe. Instantiating an object and then calling `count_fields`  on it is safe, which is the recommended usage.

Users are commended to use `count_fields`  sparingly.

Fixes https://github.com/simdjson/simdjson/issues/1876