### PR TITLE
fix: Reject surrogate pairs with invalid low surrogate

### DIFF
--- a/tests/ondemand/ondemand_misc_tests.cpp
+++ b/tests/ondemand/ondemand_misc_tests.cpp
@@ -63,6 +63,42 @@ namespace misc_tests {
     TEST_SUCCEED();
   }
 
+  // Test a surrogate pair with the low surrogate out of range
+  bool issue1894() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("\uD888\u1234")"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    std::string_view view;
+    ASSERT_ERROR(doc.get_string().get(view), STRING_ERROR);
+    TEST_SUCCEED();
+  }
+
+  bool issue1894toolarge() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("\uD888\uE000")"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    std::string_view view;
+    ASSERT_ERROR(doc.get_string().get(view), STRING_ERROR);
+    TEST_SUCCEED();
+  }
+
+  // Test the smallest surrogate pair, largest surrogate pair, and a surrogate pair in range.
+  bool issue1894success() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("\uD888\uDC00\uD800\uDC00\uDBFF\uDFFF")"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    std::string_view view;
+    ASSERT_SUCCESS(doc.get_string().get(view));
+	ASSERT_EQUAL(view, "\xf0\xb2\x80\x80\xf0\x90\x80\x80\xf4\x8f\xbf\xbf");
+    TEST_SUCCEED();
+  }
+
   bool issue1660() {
     TEST_START();
     ondemand::parser parser;
@@ -459,6 +495,9 @@ namespace misc_tests {
   bool run() {
     return
            issue1870() &&
+           issue1894() &&
+           issue1894toolarge() &&
+           issue1894success() &&
            is_alive_root_array() &&
            is_alive_root_object() &&
            is_alive_array() &&


### PR DESCRIPTION
Closes #1894

Reject low surrogates outside of the range U+DC00—U+DFFF

Related to https://unicodebook.readthedocs.io/unicode_encodings.html#utf-16-surrogate-pairs

A surrogate pair should consist of a high surrogate and low surrogate. They're used to represent 0x010000-0x10FFFF in the JSON spec because the JavaScript specification originally only supported `\uXXXX`.

Previously, simdjson would accept some combinations of valid high surrogates and invalid low surrogates due to a bug in the check. (e.g. `\uD888\u1234` was accepted)

U+D800—U+DBFF (1,024 code points): high surrogates
U+DC00—U+DFFF (1,024 code points): low surrogates
