### PR TITLE
[skip ci] Add an .editorconfig for .cpp/.h/.md for whitespace settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# https://editorconfig.org/
+root = true
+# Conservatively avoid changing defaults for other file types, e.g. raw json files for test cases,
+# Makefiles, etc.
+[*.{cpp,h,md}]
+charset                  = utf-8
+end_of_line              = lf
+indent_size              = 2
+indent_style             = space
+insert_final_newline     = true
+tab_width                = 2
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -78,6 +78,7 @@
 
 .gitattributes export-ignore
 .gitignore     export-ignore
+.editorconfig  export-ignore
 
 # Sources
 *.c     text eol=lf diff=c


### PR DESCRIPTION
Make it less likely to accidentally introduce tabs, trailing whitespace, carriage returns, non-utf8 in files, or files without trailing newlines.

https://editorconfig.org/ has plugins for various editors/IDEs and is enabled by default in some IDEs.

For now, introduce it only for the most commonly modified filetypes - I'm not familiar with the style guidelines/preferences for other files, and more extensions would increase the time to review this