### PR TITLE
[ondemand] Remove spurious start_positions,  remove max_depth parameter and deprecate

### DIFF
--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -8,7 +8,7 @@ simdjson_inline parser::parser(size_t max_capacity) noexcept
 
 simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capacity, size_t new_max_depth) noexcept {
   if (new_capacity > max_capacity()) { return CAPACITY; }
-  if (string_buf && new_capacity == capacity() && new_max_depth == max_depth()) { return SUCCESS; }
+  if (string_buf && new_capacity == capacity()) { return SUCCESS; }
 
   // string_capacity copied from document::allocate
   _capacity = 0;
@@ -21,7 +21,6 @@ simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capa
     SIMDJSON_TRY( simdjson::get_active_implementation()->create_dom_parser_implementation(new_capacity, new_max_depth, implementation) );
   }
   _capacity = new_capacity;
-  _max_depth = new_max_depth;
   return SUCCESS;
 }
 
@@ -30,7 +29,7 @@ simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(p
 
   // Allocate if needed
   if (capacity() < json.length() || !string_buf) {
-    SIMDJSON_TRY( allocate(json.length(), max_depth()) );
+    SIMDJSON_TRY( allocate(json.length()) );
   }
 
   // Run stage 1.
@@ -73,7 +72,7 @@ simdjson_warn_unused simdjson_inline simdjson_result<json_iterator> parser::iter
 
   // Allocate if needed
   if (capacity() < json.length()) {
-    SIMDJSON_TRY( allocate(json.length(), max_depth()) );
+    SIMDJSON_TRY( allocate(json.length()) );
   }
 
   // Run stage 1.
@@ -100,9 +99,6 @@ simdjson_inline size_t parser::capacity() const noexcept {
 }
 simdjson_inline size_t parser::max_capacity() const noexcept {
   return _max_capacity;
-}
-simdjson_inline size_t parser::max_depth() const noexcept {
-  return _max_depth;
 }
 
 simdjson_inline void parser::set_max_capacity(size_t max_capacity) noexcept {

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -100,7 +100,10 @@ simdjson_inline size_t parser::capacity() const noexcept {
 simdjson_inline size_t parser::max_capacity() const noexcept {
   return _max_capacity;
 }
-
+// deprecated method
+simdjson_inline size_t parser::max_depth() const noexcept {
+  return DEFAULT_MAX_DEPTH;
+}
 simdjson_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
   if(max_capacity < dom::MINIMAL_DOCUMENT_CAPACITY) {
     _max_capacity = max_capacity;

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -14,9 +14,6 @@ simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capa
   _capacity = 0;
   size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * new_capacity / 3 + SIMDJSON_PADDING, 64);
   string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
-#if SIMDJSON_DEVELOPMENT_CHECKS
-  start_positions.reset(new (std::nothrow) token_position[new_max_depth]);
-#endif
   if (implementation) {
     SIMDJSON_TRY( implementation->set_capacity(new_capacity) );
     SIMDJSON_TRY( implementation->set_max_depth(new_max_depth) );

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -280,9 +280,6 @@ private:
   size_t _max_capacity;
   size_t _max_depth{DEFAULT_MAX_DEPTH};
   std::unique_ptr<uint8_t[]> string_buf{};
-#if SIMDJSON_DEVELOPMENT_CHECKS
-  std::unique_ptr<token_position[]> start_positions{};
-#endif
 
   friend class json_iterator;
   friend class document_stream;

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -236,7 +236,7 @@ public:
    * and `max_depth` depth.
    *
    * @param capacity The new capacity.
-   * @param max_depth The new max_depth. Defaults to DEFAULT_MAX_DEPTH.
+   * @param max_depth The new max_depth. Defaults to DEFAULT_MAX_DEPTH. (This parameter has no effect.)
    * @return The error, if there is one.
    */
   simdjson_warn_unused error_code allocate(size_t capacity, size_t max_depth=DEFAULT_MAX_DEPTH) noexcept;

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -230,8 +230,6 @@ public:
   /** The maximum capacity of this parser (the largest document it is allowed to process). */
   simdjson_inline size_t max_capacity() const noexcept;
   simdjson_inline void set_max_capacity(size_t max_capacity) noexcept;
-  /** The maximum depth of this parser (the most deeply nested objects and arrays it can process). */
-  simdjson_inline size_t max_depth() const noexcept;
 
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
@@ -278,7 +276,6 @@ private:
   std::unique_ptr<internal::dom_parser_implementation> implementation{};
   size_t _capacity{0};
   size_t _max_capacity;
-  size_t _max_depth{DEFAULT_MAX_DEPTH};
   std::unique_ptr<uint8_t[]> string_buf{};
 
   friend class json_iterator;

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -230,7 +230,8 @@ public:
   /** The maximum capacity of this parser (the largest document it is allowed to process). */
   simdjson_inline size_t max_capacity() const noexcept;
   simdjson_inline void set_max_capacity(size_t max_capacity) noexcept;
-
+  /** Deprecated method. */
+  simdjson_inline size_t max_depth() const noexcept;
   /**
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
    * and `max_depth` depth.


### PR DESCRIPTION
The On Demand parser does not have a maximal depth. In debug mode, it was used to allocate a buffer but the buffer was never used. We are removing it.

There is a `current_depth()` method as part of the `document` instance which a user may check if, for example, they want to limit how deep the parsing may be. 

Fixes https://github.com/simdjson/simdjson/issues/1903
