### PR TITLE
Adding a couple of string tests.

### DIFF
--- a/tests/ondemand/ondemand_misc_tests.cpp
+++ b/tests/ondemand/ondemand_misc_tests.cpp
@@ -52,6 +52,30 @@ namespace misc_tests {
     TEST_SUCCEED();
   }
 
+  bool issue_uffff() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"(   "wow:\uFFFF"   )"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    std::string_view view;
+    ASSERT_SUCCESS( doc.get_string().get(view));
+    ASSERT_EQUAL(view, "wow:\uFFFF");
+    TEST_SUCCEED();
+  }
+
+  bool issue_backslash() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"(   "sc:\\./"   )"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    std::string_view view;
+    ASSERT_SUCCESS( doc.get_string().get(view));
+    ASSERT_EQUAL(view, "sc:\\./");
+    TEST_SUCCEED();
+  }
+
   bool issue1870() {
     TEST_START();
     ondemand::parser parser;
@@ -496,6 +520,8 @@ namespace misc_tests {
 
   bool run() {
     return
+           issue_uffff() &&
+           issue_backslash() &&
            issue1870() &&
            issue1894() &&
            issue1894toolarge() &&


### PR DESCRIPTION
We check that simdjson correctly decodes the UTF-8 strings  `"wow:\uFFFF"` and `"sc:\\./"`, escaping as needed.

(This is a very minor PR.)