### PR TITLE
Fix export component for simdjsonTargets.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ install(
     EXPORT simdjsonTargets
     NAMESPACE simdjson::
     DESTINATION "${SIMDJSON_INSTALL_CMAKEDIR}"
-    COMPONENT example_Development
+    COMPONENT simdjson_Development
 )
 
 # pkg-config


### PR DESCRIPTION
This fixes a bug that caused simdjsonTargets.cmake not to be included in CPack-generated packages, which—unlike `cmake --install`—does not pick up this mislabeled install component.

I git-grepped through the code base, after this change all components are either `simdjson_Development` or `simdjson_Runtime`.