### PR TITLE
Better way to put -Og in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,18 +95,18 @@ if(
   )
 endif()
 
-
 # GCC and Clang have horrendous Debug builds when using SIMD.
 # A common fix is to use '-Og' instead.
 # bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54412
 if(
     (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR
-        CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    AND CMAKE_BUILD_TYPE STREQUAL "Debug"
+        CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+        CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
 )
+  message(STATUS "Adding -Og to compile flag")
   simdjson_add_props(
       target_compile_options PRIVATE
-      -Og
+      $<$<CONFIG:DEBUG>:-Og>
   )
 endif()
 

--- a/tests/dom/document_stream_tests.cpp
+++ b/tests/dom/document_stream_tests.cpp
@@ -797,7 +797,7 @@ namespace document_stream_tests {
       simdjson::dom::document_stream stream;
       ASSERT_SUCCESS( parser.parse_many(str, batch_size).get(stream) );
       for (auto doc : stream) {
-        int64_t keyid;
+        int64_t keyid{};
         ASSERT_SUCCESS( doc["id"].get(keyid) );
         ASSERT_EQUAL( keyid, int64_t(count) );
 
@@ -837,7 +837,7 @@ namespace document_stream_tests {
       simdjson::dom::document_stream stream;
       ASSERT_SUCCESS( parser.parse_many(str, batch_size).get(stream) );
       for (auto doc : stream) {
-        int64_t keyid;
+        int64_t keyid{};
         ASSERT_SUCCESS( doc["id"].get(keyid) );
         ASSERT_EQUAL( keyid, int64_t(count) );
 

--- a/tests/dom/errortests.cpp
+++ b/tests/dom/errortests.cpp
@@ -46,7 +46,7 @@ namespace parser_load {
     ASSERT_SUCCESS(parser.parse_many(DOC).get(docs));
     for (auto doc : docs) {
       count++;
-      uint64_t val;
+      uint64_t val{};
       auto error = doc.get(val);
       if (count == 3) {
         ASSERT_ERROR(error, TAPE_ERROR);
@@ -83,7 +83,7 @@ namespace parser_load {
     ASSERT_SUCCESS(parser.parse_many(DOC).get(docs));
     for (auto doc : docs) {
       count++;
-      uint64_t val;
+      uint64_t val{};
       auto error = doc.get(val);
       if (count == 3) {
         ASSERT_ERROR(error, TAPE_ERROR);

--- a/tests/dom/integer_tests.cpp
+++ b/tests/dom/integer_tests.cpp
@@ -33,12 +33,12 @@ static bool parse_and_validate(const std::string src, T expected) {
   simdjson::dom::parser parser;
 
   if constexpr (std::is_same<int64_t, T>::value) {
-    int64_t actual;
+    int64_t actual{};
     ASSERT_SUCCESS( parser.parse(pstr)["key"].get(actual) );
     std::cout << std::boolalpha << "test: " << (expected == actual) << std::endl;
     ASSERT_EQUAL( expected, actual );
   } else {
-    uint64_t actual;
+    uint64_t actual{};
     ASSERT_SUCCESS( parser.parse(pstr)["key"].get(actual) );
     std::cout << std::boolalpha << "test: " << (expected == actual) << std::endl;
     ASSERT_EQUAL( expected, actual );

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -567,7 +567,7 @@ namespace document_stream_tests {
             size_t count{0};
             ASSERT_SUCCESS( parser.iterate_many(str, batch_size).get(stream) );
             for (auto doc : stream) {
-                int64_t keyid;
+                int64_t keyid{};
                 ASSERT_SUCCESS( doc["id"].get(keyid) );
                 ASSERT_EQUAL( keyid, int64_t(count) );
 
@@ -643,7 +643,7 @@ namespace document_stream_tests {
             size_t count{0};
             ASSERT_SUCCESS( parser.iterate_many(str, batch_size).get(stream) );
             for (auto doc : stream) {
-                int64_t keyid;
+                int64_t keyid{};
                 ASSERT_SUCCESS( doc["id"].get(keyid) );
                 ASSERT_EQUAL( keyid, int64_t(count) );
 

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -778,9 +778,9 @@ bool ndjson_basics_example() {
   size_t count{0};
   int64_t expected[3] = {1,2,3};
   for (auto doc : docs) {
-    int64_t actual;
+    int64_t actual{};
     ASSERT_SUCCESS( doc["foo"].get(actual) );
-    ASSERT_EQUAL( actual,expected[count++] );
+    ASSERT_EQUAL( actual, expected[count++] );
   }
   TEST_SUCCEED();
 }


### PR DESCRIPTION
Credit to @spnda for this better approach. It should cover ClangCL which is nice.
