### PR TITLE
Fix: Defining maximal DOM parser capacity

### DIFF
--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -226,7 +226,7 @@ inline error_code parser::ensure_capacity(document& target_document, size_t desi
 }
 
 simdjson_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
-  if(max_capacity < MINIMAL_DOCUMENT_CAPACITY) {
+  if(max_capacity > MINIMAL_DOCUMENT_CAPACITY) {
     _max_capacity = max_capacity;
   } else {
     _max_capacity = MINIMAL_DOCUMENT_CAPACITY;


### PR DESCRIPTION
We were noticing memory allocation issues with the `dom::` parser, and it led to this line, where potentially a different comparison operator should have been used.

If it is indeed the case, the `if`-`else` statement can be replaced with a simpler one-liner.

```cpp
max_capacity_ = std::max(MINIMAL_DOCUMENT_CAPACITY, max_capacity)
```

