### PR TITLE
Add link to Perl binding (JSON::SIMD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ We distinguish between "bindings" (which just wrap the C++ code) and a port to a
 - [hermes-json](https://hackage.haskell.org/package/hermes-json): haskell bindings.
 - [simdjzon](https://github.com/travisstaloch/simdjzon): zig port.
 - [JSON-Simd](https://github.com/rawleyfowler/JSON-simd): Raku bindings.
+- [JSON::SIMD](https://metacpan.org/pod/JSON::SIMD): Perl bindings; fully-featured JSON module that uses simdjson for decoding.
 
 About simdjson
 --------------


### PR DESCRIPTION
As requested, here is a pull request with the link to the Perl module.

Closes #1990.