### PR TITLE
Some systems release without NDEBUG set, let us not assert in these cases.

### DIFF
--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -170,8 +170,9 @@ use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
 #define simdjson_strncasecmp strncasecmp
 #endif
 
-#ifdef NDEBUG
-
+#if defined(NDEBUG) || defined(__OPTIMIZE__) || (defined(_MSC_VER) && !defined(_DEBUG))
+// If NDEBUG is set, or __OPTIMIZE__ is set, or we are under MSVC in release mode,
+// then do away with asserts and use __assume.
 #if SIMDJSON_VISUAL_STUDIO
 #define SIMDJSON_UNREACHABLE() __assume(0)
 #define SIMDJSON_ASSUME(COND) __assume(COND)
@@ -180,8 +181,8 @@ use a 64-bit target such as x64, 64-bit ARM or 64-bit PPC.")
 #define SIMDJSON_ASSUME(COND) do { if (!(COND)) __builtin_unreachable(); } while (0)
 #endif
 
-#else // NDEBUG
-
+#else // defined(NDEBUG) || defined(__OPTIMIZE__) || (defined(_MSC_VER) && !defined(_DEBUG))
+// This should only ever be enabled in debug mode.
 #define SIMDJSON_UNREACHABLE() assert(0);
 #define SIMDJSON_ASSUME(COND) assert(COND)
 

--- a/tests/dom/stringparsingcheck.cpp
+++ b/tests/dom/stringparsingcheck.cpp
@@ -60,7 +60,6 @@ static inline void write_utf8(unsigned codepoint, char *&end) {
     *end++ = static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));
     *end++ = static_cast<char>(0x80 | (codepoint & 0x3F));
   } else {
-    assert(codepoint < 0x200000);
     *end++ = static_cast<char>(0xF0 | (codepoint >> 18));
     *end++ = static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F));
     *end++ = static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));


### PR DESCRIPTION
We should only use runtime asserts in simdjson when the software is built in debug mode.