### PR TITLE
update various actions in GitHub Actions to v3

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -124,7 +124,7 @@ jobs:
         done
 
     - name: Save the corpus as a github artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: corpus
         path: corpus.tar
@@ -147,7 +147,7 @@ jobs:
       run: tar cf valgrind.tar valgrind-*.txt
 
     - name: Save valgrind output as a github artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: valgrindresults
@@ -155,7 +155,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: Archive any crashes as an artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: crashes

--- a/.github/workflows/power-fuzz.yml
+++ b/.github/workflows/power-fuzz.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build on ubuntu-20.04 ppc64le
     steps:
-      - uses: actions/checkout@v2.1.0
+      - uses: actions/checkout@v3
       - uses: uraimo/run-on-arch-action@v2.0.5
         name: Run commands
         id: runcmd

--- a/.github/workflows/ubuntu22-cxx20.yml
+++ b/.github/workflows/ubuntu22-cxx20.yml
@@ -9,8 +9,8 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
         with:
           path: dependencies/.cache
           key: ${{ hashFiles('dependencies/CMakeLists.txt') }}

--- a/.github/workflows/vs17-ci-cxx20.yml
+++ b/.github/workflows/vs17-ci-cxx20.yml
@@ -19,7 +19,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Configure
       run: |
         cmake -DSIMDJSON_CXX_STANDARD=20 -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build


### PR DESCRIPTION
The updated actions are [actions/cache](https://github.com/actions/cache), [actions/checkout](https://github.com/actions/checkout) and [actions/upload-artifact](https://github.com/actions/upload-artifact).

Changes in [actions/cache](https://github.com/actions/cache):

> ### 3.0.0
> - Updated minimum runner version support from node 12 -> node 16
> 
> ### 3.0.1
> - Added support for caching from GHES 3.5.
> - Fixed download issue for files > 2GB during restore.
> 
> ### 3.0.2
> - Added support for dynamic cache size cap on GHES.
> 
> ### 3.0.3
> - Fixed avoiding empty cache save when no files are available for caching. ([issue](https://github.com/actions/cache/issues/624))
> 
> ### 3.0.4
> - Fixed tar creation error while trying to create tar with path as `~/` home folder on `ubuntu-latest`. ([issue](https://github.com/actions/cache/issues/689))
> 
> ### 3.0.5
> - Removed error handling by consuming actions/cache 3.0 toolkit, Now cache server error handling will be done by toolkit. ([PR](https://github.com/actions/cache/pull/834))
> 
> ### 3.0.6
> - Fixed [#809](https://github.com/actions/cache/issues/809) - zstd -d: no such file or directory error
> - Fixed [#833](https://github.com/actions/cache/issues/833) - cache doesn't work with github workspace directory
> 
> ### 3.0.7
> - Fixed [#810](https://github.com/actions/cache/issues/810) - download stuck issue. A new timeout is introduced in the download process to abort the download if it gets stuck and doesn't finish within an hour.
> 
> ### 3.0.8
> - Fix zstd not working for windows on gnu tar in issues [#888](https://github.com/actions/cache/issues/888) and [#891](https://github.com/actions/cache/issues/891).
> - Allowing users to provide a custom timeout as input for aborting download of a cache segment using an environment variable `SEGMENT_DOWNLOAD_TIMEOUT_MINS`. Default is 60 minutes.
> 
> ### 3.0.9
> - Enhanced the warning message for cache unavailablity in case of GHES.
> 
> ### 3.0.10
> - Fix a bug with sorting inputs.
> - Update definition for restore-keys in README.md
> 
> ### 3.0.11
> - Update toolkit version to 3.0.5 to include `@actions/core@^1.10.0`
> - Update `@actions/cache` to use updated `saveState` and `setOutput` functions from `@actions/core@^1.10.0`
> 
> ### 3.1.0-beta.1
> - Update `@actions/cache` on windows to use gnu tar and zstd by default and fallback to bsdtar and zstd if gnu tar is not available. ([issue](https://github.com/actions/cache/issues/984))
> 
> ### 3.1.0-beta.2
> - Added support for fallback to gzip to restore old caches on windows.
> 
> ### 3.1.0-beta.3
> - Bug fixes for bsdtar fallback if gnutar not available and gzip fallback if cache saved using old cache action on windows.
> 
> ### 3.2.0-beta.1
> - Added two new actions - [restore](restore/action.yml) and [save](save/action.yml) for granular control on cache.
> 
> ### 3.2.0
> - Released the two new actions - [restore](restore/action.yml) and [save](save/action.yml) for granular control on cache
> 
> ### 3.2.1
> - Update `@actions/cache` on windows to use gnu tar and zstd by default and fallback to bsdtar and zstd if gnu tar is not available. ([issue](https://github.com/actions/cache/issues/984))
> - Added support for fallback to gzip to restore old caches on windows.
> - Added logs for cache version in case of a cache miss.
>
> ### 3.2.2
> - Reverted the changes made in 3.2.1 to use gnu tar and zstd by default on windows.
>
> ### 3.2.3
> - Support cross os caching on Windows as an opt-in feature.
> - Fix issue with symlink restoration on Windows for cross-os caches.
>
> ### 3.2.4
> - Added option to fail job on cache miss.
>
> ### 3.2.5
> - Added fix to prevent from setting MYSYS environment variable globally.
>
> ### 3.2.6
> - Fix zstd not being used after zstd version upgrade to 1.5.4 on hosted runners.
>
> ### 3.3.0
> - Added option to lookup cache without downloading it.
>
> ### 3.3.1
> - Reduced segment size to 128MB and segment timeout to 10 minutes to fail fast in case the cache download is stuck.

Changes in [actions/checkout](https://github.com/actions/checkout):

> ## v3.5.3
> - Fix: Checkout fail in self-hosted runners when faulty submodule are checked-in
> - Fix typos found by codespell
> - Add support for sparse checkouts
>
> ## v3.5.2
> - Fix api endpoint for GHES
>
> ## v3.5.1
> - Fix slow checkout on Windows
>
> ## v3.5.0
> - Add new public key for known_hosts
>
> ## v3.4.0
> - Upgrade codeql actions to v2
> - Upgrade dependencies
> - Upgrade @actions/io
>
> ## v3.3.0
> - Implement branch list using callbacks from exec function
> - Add in explicit reference to private checkout options
> - Fix comment typos
>
> ## v3.2.0
> - Add GitHub Action to perform release
> - Fix status badge
> - Replace datadog/squid with ubuntu/squid Docker image
> - Wrap pipeline commands for submoduleForeach in quotes
> - Update @actions/io to 1.1.2
> - Upgrading version to 3.2.0
>
> ## v3.1.0
> - Use @actions/core `saveState` and `getState`
> - Add `github-server-url` input
>
> ## v3.0.2
> - Add input `set-safe-directory`
>
> ## v3.0.1
> - Fixed an issue where checkout failed to run in container jobs due to the new git setting `safe.directory`
> - Bumped various npm package versions
>
> ## v3.0.0
>
> - Update to node 16

Changes in [actions/upload-artifact](https://github.com/actions/upload-artifact):
> ## v3.1.2
> - Update all `@actions/*` NPM packages to their latest versions
> - Update all dev dependencies to their most recent versions
>
> ## v3.1.1
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.1.0
> - Bump @actions/artifact to v1.1.0
>   - Adds checksum headers on artifact upload
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

As far as I can tell this should all be backwards compatible, so I do not expect any breakage.

Still using the outdated actions will generate several warnings in CI runs, for example in https://github.com/simdjson/simdjson/actions/runs/5279348647:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings.