### PR TITLE
Add pretty print for DOM

### DIFF
--- a/doc/dom.md
+++ b/doc/dom.md
@@ -105,7 +105,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   with the `size()` method.
 * **Checking an Element Type:** You can check an element's type with `element.type()`. It
   returns an `element_type` with values such as `simdjson::dom::element_type::ARRAY`, `simdjson::dom::element_type::OBJECT`, `simdjson::dom::element_type::INT64`,  `simdjson::dom::element_type::UINT64`,`simdjson::dom::element_type::DOUBLE`, `simdjson::dom::element_type::STRING`, `simdjson::dom::element_type::BOOL` or, `simdjson::dom::element_type::NULL_VALUE`.
-* **Output to streams and strings:** Given a document or an element (or node) out of a JSON document, you can output a minified string version using the C++ stream idiom (`out << element`). You can also request the construction of a minified string version (`simdjson::minify(element)`). Numbers are serialized as 64-bit floating-point numbers (`double`).
+* **Output to streams and strings:** Given a document or an element (or node) out of a JSON document, you can output a minified string version using the C++ stream idiom (`out << element`). You can also request the construction of a minified string version (`simdjson::minify(element)`) or a prettified string version (`simdjson::prettify(element)`). Numbers are serialized as 64-bit floating-point numbers (`double`).
 
 ### Examples
 

--- a/include/simdjson/dom/serialization-inl.h
+++ b/include/simdjson/dom/serialization-inl.h
@@ -100,6 +100,8 @@ char *fast_itoa(char *output, uint64_t value) noexcept {
   std::memcpy(output, write_pointer, len);
   return output + len;
 }
+
+
 } // anonymous namespace
 namespace internal {
 
@@ -107,19 +109,22 @@ namespace internal {
  * Minifier/formatter code.
  **/
 
-simdjson_inline void mini_formatter::number(uint64_t x) {
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::number(uint64_t x) {
   char number_buffer[24];
   char *newp = fast_itoa(number_buffer, x);
   buffer.insert(buffer.end(), number_buffer, newp);
 }
 
-simdjson_inline void mini_formatter::number(int64_t x) {
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::number(int64_t x) {
   char number_buffer[24];
   char *newp = fast_itoa(number_buffer, x);
   buffer.insert(buffer.end(), number_buffer, newp);
 }
 
-simdjson_inline void mini_formatter::number(double x) {
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::number(double x) {
   char number_buffer[24];
   // Currently, passing the nullptr to the second argument is
   // safe because our implementation does not check the second
@@ -128,31 +133,51 @@ simdjson_inline void mini_formatter::number(double x) {
   buffer.insert(buffer.end(), number_buffer, newp);
 }
 
-simdjson_inline void mini_formatter::start_array() { one_char('['); }
-simdjson_inline void mini_formatter::end_array() { one_char(']'); }
-simdjson_inline void mini_formatter::start_object() { one_char('{'); }
-simdjson_inline void mini_formatter::end_object() { one_char('}'); }
-simdjson_inline void mini_formatter::comma() { one_char(','); }
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::start_array() { one_char('['); }
 
 
-simdjson_inline void mini_formatter::true_atom() {
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::end_array() { one_char(']'); }
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::start_object() { one_char('{'); }
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::end_object() { one_char('}'); }
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::comma() { one_char(','); }
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::true_atom() {
   const char * s = "true";
   buffer.insert(buffer.end(), s, s + 4);
 }
-simdjson_inline void mini_formatter::false_atom() {
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::false_atom() {
   const char * s = "false";
   buffer.insert(buffer.end(), s, s + 5);
 }
-simdjson_inline void mini_formatter::null_atom() {
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::null_atom() {
   const char * s = "null";
   buffer.insert(buffer.end(), s, s + 4);
 }
-simdjson_inline void mini_formatter::one_char(char c) { buffer.push_back(c); }
-simdjson_inline void mini_formatter::key(std::string_view unescaped) {
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::one_char(char c) { buffer.push_back(c); }
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::key(std::string_view unescaped) {
   string(unescaped);
   one_char(':');
 }
-simdjson_inline void mini_formatter::string(std::string_view unescaped) {
+
+template<class formatter>
+simdjson_inline void base_formatter<formatter>::string(std::string_view unescaped) {
   one_char('\"');
   size_t i = 0;
   // Fast path for the case where we have no control character, no ", and no backslash.
@@ -231,14 +256,46 @@ simdjson_inline void mini_formatter::string(std::string_view unescaped) {
   one_char('\"');
 }
 
-inline void mini_formatter::clear() {
+
+template<class formatter>
+inline void base_formatter<formatter>::clear() {
   buffer.clear();
 }
 
-simdjson_inline std::string_view mini_formatter::str() const {
+template<class formatter>
+simdjson_inline std::string_view base_formatter<formatter>::str() const {
   return std::string_view(buffer.data(), buffer.size());
 }
 
+simdjson_inline void mini_formatter::print_newline() {
+    return;
+}
+
+simdjson_inline void mini_formatter::print_indents(size_t depth) {
+    (void)depth;
+    return;
+}
+
+simdjson_inline void mini_formatter::print_space() {
+    return;
+}
+
+simdjson_inline void pretty_formatter::print_newline() {
+    one_char('\n');
+}
+
+simdjson_inline void pretty_formatter::print_indents(size_t depth) {
+    if(this->indent_step <= 0) {
+        return;
+    }
+    for(size_t i = 0; i < this->indent_step * depth; i++) {
+        one_char(' ');
+    }
+}
+
+simdjson_inline void pretty_formatter::print_space() {
+    one_char(' ');
+}
 
 /***
  * String building code.
@@ -258,11 +315,16 @@ inline void string_builder<serializer>::append(simdjson::dom::element value) {
     // print commas after each value
     if (after_value) {
       format.comma();
+      format.print_newline();
     }
+
+    format.print_indents(depth);
+
     // If we are in an object, print the next key and :, and skip to the next
     // value.
     if (is_object[depth]) {
       format.key(iter.get_string_view());
+      format.print_space();
       iter.json_index++;
     }
     switch (iter.tape_ref_type()) {
@@ -291,6 +353,7 @@ inline void string_builder<serializer>::append(simdjson::dom::element value) {
 
       is_object[depth] = false;
       after_value = false;
+      format.print_newline();
       continue;
     }
 
@@ -318,6 +381,7 @@ inline void string_builder<serializer>::append(simdjson::dom::element value) {
 
       is_object[depth] = true;
       after_value = false;
+      format.print_newline();
       continue;
     }
 
@@ -362,17 +426,21 @@ inline void string_builder<serializer>::append(simdjson::dom::element value) {
     // Handle multiple ends in a row
     while (depth != 0 && (iter.tape_ref_type() == tape_type::END_ARRAY ||
                           iter.tape_ref_type() == tape_type::END_OBJECT)) {
+      format.print_newline();
+      depth--;
+      format.print_indents(depth);
       if (iter.tape_ref_type() == tape_type::END_ARRAY) {
         format.end_array();
       } else {
         format.end_object();
       }
-      depth--;
       iter.json_index++;
     }
 
     // Stop when we're at depth 0
   } while (depth != 0);
+
+  format.print_newline();
 }
 
 template <class serializer>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ link_libraries(simdjson)
 add_cpp_test(unicode_tests       LABELS dom acceptance per_implementation)
 add_cpp_test(minify_tests        LABELS other acceptance per_implementation)
 add_cpp_test(padded_string_tests LABELS other acceptance                   )
+add_cpp_test(prettify_tests      LABELS other acceptance per_implementation)
 
 if(MSVC AND BUILD_SHARED_LIBS)
   # Copy the simdjson dll into the tests directory

--- a/tests/prettify_tests.cpp
+++ b/tests/prettify_tests.cpp
@@ -1,0 +1,63 @@
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <set>
+#include <sstream>
+#include <string>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+#include "cast_tester.h"
+#include "simdjson.h"
+#include "test_macros.h"
+
+const char *test_files[] = {
+    TWITTER_JSON, TWITTER_TIMELINE_JSON, REPEAT_JSON, CANADA_JSON,
+    MESH_JSON,    APACHE_JSON,           GSOC_JSON};
+
+/**
+ * The general idea of these tests if that if you take a JSON file,
+ * load it, then convert it into a string, then parse that, and
+ * convert it again into a second string, then the two strings should
+ * be  identifical. If not, then something was lost or added in the
+ * process.
+ */
+
+bool load_prettify(const char *filename) {
+  std::cout << "Loading " << filename << std::endl;
+  simdjson::dom::parser parser;
+  simdjson::dom::element doc;
+  auto error = parser.load(filename).get(doc);
+  if (error) { std::cerr << error << std::endl; return false; }
+  auto serial1 = simdjson::prettify(doc);
+  error = parser.parse(serial1).get(doc);
+  if (error) { std::cerr << error << std::endl; return false; }
+  auto serial2 = simdjson::prettify(doc);
+  bool match = (serial1 == serial2);
+  if (match) {
+    std::cout << "Parsing prettify and calling prettify again results in the same "
+                 "content."
+              << std::endl;
+  } else {
+    std::cout << "The content differs!" << std::endl;
+  }
+  return match;
+}
+
+bool prettify_test() {
+  std::cout << "Running " << __func__ << std::endl;
+
+  for (size_t i = 0; i < sizeof(test_files) / sizeof(test_files[0]); i++) {
+    bool ok = load_prettify(test_files[i]);
+    if (!ok) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int main() { return prettify_test() ? EXIT_SUCCESS : EXIT_FAILURE; }


### PR DESCRIPTION
Add pretty print for DOM with documentation.
Currently, the indentation is fixed to four spaces.

Close #1329.
