### PR TITLE
Peek(0) is an error on 32-bit systems, where pointers are indistingui…

### DIFF
--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -254,7 +254,7 @@ simdjson_inline const uint8_t *json_iterator::return_current_and_advance() noexc
 
 simdjson_inline const uint8_t *json_iterator::unsafe_pointer() const noexcept {
   // deliberately done without safety guard:
-  return token.peek(0);
+  return token.peek();
 }
 
 simdjson_inline const uint8_t *json_iterator::peek(int32_t delta) const noexcept {

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -96,7 +96,7 @@ simdjson_inline simdjson_result<std::string_view> object::raw_json() noexcept {
   const uint8_t * starting_point{iter.peek_start()};
   auto error = consume();
   if(error) { return error; }
-  const uint8_t * final_point{iter._json_iter->peek(0)};
+  const uint8_t * final_point{iter._json_iter->peek()};
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 


### PR DESCRIPTION
…shable from int32_t

yeah, that.  I know 32 bit systems aren't really supported, especially since #1508 isn't done, but having a working 32-bit version helps in my project, SilliconJson.  Since the message that prints if you do use a 32 bit system doesn't say "this won't work at all", lets keep it somewhat working.
