### PR TITLE
Simplifying CI

### DIFF
--- a/.github/workflows/ubuntu22-clang13.yml
+++ b/.github/workflows/ubuntu22-clang13.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           path: dependencies/.cache
           key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
-      - name: Install clang++-13
-        run: sudo apt-get install -y clang++-13
       - name: Use cmake
         run: |
           mkdir build &&

--- a/.github/workflows/ubuntu22-clang14.yml
+++ b/.github/workflows/ubuntu22-clang14.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           path: dependencies/.cache
           key: ${{ hashFiles('dependencies/CMakeLists.txt') }}
-      - name: Install clang++-14
-        run: sudo apt-get install -y clang++-14
       - name: Use cmake
         run: |
           mkdir build &&


### PR DESCRIPTION
These lines should not be necessary: clang-14 and clang-13 are documented as being available by default with ubuntu-22 under GitHub Actions.