### PR TITLE
Icelake processes 64 bytes at a time when processing strings.

### DIFF
--- a/include/simdjson/icelake/stringparsing_defs.h
+++ b/include/simdjson/icelake/stringparsing_defs.h
@@ -16,7 +16,7 @@ using namespace simd;
 // Holds backslashes and quotes locations.
 struct backslash_and_quote {
 public:
-  static constexpr uint32_t BYTES_PROCESSED = 32;
+  static constexpr uint32_t BYTES_PROCESSED = 64;
   simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }


### PR DESCRIPTION
When processing strings, the haswell and icelake kernels call the `simd8<uint8_t>` each time a string is accessed.

```
simd8<uint8_t> v(src);
```

For haswell, `simd8<uint8_t>` is a wrapper around `__m256i` (32 bytes), for icelake, it is a wrapper around `__m512i` (64 bytes). Yet we consider currently that both of them read 32 bytes. This potentially means that the icelake kernel will advance by only 32 bytes even though it reads 64 bytes. It should still provide the correct answers, but it will be wasteful.

For westmere, we call two constructors, consuming 16 bytes each...

```
simd8<uint8_t> v0(src);
simd8<uint8_t> v1(src + 16);
```

For neon, it is much the same:
```
simd8<uint8_t> v0(src);
simd8<uint8_t> v1(src + sizeof(v0));
```


Credit @jkeiser 