### PR TITLE
Redesigning visit_primitive so that it is optimized for strings and numbers (DOM backend)

### DIFF
--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -303,15 +303,17 @@ simdjson_warn_unused simdjson_inline error_code json_iterator::visit_root_primit
 }
 template<typename V>
 simdjson_warn_unused simdjson_inline error_code json_iterator::visit_primitive(V &visitor, const uint8_t *value) noexcept {
+  // Use the fact that most scalars are going to be either strings or numbers.
+  if(*value == '"') {
+    return visitor.visit_string(*this, value);
+  } else if (((*value - '0')  < 10) || (*value == '-')) {
+    return visitor.visit_number(*this, value);
+  }
+  // true, false, null are uncommon.
   switch (*value) {
-    case '"': return visitor.visit_string(*this, value);
     case 't': return visitor.visit_true_atom(*this, value);
     case 'f': return visitor.visit_false_atom(*this, value);
     case 'n': return visitor.visit_null_atom(*this, value);
-    case '-':
-    case '0': case '1': case '2': case '3': case '4':
-    case '5': case '6': case '7': case '8': case '9':
-      return visitor.visit_number(*this, value);
     default:
       log_error("Non-value found when value was expected!");
       return TAPE_ERROR;


### PR DESCRIPTION
Originally, simdjson relied on computed gotos but given that it is not a standard C/C++ feature, it made the code ugly as you needed fallback code.

Cleverly @jkeiser showed that you could get much of the same performance using switch/cases. Unfortunately, switch/cases are a high level abstraction: it can be compiled in different manners. We would want them compiled as computed gotos, but that's not when GCC and LLVM do.

We can try to bypass them if we think we can do better. In particular, the compiler has no idea that most JSON is made of strings and numbers. We can try to tell it. The gains might be modest, but widespread.

The current PR will only affect the DOM performance.

We can use an array of strings as a test case:

```Python
print("[")
for i in range(1000000):
  print("\"key"+str(i)+"\",\"value"+str(i)+"\",")
print("\"key1000000\",\"value1000000\"")
print("]")
```

With this test case, we get a reduction of 10% of the number of instructions in stage 2 (on two different platforms) which is quite large in our context. The actual overall performance gain is nearly 5% for this synthetic case.

For our reference test case, twitter.json, there are some robust gains as well.

This PR suggests that we may want to revisit the switch case as, evidently, a single switch/case can explain 10% of our instruction counts in stage 2.

## Twitter.json (Apple M2 LLVM 14)

Master:
```
$ sudo ./build/benchmark/dom/parse -n 1000 jsonexamples/twitter.json
number of iterations 1000

jsonexamples/twitter.json
=========================
     9867 blocks -     631515 bytes - 55262 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  17.6877 ns per block ( 89.75%) -   0.2764 ns per byte -   3.1584 ns per structural -   3.6181 GB/s
|    Cycles       :  62.8003 per block    ( 98.38%) -   0.9813 per byte    -  11.2141 per structural    -    3.551 GHz est. frequency
|    Instructions : 378.6804 per block    ( 99.99%) -   5.9172 per byte    -  67.6200 per structural    -    6.030 per cycle
|- Stage 1
|    Speed        :   9.5384 ns per block ( 48.40%) -   0.1490 ns per byte -   1.7032 ns per structural -   6.7093 GB/s
|    Cycles       :  33.8544 per block    ( 53.04%) -   0.5290 per byte    -   6.0453 per structural    -    3.549 GHz est. frequency
|    Instructions : 192.6110 per block    ( 50.86%) -   3.0097 per byte    -  34.3941 per structural    -    5.689 per cycle
|- Stage 2
|    Speed        :   8.1493 ns per block ( 41.35%) -   0.1273 ns per byte -   1.4552 ns per structural -   7.8530 GB/s
|    Cycles       :  28.9459 per block    ( 45.35%) -   0.4523 per byte    -   5.1688 per structural    -    3.552 GHz est. frequency
|    Instructions : 186.0694 per block    ( 49.13%) -   2.9075 per byte    -  33.2260 per structural    -    6.428 per cycle
```

This PR:
```
$ sudo ./buildpr/benchmark/dom/parse -n 1000 jsonexamples/twitter.json
number of iterations 1000

jsonexamples/twitter.json
=========================
     9867 blocks -     631515 bytes - 55262 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  17.5061 ns per block ( 91.06%) -   0.2735 ns per byte -   3.1260 ns per structural -   3.6557 GB/s
|    Cycles       :  62.1522 per block    ( 99.27%) -   0.9712 per byte    -  11.0984 per structural    -    3.550 GHz est. frequency
|    Instructions : 374.1733 per block    ( 99.99%) -   5.8468 per byte    -  66.8152 per structural    -    6.020 per cycle
|- Stage 1
|    Speed        :   9.5088 ns per block ( 49.46%) -   0.1486 ns per byte -   1.6980 ns per structural -   6.7302 GB/s
|    Cycles       :  33.7263 per block    ( 53.87%) -   0.5270 per byte    -   6.0224 per structural    -    3.547 GHz est. frequency
|    Instructions : 192.6107 per block    ( 51.47%) -   3.0097 per byte    -  34.3940 per structural    -    5.711 per cycle
|- Stage 2
|    Speed        :   7.9845 ns per block ( 41.53%) -   0.1248 ns per byte -   1.4258 ns per structural -   8.0151 GB/s
|    Cycles       :  28.3747 per block    ( 45.32%) -   0.4434 per byte    -   5.0668 per structural    -    3.554 GHz est. frequency
|    Instructions : 181.5625 per block    ( 48.52%) -   2.8371 per byte    -  32.4212 per structural    -    6.399 per cycle

5788.7 documents parsed per second (best)
```


## array of strings (Apple M2 LLVM 14)

Master:

```
$ sudo ./build/benchmark/dom/parse -n 1000 array.json
number of iterations 1000

array.json
==========
   418403 blocks -   26777812 bytes - 4000004 structurals ( 14.9 %)
special blocks with: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals    418404 (100.0 %) - 8+ structurals    418403 (100.0 %) - 16+ structurals         1 (  0.0 %)
special block flips: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         0 (  0.0 %) - 8+ structurals         1 (  0.0 %) - 16+ structurals         1 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  24.2599 ns per block ( 91.21%) -   0.3791 ns per byte -   2.5376 ns per structural -   2.6381 GB/s
|    Cycles       :  82.1519 per block    ( 95.84%) -   1.2836 per byte    -   8.5932 per structural    -    3.386 GHz est. frequency
|    Instructions : 567.5022 per block    ( 99.77%) -   8.8672 per byte    -  59.3612 per structural    -    6.908 per cycle
|- Stage 1
|    Speed        :   9.4866 ns per block ( 35.67%) -   0.1482 ns per byte -   0.9923 ns per structural -   6.7463 GB/s
|    Cycles       :  32.0976 per block    ( 37.45%) -   0.5015 per byte    -   3.3574 per structural    -    3.383 GHz est. frequency
|    Instructions : 199.3501 per block    ( 35.05%) -   3.1149 per byte    -  20.8522 per structural    -    6.211 per cycle
|- Stage 2
|    Speed        :  14.6585 ns per block ( 55.11%) -   0.2290 ns per byte -   1.5333 ns per structural -   4.3661 GB/s
|    Cycles       :  49.6449 per block    ( 57.92%) -   0.7757 per byte    -   5.1929 per structural    -    3.387 GHz est. frequency
|    Instructions : 368.1347 per block    ( 64.72%) -   5.7521 per byte    -  38.5072 per structural    -    7.415 per cycle

98.5 documents parsed per second (best)
```

PR:

```
sudo ./buildpr/benchmark/dom/parse -n 1000 array.json
number of iterations 1000

array.json
==========
   418403 blocks -   26777812 bytes - 4000004 structurals ( 14.9 %)
special blocks with: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals    418404 (100.0 %) - 8+ structurals    418403 (100.0 %) - 16+ structurals         1 (  0.0 %)
special block flips: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         0 (  0.0 %) - 8+ structurals         1 (  0.0 %) - 16+ structurals         1 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  22.8639 ns per block ( 93.14%) -   0.3572 ns per byte -   2.3916 ns per structural -   2.7992 GB/s
|    Cycles       :  77.2913 per block    ( 96.03%) -   1.2077 per byte    -   8.0847 per structural    -    3.381 GHz est. frequency
|    Instructions : 529.2697 per block    ( 99.79%) -   8.2699 per byte    -  55.3621 per structural    -    6.848 per cycle
|- Stage 1
|    Speed        :   9.3866 ns per block ( 38.24%) -   0.1467 ns per byte -   0.9818 ns per structural -   6.8182 GB/s
|    Cycles       :  32.5983 per block    ( 40.50%) -   0.5093 per byte    -   3.4098 per structural    -    3.473 GHz est. frequency
|    Instructions : 199.4269 per block    ( 37.60%) -   3.1161 per byte    -  20.8602 per structural    -    6.118 per cycle
|- Stage 2
|    Speed        :  13.3258 ns per block ( 54.28%) -   0.2082 ns per byte -   1.3939 ns per structural -   4.8027 GB/s
|    Cycles       :  45.0695 per block    ( 55.99%) -   0.7042 per byte    -   4.7143 per structural    -    3.382 GHz est. frequency
|    Instructions : 329.8846 per block    ( 62.20%) -   5.1545 per byte    -  34.5062 per structural    -    7.319 per cycle

104.5 documents parsed per second (best)
```

## Twitter.json (Intel Ice Lake GCC 12)


Master:
```
$ ./build/benchmark/dom/parse jsonexamples/twitter.json 
number of iterations 200 
                                                     
jsonexamples/twitter.json
=========================
     9867 blocks -     631515 bytes - 55262 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  30.5919 ns per block ( 96.48%) -   0.4780 ns per byte -   5.4627 ns per structural -   2.0919 GB/s
|    Cycles       :  61.1300 per block    ( 98.70%) -   0.9552 per byte    -  10.9158 per structural    -    1.998 GHz est. frequency
|    Instructions : 208.5574 per block    (100.00%) -   3.2589 per byte    -  37.2416 per structural    -    3.412 per cycle
|    Misses       :     467 branch misses ( 93.70%) - 0 cache misses (  0.00%) - 27408.00 cache references
|- Stage 1
|    Speed        :  10.8157 ns per block ( 34.11%) -   0.1690 ns per byte -   1.9313 ns per structural -   5.9170 GB/s
|    Cycles       :  21.6282 per block    ( 34.92%) -   0.3380 per byte    -   3.8621 per structural    -    2.000 GHz est. frequency
|    Instructions :  70.5208 per block    ( 33.81%) -   1.1020 per byte    -  12.5927 per structural    -    3.261 per cycle
|    Misses       :      94 branch misses ( 18.86%) - 0 cache misses (  0.00%) - 11429.00 cache references
|- Stage 2
|    Speed        :  19.6680 ns per block ( 62.03%) -   0.3073 ns per byte -   3.5121 ns per structural -   3.2538 GB/s
|    Cycles       :  39.2818 per block    ( 63.42%) -   0.6138 per byte    -   7.0145 per structural    -    1.997 GHz est. frequency
|    Instructions : 138.0366 per block    ( 66.19%) -   2.1569 per byte    -  24.6489 per structural    -    3.514 per cycle
|    Misses       :     363 branch misses ( 72.83%) - 0 cache misses (  0.00%) - 15982.00 cache references

3312.6 documents parsed per second (best)
```

This PR:
```
$ ./build/benchmark/dom/parse jsonexamples/twitter.json 
number of iterations 200 
                                                     
jsonexamples/twitter.json
=========================
     9867 blocks -     631515 bytes - 55262 structurals (  8.8 %)
special blocks with: utf8      2284 ( 23.1 %) - escape       598 (  6.1 %) - 0 structurals      1287 ( 13.0 %) - 1+ structurals      8581 ( 87.0 %) - 8+ structurals      3272 ( 33.2 %) - 16+ structurals         0 (  0.0 %)
special block flips: utf8      1104 ( 11.2 %) - escape       642 (  6.5 %) - 0 structurals       940 (  9.5 %) - 1+ structurals       940 (  9.5 %) - 8+ structurals      2593 ( 26.3 %) - 16+ structurals         0 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  29.5253 ns per block ( 94.71%) -   0.4614 ns per byte -   5.2723 ns per structural -   2.1675 GB/s
|    Cycles       :  58.9719 per block    ( 96.85%) -   0.9215 per byte    -  10.5305 per structural    -    1.997 GHz est. frequency
|    Instructions : 208.1653 per block    (100.00%) -   3.2528 per byte    -  37.1716 per structural    -    3.530 per cycle
|    Misses       :     506 branch misses ( 97.35%) - 24 cache misses ( 65.78%) - 26581.00 cache references
|- Stage 1
|    Speed        :  10.2690 ns per block ( 32.94%) -   0.1605 ns per byte -   1.8337 ns per structural -   6.2320 GB/s
|    Cycles       :  20.5285 per block    ( 33.71%) -   0.3208 per byte    -   3.6657 per structural    -    1.999 GHz est. frequency
|    Instructions :  70.5208 per block    ( 33.88%) -   1.1020 per byte    -  12.5927 per structural    -    3.435 per cycle
|    Misses       :     148 branch misses ( 28.47%) - 9 cache misses ( 24.67%) - 11151.00 cache references
|- Stage 2
|    Speed        :  19.2508 ns per block ( 61.75%) -   0.3008 ns per byte -   3.4376 ns per structural -   3.3243 GB/s
|    Cycles       :  38.4372 per block    ( 63.13%) -   0.6006 per byte    -   6.8636 per structural    -    1.997 GHz est. frequency
|    Instructions : 137.6445 per block    ( 66.12%) -   2.1508 per byte    -  24.5788 per structural    -    3.581 per cycle
|    Misses       :     387 branch misses ( 74.45%) - 15 cache misses ( 41.11%) - 15439.00 cache references

3432.2 documents parsed per second (best)
```

## array of strings (Intel Ice Lake GCC 12)

Master:
```
./build/benchmark/dom/parse array.json 
number of iterations 200 
                                                     
array.json
==========
   418403 blocks -   26777812 bytes - 4000004 structurals ( 14.9 %)
special blocks with: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals    418404 (100.0 %) - 8+ structurals    418403 (100.0 %) - 16+ structurals         1 (  0.0 %)
special block flips: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         0 (  0.0 %) - 8+ structurals         1 (  0.0 %) - 16+ structurals         1 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  33.0078 ns per block ( 96.59%) -   0.5157 ns per byte -   3.4526 ns per structural -   1.9389 GB/s
|    Cycles       : 101.9085 per block    ( 99.53%) -   1.5923 per byte    -  10.6597 per structural    -    3.087 GHz est. frequency
|    Instructions : 334.9660 per block    (100.00%) -   5.2339 per byte    -  35.0377 per structural    -    3.287 per cycle
|    Misses       :       6 branch misses ( 91.25%) - 265293 cache misses ( 97.13%) - 1973927.00 cache references
|- Stage 1
|    Speed        :   8.1805 ns per block ( 23.94%) -   0.1278 ns per byte -   0.8557 ns per structural -   7.8235 GB/s
|    Cycles       :  25.2637 per block    ( 24.67%) -   0.3947 per byte    -   2.6426 per structural    -    3.088 GHz est. frequency
|    Instructions :  62.5010 per block    ( 18.66%) -   0.9766 per byte    -   6.5377 per structural    -    2.474 per cycle
|    Misses       :       3 branch misses ( 45.63%) - 92416 cache misses ( 33.84%) - 637788.00 cache references
|- Stage 2
|    Speed        :  24.7905 ns per block ( 72.55%) -   0.3874 ns per byte -   2.5931 ns per structural -   2.5816 GB/s
|    Cycles       :  76.5263 per block    ( 74.74%) -   1.1957 per byte    -   8.0047 per structural    -    3.087 GHz est. frequency
|    Instructions : 272.4650 per block    ( 81.34%) -   4.2573 per byte    -  28.5001 per structural    -    3.560 per cycle
|    Misses       :       3 branch misses ( 45.63%) - 176145 cache misses ( 64.49%) - 1336133.00 cache references

72.4 documents parsed per second (best)
```

PR:

```
$ ./build/benchmark/dom/parse array.json 
number of iterations 200 
                                                     
array.json
==========
   418403 blocks -   26777812 bytes - 4000004 structurals ( 14.9 %)
special blocks with: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals    418404 (100.0 %) - 8+ structurals    418403 (100.0 %) - 16+ structurals         1 (  0.0 %)
special block flips: utf8         0 (  0.0 %) - escape         0 (  0.0 %) - 0 structurals         0 (  0.0 %) - 1+ structurals         0 (  0.0 %) - 8+ structurals         1 (  0.0 %) - 16+ structurals         1 (  0.0 %)

All Stages (excluding allocation)
|    Speed        :  31.1893 ns per block ( 92.64%) -   0.4873 ns per byte -   3.2624 ns per structural -   2.0520 GB/s
|    Cycles       :  96.3086 per block    ( 99.52%) -   1.5048 per byte    -  10.0740 per structural    -    3.088 GHz est. frequency
|    Instructions : 306.2855 per block    (100.00%) -   4.7857 per byte    -  32.0377 per structural    -    3.180 per cycle
|    Misses       :       6 branch misses ( 88.56%) - 274893 cache misses ( 98.55%) - 1971258.00 cache references
|- Stage 1
|    Speed        :   8.1811 ns per block ( 24.30%) -   0.1278 ns per byte -   0.8558 ns per structural -   7.8229 GB/s
|    Cycles       :  25.2443 per block    ( 26.09%) -   0.3944 per byte    -   2.6406 per structural    -    3.086 GHz est. frequency
|    Instructions :  62.5010 per block    ( 20.41%) -   0.9766 per byte    -   6.5377 per structural    -    2.476 per cycle
|    Misses       :       3 branch misses ( 44.28%) - 97305 cache misses ( 34.88%) - 637791.00 cache references
|- Stage 2
|    Speed        :  22.9772 ns per block ( 68.24%) -   0.3590 ns per byte -   2.4034 ns per structural -   2.7854 GB/s
|    Cycles       :  70.9409 per block    ( 73.31%) -   1.1085 per byte    -   7.4205 per structural    -    3.087 GHz est. frequency
|    Instructions : 243.7846 per block    ( 79.59%) -   3.8091 per byte    -  25.5001 per structural    -    3.436 per cycle
|    Misses       :       3 branch misses ( 44.28%) - 175787 cache misses ( 63.02%) - 1333236.00 cache references

76.6 documents parsed per second (best)
```