### PR TITLE
Add simdjson_static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ string(
 set(SIMDJSON_LIB_VERSION "16.0.0" CACHE STRING "simdjson library version")
 set(SIMDJSON_LIB_SOVERSION "16" CACHE STRING "simdjson library soversion")
 
+option(SIMDJSON_BUILD_STATIC_LIB "Build simdjson_static library along with simdjson" OFF)
+
 option(SIMDJSON_ENABLE_THREADS "Link with thread support" ON)
 
 include(cmake/simdjson-props.cmake)
@@ -56,8 +58,17 @@ include(cmake/developer-options.cmake)
 
 # ---- simdjson library ----
 
-add_library(simdjson src/simdjson.cpp)
+set(SIMDJSON_SOURCES src/simdjson.cpp)
+
+add_library(simdjson ${SIMDJSON_SOURCES})
 add_library(simdjson::simdjson ALIAS simdjson)
+set(SIMDJSON_LIBRARIES simdjson)
+
+if(SIMDJSON_BUILD_STATIC_LIB)
+  add_library(simdjson_static STATIC ${SIMDJSON_SOURCES})
+  add_library(simdjson::simdjson_static ALIAS simdjson_static)
+  list(APPEND SIMDJSON_LIBRARIES simdjson_static)
+endif()
 
 set_target_properties(
     simdjson PROPERTIES
@@ -117,6 +128,9 @@ if(SIMDJSON_ENABLE_THREADS)
 endif()
 
 simdjson_apply_props(simdjson)
+if(SIMDJSON_BUILD_STATIC_LIB)
+  simdjson_apply_props(simdjson_static)
+endif()
 
 # ---- Install rules ----
 
@@ -138,6 +152,13 @@ install(
     ARCHIVE COMPONENT simdjson_Development
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
+if(SIMDJSON_BUILD_STATIC_LIB)
+  install(
+      TARGETS simdjson_static
+      EXPORT simdjsonTargets
+      ARCHIVE COMPONENT simdjson_Development
+  )
+endif()
 
 configure_file(cmake/simdjson-config.cmake.in simdjson-config.cmake @ONLY)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,14 +152,6 @@ install(
     ARCHIVE COMPONENT simdjson_Development
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
-if(SIMDJSON_BUILD_STATIC_LIB)
-  install(
-      TARGETS simdjson_static
-      EXPORT simdjsonTargets
-      ARCHIVE COMPONENT simdjson_Development
-  )
-endif()
-
 configure_file(cmake/simdjson-config.cmake.in simdjson-config.cmake @ONLY)
 
 write_basic_package_version_file(
@@ -187,6 +179,20 @@ install(
     DESTINATION "${SIMDJSON_INSTALL_CMAKEDIR}"
     COMPONENT simdjson_Development
 )
+
+if(SIMDJSON_BUILD_STATIC_LIB)
+  install(
+      TARGETS simdjson_static
+      EXPORT simdjson_staticTargets
+      ARCHIVE COMPONENT simdjson_Development
+  )
+  install(
+      EXPORT simdjson_staticTargets
+      NAMESPACE simdjson::
+      DESTINATION "${SIMDJSON_INSTALL_CMAKEDIR}"
+      COMPONENT simdjson_Development
+  )
+endif()
 
 # pkg-config
 include(cmake/JoinPaths.cmake)

--- a/cmake/simdjson-config.cmake.in
+++ b/cmake/simdjson-config.cmake.in
@@ -4,3 +4,4 @@ if("@SIMDJSON_ENABLE_THREADS@")
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/simdjsonTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/simdjson_staticTargets.cmake" OPTIONAL)


### PR DESCRIPTION
- Fix #2066
- Chose variable name `SIMDJSON_BUILD_STATIC_LIB` as `SIMDJSON_BUILD_STATIC` is mkared as deprecated
- Please confirm that `simdjson_xxx_props` are used properly
- ~~Still WIP, as~~ I am at the same time trying this branch on Conda-Forge https://github.com/conda-forge/simdjson-feedstock/pull/56

Note: if any maintainer of this project would like to become a co-maintainer of the Conda-Forge package, you are most welcome.
