### PR TITLE
add a total order for elements

### DIFF
--- a/include/simdjson/dom/element-inl.h
+++ b/include/simdjson/dom/element-inl.h
@@ -410,6 +410,12 @@ inline simdjson_result<element> element::at_key(std::string_view key) const noex
 inline simdjson_result<element> element::at_key_case_insensitive(std::string_view key) const noexcept {
   return get<object>().at_key_case_insensitive(key);
 }
+inline bool element::operator<(const element &other) const noexcept {
+  return tape.json_index < other.tape.json_index;
+}
+inline bool element::operator==(const element &other) const noexcept {
+  return tape.json_index == other.tape.json_index;
+}
 
 inline bool element::dump_raw_tape(std::ostream &out) const noexcept {
   SIMDJSON_DEVELOPMENT_ASSERT(tape.usable()); // https://github.com/simdjson/simdjson/issues/1914

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -451,6 +451,22 @@ public:
    */
   inline simdjson_result<element> at_key_case_insensitive(std::string_view key) const noexcept;
 
+  /**
+   * operator< defines a total order for element allowing to use them in
+   * ordered C++ STL containers
+   *
+   * @return TRUE if the key appears before the other one in the tape
+   */
+  inline bool operator<(const element &other) const noexcept;
+
+  /**
+   * operator== allows to verify if two element values reference the
+   * same JSON item
+   *
+   * @return TRUE if the two values references the same JSON element
+   */
+  inline bool operator==(const element &other) const noexcept;
+
   /** @private for debugging. Prints out the root element. */
   inline bool dump_raw_tape(std::ostream &out) const noexcept;
 

--- a/tests/dom/document_tests.cpp
+++ b/tests/dom/document_tests.cpp
@@ -51,6 +51,10 @@ namespace document_tests {
     simdjson::dom::array array;
     ASSERT_SUCCESS( parser.parse(smalljson).get(array) );
     ASSERT_EQUAL( array.size(), 3 );
+    ASSERT_EQUAL( *array.begin() < *array.end(), true );
+    ASSERT_EQUAL( *array.end() < *array.begin(), false );
+    ASSERT_EQUAL( *array.begin() == *array.begin(), true );
+    ASSERT_EQUAL( *array.begin() == *array.end(), false );
     return true;
   }
   bool count_object_example() {
@@ -60,6 +64,10 @@ namespace document_tests {
     simdjson::dom::object object;
     ASSERT_SUCCESS( parser.parse(smalljson).get(object) );
     ASSERT_EQUAL( object.size(), 3 );
+    ASSERT_EQUAL( (*object.begin()).value < (*object.end()).value, true );
+    ASSERT_EQUAL( (*object.end()).value < (*object.begin()).value, false );
+    ASSERT_EQUAL( (*object.begin()).value == (*object.begin()).value, true );
+    ASSERT_EQUAL( (*object.begin()).value == (*object.end()).value, false );
     return true;
   }
   bool padded_with_open_bracket() {


### PR DESCRIPTION
Add a total order for `element`s (ie `operator<` and `operator==`) based on the tape position of each element.

This allows to keep `element`s in an C++ ordered STL container.

Why would I use such an expensive operation - which includes allocation - such as adding `element`s to a `map`?

I am using `simdjson`s internal `dom` to keep a parsed copy of a JSON file in memory to be accessed on-demand by a Node.js program. This addition allows me to keep references to the JavaScript proxy objects that I am returning. Ie, if the user code calls:

```
document.path('/some/path')
```

I can return the previously created object in an environment where creating objects can be expensive.