### PR TITLE
This provides verbose static_assert messages

### DIFF
--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -212,10 +212,10 @@ public:
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
-      + "The supported types are Boolean (bool), numbers (double, uint64_t, int64_t), "
-      + "strings (std::string_view, const char *), arrays (dom::array) and objects (dom::object). "
-      + "We recommand you use get_double(), get_bool(), get_uint64(), get_int64(), "
-      + "get_object(), get_array() or get_string() instead of the get template.");
+      "The supported types are Boolean (bool), numbers (double, uint64_t, int64_t), "
+      "strings (std::string_view, const char *), arrays (dom::array) and objects (dom::object). "
+      "We recommand you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      "get_object(), get_array() or get_string() instead of the get template.");
   }
 
   /**

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -211,7 +211,11 @@ public:
   inline simdjson_result<T> get() const noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
-    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
+      + "The supported types are Boolean (bool), numbers (double, uint64_t, int64_t), "
+      + "strings (std::string_view, const char *), arrays (dom::array) and objects (dom::object). "
+      + "We recommand you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      + "get_object(), get_array() or get_string() instead of the get template.");
   }
 
   /**
@@ -450,6 +454,22 @@ public:
    *         - NO_SUCH_FIELD if the field does not exist in the object
    */
   inline simdjson_result<element> at_key_case_insensitive(std::string_view key) const noexcept;
+
+  /**
+   * operator< defines a total order for element allowing to use them in
+   * ordered C++ STL containers
+   *
+   * @return TRUE if the key appears before the other one in the tape
+   */
+  inline bool operator<(const element &other) const noexcept;
+
+  /**
+   * operator== allows to verify if two element values reference the
+   * same JSON item
+   *
+   * @return TRUE if the two values references the same JSON element
+   */
+  inline bool operator==(const element &other) const noexcept;
 
   /** @private for debugging. Prints out the root element. */
   inline bool dump_raw_tape(std::ostream &out) const noexcept;

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -160,13 +160,19 @@ public:
   template<typename T> simdjson_inline simdjson_result<T> get() & noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
-    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
+      + "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      + "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      + " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
   }
   /** @overload template<typename T> simdjson_result<T> get() & noexcept */
   template<typename T> simdjson_inline simdjson_result<T> get() && noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
-    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
+      + "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      + "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      + " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
   }
 
   /**

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -161,18 +161,18 @@ public:
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
-      + "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
-      + "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
-      + " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
+      "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
   }
   /** @overload template<typename T> simdjson_result<T> get() & noexcept */
   template<typename T> simdjson_inline simdjson_result<T> get() && noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
-      + "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
-      + "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
-      + " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
+      "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
   }
 
   /**

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -39,9 +39,9 @@ public:
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
-      + "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
-      + "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
-      + " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
+      "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
   }
 
   /**

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -38,7 +38,10 @@ public:
   template<typename T> simdjson_inline simdjson_result<T> get() noexcept {
     // Unless the simdjson library provides an inline implementation, calling this method should
     // immediately fail.
-    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library.");
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
+      + "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      + "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      + " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template.");
   }
 
   /**


### PR DESCRIPTION
The get template seems to still cause confusion. In retrospect, it is probably a design mistake to include an open-ended template in a public API. People repeatedly do the following:

```C++
myclass class;

my_simdjson.get(class); // fails!!!
```



In C++20 and better, we can use concepts which can bring some sanity back.