### PR TITLE
Automating string reallocation when it is possible

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1653,7 +1653,7 @@ JSON string to a user-provided buffer:
 
 General Direct Access to the Raw JSON String
 --------------------------------
-If your value is a string, the `raw_json_string` gives you direct access to the unprocess
+If your value is a string, the `raw_json_string` you with `get_raw_json_string()` gives you direct access to the unprocessed
 string. The simdjson library allows you to have access to the raw underlying JSON
 more generally.
 

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -179,8 +179,8 @@ strcpy(json, "[1]");
 ondemand::document doc = parser.iterate(json, strlen(json), sizeof(json));
 ```
 
-The simdjson library will also accept `std::string` instances, as long as the `capacity()` of
-the string exceeds the `size()` by at least `SIMDJSON_PADDING`. You can increase the `capacity()` with the `reserve()` function of your strings.
+The simdjson library will also accept `std::string` instances. If the provided
+reference is non-const, it will allocate padding as needed.
 
 You can copy your data directly on a `simdjson::padded_string` as follows:
 

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -68,6 +68,13 @@ simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(s
   return iterate(padded_string_view(json, allocated));
 }
 
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(std::string &json) & noexcept {
+  if(json.capacity() - json.size() < SIMDJSON_PADDING) {
+    json.reserve(json.capacity() + SIMDJSON_PADDING);
+  }
+  return iterate(padded_string_view(json));
+}
+
 simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const std::string &json) & noexcept {
   return iterate(padded_string_view(json));
 }

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -70,7 +70,7 @@ simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(s
 
 simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(std::string &json) & noexcept {
   if(json.capacity() - json.size() < SIMDJSON_PADDING) {
-    json.reserve(json.capacity() + SIMDJSON_PADDING);
+    json.reserve(json.size() + SIMDJSON_PADDING);
   }
   return iterate(padded_string_view(json));
 }

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -107,6 +107,8 @@ public:
   /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
   simdjson_warn_unused simdjson_result<document> iterate(const std::string &json) & noexcept;
   /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
+  simdjson_warn_unused simdjson_result<document> iterate(std::string &json) & noexcept;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
   simdjson_warn_unused simdjson_result<document> iterate(const simdjson_result<padded_string> &json) & noexcept;
   /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
   simdjson_warn_unused simdjson_result<document> iterate(const simdjson_result<padded_string_view> &json) & noexcept;

--- a/tests/ondemand/ondemand_parse_api_tests.cpp
+++ b/tests/ondemand/ondemand_parse_api_tests.cpp
@@ -144,14 +144,20 @@ namespace parse_api_tests {
     }
 
     {
-      std::string json = "12";
+      std::string json = "12345642314123421321321321321321312321321321321312";
       json.shrink_to_fit();
       cout << "- string, 0 padding" << endl;
-      ASSERT_ERROR( parser.iterate(json), INSUFFICIENT_PADDING );
+      ASSERT_SUCCESS( parser.iterate(json) );
+    }
+
+    {
+      std::string json = "12345642314123421321321321321321312321321321321312";
+      json.shrink_to_fit();
+      cout << "- string, 0 padding" << endl;
+      ASSERT_ERROR( parser.iterate((const std::string&)json), INSUFFICIENT_PADDING );
       // It's actually kind of hard to allocate "just enough" capacity, since the string tends
       // to grow more than you tell it to.
     }
-
     TEST_SUCCEED();
   }
 


### PR DESCRIPTION

We want the following to just work...

```C++
std::string json = "12345642314123421321321321321321312321321321321312";
json.shrink_to_fit();      
parser.iterate(json);
```