### PR TITLE
Fix Visual Studio 64-bit ARM regression

### DIFF
--- a/include/simdjson/arm64/simd.h
+++ b/include/simdjson/arm64/simd.h
@@ -21,7 +21,7 @@ namespace {
 #define simdjson_make_uint8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                   \
    ([=]() {                                                                        \
-     uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};           \
      return vld1q_u8(array);                                                       \
    }())
@@ -30,7 +30,7 @@ namespace {
 #define simdjson_make_int8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                  \
    ([=]() {                                                                       \
-     int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};          \
      return vld1q_s8(array);                                                      \
    }())
@@ -38,29 +38,29 @@ namespace {
 
 #ifndef simdjson_make_uint8x8_t
 #define simdjson_make_uint8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
-   ([=]() {                                                                   \
-     uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
-     return vld1_u8(array);                                                   \
+   ([=]() {                                                                    \
+     uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
+     return vld1_u8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_int8x8_t
 #define simdjson_make_int8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
-   ([=]() {                                                                   \
-     int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
-     return vld1_s8(array);                                                   \
+   ([=]() {                                                                    \
+     int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                 \
+     return vld1_s8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_uint16x8_t
-#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
+#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)               \
    ([=]() {                                                                    \
-     uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
+     uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};               \
      return vld1q_u16(array);                                                  \
    }())
 #endif
 #ifndef simdjson_make_int16x8_t
-#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
+#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
    ([=]() {                                                                    \
-     int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
+     int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
      return vld1q_s16(array);                                                  \
    }())
 #endif

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-11-30 18:06:50 -0500. Do not edit! */
+/* auto-generated on 2023-12-01 13:15:00 -0500. Do not edit! */
 /* including simdjson.cpp:  */
 /* begin file simdjson.cpp */
 #define SIMDJSON_SRC_SIMDJSON_CPP
@@ -7570,7 +7570,7 @@ namespace {
 #define simdjson_make_uint8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                   \
    ([=]() {                                                                        \
-     static uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};           \
      return vld1q_u8(array);                                                       \
    }())
@@ -7579,7 +7579,7 @@ namespace {
 #define simdjson_make_int8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                  \
    ([=]() {                                                                       \
-     static int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};          \
      return vld1q_s8(array);                                                      \
    }())
@@ -7587,29 +7587,29 @@ namespace {
 
 #ifndef simdjson_make_uint8x8_t
 #define simdjson_make_uint8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
-   ([=]() {                                                                   \
-     static uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
-     return vld1_u8(array);                                                   \
+   ([=]() {                                                                    \
+     uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
+     return vld1_u8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_int8x8_t
 #define simdjson_make_int8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
-   ([=]() {                                                                   \
-     static int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
-     return vld1_s8(array);                                                   \
+   ([=]() {                                                                    \
+     int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                 \
+     return vld1_s8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_uint16x8_t
-#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
+#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)               \
    ([=]() {                                                                    \
-     static uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
+     uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};               \
      return vld1q_u16(array);                                                  \
    }())
 #endif
 #ifndef simdjson_make_int16x8_t
-#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
+#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
    ([=]() {                                                                    \
-     static int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
+     int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
      return vld1q_s16(array);                                                  \
    }())
 #endif
@@ -10275,7 +10275,7 @@ namespace {
 #define simdjson_make_uint8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                   \
    ([=]() {                                                                        \
-     static uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};           \
      return vld1q_u8(array);                                                       \
    }())
@@ -10284,7 +10284,7 @@ namespace {
 #define simdjson_make_int8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                  \
    ([=]() {                                                                       \
-     static int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};          \
      return vld1q_s8(array);                                                      \
    }())
@@ -10292,29 +10292,29 @@ namespace {
 
 #ifndef simdjson_make_uint8x8_t
 #define simdjson_make_uint8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
-   ([=]() {                                                                   \
-     static uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
-     return vld1_u8(array);                                                   \
+   ([=]() {                                                                    \
+     uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
+     return vld1_u8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_int8x8_t
 #define simdjson_make_int8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
-   ([=]() {                                                                   \
-     static int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
-     return vld1_s8(array);                                                   \
+   ([=]() {                                                                    \
+     int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                 \
+     return vld1_s8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_uint16x8_t
-#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
+#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)               \
    ([=]() {                                                                    \
-     static uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
+     uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};               \
      return vld1q_u16(array);                                                  \
    }())
 #endif
 #ifndef simdjson_make_int16x8_t
-#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
+#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
    ([=]() {                                                                    \
-     static int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
+     int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
      return vld1q_s16(array);                                                  \
    }())
 #endif

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -1,4 +1,4 @@
-/* auto-generated on 2023-11-30 18:06:50 -0500. Do not edit! */
+/* auto-generated on 2023-12-01 13:15:00 -0500. Do not edit! */
 /* including simdjson.h:  */
 /* begin file simdjson.h */
 #ifndef SIMDJSON_H
@@ -10654,7 +10654,7 @@ namespace {
 #define simdjson_make_uint8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                   \
    ([=]() {                                                                        \
-     static uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};           \
      return vld1q_u8(array);                                                       \
    }())
@@ -10663,7 +10663,7 @@ namespace {
 #define simdjson_make_int8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                  \
    ([=]() {                                                                       \
-     static int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};          \
      return vld1q_s8(array);                                                      \
    }())
@@ -10671,29 +10671,29 @@ namespace {
 
 #ifndef simdjson_make_uint8x8_t
 #define simdjson_make_uint8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
-   ([=]() {                                                                   \
-     static uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
-     return vld1_u8(array);                                                   \
+   ([=]() {                                                                    \
+     uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
+     return vld1_u8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_int8x8_t
 #define simdjson_make_int8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
-   ([=]() {                                                                   \
-     static int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
-     return vld1_s8(array);                                                   \
+   ([=]() {                                                                    \
+     int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                 \
+     return vld1_s8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_uint16x8_t
-#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
+#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)               \
    ([=]() {                                                                    \
-     static uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
+     uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};               \
      return vld1q_u16(array);                                                  \
    }())
 #endif
 #ifndef simdjson_make_int16x8_t
-#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
+#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
    ([=]() {                                                                    \
-     static int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
+     int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
      return vld1q_s16(array);                                                  \
    }())
 #endif
@@ -26146,7 +26146,7 @@ namespace {
 #define simdjson_make_uint8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                   \
    ([=]() {                                                                        \
-     static uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     uint8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};           \
      return vld1q_u8(array);                                                       \
    }())
@@ -26155,7 +26155,7 @@ namespace {
 #define simdjson_make_int8x16_t(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, \
                              x13, x14, x15, x16)                                  \
    ([=]() {                                                                       \
-     static int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,             \
+     int8_t array[16] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8,                    \
                                  x9, x10, x11, x12, x13, x14, x15, x16};          \
      return vld1q_s8(array);                                                      \
    }())
@@ -26163,29 +26163,29 @@ namespace {
 
 #ifndef simdjson_make_uint8x8_t
 #define simdjson_make_uint8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
-   ([=]() {                                                                   \
-     static uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
-     return vld1_u8(array);                                                   \
+   ([=]() {                                                                    \
+     uint8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
+     return vld1_u8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_int8x8_t
 #define simdjson_make_int8x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
-   ([=]() {                                                                   \
-     static int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
-     return vld1_s8(array);                                                   \
+   ([=]() {                                                                    \
+     int8_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                 \
+     return vld1_s8(array);                                                    \
    }())
 #endif
 #ifndef simdjson_make_uint16x8_t
-#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
+#define simdjson_make_uint16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)               \
    ([=]() {                                                                    \
-     static uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};        \
+     uint16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};               \
      return vld1q_u16(array);                                                  \
    }())
 #endif
 #ifndef simdjson_make_int16x8_t
-#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                 \
+#define simdjson_make_int16x8_t(x1, x2, x3, x4, x5, x6, x7, x8)                \
    ([=]() {                                                                    \
-     static int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};         \
+     int16_t array[8] = {x1, x2,  x3,  x4,  x5,  x6,  x7,  x8};                \
      return vld1q_s16(array);                                                  \
    }())
 #endif


### PR DESCRIPTION
The latest patch release (3.6.1) broke the library for Visual Studio users targeting 64-bit hardware.
