### PR TITLE
update actions/checkout in GitHub Actions to v4

### DIFF
--- a/.github/workflows/alpine.yml
+++ b/.github/workflows/alpine.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/debian.yaml
+++ b/.github/workflows/debian.yaml
@@ -16,7 +16,7 @@ jobs:
       image: debian:testing
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,7 +19,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Doxygen
         run: sudo apt-get install doxygen graphviz -y
       - run: mkdir docs

--- a/.github/workflows/fix-trailing-whitespace.yml
+++ b/.github/workflows/fix-trailing-whitespace.yml
@@ -6,7 +6,7 @@ jobs:
   whitespace:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Remove whitespace and check the diff
         run: |
           set -eu

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -38,7 +38,7 @@ jobs:
         chmod +x llvm.sh
         sudo ./llvm.sh $CLANGVERSION
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - uses: actions/cache@v3
       with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/msys2-clang.yml
+++ b/.github/workflows/msys2-clang.yml
@@ -24,7 +24,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -26,7 +26,7 @@ jobs:
       CMAKE_GENERATOR: Ninja
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/power-fuzz.yml
+++ b/.github/workflows/power-fuzz.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Build on ubuntu-20.04 ppc64le
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2.0.5
         name: Run commands
         id: runcmd

--- a/.github/workflows/ppc64.yml
+++ b/.github/workflows/ppc64.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Test
         id: runcmd

--- a/.github/workflows/riscv64.yml
+++ b/.github/workflows/riscv64.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Test
         id: runcmd

--- a/.github/workflows/s390x.yml
+++ b/.github/workflows/s390x.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: uraimo/run-on-arch-action@v2
         name: Test
         id: runcmd

--- a/.github/workflows/ubuntu20-checkperf.yml
+++ b/.github/workflows/ubuntu20-checkperf.yml
@@ -15,7 +15,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu20-gcc8.yml
+++ b/.github/workflows/ubuntu20-gcc8.yml
@@ -12,7 +12,7 @@ jobs:
       CXX: g++-8
       CC: gcc-8
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu20-noexcept.yml
+++ b/.github/workflows/ubuntu20-noexcept.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu20-nothread.yml
+++ b/.github/workflows/ubuntu20-nothread.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu20-sani.yml
+++ b/.github/workflows/ubuntu20-sani.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache
@@ -27,7 +27,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu22-clang13.yml
+++ b/.github/workflows/ubuntu22-clang13.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu22-clang14.yml
+++ b/.github/workflows/ubuntu22-clang14.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu22-cxx20.yml
+++ b/.github/workflows/ubuntu22-cxx20.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu22-gcc12.yml
+++ b/.github/workflows/ubuntu22-gcc12.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu22-glibcxxassertions.yml
+++ b/.github/workflows/ubuntu22-glibcxxassertions.yml
@@ -8,7 +8,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu22-threadsani.yml
+++ b/.github/workflows/ubuntu22-threadsani.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/ubuntu22.yml
+++ b/.github/workflows/ubuntu22.yml
@@ -9,7 +9,7 @@ jobs:
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: dependencies/.cache

--- a/.github/workflows/vs17-arm-ci.yml
+++ b/.github/workflows/vs17-arm-ci.yml
@@ -14,7 +14,7 @@ jobs:
            - {arch: ARM64}
      steps:
        - name: checkout
-         uses: actions/checkout@v3
+         uses: actions/checkout@v4
        - name: Use cmake
          run: |
            cmake -A ${{ matrix.arch }} -DCMAKE_CROSSCOMPILING=1 -DSIMDJSON_DEVELOPER_MODE=ON -D SIMDJSON_GOOGLE_BENCHMARKS=OFF -DSIMDJSON_EXCEPTIONS=OFF -B build  &&

--- a/.github/workflows/vs17-ci-cxx20.yml
+++ b/.github/workflows/vs17-ci-cxx20.yml
@@ -19,7 +19,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake -DSIMDJSON_CXX_STANDARD=20 -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build

--- a/.github/workflows/vs17-ci.yml
+++ b/.github/workflows/vs17-ci.yml
@@ -19,7 +19,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64, shared: OFF}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -DBUILD_SHARED_LIBS=${{matrix.shared}} -B build

--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -16,7 +16,7 @@ jobs:
           - {gen: Visual Studio 17 2022, arch: x64}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Configure
       run: |
         cmake -G "${{matrix.gen}}" -A ${{matrix.arch}}  -T ClangCL -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -B build

--- a/.github/workflows/vs17-noexcept-ci.yml
+++ b/.github/workflows/vs17-noexcept-ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: windows-vs17
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/cache@v3
       with:
         path: dependencies/.cache


### PR DESCRIPTION
This updates [actions/checkout](https://github.com/actions/checkout) to v4, it's current version.

Changelog:

> ## v4.1.0
> - Add support for partial checkout filters
>
> ## v4.0.0
> - Support fetching without the --progress option
> - Update to node20

As far as I can tell this should be backwards compatible, so I do not expect any breakage.