### PR TITLE
Add `load_into_document` to `simdjson::dom::parser`

### DIFF
--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -92,10 +92,14 @@ inline simdjson_result<size_t> parser::read_file(const std::string &path) noexce
 }
 
 inline simdjson_result<element> parser::load(const std::string &path) & noexcept {
+  return load_into_document(doc, path);
+}
+
+inline simdjson_result<element> parser::load_into_document(document& provided_doc, const std::string &path) & noexcept {
   size_t len;
   auto _error = read_file(path).get(len);
   if (_error) { return _error; }
-  return parse(loaded_bytes.get(), len, false);
+  return parse_into_document(provided_doc, loaded_bytes.get(), len, false);
 }
 
 inline simdjson_result<document_stream> parser::load_many(const std::string &path, size_t batch_size) noexcept {

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -95,6 +95,53 @@ public:
    */
   inline simdjson_result<element> load(const std::string &path) & noexcept;
   inline simdjson_result<element> load(const std::string &path) &&  = delete ;
+
+  /**
+   * Load a JSON document from a file into a provide document instance and return a temporary reference to it.
+   * It is similar to the function `load` except that instead of parsing into the internal
+   * `document` instance associated with the parser, it allows the user to provide a document
+   * instance.
+   *
+   *   dom::parser parser;
+   *   dom::document doc;
+   *   element doc_root = parser.load_into_document(doc, "jsonexamples/twitter.json");
+   *
+   * The function is eager: the file's content is loaded in memory inside the parser instance
+   * and immediately parsed. The file can be deleted after the `parser.load_into_document` call.
+   *
+   * ### IMPORTANT: Document Lifetime
+   *
+   * After the call to load_into_document, the parser is no longer needed.
+   *
+   * The JSON document lives in the document instance: you must keep the document
+   * instance alive while you navigate through it (i.e., used the returned value from
+   * load_into_document). You are encourage to reuse the document instance
+   * many times with new data to avoid reallocations:
+   *
+   *   dom::document doc;
+   *   element doc_root1 = parser.load_into_document(doc, "jsonexamples/twitter.json");
+   *   //... doc_root1 is a pointer inside doc
+   *   element doc_root2 = parser.load_into_document(doc, "jsonexamples/twitter.json");
+   *   //... doc_root2 is a pointer inside doc
+   *   // at this point doc_root1 is no longer safe
+   *
+   * Moving the document instance is safe, but it invalidates the element instances. After
+   * moving a document, you can recover safe access to the document root with its `root()` method.
+   *
+   * @param doc The document instance where the parsed data will be stored (on success).
+   * @param path The path to load.
+   * @return The document, or an error:
+   *         - IO_ERROR if there was an error opening or reading the file.
+   *           Be mindful that on some 32-bit systems,
+   *           the file size might be limited to 2 GB.
+   *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails.
+   *         - CAPACITY if the parser does not have enough capacity and len > max_capacity.
+   *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
+   *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
+   */
+  inline simdjson_result<element> load_into_document(document& doc, const std::string &path) & noexcept;
+  inline simdjson_result<element> load_into_document(document& doc, const std::string &path) && =delete;
+
   /**
    * Parse a JSON document and return a temporary reference to it.
    *

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -452,14 +452,18 @@ namespace parse_api_tests {
     element doc_root1 = parser.parse_into_document(doc, input);
     if(simdjson::to_string(doc_root1) != "[1,2,3]") { return false; }
     //... doc_root1 is a pointer inside doc
-    element doc_root2 = parser.parse_into_document(doc, input);
+    element doc_root2 = parser.load_into_document(doc, TWITTER_JSON);
     //... doc_root2 is a pointer inside doc
-    if(simdjson::to_string(doc_root2) != "[1,2,3]") { return false; }
+    if(uint64_t(doc_root2["search_metadata"]["count"]) != 100) { return false; }
+    if(uint64_t(doc.root()["search_metadata"]["count"]) != 100) { return false; }
+    element doc_root3 = parser.parse_into_document(doc, input);
+    //... doc_root3 is a pointer inside doc
+    if(simdjson::to_string(doc_root3) != "[1,2,3]") { return false; }
 
     // Here let us take moving the document:
     dom::document docm = std::move(doc);
-    element doc_root3 = docm.root();
-    if(simdjson::to_string(doc_root3) != "[1,2,3]") { return false; }
+    element doc_root4 = docm.root();
+    if(simdjson::to_string(doc_root4) != "[1,2,3]") { return false; }
     return true;
   }
 


### PR DESCRIPTION
I've found `parse_into_document` quite useful, but there was previously no `load` counterpart to `parse_into_document`. It seemed simple enough to add so this PR does exactly that.