### PR TITLE
Allow some iterators to be used in standard C++ iterator functions

### DIFF
--- a/include/simdjson/dom/array.h
+++ b/include/simdjson/dom/array.h
@@ -19,11 +19,14 @@ public:
   public:
     using value_type = element;
     using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = value_type;
+    using iterator_category = std::forward_iterator_tag;
 
     /**
      * Get the actual value
      */
-    inline value_type operator*() const noexcept;
+    inline reference operator*() const noexcept;
     /**
      * Get the next value.
      *

--- a/include/simdjson/dom/object.h
+++ b/include/simdjson/dom/object.h
@@ -18,13 +18,16 @@ public:
 
   class iterator {
   public:
-    using value_type = key_value_pair;
+    using value_type = const key_value_pair;
     using difference_type = std::ptrdiff_t;
+    using pointer = void;
+    using reference = value_type;
+    using iterator_category = std::forward_iterator_tag;
 
     /**
      * Get the actual key/value pair
      */
-    inline const value_type operator*() const noexcept;
+    inline reference operator*() const noexcept;
     /**
      * Get the next key/value pair.
      *

--- a/include/simdjson/generic/ondemand/document_stream.h
+++ b/include/simdjson/generic/ondemand/document_stream.h
@@ -122,10 +122,9 @@ public:
   class iterator {
   public:
     using value_type = simdjson_result<document>;
-    using reference  = value_type;
-
+    using reference  = simdjson_result<ondemand::document_reference>;
+    using pointer    = void;
     using difference_type   = std::ptrdiff_t;
-
     using iterator_category = std::input_iterator_tag;
 
     /**
@@ -135,7 +134,7 @@ public:
     /**
      * Get the current document (or error).
      */
-    simdjson_inline simdjson_result<ondemand::document_reference> operator*() noexcept;
+    simdjson_inline reference operator*() noexcept;
     /**
      * Advance to the next document (prefix).
      */

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -908,6 +908,43 @@ namespace dom_api_tests {
     return true;
   }
 
+  bool object_iterator_advance() {
+    std::cout << "Running " << __func__ << std::endl;
+    string json(R"({ "a": 1, "b": 2, "c": 3 })");
+    const char* expected_key[] = { "a", "b", "c" };
+    uint64_t expected_value[] = { 1, 2, 3 };
+
+    dom::parser parser;
+    dom::object object;
+    ASSERT_SUCCESS( parser.parse(json).get(object) );
+    auto iter = object.begin();
+    for (auto i = 0; i * sizeof(expected_value[0]) < sizeof(expected_value); i++) {
+      auto [key, value] = *iter;
+      ASSERT_EQUAL( key, expected_key[i] );
+      ASSERT_EQUAL( value.get_uint64().value_unsafe(), expected_value[i] );
+      std::advance( iter, 1 );
+    }
+    return true;
+  }
+
+  bool array_iterator_advance() {
+    std::cout << "Running " << __func__ << std::endl;
+    string json(R"([ 1, 10, 100 ])");
+    uint64_t expected_value[] = { 1, 10, 100 };
+
+    dom::parser parser;
+    dom::array array;
+    ASSERT_SUCCESS( parser.parse(json).get(array) );
+    auto iter = array.begin();
+    for (auto i = 0; i * sizeof(expected_value[0]) < sizeof(expected_value); i++) {
+      uint64_t v;
+      ASSERT_SUCCESS( (*iter).get(v) );
+      ASSERT_EQUAL( v, expected_value[i] );
+      std::advance( iter, 1 );
+    }
+    return true;
+  }
+
   bool string_value() {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"([ "hi", "has backslash\\" ])");
@@ -1287,6 +1324,8 @@ namespace dom_api_tests {
            array_iterator() &&
            object_iterator_empty() &&
            array_iterator_empty() &&
+           object_iterator_advance() &&
+           array_iterator_advance() &&
            string_value() &&
            numeric_values() &&
            boolean_values() &&

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -322,6 +322,24 @@ namespace document_stream_tests {
         TEST_SUCCEED();
     }
 
+    bool simple_document_iteration_advance() {
+        TEST_START();
+        auto json = R"([1,[1,2]] {"a":1,"b":2} {"o":{"1":1,"2":2}} [1,2,3])"_padded;
+        ondemand::parser parser;
+        ondemand::document_stream stream;
+        ASSERT_SUCCESS(parser.iterate_many(json).get(stream));
+        std::string_view expected[4] = {"[1,[1,2]]", "{\"a\":1,\"b\":2}", "{\"o\":{\"1\":1,\"2\":2}}", "[1,2,3]"};
+        auto iter = stream.begin();
+        for (auto i = 0; i < 4; i++) {
+            auto doc = *iter;
+            std::string_view view;
+            ASSERT_SUCCESS(to_json_string(doc).get(view));
+            ASSERT_EQUAL(view, expected[i]);
+            std::advance(iter, 1);
+        }
+        TEST_SUCCEED();
+    }
+
     bool skipbom() {
         TEST_START();
         auto json = "\xEF\xBB\xBF[1,[1,2]] {\"a\":1,\"b\":2} {\"o\":{\"1\":1,\"2\":2}} [1,2,3]"_padded;
@@ -856,6 +874,7 @@ namespace document_stream_tests {
             simple_document_iteration() &&
             simple_document_iteration_multiple_batches() &&
             simple_document_iteration_with_parsing() &&
+            simple_document_iteration_advance() &&
             atoms_json() &&
             doc_index() &&
             doc_index_multiple_batches() &&


### PR DESCRIPTION
Some iterators are implemented to be like `std::iterator` but don't actually allow themselves to be used where `std::iterator` can usually be used, because of some missing trait information. This PR adds that information.

I've not touched `simdjson::ondemand::{array,object}_iterator` as I don't think these can be valid standard iterators given the `MUST ONLY BE CALLED ONCE PER ITERATION` comment for `operator*`.