### PR TITLE
Better documentation and support for the case where you have a single implementation.

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -80,7 +80,7 @@ simdjson's source structure, from the top level, looks like this:
     * simdjson/internal/*.h: the `simdjson::internal` namespace. Private classes and functions used by the rest of simdjson.
   * simdjson/dom.h: the `simdjson::dom` namespace. Includes all public DOM classes.
     * simdjson/dom/*.h: Declarations/definitions for individual DOM classes.
-  * simdjson/arm64|fallback|haswell|icelake|ppc64|westmere.h: `simdjson::<implementation>` namesapce. Common implementation-specific tools like number and string parsing, as well as minification.
+  * simdjson/arm64|fallback|haswell|icelake|ppc64|westmere.h: `simdjson::<implementation>` namespace. Common implementation-specific tools like number and string parsing, as well as minification.
     * simdjson/arm64|fallback|haswell|icelake|ppc64|westmere/*.h: implementation-specific functions such as , etc.
     * simdjson/generic/*.h: the bulk of the actual code, written generically and compiled for each implementation, using functions defined in the implementation's .h files.
       * simdjson/generic/dependencies.h: dependencies on common, non-implementation-specific simdjson classes. This will be included before including amalgamated.h.

--- a/doc/implementation-selection.md
+++ b/doc/implementation-selection.md
@@ -26,7 +26,7 @@ The current implementations are:
 
 In many cases, you don't know where your compiled binary is going to run, so simdjson automatically
 compiles *all* the implementations into the executable. On Intel, it will include 4 implementations
-(icelake, haswell, westmere and fallback), on ARM it will include 2 (arm64 and fallback), and on PPC
+(icelake, haswell, westmere and fallback), on 64-bit ARM it will include just one since running dispatching is  unnecessary, and on PPC
 it will include 2 (ppc64 and fallback).
 
 If you know more about where you're going to run and want to save the space, you can disable any of
@@ -75,8 +75,7 @@ And look them up by name:
 ```c++
 cout << simdjson::get_available_implementations()["fallback"]->description() << endl;
 ```
-Though the fallback implementation should always be available, others might be missing. When
-an implementation is not available, the bracket call `simdjson::get_available_implementations()[name]`
+When an implementation is not available, the bracket call `simdjson::get_available_implementations()[name]`
 will return the null pointer.
 
 The available implementations have been compiled but may not necessarily be run safely on your system

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -98,6 +98,38 @@ static const simdjson::westmere::implementation* get_westmere_singleton() {
 namespace simdjson {
 namespace internal {
 
+// When there is a single implementation, we should not pay a price
+// for dispatching to the best implementation. We should just use the
+// one we have. This is a compile-time check.
+#define SIMDJSON_SINGLE_IMPLEMENTATION (SIMDJSON_IMPLEMENTATION_ICELAKE \
+             + SIMDJSON_IMPLEMENTATION_HASWELL + SIMDJSON_IMPLEMENTATION_WESTMERE \
+             + SIMDJSON_IMPLEMENTATION_ARM64 + SIMDJSON_IMPLEMENTATION_PPC64 \
+             + SIMDJSON_IMPLEMENTATION_FALLBACK == 1)
+
+#if SIMDJSON_SINGLE_IMPLEMENTATION
+  static const implementation* get_single_implementation() {
+    return
+#if SIMDJSON_IMPLEMENTATION_ICELAKE
+    get_icelake_singleton();
+#endif
+#if SIMDJSON_IMPLEMENTATION_HASWELL
+    get_haswell_singleton();
+#endif
+#if SIMDJSON_IMPLEMENTATION_WESTMERE
+    get_westmere_singleton();
+#endif
+#if SIMDJSON_IMPLEMENTATION_ARM64
+    get_arm64_singleton();
+#endif
+#if SIMDJSON_IMPLEMENTATION_PPC64
+    get_ppc64_singleton();
+#endif
+#if SIMDJSON_IMPLEMENTATION_FALLBACK
+    get_fallback_singleton();
+#endif
+}
+#endif
+
 // Static array of known implementations. We're hoping these get baked into the executable
 // without requiring a static initializer.
 
@@ -227,9 +259,16 @@ SIMDJSON_DLLIMPORTEXPORT const internal::available_implementation_list& get_avai
 }
 
 SIMDJSON_DLLIMPORTEXPORT internal::atomic_ptr<const implementation>& get_active_implementation() {
-    static const internal::detect_best_supported_implementation_on_first_use detect_best_supported_implementation_on_first_use_singleton;
-    static internal::atomic_ptr<const implementation> active_implementation{&detect_best_supported_implementation_on_first_use_singleton};
-    return active_implementation;
+#if SIMDJSON_SINGLE_IMPLEMENTATION
+  // We immediately select the only implementation we have, skipping the
+  // detect_best_supported_implementation_on_first_use_singleton.
+  static internal::atomic_ptr<const implementation> active_implementation{internal::get_single_implementation()};
+  return active_implementation;
+#else
+  static const internal::detect_best_supported_implementation_on_first_use detect_best_supported_implementation_on_first_use_singleton;
+  static internal::atomic_ptr<const implementation> active_implementation{&detect_best_supported_implementation_on_first_use_singleton};
+  return active_implementation;
+#endif
 }
 
 simdjson_warn_unused error_code minify(const char *buf, size_t len, char *dst, size_t &dst_len) noexcept {


### PR DESCRIPTION
This updates the documentation to indicate that the fallback implementation might be omitted (if it is not needed). A documentation issue reported by @TkTech 

We also skip runtime dispatching when a single implementation is available.

See https://github.com/simdjson/simdjson/issues/2117