### PR TITLE
fixing issue 2120

### DIFF
--- a/include/simdjson/padded_string_view-inl.h
+++ b/include/simdjson/padded_string_view-inl.h
@@ -11,6 +11,7 @@ namespace simdjson {
 inline padded_string_view::padded_string_view(const char* s, size_t len, size_t capacity) noexcept
   : std::string_view(s, len), _capacity(capacity)
 {
+  if(_capacity < len) { _capacity = len; }
 }
 
 inline padded_string_view::padded_string_view(const uint8_t* s, size_t len, size_t capacity) noexcept
@@ -26,6 +27,7 @@ inline padded_string_view::padded_string_view(const std::string &s) noexcept
 inline padded_string_view::padded_string_view(std::string_view s, size_t capacity) noexcept
   : std::string_view(s), _capacity(capacity)
 {
+  if(_capacity < s.length()) { _capacity = s.length(); }
 }
 
 inline size_t padded_string_view::capacity() const noexcept { return _capacity; }

--- a/include/simdjson/padded_string_view.h
+++ b/include/simdjson/padded_string_view.h
@@ -28,7 +28,8 @@ public:
    *
    * @param s The string.
    * @param len The length of the string (not including padding).
-   * @param capacity The allocated length of the string, including padding.
+   * @param capacity The allocated length of the string, including padding. If the capacity is less
+   *       than the length, the capacity will be set to the length.
    */
   explicit inline padded_string_view(const char* s, size_t len, size_t capacity) noexcept;
   /** overload explicit inline padded_string_view(const char* s, size_t len) noexcept */
@@ -47,7 +48,8 @@ public:
    * Promise the given string_view has at least SIMDJSON_PADDING extra bytes allocated to it.
    *
    * @param s The string.
-   * @param capacity The allocated length of the string, including padding.
+   * @param capacity The allocated length of the string, including padding. If the capacity is less
+   *      than the length, the capacity will be set to the length.
    */
   explicit inline padded_string_view(std::string_view s, size_t capacity) noexcept;
 

--- a/tests/dom/CMakeLists.txt
+++ b/tests/dom/CMakeLists.txt
@@ -78,14 +78,16 @@ if (BASH AND (NOT WIN32) AND SIMDJSON_BASH AND (TARGET json2json)) # The scripts
         $<TARGET_FILE:checkimplementation>
     )
   endif()
-  add_test(
-    NAME simdjson_force_implementation_error
-    COMMAND
-      ${CMAKE_COMMAND} -E env
-      SIMDJSON_FORCE_IMPLEMENTATION=doesnotexist
-      $<TARGET_FILE:json2json> ${EXAMPLE_JSON}
-  )
-  set_tests_properties(simdjson_force_implementation_error PROPERTIES WILL_FAIL TRUE)
+  if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL amd64)
+    add_test(
+      NAME simdjson_force_implementation_error
+      COMMAND
+        ${CMAKE_COMMAND} -E env
+        SIMDJSON_FORCE_IMPLEMENTATION=doesnotexist
+        $<TARGET_FILE:json2json> ${EXAMPLE_JSON}
+    )
+    set_tests_properties(simdjson_force_implementation_error PROPERTIES WILL_FAIL TRUE)
+  endif()
 endif()
 
 #

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -6,6 +6,15 @@ using namespace simdjson;
 namespace error_tests {
   using namespace std;
 
+  bool issue2120() {
+    TEST_START();
+    ondemand::parser parser;
+    size_t bad_capacity = 0;
+    ondemand::document doc;
+    ASSERT_ERROR( parser.iterate("{\"a\": 0 }", bad_capacity).get(doc), INSUFFICIENT_PADDING);
+    TEST_SUCCEED();
+  }
+
   bool badbadjson() {
     TEST_START();
     ondemand::parser parser;
@@ -366,6 +375,7 @@ namespace error_tests {
 
   bool run() {
     return
+           issue2120() &&
            badbadjson() &&
            badbadjson2() &&
            issue1834() &&


### PR DESCRIPTION
Currently, we trust the user to provide us with a correct value of capacity. In particular, capacity must be larger or equal to the length.

In this PR, we check the value of capacity and if it is smaller than the length, we set it to the length.


Fixes https://github.com/simdjson/simdjson/issues/2120