### PR TITLE
adopting string literals

### DIFF
--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -213,13 +213,14 @@ simdjson_inline token_position json_iterator::end_position() const noexcept {
 }
 
 inline std::string json_iterator::to_string() const noexcept {
+  using namespace std::string_literals;
   if( !is_alive() ) { return "dead json_iterator instance"; }
   const char * current_structural = reinterpret_cast<const char *>(token.peek());
-  return std::string("json_iterator [ depth : ") + std::to_string(_depth)
-          + std::string(", structural : '") + std::string(current_structural,1)
-          + std::string("', offset : ") + std::to_string(token.current_offset())
-          + std::string("', error : ") + error_message(error)
-          + std::string(" ]");
+  return "json_iterator [ depth : "s + std::to_string(_depth)
+          + ", structural : '"s + std::string(current_structural,1)
+          + "', offset : "s + std::to_string(token.current_offset())
+          + "', error : "s + error_message(error)
+          + " ]"s;
 }
 
 inline simdjson_result<const char *> json_iterator::current_location() const noexcept {

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -213,14 +213,13 @@ simdjson_inline token_position json_iterator::end_position() const noexcept {
 }
 
 inline std::string json_iterator::to_string() const noexcept {
-  using namespace std::string_literals;
   if( !is_alive() ) { return "dead json_iterator instance"; }
   const char * current_structural = reinterpret_cast<const char *>(token.peek());
-  return "json_iterator [ depth : "s + std::to_string(_depth)
-          + ", structural : '"s + std::string(current_structural,1)
-          + "', offset : "s + std::to_string(token.current_offset())
-          + "', error : "s + error_message(error)
-          + " ]"s;
+  return std::string("json_iterator [ depth : ") + std::to_string(_depth)
+          + std::string(", structural : '") + std::string(current_structural,1)
+          + std::string("', offset : ") + std::to_string(token.current_offset())
+          + std::string("', error : ") + error_message(error)
+          + std::string(" ]");
 }
 
 inline simdjson_result<const char *> json_iterator::current_location() const noexcept {

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -10,6 +10,7 @@
 #include <sstream>
 #include <utility>
 #include <unistd.h>
+using namespace std::string_literals;
 
 #include "simdjson.h"
 #include "cast_tester.h"
@@ -2279,14 +2280,14 @@ bool simple_overflows() {
   std::cout << "Running " << __func__ << std::endl;
   simdjson::dom::parser parser;
   simdjson::dom::element doc;
-  ASSERT_ERROR( parser.parse(std::string("[f]")).get(doc), simdjson::F_ATOM_ERROR);
-  ASSERT_ERROR( parser.parse(std::string("[t]")).get(doc), simdjson::T_ATOM_ERROR);
-  ASSERT_ERROR( parser.parse(std::string("[n]")).get(doc), simdjson::N_ATOM_ERROR);
-  ASSERT_ERROR( parser.parse(std::string("[-]")).get(doc), simdjson::NUMBER_ERROR);
-  ASSERT_ERROR( parser.parse(std::string("{\"a\":f}")).get(doc), simdjson::F_ATOM_ERROR);
-  ASSERT_ERROR( parser.parse(std::string("{\"a\":t}")).get(doc), simdjson::T_ATOM_ERROR);
-  ASSERT_ERROR( parser.parse(std::string("{\"a\":n}")).get(doc), simdjson::N_ATOM_ERROR);
-  ASSERT_ERROR( parser.parse(std::string("{\"a\":-}")).get(doc), simdjson::NUMBER_ERROR);
+  ASSERT_ERROR( parser.parse("[f]"s).get(doc), simdjson::F_ATOM_ERROR);
+  ASSERT_ERROR( parser.parse("[t]"s).get(doc), simdjson::T_ATOM_ERROR);
+  ASSERT_ERROR( parser.parse("[n]"s).get(doc), simdjson::N_ATOM_ERROR);
+  ASSERT_ERROR( parser.parse("[-]"s).get(doc), simdjson::NUMBER_ERROR);
+  ASSERT_ERROR( parser.parse("{\"a\":f}"s).get(doc), simdjson::F_ATOM_ERROR);
+  ASSERT_ERROR( parser.parse("{\"a\":t}"s).get(doc), simdjson::T_ATOM_ERROR);
+  ASSERT_ERROR( parser.parse("{\"a\":n}"s).get(doc), simdjson::N_ATOM_ERROR);
+  ASSERT_ERROR( parser.parse("{\"a\":-}"s).get(doc), simdjson::NUMBER_ERROR);
   return true;
 }
 

--- a/tests/dom/document_stream_tests.cpp
+++ b/tests/dom/document_stream_tests.cpp
@@ -1,8 +1,9 @@
-#include <string>
-#include <vector>
 #include <cctype>
-#include <unistd.h>
 #include <random>
+#include <string>
+#include <unistd.h>
+#include <vector>
+using namespace std::string_literals;
 
 #include "simdjson.h"
 #include "test_macros.h"
@@ -879,7 +880,7 @@ namespace document_stream_tests {
   bool issue1649() {
     std::cout << "Running " << __func__ << std::endl;
     std::size_t batch_size = 637;
-    const auto json=simdjson::padded_string(std::string("\xd7"));
+    const auto json=simdjson::padded_string("\xd7"s);
     simdjson::dom::parser parser;
     simdjson::dom::document_stream docs;
     if(parser.parse_many(json,batch_size).get(docs)) {

--- a/tests/dom/document_tests.cpp
+++ b/tests/dom/document_tests.cpp
@@ -1,6 +1,7 @@
 #include <string>
 #include <vector>
 #include <unistd.h>
+using namespace std::string_literals;
 
 #include "simdjson.h"
 #include "test_macros.h"
@@ -138,10 +139,10 @@ namespace document_tests {
       if (n >= buf.size()) { abort(); }
       data.emplace_back(std::string(buf.data(), n));
     }
-    data.emplace_back(std::string("true"));
-    data.emplace_back(std::string("false"));
-    data.emplace_back(std::string("null"));
-    data.emplace_back(std::string("0.1"));
+    data.emplace_back("true"s);
+    data.emplace_back("false"s);
+    data.emplace_back("null"s);
+    data.emplace_back("0.1"s);
     size_t maxsize = 0;
     for (auto &s : data) {
       if (maxsize < s.size())

--- a/tests/dom/pointercheck.cpp
+++ b/tests/dom/pointercheck.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <iostream>
+#include <string>
+using namespace std::string_literals;
 
 #include "simdjson.h"
 #include "test_macros.h"
@@ -162,7 +164,7 @@ bool issue1142() {
   dom::parser parser;
   dom::element example = parser.parse(example_json);
   auto e0 = dom::array(example).at(0).at_pointer("");
-  ASSERT_EQUAL(std::string("1"), simdjson::minify(e0))
+  ASSERT_EQUAL("1"s, simdjson::minify(e0))
   auto o = dom::array(example).at(2).at_pointer("");
   ASSERT_EQUAL(std::string(R"({"1":"bla"})"), simdjson::minify(o))
   std::string_view s0 = dom::array(example).at(2).at_pointer("/1").at_pointer("");

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -1,3 +1,6 @@
+#include <string>
+using namespace std::string_literals;
+
 #include "simdjson.h"
 #include "test_ondemand.h"
 
@@ -234,7 +237,7 @@ namespace document_stream_tests {
                 ASSERT_EQUAL(odstream.truncated_bytes(), 305);
                 break;
             } else if (err) {
-               TEST_FAIL(std::string("ondemand: error accessing jsonpointer: ") + simdjson::error_message(err));
+               TEST_FAIL("ondemand: error accessing jsonpointer: "s + simdjson::error_message(err));
             }
         }
         ASSERT_EQUAL(odstream.truncated_bytes(), 305);

--- a/tests/ondemand/ondemand_json_pointer_tests.cpp
+++ b/tests/ondemand/ondemand_json_pointer_tests.cpp
@@ -1,6 +1,7 @@
 #include "simdjson.h"
 #include "test_ondemand.h"
 #include <string>
+using namespace std::string_literals;
 
 using namespace simdjson;
 
@@ -195,7 +196,7 @@ namespace json_pointer_tests {
         ASSERT_SUCCESS(parser.iterate(cars_json).get(cars));
         for (int i = 0; i < 3; i++) {
             double x;
-            std::string json_pointer = std::string("/") + std::to_string(i) + std::string("/tire_pressure/1");
+            std::string json_pointer = "/"s + std::to_string(i) + "/tire_pressure/1"s;
             ASSERT_SUCCESS(cars.at_pointer(json_pointer).get(x));
             measured.push_back(x);
         }
@@ -315,7 +316,7 @@ namespace json_pointer_tests {
         std::vector<car_type> content;
         for (int i = 0; i < 3; i++) {
             ondemand::object obj;
-            std::string json_pointer = std::string("/") + std::to_string(i);
+            std::string json_pointer = "/"s + std::to_string(i);
             // Each successive at_pointer call invalidates
             // previously parsed values, strings, objects and array.
             ASSERT_SUCCESS(cars.at_pointer(json_pointer).get(obj));
@@ -360,7 +361,7 @@ namespace json_pointer_tests {
         ondemand::document cars = parser.iterate(cars_json);
         std::vector<car_type> content;
         for (int i = 0; i < 3; i++) {
-            std::string json_pointer = std::string("/") + std::to_string(i);
+            std::string json_pointer = "/"s + std::to_string(i);
             // Each successive at_pointer call invalidates
             // previously parsed values, strings, objects and array.
             ondemand::object obj(cars.at_pointer(json_pointer).get_object());

--- a/tests/ondemand/ondemand_misc_tests.cpp
+++ b/tests/ondemand/ondemand_misc_tests.cpp
@@ -550,7 +550,7 @@ namespace misc_tests {
   simdjson_warn_unused bool test_raw_json_token(string_view json, string_view expected_token, int expected_start_index = 0) {
     string title("'");
     title.append(json.data(), json.length());
-    title += std::string("'");
+    title += "'"s;
     padded_string json_padded = json;
     SUBTEST(title, test_ondemand_doc(json_padded, [&](auto doc) {
       string_view token;
@@ -564,11 +564,11 @@ namespace misc_tests {
     // Test values
     auto json_in_hash = string(R"({"a":)");
     json_in_hash.append(json.data(), json.length());
-    json_in_hash += std::string("}");
+    json_in_hash += "}"s;
     json_padded = json_in_hash;
-    title = std::string("'");
+    title = "'"s;
     title.append(json_in_hash.data(), json_in_hash.length());
-    title += std::string("'");
+    title += "'"s;
     SUBTEST(title, test_ondemand_doc(json_padded, [&](auto doc) {
       string_view token;
       ASSERT_SUCCESS( doc["a"].raw_json_token().get(token) );

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -1071,6 +1071,7 @@ bool json_pointer_simple() {
 
 bool json_pointer_multiple() {
 	TEST_START();
+	using namespace std::string_literals;
 	ondemand::parser parser;
 	ondemand::document cars;
 	size_t size;
@@ -1078,7 +1079,7 @@ bool json_pointer_multiple() {
 	ASSERT_SUCCESS(cars.count_elements().get(size));
 	double expected[] = {39.9, 31, 30};
 	for (size_t i = 0; i < size; i++) {
-		std::string json_pointer = std::string("/") + std::to_string(i) + std::string("/tire_pressure/1");
+		std::string json_pointer = "/"s + std::to_string(i) + "/tire_pressure/1"s;
 		double x;
 		ASSERT_SUCCESS(cars.at_pointer(json_pointer).get(x));
 		ASSERT_EQUAL(x,expected[i]);

--- a/tests/ondemand/ondemand_scalar_tests.cpp
+++ b/tests/ondemand/ondemand_scalar_tests.cpp
@@ -80,7 +80,7 @@ namespace scalar_tests {
     }
 
     {
-      padded_string array_json = std::string("[") + std::string(json) + "]";
+      padded_string array_json = "["s + std::string(json) + "]";
       std::cout << "- JSON: " << array_json << endl;
       SUBTEST( "simdjson_result<value>", test_ondemand_doc(array_json, [&](auto doc_result) {
         int count = 0;
@@ -123,7 +123,7 @@ namespace scalar_tests {
     }
 
     {
-      padded_string whitespace_array_json = std::string("[") + std::string(json) + " ]";
+      padded_string whitespace_array_json = "["s + std::string(json) + " ]";
       std::cout << "- JSON: " << whitespace_array_json << endl;
 
       SUBTEST( "simdjson_result<value>", test_ondemand_doc(whitespace_array_json, [&](auto doc_result) {
@@ -256,7 +256,7 @@ namespace scalar_tests {
       ASSERT_EQUAL( expected, T(doc) );
       return true;
     }));
-    padded_string array_json = std::string("[") + std::string(json) + "]";
+    padded_string array_json = "["s + std::string(json) + "]";
     std::cout << "- JSON: " << array_json << endl;
     SUBTEST( "value", test_ondemand_doc(array_json, [&](auto doc_result) {
       int count = 0;


### PR DESCRIPTION
Instead of `std::string("my string")`, one can do `"my string"s`. Because it is C++14/C++17, we don't want to use it in the core library, but it can make for nicer code sometimes.

cc @FranciscoThiesen 

Related to https://github.com/simdjson/simdjson/pull/2127