### PR TITLE
Unconfusing clang

### DIFF
--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -535,7 +535,7 @@ simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdj
 
 
 #if SIMDJSON_EXCEPTIONS
-template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document>::value == false>>
+template <class T, typename std::enable_if<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document>::value == false>::type>
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator T() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
@@ -847,7 +847,7 @@ simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdj
   return first.get_number();
 }
 #if SIMDJSON_EXCEPTIONS
-template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::value == false>>
+template <class T, typename std::enable_if<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::value == false>::type>
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator T() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -535,6 +535,11 @@ simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdj
 
 
 #if SIMDJSON_EXCEPTIONS
+template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document>::value == false>>
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator T() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;
@@ -842,6 +847,11 @@ simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdj
   return first.get_number();
 }
 #if SIMDJSON_EXCEPTIONS
+template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::value == false>>
+simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator T() noexcept(false) {
+  if (error()) { throw simdjson_error(error()); }
+  return first;
+}
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
   return first;

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -784,7 +784,7 @@ public:
   template<typename T> simdjson_inline error_code get(T &out) & noexcept;
   template<typename T> simdjson_inline error_code get(T &out) && noexcept;
 #if SIMDJSON_EXCEPTIONS
-  template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document>::value == false>>
+  template <class T, typename std::enable_if<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document>::value == false>::type>
   explicit simdjson_inline operator T() noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
@@ -855,7 +855,7 @@ public:
   simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> get_value() noexcept;
   simdjson_inline simdjson_result<bool> is_null() noexcept;
 #if SIMDJSON_EXCEPTIONS
-  template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::value == false>>
+  template <class T, typename std::enable_if<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::value == false>::type>
   explicit simdjson_inline operator T() noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -784,7 +784,7 @@ public:
   template<typename T> simdjson_inline error_code get(T &out) & noexcept;
   template<typename T> simdjson_inline error_code get(T &out) && noexcept;
 #if SIMDJSON_EXCEPTIONS
-  template <class T>
+  template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document>::value == false>>
   explicit simdjson_inline operator T() noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);
@@ -855,7 +855,7 @@ public:
   simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> get_value() noexcept;
   simdjson_inline simdjson_result<bool> is_null() noexcept;
 #if SIMDJSON_EXCEPTIONS
-  template <class T>
+  template <class T, std::enable_if_t<std::is_same<T, SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::value == false>>
   explicit simdjson_inline operator T() noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::array() & noexcept(false);
   simdjson_inline operator SIMDJSON_IMPLEMENTATION::ondemand::object() & noexcept(false);

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -106,6 +106,17 @@ namespace error_tests {
     TEST_SUCCEED();
   }
 #if SIMDJSON_EXCEPTIONS
+  // This is a compile-only test
+  struct Class {
+      Class(std::string text)
+          : parser()
+          , doc(parser.iterate(text))
+      {
+      }
+      simdjson::ondemand::parser parser;
+      simdjson::ondemand::document doc;
+  };
+
   bool raw_json_string_except() {
     TEST_START();
     ondemand::parser parser;

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -116,7 +116,19 @@ namespace error_tests {
       simdjson::ondemand::parser parser;
       simdjson::ondemand::document doc;
   };
-
+  bool document_in_class() {
+    TEST_START();
+    std::string text = "{}";
+    Class c(text);
+    TEST_SUCCEED();
+  }
+  bool direct_document() {
+    TEST_START();
+    std::string text = "{}";
+    simdjson::ondemand::parser parser;
+    simdjson::ondemand::document doc(parser.iterate(text));
+    TEST_SUCCEED();
+  }
   bool raw_json_string_except() {
     TEST_START();
     ondemand::parser parser;
@@ -392,6 +404,8 @@ namespace error_tests {
            issue1834() &&
            issue1834_2() &&
 #if SIMDJSON_EXCEPTIONS
+           document_in_class() &&
+           direct_document() &&
            raw_json_string_except() &&
            raw_json_string_except_with_io() &&
 #endif


### PR DESCRIPTION
In some cases, clang might get confused when constructing an ondemand document in a constructor: instead of calling the move constructor, it somehow ends up trying to cast a document to a document. We can easily disallow this behavior with std::enable_if.