### PR TITLE
Add `escaped_key` method to `ondemand::field`

### DIFF
--- a/include/simdjson/generic/ondemand/field-inl.h
+++ b/include/simdjson/generic/ondemand/field-inl.h
@@ -49,6 +49,13 @@ simdjson_inline std::string_view field::key_raw_json_token() const noexcept {
   return std::string_view(reinterpret_cast<const char*>(first.buf-1), second.iter._json_iter->token.peek(-1) - first.buf + 1);
 }
 
+simdjson_inline std::string_view field::escaped_key() const noexcept {
+  SIMDJSON_ASSUME(first.buf != nullptr); // We would like to call .alive() by Visual Studio won't let us.
+  auto end_quote = second.iter._json_iter->token.peek(-1);
+  while(*end_quote != '"') end_quote--;
+  return std::string_view(reinterpret_cast<const char*>(first.buf), end_quote - first.buf);
+}
+
 simdjson_inline value &field::value() & noexcept {
   return second;
 }
@@ -86,6 +93,11 @@ simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_stri
 simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::key_raw_json_token() noexcept {
   if (error()) { return error(); }
   return first.key_raw_json_token();
+}
+
+simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::escaped_key() noexcept {
+  if (error()) { return error(); }
+  return first.escaped_key();
 }
 
 simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::unescaped_key(bool allow_replacement) noexcept {

--- a/include/simdjson/generic/ondemand/field.h
+++ b/include/simdjson/generic/ondemand/field.h
@@ -48,6 +48,11 @@ public:
    */
   simdjson_inline std::string_view key_raw_json_token() const noexcept;
   /**
+   * Get the key as a string_view. This does not include the quotes and
+   * the string is escaped as a unprocessed key.
+   */
+  simdjson_inline std::string_view escaped_key() const noexcept;
+  /**
    * Get the field value.
    */
   simdjson_inline ondemand::value &value() & noexcept;
@@ -80,6 +85,7 @@ public:
   simdjson_inline simdjson_result<std::string_view> unescaped_key(bool allow_replacement = false) noexcept;
   simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> key() noexcept;
   simdjson_inline simdjson_result<std::string_view> key_raw_json_token() noexcept;
+  simdjson_inline simdjson_result<std::string_view> escaped_key() noexcept;
   simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> value() noexcept;
 };
 

--- a/tests/ondemand/ondemand_key_string_tests.cpp
+++ b/tests/ondemand/ondemand_key_string_tests.cpp
@@ -17,11 +17,26 @@ namespace key_string_tests {
     }
     return true;
   }
+
+  bool parser_escaped_key() {
+    TEST_START();
+    ondemand::parser parser;
+    const padded_string json = "{ \"1\": \"1\", \"2\"   : \"2\", \"3\" \t : \"3\", \"abc\"\n\t\n: \"abc\", \"\\u0075\": \"\\\\u0075\" }"_padded;
+    auto doc = parser.iterate(json);
+    for(auto field : doc.get_object())  {
+      std::string_view keyv = field.escaped_key();
+      std::string_view valuev = field.value();
+      if(keyv != valuev) { return false; }
+    }
+    return true;
+  }
+
 #endif // SIMDJSON_EXCEPTIONS
   bool run() {
     return
 #if SIMDJSON_EXCEPTIONS
       parser_key_value() &&
+      parser_escaped_key() &&
 #endif // SIMDJSON_EXCEPTIONS
       true;
   }


### PR DESCRIPTION

Close #2149.

In this PR, `escaped_key()` is added to `ondemand::field` to retrieve the unproccessed escaped key without the double quote.

Feel free to comment since I'm not sure if there's a better way to implement it.

<!--
Our tests check whether you have introduced trailing white space. If such a test fails, please check the "artifacts button" above, which if you click it gives a link to a downloadable file to help you identify the issue. You can also run scripts/remove_trailing_whitespace.sh locally if you have a bash shell and the sed command available on your system.

If you plan to contribute to simdjson, please read our

CONTRIBUTING guide: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md and our
HACKING guide: https://github.com/simdjson/simdjson/blob/master/HACKING.md
-->