### PR TITLE
fix: issue #2154

### DIFF
--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -39,7 +39,7 @@ enum error_code {
   INDEX_OUT_OF_BOUNDS,        ///< JSON array index too large
   NO_SUCH_FIELD,              ///< JSON field not found in object
   IO_ERROR,                   ///< Error reading a file
-  INVALID_JSON_POINTER,       ///< Invalid JSON pointer reference
+  INVALID_JSON_POINTER,       ///< Invalid JSON pointer syntax
   INVALID_URI_FRAGMENT,       ///< Invalid URI fragment
   UNEXPECTED_ERROR,           ///< indicative of a bug in simdjson
   PARSER_IN_USE,              ///< parser is already in use.


### PR DESCRIPTION
Fixes #2154
***Note that this approach doesn't affect jsonpath (`at_path()`).**

One will still get `INVALID_JSON_POINTER` if the pointer path is syntactically ill-formed, otherwise the `NO_SUCH_FIELD` error is raised.