### PR TITLE
pull size_t from the std namespace

### DIFF
--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -11,6 +11,9 @@
 #include <strings.h>
 #endif
 
+// We are using size_t without namespace std:: throughout the project
+using std::size_t;
+
 #ifdef _MSC_VER
 #define SIMDJSON_VISUAL_STUDIO 1
 /**

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -1,4 +1,4 @@
-/* auto-generated on 2024-05-30 10:52:38 -0400. Do not edit! */
+/* auto-generated on 2024-05-31 11:26:07 +0200. Do not edit! */
 /* including simdjson.cpp:  */
 /* begin file simdjson.cpp */
 #define SIMDJSON_SRC_SIMDJSON_CPP
@@ -83,6 +83,9 @@
 // strcasecmp, strncasecmp
 #include <strings.h>
 #endif
+
+// We are using size_t without namespace std:: throughout the project
+using std::size_t;
 
 #ifdef _MSC_VER
 #define SIMDJSON_VISUAL_STUDIO 1


### PR DESCRIPTION
Fix #2190 

I have decided to use `std::size_t` in `nonstd/string_view.hpp` as there were already parts where it was used