### PR TITLE
update string_view lite to version 1.8.0

### DIFF
--- a/include/simdjson/nonstd/string_view.hpp
+++ b/include/simdjson/nonstd/string_view.hpp
@@ -6,13 +6,13 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #pragma once // We remove #pragma once here as it generates a warning in some cases. We rely on the include guard.
+#pragma once
 
 #ifndef NONSTD_SV_LITE_H_INCLUDED
 #define NONSTD_SV_LITE_H_INCLUDED
 
 #define string_view_lite_MAJOR  1
-#define string_view_lite_MINOR  7
+#define string_view_lite_MINOR  8
 #define string_view_lite_PATCH  0
 
 #define string_view_lite_VERSION  nssv_STRINGIFY(string_view_lite_MAJOR) "." nssv_STRINGIFY(string_view_lite_MINOR) "." nssv_STRINGIFY(string_view_lite_PATCH)
@@ -133,6 +133,8 @@
 // Extensions for std::string:
 
 #if nssv_CONFIG_CONVERSION_STD_STRING_FREE_FUNCTIONS
+
+#include <string>
 
 namespace nonstd {
 


### PR DESCRIPTION
This is the header as seen for the tag [v1.8.0](https://github.com/martinmoene/string-view-lite/releases/tag/v1.8.0), commit a47222b9855dd6e6d1eac38acaa495822e2caa69, on <https://github.com/martinmoene/string-view-lite>.
