### PR TITLE
Fix _DEBUG build with clang-cl on windows

### DIFF
--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -181,7 +181,7 @@ using std::size_t;
 #if defined(NDEBUG) || defined(__OPTIMIZE__) || (defined(_MSC_VER) && !defined(_DEBUG))
 // If NDEBUG is set, or __OPTIMIZE__ is set, or we are under MSVC in release mode,
 // then do away with asserts and use __assume.
-#if SIMDJSON_VISUAL_STUDIO
+#if SIMDJSON_REGULAR_VISUAL_STUDIO
 #define SIMDJSON_UNREACHABLE() __assume(0)
 #define SIMDJSON_ASSUME(COND) __assume(COND)
 #else


### PR DESCRIPTION
Fixes #2207, though I am not sure if the fix is correct.


