### PR TITLE
fix: add parse_string_if_needed function

### DIFF
--- a/include/simdjson/arm64/stringparsing_defs.h
+++ b/include/simdjson/arm64/stringparsing_defs.h
@@ -17,6 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
+  // We only copy if dst is non-null.
   simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
@@ -34,8 +35,10 @@ simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uin
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");
   simd8<uint8_t> v0(src);
   simd8<uint8_t> v1(src + sizeof(v0));
-  v0.store(dst);
-  v1.store(dst + sizeof(v0));
+  if(dst != nullptr) {
+    v0.store(dst);
+    v1.store(dst + sizeof(v0));
+  }
 
   // Getting a 64-bit bitmask is much cheaper than multiple 16-bit bitmasks on ARM; therefore, we
   // smash them together into a 64-byte mask and get the bitmask from there.

--- a/include/simdjson/fallback/stringparsing_defs.h
+++ b/include/simdjson/fallback/stringparsing_defs.h
@@ -13,6 +13,7 @@ namespace {
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 1;
+  // We only copy if dst is non-null.
   simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return c == '"'; }
@@ -25,7 +26,9 @@ public:
 
 simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // store to dest unconditionally - we can overwrite the bits we don't like later
-  dst[0] = src[0];
+  if(dst != nullptr) {
+    dst[0] = src[0];
+  }
   return { src[0] };
 }
 

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -40,6 +40,7 @@ public:
   simdjson_warn_unused error_code stage1(const uint8_t *buf, size_t len, stage1_mode partial) noexcept final;
   simdjson_warn_unused error_code stage2(dom::document &doc) noexcept final;
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
+  simdjson_warn_unused std::pair<const uint8_t *,bool> parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept final;
   simdjson_warn_unused uint8_t *parse_string(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept final;
   simdjson_warn_unused uint8_t *parse_wobbly_string(const uint8_t *src, uint8_t *dst) const noexcept final;
   inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;

--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -354,7 +354,7 @@ simdjson_inline token_position json_iterator::position() const noexcept {
 }
 
 simdjson_inline simdjson_result<std::string_view> json_iterator::unescape(raw_json_string in, bool allow_replacement) noexcept {
-  return parser->unescape(in, _string_buf_loc, allow_replacement);
+  return parser->unescape_maybe(in, _string_buf_loc, allow_replacement);
 }
 
 simdjson_inline simdjson_result<std::string_view> json_iterator::unescape_wobbly(raw_json_string in) noexcept {

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -168,7 +168,7 @@ simdjson_inline void parser::set_max_capacity(size_t max_capacity) noexcept {
   }
 }
 
-simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> parser::unescape(raw_json_string in, uint8_t *&dst, bool allow_replacement) const noexcept {
+simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> parser::unescape_maybe(raw_json_string in, uint8_t *&dst, bool allow_replacement) const noexcept {
   std::pair<const uint8_t *, bool> result = implementation->parse_string_if_needed(in.buf, dst, allow_replacement);
   const uint8_t *end = result.first;
   bool copied = result.second;
@@ -180,6 +180,14 @@ simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> parser::u
   }
   // fast path, no copy was made!!!
   return std::string_view(reinterpret_cast<const char *>(in.buf), end-in.buf);
+}
+
+simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> parser::unescape(raw_json_string in, uint8_t *&dst, bool allow_replacement) const noexcept {
+  uint8_t *end = implementation->parse_string(in.buf, dst, allow_replacement);
+  if (!end) { return STRING_ERROR; }
+  std::string_view result(reinterpret_cast<const char *>(dst), end-dst);
+  dst = end;
+  return result;
 }
 
 simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> parser::unescape_wobbly(raw_json_string in, uint8_t *&dst) const noexcept {

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -305,6 +305,32 @@ public:
   simdjson_inline simdjson_result<std::string_view> unescape(raw_json_string in, uint8_t *&dst, bool allow_replacement = false) const noexcept;
 
   /**
+   * Unescape this JSON string, replacing \\ with \, \n with newline, etc. to a user-provided buffer if
+   * needed. If no escaping is done, the string is returned as is and dst is not not changed.
+   * The result must be valid UTF-8.
+   * The provided pointer is advanced to the end of the string by reference if a copy is needed,
+    * and a string_view instance
+   * is returned. You can ensure that your buffer is large enough by allocating a block of memory at least
+   * as large as the input JSON plus SIMDJSON_PADDING and then unescape all strings to this one buffer.
+   *
+   * This unescape_maybe function is a low-level function. If you want a more user-friendly approach, you should
+   * avoid raw_json_string instances (e.g., by calling unescaped_key() instead of key() or get_string()
+   * instead of get_raw_json_string()).
+   *
+   * ## IMPORTANT: string_view lifetime
+   *
+   * The string_view is only valid as long as the bytes in dst.
+   *
+   * @param raw_json_string input
+   * @param dst A pointer to a buffer at least large enough to write this string as well as
+   *            an additional SIMDJSON_PADDING bytes.
+   * @param allow_replacement Whether we allow a replacement if the input string contains unmatched surrogate pairs.
+   * @return A string_view pointing at the unescaped string in dst
+   * @error STRING_ERROR if escapes are incorrect.
+   */
+  simdjson_inline simdjson_result<std::string_view> unescape_maybe(raw_json_string in, uint8_t *&dst, bool allow_replacement = false) const noexcept;
+
+  /**
    * Unescape this JSON string, replacing \\ with \, \n with newline, etc. to a user-provided buffer.
    * The result may not be valid UTF-8. See https://simonsapin.github.io/wtf-8/
    * The provided pointer is advanced to the end of the string by reference, and a string_view instance

--- a/include/simdjson/haswell/stringparsing_defs.h
+++ b/include/simdjson/haswell/stringparsing_defs.h
@@ -17,6 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
+  // We only copy if dst is non-null.
   simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
@@ -34,7 +35,9 @@ simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uin
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");
   simd8<uint8_t> v(src);
   // store to dest unconditionally - we can overwrite the bits we don't like later
-  v.store(dst);
+  if(dst != nullptr) {
+    v.store(dst);
+  }
   return {
       static_cast<uint32_t>((v == '\\').to_bitmask()),     // bs_bits
       static_cast<uint32_t>((v == '"').to_bitmask()), // quote_bits

--- a/include/simdjson/icelake/stringparsing_defs.h
+++ b/include/simdjson/icelake/stringparsing_defs.h
@@ -17,6 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 64;
+  // We only copy if dst is non-null.
   simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
@@ -34,7 +35,9 @@ simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uin
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");
   simd8<uint8_t> v(src);
   // store to dest unconditionally - we can overwrite the bits we don't like later
-  v.store(dst);
+  if(dst != nullptr) {
+    v.store(dst);
+  }
   return {
       static_cast<uint64_t>(v == '\\'), // bs_bits
       static_cast<uint64_t>(v == '"'), // quote_bits

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -4,6 +4,7 @@
 #include "simdjson/base.h"
 #include "simdjson/error.h"
 #include <memory>
+#include <utility>
 
 namespace simdjson {
 
@@ -101,6 +102,24 @@ public:
    * @return The error code, SUCCESS if there was no error, or EMPTY if all documents have been parsed.
    */
   simdjson_warn_unused virtual error_code stage2_next(dom::document &doc) noexcept = 0;
+
+  /**
+   * Unescape a valid UTF-8 string from src to dst, stopping at a final unescaped quote. There
+   * must be an unescaped quote terminating the string. It returns the final output
+   * position as pointer. In case of error (e.g., the string has bad escaped codes),
+   * then null_ptr is returned. If no escaping was required, then no copy is made.
+   * It is assumed that the output buffer is large
+   * enough to store the unescapedstring + SIMDJSON_PADDING bytes.
+   *
+   * Overridden by each implementation.
+   *
+   * @param str pointer to the beginning of a valid UTF-8 JSON string, must end with an unescaped quote.
+   * @param dst pointer to a destination buffer, it must point a region in memory of sufficient size.
+   * @param allow_replacement whether we allow a replacement character when the UTF-8 contains unmatched surrogate pairs.
+   * @return end of the of the written region (exclusive) or nullptr in case of error coupled with a Boolean telling you if a copy was made
+   */
+  simdjson_warn_unused virtual std::pair<const uint8_t *,bool> parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept = 0;
+
 
   /**
    * Unescape a valid UTF-8 string from src to dst, stopping at a final unescaped quote. There

--- a/include/simdjson/lasx/stringparsing_defs.h
+++ b/include/simdjson/lasx/stringparsing_defs.h
@@ -17,6 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
+  // We only copy if dst is non-null.
   simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
@@ -33,7 +34,9 @@ simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uin
   // SIMDJSON_PADDING of padding
   static_assert(SIMDJSON_PADDING >= (BYTES_PROCESSED - 1), "backslash and quote finder must process fewer than SIMDJSON_PADDING bytes");
   simd8<uint8_t> v(src);
-  v.store(dst);
+  if(dst != nullptr) {
+    v.store(dst);
+  }
   return {
       static_cast<uint32_t>((v == '\\').to_bitmask()),     // bs_bits
       static_cast<uint32_t>((v == '"').to_bitmask()), // quote_bits

--- a/include/simdjson/ppc64/stringparsing_defs.h
+++ b/include/simdjson/ppc64/stringparsing_defs.h
@@ -18,6 +18,7 @@ struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
   simdjson_inline static backslash_and_quote
+  // We only copy if dst is non-null.
   copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() {
@@ -44,8 +45,10 @@ backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
                 "SIMDJSON_PADDING bytes");
   simd8<uint8_t> v0(src);
   simd8<uint8_t> v1(src + sizeof(v0));
-  v0.store(dst);
-  v1.store(dst + sizeof(v0));
+  if(dst != nullptr) {
+    v0.store(dst);
+    v1.store(dst + sizeof(v0));
+  }
 
   // Getting a 64-bit bitmask is much cheaper than multiple 16-bit bitmasks on
   // PPC; therefore, we smash them together into a 64-byte mask and get the

--- a/src/arm64.cpp
+++ b/src/arm64.cpp
@@ -150,6 +150,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return arm64::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
   return arm64::stringparsing::parse_string(src, dst, allow_replacement);
 }

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -388,6 +388,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return fallback::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool replacement_char) const noexcept {
   return fallback::stringparsing::parse_string(src, dst, replacement_char);
 }

--- a/src/haswell.cpp
+++ b/src/haswell.cpp
@@ -147,6 +147,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return haswell::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool replacement_char) const noexcept {
   return haswell::stringparsing::parse_string(src, dst, replacement_char);
 }

--- a/src/icelake.cpp
+++ b/src/icelake.cpp
@@ -193,6 +193,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return icelake::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool replacement_char) const noexcept {
   return icelake::stringparsing::parse_string(src, dst, replacement_char);
 }

--- a/src/lasx.cpp
+++ b/src/lasx.cpp
@@ -110,6 +110,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return lasx::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
   return lasx::stringparsing::parse_string(src, dst, allow_replacement);
 }

--- a/src/lsx.cpp
+++ b/src/lsx.cpp
@@ -114,6 +114,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return lsx::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
   return lsx::stringparsing::parse_string(src, dst, allow_replacement);
 }

--- a/src/ppc64.cpp
+++ b/src/ppc64.cpp
@@ -120,6 +120,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return ppc64::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool replacement_char) const noexcept {
   return ppc64::stringparsing::parse_string(src, dst, replacement_char);
 }

--- a/src/westmere.cpp
+++ b/src/westmere.cpp
@@ -152,6 +152,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage2_next(dom::docu
   return stage2::tape_builder::parse_document<true>(*this, _doc);
 }
 
+simdjson_warn_unused std::pair<const uint8_t *, bool> dom_parser_implementation::parse_string_if_needed(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept {
+  return westmere::stringparsing::parse_string_if_needed(src, dst, allow_replacement);
+}
+
 simdjson_warn_unused uint8_t *dom_parser_implementation::parse_string(const uint8_t *src, uint8_t *dst, bool replacement_char) const noexcept {
   return westmere::stringparsing::parse_string(src, dst, replacement_char);
 }


### PR DESCRIPTION
This is a competing PR vs https://github.com/simdjson/simdjson/pull/2211 by @CarlosEduR 

The idea is that we avoid copying strings to a string  buffer when we do not need to.

@CarlosEduR  uses a sensible approach that does not require 'deep' changes. This PR is somewhat deeper. Whether this PR is better than https://github.com/simdjson/simdjson/pull/2211 is an open question.


partial fix to  https://github.com/simdjson/simdjson/issues/1470 Note that @jkeiser's idea is somewhat more involved than what we are doing currently.

Benchmarks on my ARM processor (Apple M2).


## partial tweek 

In this benchmark, we typically do not have escaped content in strings, but it does happen from time to time. I don't have an exact percentage but it is maybe 20% or 10% of the time that we have escaped content.

Using ` ./build/benchmark/bench_ondemand --benchmark_filter="partial_tweets<simdjson_ondemand>"`. Run with sudo to get performance counters.


Main:
best_instructions_per_byte=8.68026 best_instructions_per_cycle=6.57819

@CarlosEduR's PR: 
best_instructions_per_byte=9.31405 best_instructions_per_cycle=6.54882 

This PR: 
best_instructions_per_byte=8.66243 best_instructions_per_cycle=6.5704


## find tweet

This is a lucky benchmark where we never have escaped content to worry about.

Using ` ./build/benchmark/bench_ondemand --benchmark_filter="find_tweet<simdjson_ondemand>"`. Run with sudo to get performance counters.

Main
best_instructions_per_byte=4.71785 best_instructions_per_cycle=6.34339 

@CarlosEduR's PR: 
best_instructions_per_byte=4.7256 best_instructions_per_cycle=6.34974

This PR: 
best_instructions_per_byte=4.71761 best_instructions_per_cycle=6.34714 



## Conclusion

It is too early to tell which direction this goes because (1) I only tested on one system and (2) only on two benchmarks.

ARM systems do not have to contend with runtime dispatches, so this is an advantage for this PR, compared to @CarlosEduR's PR. However, @CarlosEduR's PR could do better when runtime dispatching is needed.

@CarlosEduR's PR shows a regression which is possibly caused by the fact that it tries to avoid the copy, fails and then has to fall back on the current code. Even if it only happens one time out of 5 or 10, these unlucky cases could cost you.


Overall, my preliminary results suggest that on Apple Silicon, it is not worth avoiding a write on the string buffer. 

