### PR TITLE
tag_invoke based custom types

### DIFF
--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -467,7 +467,15 @@ simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdj
 template <class T>
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator T() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
+#if __cplusplus > 201703
+  if constexpr (tag_invocable<deserialize_tag, std::type_identity<T>, SIMDJSON_IMPLEMENTATION::ondemand::value&>) {
+    return deserialize(std::type_identity<T>{}, first);
+  } else {
+#endif // C++20
   return static_cast<T>(first);
+#if __cplusplus > 201703L
+      }
+#endif
 }
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -80,6 +80,7 @@ simdjson_inline simdjson_result<bool> value::get_bool() noexcept {
 simdjson_inline simdjson_result<bool> value::is_null() noexcept {
   return iter.is_null();
 }
+
 template<> simdjson_inline simdjson_result<array> value::get() noexcept { return get_array(); }
 template<> simdjson_inline simdjson_result<object> value::get() noexcept { return get_object(); }
 template<> simdjson_inline simdjson_result<raw_json_string> value::get() noexcept { return get_raw_json_string(); }
@@ -467,15 +468,7 @@ simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::number> simdj
 template <class T>
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator T() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }
-#if __cplusplus > 201703
-  if constexpr (tag_invocable<deserialize_tag, std::type_identity<T>, SIMDJSON_IMPLEMENTATION::ondemand::value&>) {
-    return deserialize(std::type_identity<T>{}, first);
-  } else {
-#endif // C++20
-  return static_cast<T>(first);
-#if __cplusplus > 201703L
-      }
-#endif
+  return first.get<T>();
 }
 simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::operator SIMDJSON_IMPLEMENTATION::ondemand::array() noexcept(false) {
   if (error()) { throw simdjson_error(error()); }

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -7,9 +7,10 @@
 #include "simdjson/generic/ondemand/value_iterator.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
-#include <version>
-#ifdef __cpp_concepts
-#include <concepts>
+#ifdef __has_include
+#  if __has_include(<version>)
+#    include <version>
+#  endif
 #endif
 
 namespace simdjson {

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -17,7 +17,7 @@ namespace simdjson {
 
 #ifdef __cpp_concepts
   namespace tag_invoke_fn_ns {
-  void tag_invoke() = delete;
+  void tag_invoke();
 
   struct tag_invoke_fn {
     template <typename Tag, typename... Args>

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -7,10 +7,78 @@
 #include "simdjson/generic/ondemand/value_iterator.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#if __cplusplus >= 201703
+#include <concepts>
+#endif
+
 namespace simdjson {
+
+#if __cplusplus > 201703
+  namespace tag_invoke_fn_ns {
+  void tag_invoke() = delete;
+
+  struct tag_invoke_fn {
+    template <typename Tag, typename... Args>
+        requires requires(Tag tag, Args&&... args) {
+      tag_invoke(std::forward<Tag>(tag), std::forward<Args>(args)...);
+        }
+    constexpr auto operator()(Tag tag, Args&&... args) const
+      noexcept(noexcept(tag_invoke(std::forward<Tag>(tag), std::forward<Args>(args)...)))
+        -> decltype(tag_invoke(std::forward<Tag>(tag), std::forward<Args>(args)...)) {
+          return tag_invoke(std::forward<Tag>(tag), std::forward<Args>(args)...);
+        }
+  };
+  } // namespace tag_invoke_fn_ns
+
+  inline namespace tag_invoke_ns {
+  inline constexpr tag_invoke_fn_ns::tag_invoke_fn tag_invoke = {};
+  } // namespace tag_invoke_ns
+
+  template <typename Tag, typename... Args>
+  concept tag_invocable =
+    requires(Tag tag, Args... args) { tag_invoke(std::forward<Tag>(tag), std::forward<Args>(args)...); };
+
+  template <typename Tag, typename... Args>
+  concept nothrow_tag_invocable = tag_invocable<Tag, Args...> && requires(Tag tag, Args... args) {
+    {
+      tag_invoke(std::forward<Tag>(tag), std::forward<Args>(args)...)
+  } noexcept;
+  };
+
+  template <typename Tag, typename... Args>
+  using tag_invoke_result = std::invoke_result<decltype(tag_invoke), Tag, Args...>;
+
+  template <typename Tag, typename... Args>
+  using tag_invoke_result_t = std::invoke_result_t<decltype(tag_invoke), Tag, Args...>;
+
+  template <auto& Tag>
+  using tag_t = std::decay_t<decltype(Tag)>;
+
+
+
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
+class value;
+}
+}
 
+  /// Deserialize Tag
+  inline constexpr struct deserialize_tag {
+      // Customization Point
+      template <typename T>
+          requires tag_invocable<deserialize_tag, std::type_identity<T>, SIMDJSON_IMPLEMENTATION::ondemand::value&>
+      [[nodiscard]] constexpr simdjson_result<T> operator()(std::type_identity<T>, SIMDJSON_IMPLEMENTATION::ondemand::value& object) const
+        noexcept(nothrow_tag_invocable<deserialize_tag, std::type_identity<T>, SIMDJSON_IMPLEMENTATION::ondemand::value&>) {
+          return tag_invoke(*this, std::type_identity<T>{}, object);
+      }
+
+      // default implementations can also be done here
+  } deserialize{};
+#endif
+
+
+namespace SIMDJSON_IMPLEMENTATION {
+namespace ondemand {
 /**
  * An ephemeral JSON value returned during iteration. It is only valid for as long as you do
  * not access more data in the JSON document.
@@ -36,6 +104,11 @@ public:
    * @returns INCORRECT_TYPE If the JSON value is not the given type.
    */
   template<typename T> simdjson_inline simdjson_result<T> get() noexcept {
+#if __cplusplus > 201703
+  if constexpr (tag_invocable<deserialize_tag, std::type_identity<T>, value&>) {
+    return deserialize(std::type_identity<T>{}, *this);
+  } else {
+#endif // C++20
     // Unless the simdjson library or the user provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
@@ -43,6 +116,9 @@ public:
       "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
       " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template."
       " You may also add support for custom types, see our documentation.");
+#if __cplusplus > 201703L
+      }
+#endif
   }
 
   /**

--- a/tests/ondemand/CMakeLists.txt
+++ b/tests/ondemand/CMakeLists.txt
@@ -28,6 +28,7 @@ add_cpp_test(ondemand_to_string              LABELS ondemand acceptance per_impl
 add_cpp_test(ondemand_twitter_tests          LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_wrong_type_error_tests LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_iterate_many_csv       LABELS ondemand acceptance per_implementation)
+add_cpp_test(ondemand_custom_types_tests     LABELS ondemand acceptance per_implementation)
 if(NOT SIMDJSON_SANITIZE)
   add_cpp_test(ondemand_cacheline              LABELS ondemand acceptance per_implementation)
 endif()

--- a/tests/ondemand/ondemand_custom_types_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_tests.cpp
@@ -1,0 +1,154 @@
+#include "simdjson.h"
+#include "test_ondemand.h"
+
+#include <string>
+#include <vector>
+
+#if __cplusplus > 201703
+
+template <typename T>
+struct is_unique_ptr : std::false_type {
+};
+
+
+template <typename T>
+struct is_unique_ptr<std::unique_ptr<T>> : std::true_type {
+};
+
+template <typename T>
+concept is_unique_ptr_v = is_unique_ptr<T>::value;
+
+
+namespace simdjson {
+
+// this is to demonstrate that we can use concept; otherwise a simple
+// type_identity<unique_ptr<T>> as the second argument would have done the job.
+//
+// This tag_invoke MUST be inside simdjson namespace
+template <typename T>
+  requires is_unique_ptr_v<T>
+auto tag_invoke(deserialize_tag, std::type_identity<T>, ondemand::value &val) {
+  using type = typename T::element_type;
+  return simdjson_result{std::make_unique<type>(val.template get<type>())};
+}
+
+} // namespace simdjson
+
+// the old way of doing things
+template <>
+simdjson::simdjson_result<std::vector<double>>
+simdjson::ondemand::value::get() noexcept {
+  ondemand::array array;
+  auto error = get_array().get(array);
+  if (error) {
+    return error;
+  }
+  std::vector<double> vec;
+  for (auto v : array) {
+    double val;
+    error = v.get_double().get(val);
+    if (error) {
+      return error;
+    }
+    vec.push_back(val);
+  }
+  return vec;
+}
+
+#endif // C++20
+namespace key_string_tests {
+#if SIMDJSON_EXCEPTIONS && __cplusplus > 201703
+struct Car {
+  std::string make;
+  std::string model;
+  int64_t year = 0;
+  std::vector<double> tire_pressure;
+
+  friend simdjson_result<Car>
+  tag_invoke(simdjson::deserialize_tag, std::type_identity<Car>, simdjson::ondemand::value &val) {
+    simdjson::ondemand::object obj;
+    auto error = val.get_object().get(obj);
+    if (error) {
+      return error;
+    }
+    Car car{};
+    // Instead of repeatedly obj["something"], we iterate through the object
+    // which we expect to be faster.
+    for (auto field : obj) {
+      simdjson::ondemand::raw_json_string key;
+      error = field.key().get(key);
+      if (error) {
+        return error;
+      }
+      if (key == "make") {
+        error = field.value().get_string(car.make);
+        if (error) {
+          return error;
+        }
+      } else if (key == "model") {
+        error = field.value().get_string(car.model);
+        if (error) {
+          return error;
+        }
+      } else if (key == "year") {
+        error = field.value().get_int64().get(car.year);
+        if (error) {
+          return error;
+        }
+      } else if (key == "tire_pressure") {
+        error = field.value().get<std::vector<double>>().get(car.tire_pressure);
+        if (error) {
+          return error;
+        }
+      }
+    }
+    return car;
+  }
+};
+
+bool parser_key_value() {
+  TEST_START();
+  simdjson::padded_string json =
+      R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] },
+  { "make": "Kia",    "model": "Soul",   "year": 2012,
+       "tire_pressure": [ 30.1, 31.0 ] },
+  { "make": "Toyota", "model": "Tercel", "year": 1999,
+       "tire_pressure": [ 29.8, 30.0 ] }
+])"_padded;
+
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  for (auto val : doc) {
+    std::unique_ptr<Car> c(val);
+    if (c->make != "Toyota" && c->make != "Kia") {
+      return false;
+    }
+    if (c->model != "Camry" && c->model != "Soul" && c->model != "Tercel") {
+      return false;
+    }
+    if (c->year != 2018 && c->year != 2012 && c->year != 1999) {
+      return false;
+    }
+    if (c->tire_pressure.size() != 2) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+#endif // SIMDJSON_EXCEPTIONS
+bool run() {
+  return
+#if SIMDJSON_EXCEPTIONS && __cplusplus > 201703
+      parser_key_value() &&
+#endif // SIMDJSON_EXCEPTIONS
+      true;
+}
+
+} // namespace key_string_tests
+
+int main(int argc, char *argv[]) {
+  return test_main(argc, argv, key_string_tests::run);
+}

--- a/tests/ondemand/ondemand_custom_types_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_tests.cpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#if __cplusplus > 201703
+#ifdef __cpp_concepts
 
 template <typename T>
 struct is_unique_ptr : std::false_type {
@@ -55,9 +55,11 @@ simdjson::ondemand::value::get() noexcept {
   return vec;
 }
 
-#endif // C++20
-namespace key_string_tests {
-#if SIMDJSON_EXCEPTIONS && __cplusplus > 201703
+#endif // __cpp_concepts
+
+
+namespace custom_types_tests {
+#if SIMDJSON_EXCEPTIONS && defined(__cpp_concepts)
 struct Car {
   std::string make;
   std::string model;
@@ -106,7 +108,7 @@ struct Car {
   }
 };
 
-bool parser_key_value() {
+bool custom_test() {
   TEST_START();
   simdjson::padded_string json =
       R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
@@ -141,8 +143,8 @@ bool parser_key_value() {
 #endif // SIMDJSON_EXCEPTIONS
 bool run() {
   return
-#if SIMDJSON_EXCEPTIONS && __cplusplus > 201703
-      parser_key_value() &&
+#if SIMDJSON_EXCEPTIONS && defined(__cpp_concepts)
+      custom_test() &&
 #endif // SIMDJSON_EXCEPTIONS
       true;
 }
@@ -150,5 +152,5 @@ bool run() {
 } // namespace key_string_tests
 
 int main(int argc, char *argv[]) {
-  return test_main(argc, argv, key_string_tests::run);
+  return test_main(argc, argv, custom_types_tests::run);
 }

--- a/tests/ondemand/ondemand_custom_types_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_tests.cpp
@@ -108,6 +108,10 @@ struct Car {
   }
 };
 
+static_assert(simdjson::tag_invocable<simdjson::deserialize_tag,
+                            std::type_identity<std::unique_ptr<Car>>, simdjson::ondemand::value &>,
+              "It should be invocable");
+
 bool custom_test() {
   TEST_START();
   simdjson::padded_string json =


### PR DESCRIPTION
Now you can use tag_invoke to add a custom type or a group of custom types.

A follow up on [Daniel Lemire's tweet](https://x.com/lemire/status/1815544018979504145), here's a proposal on how we would use [tag_invoke](https://wg21.link/P1895) in simdjson.

There might be some small details like which namespace to use for some utilities, coding style, and other things that I have left after knowing the project's authors opinions and whether or not they want to go in this direction or not.

This allows you to:

```c++
struct Car {
  std::string make;
  std::string model;

  friend simdjson_result<Car>
  tag_invoke(simdjson::deserialize_tag, std::type_identity<Car>, simdjson::ondemand::value &val) {
    // ...
    return car;
  }
};
```

or completely going general, like:
```c++
namespace simdjson {

// this is to demonstrate that we can use concept; otherwise a simple
// type_identity<unique_ptr<T>> as the second argument would have done the job.
//
// This tag_invoke MUST be inside simdjson namespace
template <typename T>
  requires is_unique_ptr_v<T>
auto tag_invoke(deserialize_tag, std::type_identity<T>, ondemand::value &val) {
  using type = typename T::element_type;
  return simdjson_result{std::make_unique<type>(val.template get<type>())};
}

} // namespace simdjson
```

The use case would be:

```c++
  for (auto val : doc) {
    std::unique_ptr<Car> c(val); // <---- magically works
  }
```