### PR TITLE
Added the functionality to convert dom::object and dom::array to dom element.

### DIFF
--- a/include/simdjson/dom/array-inl.h
+++ b/include/simdjson/dom/array-inl.h
@@ -123,6 +123,10 @@ inline simdjson_result<element> array::at(size_t index) const noexcept {
   return INDEX_OUT_OF_BOUNDS;
 }
 
+inline array::operator element() const noexcept {
+	return element(tape);
+}
+
 //
 // array::iterator inline implementation
 //

--- a/include/simdjson/dom/array.h
+++ b/include/simdjson/dom/array.h
@@ -126,6 +126,11 @@ public:
    */
   inline simdjson_result<element> at(size_t index) const noexcept;
 
+  /**
+   * Implicitly convert object to element
+   */
+  inline operator element() const noexcept;
+
 private:
   simdjson_inline array(const internal::tape_ref &tape) noexcept;
   internal::tape_ref tape;

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -153,6 +153,10 @@ inline simdjson_result<element> object::at_key_case_insensitive(std::string_view
   return NO_SUCH_FIELD;
 }
 
+inline object::operator element() const noexcept {
+	return element(tape);
+}
+
 //
 // object::iterator inline implementation
 //

--- a/include/simdjson/dom/object.h
+++ b/include/simdjson/dom/object.h
@@ -200,6 +200,11 @@ public:
    */
   inline simdjson_result<element> at_key_case_insensitive(std::string_view key) const noexcept;
 
+  /**
+   * Implicitly convert object to element
+   */
+  inline operator element() const noexcept;
+
 private:
   simdjson_inline object(const internal::tape_ref &tape) noexcept;
 

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -970,6 +970,36 @@ namespace dom_api_tests {
     return true;
   }
 
+  bool convert_object_to_element() {
+    std::cout << "Running " << __func__ << std::endl;
+    string json(R"({ "a": 1, "b": 2, "c": 3 })");
+
+    dom::parser parser;
+    dom::object object;
+    dom::element element;
+    ASSERT_SUCCESS( parser.parse(json).get(object) );
+    element = object;
+    ASSERT_EQUAL( element["a"].get_uint64().value_unsafe(), 1 );
+    ASSERT_EQUAL( element["b"].get_uint64().value_unsafe(), 2 );
+    ASSERT_EQUAL( element["c"].get_uint64().value_unsafe(), 3 );
+    return true;
+  }
+
+  bool convert_array_to_element() {
+    std::cout << "Running " << __func__ << std::endl;
+    string json(R"([ 1, 10, 100 ])");
+
+    dom::parser parser;
+    dom::array array;
+    dom::element element;
+    ASSERT_SUCCESS( parser.parse(json).get(array) );
+    element = array;
+    ASSERT_EQUAL( element.at(0).get_uint64().value_unsafe(), 1 );
+    ASSERT_EQUAL( element.at(1).get_uint64().value_unsafe(), 10 );
+    ASSERT_EQUAL( element.at(2).get_uint64().value_unsafe(), 100 );
+    return true;
+  }
+
   bool string_value() {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"([ "hi", "has backslash\\" ])");
@@ -1351,6 +1381,8 @@ namespace dom_api_tests {
            array_iterator_empty() &&
            object_iterator_advance() &&
            array_iterator_advance() &&
+           convert_object_to_element() &&
+           convert_array_to_element() &&
            string_value() &&
            numeric_values() &&
            boolean_values() &&


### PR DESCRIPTION
closed: #2218 

Added the functionality to convert dom::object and dom::array to dom element.

Add the function "inline operator element() const noexcept" to the dom::object and dom::array classes, and add test for it.