### PR TITLE
fix: add tests related to issue 2227

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -50,6 +50,8 @@ double from_chars(const char *first, const char* end) noexcept;
 #define SIMDJSON_ISALIGNED_N(ptr, n) (((uintptr_t)(ptr) & ((n)-1)) == 0)
 
 #if SIMDJSON_REGULAR_VISUAL_STUDIO
+  // We could use [[deprecated]] but it requires C++14
+  #define simdjson_deprecated __declspec(deprecated)
 
   #define simdjson_really_inline __forceinline
   #define simdjson_never_inline __declspec(noinline)
@@ -88,6 +90,8 @@ double from_chars(const char *first, const char* end) noexcept;
   #define SIMDJSON_POP_DISABLE_UNUSED_WARNINGS
 
 #else // SIMDJSON_REGULAR_VISUAL_STUDIO
+  // We could use [[deprecated]] but it requires C++14
+  #define simdjson_deprecated __attribute__((deprecated))
 
   #define simdjson_really_inline inline __attribute__((always_inline))
   #define simdjson_never_inline inline __attribute__((noinline))

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -167,24 +167,24 @@ template<> simdjson_inline simdjson_result<int64_t> document::get() & noexcept {
 template<> simdjson_inline simdjson_result<bool> document::get() & noexcept { return get_bool(); }
 template<> simdjson_inline simdjson_result<value> document::get() & noexcept { return get_value(); }
 
-template<> simdjson_inline simdjson_result<raw_json_string> document::get() && noexcept { return get_raw_json_string(); }
-template<> simdjson_inline simdjson_result<std::string_view> document::get() && noexcept { return get_string(false); }
-template<> simdjson_inline simdjson_result<double> document::get() && noexcept { return std::forward<document>(*this).get_double(); }
-template<> simdjson_inline simdjson_result<uint64_t> document::get() && noexcept { return std::forward<document>(*this).get_uint64(); }
-template<> simdjson_inline simdjson_result<int64_t> document::get() && noexcept { return std::forward<document>(*this).get_int64(); }
-template<> simdjson_inline simdjson_result<bool> document::get() && noexcept { return std::forward<document>(*this).get_bool(); }
-template<> simdjson_inline simdjson_result<value> document::get() && noexcept { return get_value(); }
+template<> simdjson_deprecated simdjson_inline simdjson_result<raw_json_string> document::get() && noexcept { return get_raw_json_string(); }
+template<> simdjson_deprecated simdjson_inline simdjson_result<std::string_view> document::get() && noexcept { return get_string(false); }
+template<> simdjson_deprecated simdjson_inline simdjson_result<double> document::get() && noexcept { return std::forward<document>(*this).get_double(); }
+template<> simdjson_deprecated simdjson_inline simdjson_result<uint64_t> document::get() && noexcept { return std::forward<document>(*this).get_uint64(); }
+template<> simdjson_deprecated simdjson_inline simdjson_result<int64_t> document::get() && noexcept { return std::forward<document>(*this).get_int64(); }
+template<> simdjson_deprecated simdjson_inline simdjson_result<bool> document::get() && noexcept { return std::forward<document>(*this).get_bool(); }
+template<> simdjson_deprecated simdjson_inline simdjson_result<value> document::get() && noexcept { return get_value(); }
 
 template<typename T> simdjson_inline error_code document::get(T &out) & noexcept {
   return get<T>().get(out);
 }
-template<typename T> simdjson_inline error_code document::get(T &out) && noexcept {
+template<typename T> simdjson_deprecated simdjson_inline error_code document::get(T &out) && noexcept {
   return std::forward<document>(*this).get<T>().get(out);
 }
 
 #if SIMDJSON_EXCEPTIONS
 template <class T>
-simdjson_inline document::operator T() noexcept(false) { return get<T>(); }
+simdjson_deprecated simdjson_inline document::operator T() noexcept(false) { return get<T>(); }
 simdjson_inline document::operator array() & noexcept(false) { return get_array(); }
 simdjson_inline document::operator object() & noexcept(false) { return get_object(); }
 simdjson_inline document::operator uint64_t() noexcept(false) { return get_uint64(); }
@@ -471,7 +471,7 @@ simdjson_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::onde
   return first.get<T>();
 }
 template<typename T>
-simdjson_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get() && noexcept {
+simdjson_deprecated simdjson_inline simdjson_result<T> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document>(first).get<T>();
 }
@@ -487,7 +487,7 @@ simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::do
 }
 
 template<> simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>() & noexcept = delete;
-template<> simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>() && noexcept {
+template<> simdjson_deprecated simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get<SIMDJSON_IMPLEMENTATION::ondemand::document>() && noexcept {
   if (error()) { return error(); }
   return std::forward<SIMDJSON_IMPLEMENTATION::ondemand::document>(first);
 }

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -184,7 +184,9 @@ template<typename T> simdjson_deprecated simdjson_inline error_code document::ge
 
 #if SIMDJSON_EXCEPTIONS
 template <class T>
-simdjson_deprecated simdjson_inline document::operator T() noexcept(false) { return get<T>(); }
+simdjson_deprecated simdjson_inline document::operator T() && noexcept(false) { return get<T>(); }
+template <class T>
+simdjson_inline document::operator T() & noexcept(false) { return get<T>(); }
 simdjson_inline document::operator array() & noexcept(false) { return get_array(); }
 simdjson_inline document::operator object() & noexcept(false) { return get_object(); }
 simdjson_inline document::operator uint64_t() noexcept(false) { return get_uint64(); }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -224,7 +224,10 @@ public:
    * @returns An instance of type T
    */
   template <class T>
-  explicit simdjson_inline operator T() noexcept(false);
+  explicit simdjson_inline operator T() & noexcept(false);
+  template <class T>
+  explicit simdjson_deprecated simdjson_inline operator T() && noexcept(false);
+
   /**
    * Cast this JSON value to an array.
    *

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -188,7 +188,7 @@ public:
       " You may also add support for custom types, see our documentation.");
   }
   /** @overload template<typename T> simdjson_result<T> get() & noexcept */
-  template<typename T> simdjson_inline simdjson_result<T> get() && noexcept {
+  template<typename T> simdjson_deprecated simdjson_inline simdjson_result<T> get() && noexcept {
     // Unless the simdjson library or the user provides an inline implementation, calling this method should
     // immediately fail.
     static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
@@ -211,7 +211,7 @@ public:
    */
   template<typename T> simdjson_inline error_code get(T &out) & noexcept;
   /** @overload template<typename T> error_code get(T &out) & noexcept */
-  template<typename T> simdjson_inline error_code get(T &out) && noexcept;
+  template<typename T> simdjson_deprecated simdjson_inline error_code get(T &out) && noexcept;
 
 #if SIMDJSON_EXCEPTIONS
   /**
@@ -790,7 +790,7 @@ public:
   simdjson_inline simdjson_result<bool> is_null() noexcept;
 
   template<typename T> simdjson_inline simdjson_result<T> get() & noexcept;
-  template<typename T> simdjson_inline simdjson_result<T> get() && noexcept;
+  template<typename T> simdjson_deprecated simdjson_inline simdjson_result<T> get() && noexcept;
 
   template<typename T> simdjson_inline error_code get(T &out) & noexcept;
   template<typename T> simdjson_inline error_code get(T &out) && noexcept;

--- a/tests/ondemand/compilation_failure_tests/CMakeLists.txt
+++ b/tests/ondemand/compilation_failure_tests/CMakeLists.txt
@@ -13,7 +13,8 @@ function(add_dual_compile_test TEST_NAME)
   target_compile_definitions(${TEST_NAME}_should_not_compile PRIVATE COMPILATION_TEST_USE_FAILING_CODE=1)
 endfunction(add_dual_compile_test)
 
-
+add_dual_compile_test(iterate_object)
+add_dual_compile_test(iterate_array)
 add_dual_compile_test(iterate_char_star)
 add_dual_compile_test(iterate_string_view)
 add_dual_compile_test(iterate_temporary_buffer)

--- a/tests/ondemand/compilation_failure_tests/iterate_array.cpp
+++ b/tests/ondemand/compilation_failure_tests/iterate_array.cpp
@@ -24,7 +24,7 @@ int main() {
     if(error) {
         std::cout << "Failure" << std::endl;
     }
-    int64_t a;
+    int64_t a = 0;
     error = arrayv.at(0).get_int64().get(a);
     if(error) {
         std::cout << "failure" << std::endl;

--- a/tests/ondemand/compilation_failure_tests/iterate_array.cpp
+++ b/tests/ondemand/compilation_failure_tests/iterate_array.cpp
@@ -1,0 +1,34 @@
+
+#include <iostream>
+#include "simdjson.h"
+
+using namespace simdjson;
+
+int main() {
+    auto json = "[1]"_padded;
+    ondemand::parser parser;
+    auto f = [](ondemand::parser& p, simdjson::padded_string& json) -> ondemand::document {
+        ondemand::document doc;
+        auto error = p.iterate(json).get(doc);
+        if(error) { std::abort(); }
+        return doc;
+    };
+    ondemand::array arrayv;
+#if COMPILATION_TEST_USE_FAILING_CODE
+    // Not allowed as this would be unsafe, the document must remain alive.
+    auto error = f(parser).get_array().get(arrayv);
+#else
+    ondemand::document doc = f(parser, json);
+    auto error = doc.get_array().get(arrayv);
+#endif
+    if(error) {
+        std::cout << "Failure" << std::endl;
+    }
+    int64_t a;
+    error = arrayv.at(0).get_int64().get(a);
+    if(error) {
+        std::cout << "failure" << std::endl;
+    }
+    printf("a = %d\n", (int)a);
+    return EXIT_SUCCESS;
+}

--- a/tests/ondemand/compilation_failure_tests/iterate_array.cpp
+++ b/tests/ondemand/compilation_failure_tests/iterate_array.cpp
@@ -7,9 +7,9 @@ using namespace simdjson;
 int main() {
     auto json = "[1]"_padded;
     ondemand::parser parser;
-    auto f = [](ondemand::parser& p, simdjson::padded_string& json) -> ondemand::document {
+    auto f = [](ondemand::parser& p, simdjson::padded_string& jsons) -> ondemand::document {
         ondemand::document doc;
-        auto error = p.iterate(json).get(doc);
+        auto error = p.iterate(jsons).get(doc);
         if(error) { std::abort(); }
         return doc;
     };

--- a/tests/ondemand/compilation_failure_tests/iterate_object.cpp
+++ b/tests/ondemand/compilation_failure_tests/iterate_object.cpp
@@ -24,7 +24,7 @@ int main() {
     if(error) {
         std::cout << "Failure" << std::endl;
     }
-    int64_t a;
+    int64_t a = 0;
     error = objv["a"].get_int64().get(a);
     if(error) {
         std::cout << "failure" << std::endl;

--- a/tests/ondemand/compilation_failure_tests/iterate_object.cpp
+++ b/tests/ondemand/compilation_failure_tests/iterate_object.cpp
@@ -7,9 +7,9 @@ using namespace simdjson;
 int main() {
     auto json = "{\"a\":1}"_padded;
     ondemand::parser parser;
-    auto f = [](ondemand::parser& p, simdjson::padded_string& json) -> ondemand::document {
+    auto f = [](ondemand::parser& p, simdjson::padded_string& jsons) -> ondemand::document {
         ondemand::document doc;
-        auto error = p.iterate(json).get(doc);
+        auto error = p.iterate(jsons).get(doc);
         if(error) { std::abort(); }
         return doc;
     };

--- a/tests/ondemand/compilation_failure_tests/iterate_object.cpp
+++ b/tests/ondemand/compilation_failure_tests/iterate_object.cpp
@@ -1,0 +1,34 @@
+
+#include <iostream>
+#include "simdjson.h"
+
+using namespace simdjson;
+
+int main() {
+    auto json = "{\"a\":1}"_padded;
+    ondemand::parser parser;
+    auto f = [](ondemand::parser& p, simdjson::padded_string& json) -> ondemand::document {
+        ondemand::document doc;
+        auto error = p.iterate(json).get(doc);
+        if(error) { std::abort(); }
+        return doc;
+    };
+    ondemand::object objv;
+#if COMPILATION_TEST_USE_FAILING_CODE
+    // Not allowed as this would be unsafe, the document must remain alive.
+    auto error = f(parser).get_object().get(objv);
+#else
+    ondemand::document doc = f(parser, json);
+    auto error = doc.get_object().get(objv);
+#endif
+    if(error) {
+        std::cout << "Failure" << std::endl;
+    }
+    int64_t a;
+    error = objv["a"].get_int64().get(a);
+    if(error) {
+        std::cout << "failure" << std::endl;
+    }
+    printf("a = %d\n", (int)a);
+    return EXIT_SUCCESS;
+}

--- a/tests/ondemand/ondemand_compilation_tests.cpp
+++ b/tests/ondemand/ondemand_compilation_tests.cpp
@@ -59,6 +59,22 @@ void compilation_test_3() {
     }
   }
 }
+
+// Do not run this, it is only meant to compile
+void compilation_test_4() {
+  const padded_string bogus = ""_padded;
+  ondemand::parser parser;
+  int64_t x1 = (int64_t)parser.iterate(bogus);
+  double x2 = (double)parser.iterate(bogus);
+  std::string_view x = (std::string_view)parser.iterate(bogus);
+  uint64_t x3 = (uint64_t)parser.iterate(bogus);
+  bool x4 = (bool)parser.iterate(bogus);
+  (void) x1;
+  (void) x2;
+  (void) x3;
+  (void) x4;
+  (void) x;
+}
 #endif // SIMDJSON_EXCEPTIONS
 
 int main(void) {

--- a/tests/ondemand/ondemand_json_pointer_tests.cpp
+++ b/tests/ondemand/ondemand_json_pointer_tests.cpp
@@ -164,8 +164,7 @@ namespace json_pointer_tests {
         ASSERT_TRUE(is_scalar);
         ASSERT_ERROR(doc.at_pointer("").get(val), simdjson::SCALAR_DOCUMENT_AS_VALUE);
         std::cout << "  checking true"<< std::endl;
-        ASSERT_SUCCESS(parser.iterate(true_json).get(doc));
-        ASSERT_SUCCESS(doc.is_scalar().get(is_scalar));
+        ASSERT_SUCCESS(parser.iterate(true_json).is_scalar().get(is_scalar));
         ASSERT_TRUE(is_scalar);
         ASSERT_ERROR(doc.at_pointer("").get(val), simdjson::SCALAR_DOCUMENT_AS_VALUE);
         std::cout << "  checking object"<< std::endl;


### PR DESCRIPTION
The core idea is that you should never hold either an `ondemand::array` or `ondemand::object` without a corresponding `ondemand::document` being alive.

See issue https://github.com/simdjson/simdjson/issues/2227
