### PR TITLE
Extending the deserialization code with more defaults + docs

### DIFF
--- a/.github/workflows/ubuntu24-cxx20.yml
+++ b/.github/workflows/ubuntu24-cxx20.yml
@@ -1,0 +1,22 @@
+name: Ubuntu 24.04 CI (CXX 20)
+
+on: [push, pull_request]
+jobs:
+  ubuntu-build:
+    if: >-
+      ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
+      ! contains(toJSON(github.event.commits.*.message), '[skip github]')
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        cxx: [g++-13, clang++-16]
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - name: Prepare
+        run: cmake -DSIMDJSON_CXX_STANDARD=20 -DSIMDJSON_DEVELOPER_MODE=ON  -B build
+        env:
+          CXX: ${{matrix.cxx}}
+      - name: Build
+        run: cmake --build build -j=2
+      - name: Test
+        run: ctest --output-on-failure --test-dir build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -109,6 +109,23 @@
         "numbers": "cpp",
         "semaphore": "cpp",
         "stop_token": "cpp",
-        "cfenv": "cpp"
+        "cfenv": "cpp",
+        "format": "cpp",
+        "xlocmes": "cpp",
+        "xlocmon": "cpp",
+        "xlocnum": "cpp",
+        "xloctime": "cpp",
+        "xutility": "cpp",
+        "coroutine": "cpp",
+        "xfacet": "cpp",
+        "xhash": "cpp",
+        "xiosbase": "cpp",
+        "xlocale": "cpp",
+        "xlocbuf": "cpp",
+        "xlocinfo": "cpp",
+        "xmemory": "cpp",
+        "xstring": "cpp",
+        "xtr1common": "cpp",
+        "xtree": "cpp"
     }
 }

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1229,7 +1229,7 @@ You can also use the custom `Car` type as part of a template such as `std::vecto
 ```cpp
   simdjson::ondemand::parser parser;
   simdjson::ondemand::document doc = parser.iterate(json);
-  std::vector<Car> cars(doc);
+  std::vector<Car> cars = doc.get<std::vector<Car>>();
   for(Car& c : cars) {
     std::cout << c.year << std::endl;
   }

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1232,6 +1232,8 @@ You can also use the custom `Car` type as part of a template such as `std::vecto
   std::vector<Car> cars(doc);
   // visual studio users need an explicit call:
   //   std::vector<Car> cars = doc.get<std::vector<Car>>();
+  // because the compiler does not know whether to convert
+  // doc to an unsigned int or to a vector.
   for(Car& c : cars) {
     std::cout << c.year << std::endl;
   }

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -17,6 +17,8 @@ An overview of what you need to know to use simdjson, with examples.
   - [Using the parsed JSON](#using-the-parsed-json)
     - [Using the parsed JSON: additional examples](#using-the-parsed-json-additional-examples)
   - [Adding support for custom types](#adding-support-for-custom-types)
+    - [1. Specialize `simdjson::ondemand::value::get` to get custom types](#1-specialize-simdjsonondemandvalueget-to-get-custom-types)
+    - [2. Use `tag_invoke` for custom types (C++20)](#2-use-tag_invoke-for-custom-types-c20)
   - [Minifying JSON strings without parsing](#minifying-json-strings-without-parsing)
   - [UTF-8 validation (alone)](#utf-8-validation-alone)
   - [JSON Pointer](#json-pointer)
@@ -795,11 +797,11 @@ There are 2 main ways provided by simdjson to deserialize a value into a custom 
    2. Specialize `simdjson::ondemand::value::get` for each value
 2. Using `tag_invoke` *(the recommended way if your system supports C++20 or better)*
 
-##### Differences between the two
+The differences between the two approaches are as follows:
 
 1. Your compiler needs to support C++20 for `tag_invoke`.
 2. The first way limits you to know your type fully, but in the `tag_invoke` way, you can use C++20 concepts and template meta programming as well.
-3. Another difference between the two ways is that in `tag_invoke` way you may or may not mark your deserialization function (`tag_invoke` itself) as `noexcept`, but in the 
+3. Another difference between the two ways is that in `tag_invoke` way you may or may not mark your deserialization function (`tag_invoke` itself) as `noexcept`, but in the
    *template specialization* way (the first way) you HAVE TO mark your specialization as `noexcept` which means that you may need to catch exceptions so
    that your function does not throw any exception all the while it potentially can (for example any type like `std::string`, `std::vector`, etc. that has an allocator can potentially throw exceptions).
 4. Another difference is that the `tag_invoke` way can work on both `document` and `value` but in the first way you have to provide 2 distinct specializations.
@@ -840,9 +842,14 @@ type:
 ```
 
 We may do so by providing additional template definitions to the `ondemand::value` type.
-We may start by providing a definition for `std::vector<double>` as follows:
+We may start by providing a definition for `std::vector<double>` as follows. Observe
+how we guard the code with `#ifndef __cpp_concepts`: that is because the necessary code
+is automatically provided by simdjson if C++20 (and concepts) are available.
+See [Use `tag_invoke` for custom types](#2-use-tag_invoke-for-custom-types-c20) if you have
+C++20 support.
 
 ```c++
+#ifndef __cpp_concepts // because the code is unnecessary with C++20
 template <>
 simdjson_inline simdjson_result<std::vector<double>>
 simdjson::ondemand::value::get() noexcept {
@@ -858,6 +865,7 @@ simdjson::ondemand::value::get() noexcept {
   }
   return vec;
 }
+#endif
 ```
 
 We may then provide support for our `Car` struct:
@@ -875,7 +883,7 @@ simdjson_inline simdjson_result<Car> simdjson::ondemand::value::get() noexcept {
     raw_json_string key;
     error = field.key().get(key);
     if (error) { return error; }
-    
+
     if (key == "make") {
       error = field.value().get_string(car.make);
       if (error) { return error; }
@@ -913,6 +921,7 @@ struct Car {
   std::vector<double> tire_pressure;
 };
 
+#ifndef __cpp_concepts // because the code is unnecessary with C++20
 template <>
 simdjson_inline simdjson_result<std::vector<double>>
 simdjson::ondemand::value::get() noexcept {
@@ -928,6 +937,7 @@ simdjson::ondemand::value::get() noexcept {
   }
   return vec;
 }
+#endif
 
 
 template <>
@@ -970,7 +980,7 @@ int main(void) {
   ondemand::parser parser;
   ondemand::document doc = parser.iterate(json);
   for (auto val : doc) {
-    Car c(val);
+    Car c(val); // an exception may be thrown
     std::cout << c.make << std::endl;
   }
   direct();
@@ -978,7 +988,7 @@ int main(void) {
 }
 ```
 
-Observe that we require an explicit cast (`Car c(val)` instead of `for (Car c : doc) {`): it is by design.
+Observe that we require an explicit cast (`Car c(val)` instead of `for (Car c : doc) {`): it is by design. We require explicit casting.
 
 If you prefer to avoid exceptions, you may modify the `main` function as follows:
 
@@ -1029,6 +1039,7 @@ struct Car {
   std::vector<double> tire_pressure;
 };
 
+#ifndef __cpp_concepts // because the code is unnecessary with C++20
 template <>
 simdjson_inline simdjson_result<std::vector<double>>
 simdjson::ondemand::value::get() noexcept {
@@ -1042,7 +1053,7 @@ simdjson::ondemand::value::get() noexcept {
   }
   return vec;
 }
-
+#endif
 
 template <>
 simdjson_inline simdjson_result<Car> simdjson::ondemand::document::get() & noexcept {
@@ -1086,26 +1097,27 @@ int main(void) {
 }
 ```
 
-### 2. Use `tag_invoke` for custom types
+### 2. Use `tag_invoke` for custom types (C++20)
 
-Suppose you are writing this type:
+A standard approach to provide support for deserialization is to add a `tag_invoke` function
+in your own class:
 
 ```C++
 /**
  * A custom type that we want to parse.
  */
+
 struct Car {
   std::string make;
   std::string model;
+  int year = 0;
+  std::vector<double> tire_pressure;
 
-  // tag_invoke is a friend
-  // the type of val will be a reference to one of these:
-  //     simdjson::ondemand::document
-  //     simdjson::ondemand::value
   friend simdjson_result<Car>
   tag_invoke(simdjson::deserialize_tag, std::type_identity<Car>, auto &val) {
     simdjson::ondemand::object obj;
-    if (auto error = val.get_object().get(obj); error) {
+    auto error = val.get_object().get(obj);
+    if (error) {
       return error;
     }
     Car car{};
@@ -1127,11 +1139,20 @@ struct Car {
         if (error) {
           return error;
         }
+      } else if (key == "year") {
+        error = field.value().get(car.year);
+        if (error) {
+          return error;
+        }
+      } else if (key == "tire_pressure") {
+        error = field.value().get(car.tire_pressure);
+        if (error) {
+          return error;
+        }
       }
     }
     return car;
   }
-  
 };
 ```
 
@@ -1141,7 +1162,82 @@ Let us explain each argument of `tag_invoke`:
 - `std::type_identity<T>`: We specify the custom type we want here
 - `simdjson::ondemand::value&` or `simdjson::ondemand::document&`: the value or document that we want to deserialize from; you may want to just specify `auto&` to capture both of them.
 
-Suppose your custom types are `std::unique_ptr<any type>`, you could:
+You can use it like so:
+
+```cpp
+  simdjson::padded_string json =
+      R"( { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] })"_padded;
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  Car c(doc);
+  std::cout << c.make << std::endl;
+```
+
+Observe how we first get an instance of `document` and then we cast.
+
+You can also handle errors explicitly:
+
+```cpp
+  simdjson::padded_string json =
+      R"( { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] })"_padded;
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  Car c;
+  auto error = doc.get(c);
+  if(error) { std::cerr << simdjson::error_message(error); return false; }
+  std::cout << c.make << std::endl;
+```
+
+You can also read instances of `Car` from an array or an object:
+```cpp
+  simdjson::padded_string json =
+      R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] },
+  { "make": "Kia",    "model": "Soul",   "year": 2012,
+       "tire_pressure": [ 30.1, 31.0 ] },
+  { "make": "Toyota", "model": "Tercel", "year": 1999,
+       "tire_pressure": [ 29.8, 30.0 ] }
+])"_padded;
+
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  for (auto val : doc) {
+    Car c(val); // an exception may be thrown
+    std::cout << c.year << std::endl;
+  }
+```
+
+Observe how we first get a generic (`val`) which we cast to `Car`. It is by design: we require
+explicit casting. The cast may throw an exception.
+
+Once more, you can handle errors explicitly:
+
+```cpp
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  for (auto val : doc) {
+    Car c;
+    auto error = val.get(c);
+    if(error) { std::cerr << simdjson::error_message(error) << std::endl; return false; }
+  }
+```
+
+You can also use the custom `Car` type as part of a template such as `std::vector`:
+
+```cpp
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  std::vector<Car> cars(doc);
+  for(Car& c : cars) {
+    std::cout << c.year << std::endl;
+  }
+```
+
+You can also extend support to arbitrary templates.
+Suppose your custom types are `std::unique_ptr<any type>`,
+you could add the following `tag_invoke`:
 
 ```C++
 namespace simdjson {
@@ -1155,19 +1251,17 @@ namespace simdjson {
 } // namespace simdjson
 ```
 
-You can also mark your `tag_invoke` function as `noexcept` and we will obey that, but that's not true for the *template specialization* way.
+You can also mark your `tag_invoke` function as `noexcept` and we will obey that, unlike the *template specialization* way.
 
-You'd use it like this:
+You would use it like this:
 ```C++
 int main() {
-  auto const json = R"( {
-    "make": "Toyota",
-    "model": "Camry",
-])"_padded;
-  ondemand::parser parser;
-  ondemand::document doc = parser.iterate(json);
+  auto const json = R"( { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] })"_padded;
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
   std::unique_ptr<Car> c(doc);
-  std::cout << c.make << std::endl;
+  std::cout << c->make << std::endl;
   return EXIT_SUCCESS;
 }
 ```

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1229,7 +1229,9 @@ You can also use the custom `Car` type as part of a template such as `std::vecto
 ```cpp
   simdjson::ondemand::parser parser;
   simdjson::ondemand::document doc = parser.iterate(json);
-  std::vector<Car> cars = doc.get<std::vector<Car>>();
+  std::vector<Car> cars(doc);
+  // visual studio users need an explicit call:
+  //   std::vector<Car> cars = doc.get<std::vector<Car>>();
   for(Car& c : cars) {
     std::cout << c.year << std::endl;
   }

--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -7,7 +7,8 @@
 #endif
 
 #ifdef __cpp_concepts
-
+// Deliberately empy. In the future, if the library needs to define concepts, it
+// can be done here.
 namespace simdjson {
 namespace concepts {
 } // namespace concepts

--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -7,15 +7,9 @@
 #endif
 
 #ifdef __cpp_concepts
-#include <utility>
-#include <vector>
 
 namespace simdjson {
 namespace concepts {
-template <typename C> struct is_vector : std::false_type {};
-template <typename T> struct is_vector<std::vector<T>> : std::true_type {};
-template <typename C>
-concept std_vector = is_vector<C>::value;
 } // namespace concepts
 } // namespace simdjson
 #endif

--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -8,6 +8,7 @@
 
 #ifdef __cpp_concepts
 #include <utility>
+#include <vector>
 
 namespace simdjson {
 namespace concepts {

--- a/include/simdjson/generic/ondemand/amalgamated.h
+++ b/include/simdjson/generic/ondemand/amalgamated.h
@@ -4,6 +4,7 @@
 
 // Stuff other things depend on
 #include "simdjson/generic/ondemand/base.h"
+#include "simdjson/generic/ondemand/deserialize.h"
 #include "simdjson/generic/ondemand/value_iterator.h"
 #include "simdjson/generic/ondemand/value.h"
 #include "simdjson/generic/ondemand/logger.h"
@@ -40,3 +41,5 @@
 #include "simdjson/generic/ondemand/token_iterator-inl.h"
 #include "simdjson/generic/ondemand/value-inl.h"
 #include "simdjson/generic/ondemand/value_iterator-inl.h"
+
+#include "simdjson/generic/ondemand/tag_invoke.h"

--- a/include/simdjson/generic/ondemand/deserialize.h
+++ b/include/simdjson/generic/ondemand/deserialize.h
@@ -71,6 +71,7 @@ class document;
 /// Deserialize Tag
 inline constexpr struct deserialize_tag {
   using value_type = SIMDJSON_IMPLEMENTATION::ondemand::value;
+  using result_value_type = typename simdjson::simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>;
   using document_type = SIMDJSON_IMPLEMENTATION::ondemand::document;
 
   // Customization Point for value
@@ -79,6 +80,15 @@ inline constexpr struct deserialize_tag {
   [[nodiscard]] constexpr simdjson_result<T>
   operator()(std::type_identity<T>, value_type &object) const
       noexcept(nothrow_tag_invocable<deserialize_tag, std::type_identity<T>, value_type&>) {
+    return tag_invoke(*this, std::type_identity<T>{}, object);
+  }
+
+  // Customization Point for result value
+  template <typename T>
+    requires tag_invocable<deserialize_tag, std::type_identity<T>, result_value_type&>
+  [[nodiscard]] constexpr simdjson_result<T>
+  operator()(std::type_identity<T>, result_value_type &object) const
+      noexcept(nothrow_tag_invocable<deserialize_tag, std::type_identity<T>, result_value_type&>) {
     return tag_invoke(*this, std::type_identity<T>{}, object);
   }
 
@@ -93,6 +103,20 @@ inline constexpr struct deserialize_tag {
 
   // default implementations can also be done here
 } deserialize{};
+
+
+
+
+
+
+namespace concepts {
+template <typename C> struct is_vector : std::false_type {};
+template <typename T> struct is_vector<std::vector<T>> : std::true_type {};
+template <typename C>
+concept std_vector = is_vector<C>::value;
+
+} // namespace simdjson::concepts
+
 #endif
 
 } // namespace simdjson

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -14,6 +14,7 @@
 #include "simdjson/generic/ondemand/raw_json_string.h"
 #include "simdjson/generic/ondemand/value.h"
 #include "simdjson/generic/ondemand/value_iterator-inl.h"
+#include "simdjson/generic/ondemand/deserialize.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 namespace simdjson {

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -4,9 +4,9 @@
 #define SIMDJSON_GENERIC_ONDEMAND_DOCUMENT_H
 #include "simdjson/generic/ondemand/base.h"
 #include "simdjson/generic/ondemand/json_iterator.h"
+#include "simdjson/generic/ondemand/deserialize.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
-#include "simdjson/deserialize.h"
 
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
@@ -218,7 +218,7 @@ public:
     requires (!tag_invocable<deserialize_tag, std::type_identity<T>, document&>)
 #endif
   simdjson_inline simdjson_result<T> get() && noexcept {
-      static_assert(!std::is_same_v<T, array> && !std::is_same_v<T, object>, "You should never hold either an ondemand::array or ondemand::object without a corresponding ondemand::document being alive; that would be Undefined Behaviour.");
+      static_assert(!std::is_same<T, array>::value && !std::is_same<T, object>::value, "You should never hold either an ondemand::array or ondemand::object without a corresponding ondemand::document being alive; that would be Undefined Behaviour.");
       return static_cast<document&>(*this).get<T>();
   }
 

--- a/include/simdjson/generic/ondemand/tag_invoke.h
+++ b/include/simdjson/generic/ondemand/tag_invoke.h
@@ -1,0 +1,77 @@
+#ifndef SIMDJSON_TAG_INVOKE_H
+
+#ifndef SIMDJSON_CONDITIONAL_INCLUDE
+#define SIMDJSON_TAG_INVOKE_H
+#include "simdjson/generic/ondemand/base.h"
+#endif // SIMDJSON_CONDITIONAL_INCLUDE
+#ifdef __has_include
+#if __has_include(<version>)
+#include <version>
+#endif
+#endif
+
+#ifdef __cpp_concepts
+#include <utility>
+/**
+ * Provides convenience functions for deserialization of common types.
+ */
+namespace simdjson {
+namespace SIMDJSON_IMPLEMENTATION {
+namespace ondemand {
+
+template <typename T>
+  requires std::unsigned_integral<T>
+simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept {
+  uint64_t x;
+  SIMDJSON_TRY(val.get_uint64().get(x));
+  if(x > std::numeric_limits<T>::max() || x < std::numeric_limits<T>::min()) {
+    return NUMBER_OUT_OF_RANGE;
+  }
+  return static_cast<T>(x);
+}
+
+template <typename T>
+  requires std::floating_point<T>
+simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept{
+  double x;
+  SIMDJSON_TRY(val.get_double().get(x));
+  return static_cast<T>(x);
+}
+
+template <typename T>
+  requires std::signed_integral<T>
+simdjson_result<T> tag_invoke(simdjson::deserialize_tag, std::type_identity<T>, auto &val) noexcept {
+  int64_t x;
+  SIMDJSON_TRY(val.get_int64().get(x));
+  if(x > std::numeric_limits<T>::max() || x < std::numeric_limits<T>::min()) {
+    return NUMBER_OUT_OF_RANGE;
+  }
+  return static_cast<T>(x);
+}
+
+
+template <>
+simdjson_result<std::string> tag_invoke(deserialize_tag, std::type_identity<std::string>, auto &val) noexcept{
+  std::string s;
+  SIMDJSON_TRY(val.get_string(s));
+  return s;
+}
+
+template <typename T>
+  requires concepts::std_vector<T>
+simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) {
+  T vec;
+  array array;
+  SIMDJSON_TRY(val.get_array().get(array));
+  for (auto v : array) {
+    typename T::value_type value;
+    SIMDJSON_TRY(v.get<typename T::value_type>().get(value));
+    vec.push_back(value);
+  }
+  return vec;
+}
+}
+}
+}
+#endif // __cpp_concepts
+#endif // SIMDJSON_TAG_INVOKE_H

--- a/include/simdjson/generic/ondemand/tag_invoke.h
+++ b/include/simdjson/generic/ondemand/tag_invoke.h
@@ -49,10 +49,10 @@ simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val)
   return static_cast<T>(x);
 }
 
-
-template <>
-simdjson_result<std::string> tag_invoke(deserialize_tag, std::type_identity<std::string>, auto &val) noexcept{
-  std::string s;
+template <typename T>
+  requires std::same_as<T, std::string>
+simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept{
+  T s;
   SIMDJSON_TRY(val.get_string(s));
   return s;
 }

--- a/include/simdjson/generic/ondemand/tag_invoke.h
+++ b/include/simdjson/generic/ondemand/tag_invoke.h
@@ -35,7 +35,7 @@ simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val)
 
 template <typename T>
   requires std::floating_point<T>
-simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept{
+simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept {
   double x;
   SIMDJSON_TRY(val.get_double().get(x));
   return static_cast<T>(x);
@@ -54,21 +54,29 @@ simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val)
 
 template <typename T>
   requires std::same_as<T, std::string>
-simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept{
+simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept {
   T s;
   SIMDJSON_TRY(val.get_string(s));
   return s;
 }
 
 template <class jsonval>
-simdjson_result<std::string> tag_invoke(deserialize_tag, std::type_identity<std::string>, jsonval &val) noexcept{
+simdjson_result<std::string> tag_invoke(deserialize_tag, std::type_identity<std::string>, jsonval &val) noexcept {
   std::string s;
   SIMDJSON_TRY(val.get_string(s));
   return s;
 }
 
+/**
+ * STL containers have several constructors including one that takes a single
+ * size argument. Thus some compilers (Visual Studio) will not be able to
+ * disambiguate between the size and container constructor. Users should
+ * explicitly specify the type of the container as needed: e.g.,
+ * doc.get<std::vector<int>>().
+ */
+
 template <typename T, class jsonval>
-simdjson_result<std::vector<T>> tag_invoke(deserialize_tag, std::type_identity<std::vector<T>>, jsonval &val) noexcept{
+simdjson_result<std::vector<T>> tag_invoke(deserialize_tag, std::type_identity<std::vector<T>>, jsonval &val) noexcept {
   std::vector<T> vec;
   array array;
   SIMDJSON_TRY(val.get_array().get(array));
@@ -81,7 +89,7 @@ simdjson_result<std::vector<T>> tag_invoke(deserialize_tag, std::type_identity<s
 }
 
 template <typename T, class jsonval>
-simdjson_result<std::list<T>> tag_invoke(deserialize_tag, std::type_identity<std::list<T>>, jsonval &val) noexcept{
+simdjson_result<std::list<T>> tag_invoke(deserialize_tag, std::type_identity<std::list<T>>, jsonval &val) noexcept {
   std::list<T> vec;
   array array;
   SIMDJSON_TRY(val.get_array().get(array));

--- a/include/simdjson/generic/ondemand/tag_invoke.h
+++ b/include/simdjson/generic/ondemand/tag_invoke.h
@@ -24,7 +24,7 @@ template <typename T>
 simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept {
   uint64_t x;
   SIMDJSON_TRY(val.get_uint64().get(x));
-  if(x > std::numeric_limits<T>::max() || x < std::numeric_limits<T>::min()) {
+  if(x > (std::numeric_limits<T>::max)() || x < (std::numeric_limits<T>::min)()) {
     return NUMBER_OUT_OF_RANGE;
   }
   return static_cast<T>(x);
@@ -43,7 +43,7 @@ template <typename T>
 simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) noexcept {
   int64_t x;
   SIMDJSON_TRY(val.get_int64().get(x));
-  if(x > std::numeric_limits<T>::max() || x < std::numeric_limits<T>::min()) {
+  if(x > (std::numeric_limits<T>::max)() || x < (std::numeric_limits<T>::min)()) {
     return NUMBER_OUT_OF_RANGE;
   }
   return static_cast<T>(x);

--- a/include/simdjson/generic/ondemand/tag_invoke.h
+++ b/include/simdjson/generic/ondemand/tag_invoke.h
@@ -12,6 +12,9 @@
 
 #ifdef __cpp_concepts
 #include <utility>
+#include <vector>
+#include <list>
+
 /**
  * Provides convenience functions for deserialization of common types.
  */
@@ -57,15 +60,34 @@ simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val)
   return s;
 }
 
-template <typename T>
-  requires concepts::std_vector<T>
-simdjson_result<T> tag_invoke(deserialize_tag, std::type_identity<T>, auto &val) {
-  T vec;
+template <class jsonval>
+simdjson_result<std::string> tag_invoke(deserialize_tag, std::type_identity<std::string>, jsonval &val) noexcept{
+  std::string s;
+  SIMDJSON_TRY(val.get_string(s));
+  return s;
+}
+
+template <typename T, class jsonval>
+simdjson_result<std::vector<T>> tag_invoke(deserialize_tag, std::type_identity<std::vector<T>>, jsonval &val) noexcept{
+  std::vector<T> vec;
   array array;
   SIMDJSON_TRY(val.get_array().get(array));
   for (auto v : array) {
-    typename T::value_type value;
-    SIMDJSON_TRY(v.get<typename T::value_type>().get(value));
+    T value;
+    SIMDJSON_TRY(v.get<T>().get(value));
+    vec.push_back(value);
+  }
+  return vec;
+}
+
+template <typename T, class jsonval>
+simdjson_result<std::list<T>> tag_invoke(deserialize_tag, std::type_identity<std::list<T>>, jsonval &val) noexcept{
+  std::list<T> vec;
+  array array;
+  SIMDJSON_TRY(val.get_array().get(array));
+  for (auto v : array) {
+    T value;
+    SIMDJSON_TRY(v.get<T>().get(value));
     vec.push_back(value);
   }
   return vec;

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -5,9 +5,8 @@
 #include "simdjson/generic/ondemand/base.h"
 #include "simdjson/generic/implementation_simdjson_result_base.h"
 #include "simdjson/generic/ondemand/value_iterator.h"
+#include "simdjson/generic/ondemand/deserialize.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
-
-#include "simdjson/deserialize.h"
 
 namespace simdjson {
 

--- a/tests/ondemand/ondemand_custom_types_document_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_document_tests.cpp
@@ -150,7 +150,11 @@ bool custom_test_crazier() {
 
   simdjson::ondemand::parser parser;
   simdjson::ondemand::document doc = parser.iterate(json);
+#if SIMDJSON_REGULAR_VISUAL_STUDIO
   std::vector<Car> cars = doc.get<std::vector<Car>>();
+#else
+  std::vector<Car> cars(doc);
+#endif
   for(Car& c : cars) {
     std::cout << c.year << std::endl;
     if (c.make != "Toyota" && c.make != "Kia") {

--- a/tests/ondemand/ondemand_custom_types_document_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_document_tests.cpp
@@ -14,25 +14,6 @@ auto tag_invoke(deserialize_tag, std::type_identity<std::unique_ptr<T>>, auto &v
   return simdjson_result{std::make_unique<T>(val.template get<T>())};
 }
 
-// vector<T>
-template <typename T, typename AllocT = std::allocator<T>>
-  requires (std::is_default_constructible_v<T>)
-simdjson_result<std::vector<T, AllocT>> tag_invoke(deserialize_tag, std::type_identity<std::vector<T, AllocT>>, auto &value) {
-  ondemand::array array;
-  if (auto error = value.get_array().get(array)) {
-    return error;
-  }
-  std::vector<T, AllocT> vec;
-  for (auto v : array) {
-    T val;
-    if (auto error = v.template get<T>().get(val)) {
-      return error;
-    }
-    vec.push_back(val);
-  }
-  return vec;
-}
-
 } // namespace simdjson
 
 #endif // __cpp_concepts
@@ -169,7 +150,7 @@ bool custom_test_crazier() {
 
   simdjson::ondemand::parser parser;
   simdjson::ondemand::document doc = parser.iterate(json);
-  std::vector<Car> cars(doc);
+  std::vector<Car> cars = doc.get<std::vector<Car>>();
   for(Car& c : cars) {
     std::cout << c.year << std::endl;
     if (c.make != "Toyota" && c.make != "Kia") {

--- a/tests/ondemand/ondemand_custom_types_document_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_document_tests.cpp
@@ -128,14 +128,89 @@ bool custom_test() {
   if (car->tire_pressure.size() != 2) {
     return false;
   }
-  return true;
+  TEST_SUCCEED();
 }
 
+bool readme_test() {
+  TEST_START();
+  auto const json = R"( { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] })"_padded;
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  std::unique_ptr<Car> c(doc);
+  std::cout << c->make << std::endl;
+  TEST_SUCCEED();
+}
+
+
+bool simple_document_test() {
+  TEST_START();
+  simdjson::padded_string json =
+      R"( { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] })"_padded;
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  Car c(doc);
+  std::cout << c.make << std::endl;
+  ASSERT_EQUAL(c.make, "Toyota");
+  TEST_SUCCEED();
+}
+
+bool custom_test_crazier() {
+  TEST_START();
+  simdjson::padded_string json =
+      R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] },
+  { "make": "Kia",    "model": "Soul",   "year": 2012,
+       "tire_pressure": [ 30.1, 31.0 ] },
+  { "make": "Toyota", "model": "Tercel", "year": 1999,
+       "tire_pressure": [ 29.8, 30.0 ] }
+])"_padded;
+
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  std::vector<Car> cars(doc);
+  for(Car& c : cars) {
+    std::cout << c.year << std::endl;
+    if (c.make != "Toyota" && c.make != "Kia") {
+      return false;
+    }
+    if (c.model != "Camry" && c.model != "Soul" && c.model != "Tercel") {
+      return false;
+    }
+    if (c.year != 2018 && c.year != 2012 && c.year != 1999) {
+      return false;
+    }
+    if (c.tire_pressure.size() != 2) {
+      return false;
+    }
+  }
+  TEST_SUCCEED();
+}
+
+bool simple_document_test_no_except() {
+  TEST_START();
+  simdjson::padded_string json =
+      R"( { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] })"_padded;
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  Car c;
+  auto error = doc.get(c);
+  if(error) { std::cerr << simdjson::error_message(error); return false; }
+  std::cout << c.make << std::endl;
+  ASSERT_EQUAL(c.make, "Toyota");
+  TEST_SUCCEED();
+}
 #endif // SIMDJSON_EXCEPTIONS
 bool run() {
   return
 #if SIMDJSON_EXCEPTIONS && defined(__cpp_concepts)
+      readme_test() &&
       custom_test() &&
+      simple_document_test() &&
+      simple_document_test_no_except() &&
+      custom_test_crazier() &&
 #endif // SIMDJSON_EXCEPTIONS
       true;
 }

--- a/tests/ondemand/ondemand_custom_types_document_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_document_tests.cpp
@@ -40,10 +40,10 @@ simdjson_result<std::vector<T, AllocT>> tag_invoke(deserialize_tag, std::type_id
 namespace doc_custom_types_tests {
 #if SIMDJSON_EXCEPTIONS && defined(__cpp_concepts)
 struct Car {
-  std::string make;
-  std::string model;
-  int64_t year = 0;
-  std::vector<double> tire_pressure;
+  std::string make{};
+  std::string model{};
+  int64_t year{};
+  std::vector<double> tire_pressure{};
 
   friend simdjson_result<Car> tag_invoke(simdjson::deserialize_tag,
                                          std::type_identity<Car>, auto &val) {

--- a/tests/ondemand/ondemand_custom_types_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_tests.cpp
@@ -41,10 +41,10 @@ auto tag_invoke(deserialize_tag, std::type_identity<T>, ondemand::value &val) {
 namespace custom_types_tests {
 #if SIMDJSON_EXCEPTIONS && defined(__cpp_concepts)
 struct Car {
-  std::string make;
-  std::string model;
-  int year = 0;
-  std::vector<double> tire_pressure;
+  std::string make{};
+  std::string model{};
+  int year{};
+  std::vector<double> tire_pressure{};
 
   friend simdjson_result<Car>
   tag_invoke(simdjson::deserialize_tag, std::type_identity<Car>, auto &val) {

--- a/tests/ondemand/ondemand_custom_types_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_tests.cpp
@@ -207,7 +207,7 @@ bool custom_test_crazier() {
 
   simdjson::ondemand::parser parser;
   simdjson::ondemand::document doc = parser.iterate(json);
-  std::vector<Car> cars(doc);
+  std::vector<Car> cars = doc.get<std::vector<Car>>();
   for(Car& c : cars) {
     std::cout << c.year << std::endl;
     if (c.make != "Toyota" && c.make != "Kia") {

--- a/tests/ondemand/ondemand_custom_types_tests.cpp
+++ b/tests/ondemand/ondemand_custom_types_tests.cpp
@@ -193,40 +193,6 @@ bool custom_test_crazy() {
   TEST_SUCCEED();
 }
 
-
-bool custom_test_crazier() {
-  TEST_START();
-  simdjson::padded_string json =
-      R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
-       "tire_pressure": [ 40.1, 39.9 ] },
-  { "make": "Kia",    "model": "Soul",   "year": 2012,
-       "tire_pressure": [ 30.1, 31.0 ] },
-  { "make": "Toyota", "model": "Tercel", "year": 1999,
-       "tire_pressure": [ 29.8, 30.0 ] }
-])"_padded;
-
-  simdjson::ondemand::parser parser;
-  simdjson::ondemand::document doc = parser.iterate(json);
-  std::vector<Car> cars = doc.get<std::vector<Car>>();
-  for(Car& c : cars) {
-    std::cout << c.year << std::endl;
-    if (c.make != "Toyota" && c.make != "Kia") {
-      return false;
-    }
-    if (c.model != "Camry" && c.model != "Soul" && c.model != "Tercel") {
-      return false;
-    }
-    if (c.year != 2018 && c.year != 2012 && c.year != 1999) {
-      return false;
-    }
-    if (c.tire_pressure.size() != 2) {
-      return false;
-    }
-  }
-  TEST_SUCCEED();
-}
-
-
 bool custom_no_except() {
   TEST_START();
   simdjson::padded_string json =
@@ -255,7 +221,6 @@ bool run() {
       custom_test() &&
       custom_uniqueptr_test() &&
       custom_no_except() &&
-      custom_test_crazier() &&
 #endif // SIMDJSON_EXCEPTIONS
       true;
 }

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -49,6 +49,7 @@ struct Car {
   std::vector<double> tire_pressure;
 };
 
+#ifndef __cpp_concepts
 template <>
 simdjson_inline simdjson_result<std::vector<double>>
 simdjson::ondemand::value::get() noexcept {
@@ -66,7 +67,7 @@ simdjson::ondemand::value::get() noexcept {
   }
   return vec;
 }
-
+#endif
 
 
 template <>
@@ -193,8 +194,8 @@ int custom_type_with_exceptions() {
 ])"_padded;
   ondemand::parser parser;
   ondemand::document doc = parser.iterate(json);
-  for (auto val : doc) {
-    Car c(val);
+  for (auto value : doc) {
+    Car c(value);
     std::cout << c.make << std::endl;
   }
   return 0;


### PR DESCRIPTION
This is basically a small extension to an earlier PR by @the-moisrex

It helps a bit with https://github.com/simdjson/simdjson/issues/2230

With this PR, you can do...

```cpp
  simdjson::padded_string json =
      R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
       "tire_pressure": [ 40.1, 39.9 ] },
  { "make": "Kia",    "model": "Soul",   "year": 2012,
       "tire_pressure": [ 30.1, 31.0 ] },
  { "make": "Toyota", "model": "Tercel", "year": 1999,
       "tire_pressure": [ 29.8, 30.0 ] }
])"_padded;

  simdjson::ondemand::parser parser;
  simdjson::ondemand::document doc = parser.iterate(json);
  std::vector<Car> cars(doc);
```