### PR TITLE
Fix ndjson spec link

### DIFF
--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -125,7 +125,7 @@ Whitespace Characters:
 - **Nothing**
 
 Some official formats **(non-exhaustive list)**:
-- [Newline-Delimited JSON (NDJSON)](http://ndjson.org/)
+- [Newline-Delimited JSON (NDJSON)]([http://ndjson.org/](https://github.com/ndjson/ndjson-spec))
 - [JSON lines (JSONL)](http://jsonlines.org/)
 - [Record separator-delimited JSON (RFC 7464)](https://tools.ietf.org/html/rfc7464) <- Not supported by JsonStream!
 - [More on Wikipedia...](https://en.wikipedia.org/wiki/JSON_streaming)

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -125,7 +125,7 @@ Whitespace Characters:
 - **Nothing**
 
 Some official formats **(non-exhaustive list)**:
-- [Newline-Delimited JSON (NDJSON)]([http://ndjson.org/](https://github.com/ndjson/ndjson-spec))
+- [Newline-Delimited JSON (NDJSON)](https://github.com/ndjson/ndjson-spec)
 - [JSON lines (JSONL)](http://jsonlines.org/)
 - [Record separator-delimited JSON (RFC 7464)](https://tools.ietf.org/html/rfc7464) <- Not supported by JsonStream!
 - [More on Wikipedia...](https://en.wikipedia.org/wiki/JSON_streaming)


### PR DESCRIPTION
The link in the readme of parse_many links to a casino spam site