### PR TITLE
object::find_all: find multiple keys in one go

### DIFF
--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -303,6 +303,7 @@ simdjson_inline  simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPL
   return first.raw_json();
 }
 
+#ifdef __cpp_concepts
 template <typename ...StrT>
   requires SIMDJSON_IMPLEMENTATION::ondemand::details::all_string_views<StrT...>
 [[nodiscard]] simdjson_inline std::array<simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>, sizeof...(StrT)> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::object>::find_all(StrT... keys) & noexcept {
@@ -318,6 +319,7 @@ template <typename ...StrT>
   if (error()) { return array_type{((std::ignore = keys), error())...}; }
   return static_cast<SIMDJSON_IMPLEMENTATION::ondemand::object&>(first).find_all(keys...);
 }
+#endif
 } // namespace simdjson
 
 #endif // SIMDJSON_GENERIC_ONDEMAND_OBJECT_INL_H

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -11,6 +11,7 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
+#ifdef __cpp_concepts
 namespace details {
 
 /// default false:
@@ -40,6 +41,7 @@ struct is_all_string_views<T1, T...> {
 template <typename ...T>
 concept all_string_views = is_all_string_views<T...>::value;
 }
+#endif
 
 /**
  * A forward-only JSON object field iterator.

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -7,6 +7,10 @@
 #include "simdjson/generic/ondemand/value_iterator.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#ifdef __cpp_concepts
+#include <array>
+#endif
+
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {

--- a/tests/ondemand/CMakeLists.txt
+++ b/tests/ondemand/CMakeLists.txt
@@ -28,6 +28,7 @@ add_cpp_test(ondemand_to_string              LABELS ondemand acceptance per_impl
 add_cpp_test(ondemand_twitter_tests          LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_wrong_type_error_tests LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_iterate_many_csv       LABELS ondemand acceptance per_implementation)
+add_cpp_test(ondemand_multi_get_tests        LABELS ondemand acceptance per_implementation)
 if(NOT SIMDJSON_SANITIZE)
   add_cpp_test(ondemand_cacheline              LABELS ondemand acceptance per_implementation)
 endif()

--- a/tests/ondemand/ondemand_multi_get_tests.cpp
+++ b/tests/ondemand/ondemand_multi_get_tests.cpp
@@ -1,0 +1,140 @@
+#include "simdjson.h"
+#include "test_ondemand.h"
+
+using namespace simdjson;
+
+namespace multi_get_tests {
+#ifdef __cpp_concepts
+struct Car {
+  std::string_view make;
+  std::string_view model;
+  std::uint64_t year = 0;
+
+  static simdjson_result<Car> create(auto& value) {
+    simdjson::ondemand::object obj;
+    auto error = value.get_object().get(obj);
+    if (error) {
+      return error;
+    }
+    Car car{};
+    // Instead of this:
+    //     for (auto field : obj) {
+    //       simdjson::ondemand::raw_json_string key;
+    //       error = field.key().get(key);
+    //       if (error) {
+    //         return error;
+    //       }
+    //       if (key == "make") {
+    //         error = field.value().get_string(car.make);
+    //         if (error) {
+    //           return error;
+    //         }
+    //       } else if (key == "model") {
+    //         error = field.value().get_string(car.model);
+    //         if (error) {
+    //           return error;
+    //         }
+    //       } else if (key == "year") {
+    //         error = field.value().get(car.year);
+    //         if (error) {
+    //           return error;
+    //         }
+    //     }
+    //
+    // we can do this now:
+    auto [make, model, year] = obj.find_all("make", "model", "year");
+    if (make.error() != SUCCESS) {
+      return make.error();
+    }
+    if (model.error() != SUCCESS) {
+      return model.error();
+    }
+    if (year.error() != SUCCESS) {
+      return year.error();
+    }
+    make.get(car.make);
+    model.get(car.model);
+    year.get(car.year);
+    return car;
+  }
+};
+
+bool get_3() {
+  TEST_START();
+  auto json = R"(   {"one": 1, "two": 2, "three": 153 }  )"_padded;
+  ondemand::parser parser;
+  ondemand::document doc = parser.iterate(json);
+  ondemand::object obj = doc.get_object();
+  auto [one, two, three] = obj.find_all("one", "two", "three");
+  int long one_value, two_value, three_value;
+  ASSERT_SUCCESS(one.get_int64().get(one_value));
+  ASSERT_SUCCESS(two.get_int64().get(two_value));
+  ASSERT_SUCCESS(three.get_int64().get(three_value));
+  ASSERT_EQUAL(one_value, 1);
+  ASSERT_EQUAL(two_value, 2);
+  ASSERT_EQUAL(three_value, 153);
+  TEST_SUCCEED();
+}
+
+bool one_key_not_found() {
+  TEST_START();
+  auto json = R"(   {"one": 1, "three": 153 }  )"_padded;
+  ondemand::parser parser;
+  ondemand::document doc = parser.iterate(json);
+  auto [one, two, three] = doc.get_object().find_all("one", "two", "three");
+  int long one_value, three_value;
+  ASSERT_SUCCESS(one.get_int64().get(one_value));
+  ASSERT_EQUAL(two.get_int64().error(), UNINITIALIZED);
+  ASSERT_SUCCESS(three.get_int64().get(three_value));
+  ASSERT_EQUAL(one_value, 1);
+  ASSERT_EQUAL(three_value, 153);
+  TEST_SUCCEED();
+}
+
+bool car_example() {
+  TEST_START();
+  simdjson::padded_string json =
+      R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] },
+  { "make": "Kia",    "model": "Soul",   "year": 2012,
+       "tire_pressure": [ 30.1, 31.0 ] },
+  { "make": "Toyota", "model": "Tercel", "year": 1999,
+       "tire_pressure": [ 29.8, 30.0 ] }
+])"_padded;
+
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  for (auto val : doc) {
+    auto car = Car::create(val);
+    ASSERT_EQUAL(car.error(), SUCCESS);
+    Car const c(car.value());
+    if (c.make != "Toyota" && c.make != "Kia") {
+      return false;
+    }
+    if (c.model != "Camry" && c.model != "Soul" && c.model != "Tercel") {
+      return false;
+    }
+    if (c.year != 2018 && c.year != 2012 && c.year != 1999) {
+      return false;
+    }
+  }
+
+  TEST_SUCCEED();
+}
+
+#endif
+bool run() {
+  return
+#ifdef __cpp_concepts
+      get_3() &&
+      one_key_not_found() &&
+      car_example() &&
+#endif
+      true;
+}
+
+} // namespace multi_get_tests
+
+int main(int argc, char *argv[]) {
+  return test_main(argc, argv, multi_get_tests::run);
+}

--- a/tests/ondemand/ondemand_multi_get_tests.cpp
+++ b/tests/ondemand/ondemand_multi_get_tests.cpp
@@ -8,7 +8,7 @@ namespace multi_get_tests {
 struct Car {
   std::string_view make;
   std::string_view model;
-  std::uint64_t year = 0;
+  std::int64_t year = 0;
 
   static simdjson_result<Car> create(auto& value) {
     simdjson::ondemand::object obj;
@@ -66,7 +66,7 @@ bool get_3() {
   ondemand::document doc = parser.iterate(json);
   ondemand::object obj = doc.get_object();
   auto [one, two, three] = obj.find_all("one", "two", "three");
-  int long one_value, two_value, three_value;
+  std::int64_t one_value, two_value, three_value;
   ASSERT_SUCCESS(one.get_int64().get(one_value));
   ASSERT_SUCCESS(two.get_int64().get(two_value));
   ASSERT_SUCCESS(three.get_int64().get(three_value));
@@ -82,7 +82,7 @@ bool one_key_not_found() {
   ondemand::parser parser;
   ondemand::document doc = parser.iterate(json);
   auto [one, two, three] = doc.get_object().find_all("one", "two", "three");
-  int long one_value, three_value;
+  std::int64_t one_value, three_value;
   ASSERT_SUCCESS(one.get_int64().get(one_value));
   ASSERT_EQUAL(two.get_int64().error(), UNINITIALIZED);
   ASSERT_SUCCESS(three.get_int64().get(three_value));


### PR DESCRIPTION
Instead of iterating through an object to find multiple keys, or iterating multiple times, we can now use `find_all`.


Instead of this:
```c++
     for (auto field : obj) {
       simdjson::ondemand::raw_json_string key;
       error = field.key().get(key);
       if (error) {
         return error;
       }
       if (key == "make") {
         error = field.value().get_string(car.make);
         if (error) {
           return error;
         }
       } else if (key == "model") {
         error = field.value().get_string(car.model);
         if (error) {
           return error;
         }
       } else if (key == "year") {
         error = field.value().get(car.year);
         if (error) {
           return error;
         }
     }
```

We can do this now:
```c++
    auto [make, model, year] = obj.find_all("make", "model", "year");
    make.get(car.make);
    model.get(car.model);
    year.get(car.year);
```

There's still a few places where we might need to change like in `document` and `value`; but I first wanted to see if the maintainers wanted anything like this or not.