### PR TITLE
Allow progressively building bitmask

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -45,3 +45,11 @@ Diagnostics:
     Suppress:
         - pragma_attribute_no_pop_eof
         - pragma_attribute_stack_mismatch
+---
+# clang 18
+If:
+    PathMatch:
+        - dependencies/.cache/json11/json11.cpp
+CompileFlags:
+    Add:
+        - -Wno-unqualified-std-cast-call

--- a/include/simdjson/icelake/simd.h
+++ b/include/simdjson/icelake/simd.h
@@ -314,6 +314,20 @@ namespace simd {
     simdjson_inline uint64_t get_bit() const { return _mm512_movepi8_mask(_mm512_slli_epi16(*this, 7-N)); }
   };
 
+  template <int N = 0>
+  struct simd_bitmask64_builder;
+
+  template<>
+  struct simd_bitmask64_builder<1> {
+    const __mmask64 bitmask;
+    operator __mmask64() && { return bitmask; }
+  }; // struct simd_bitmask64_builder<2>
+
+  template<>
+  struct simd_bitmask64_builder<0> {
+    simdjson_inline simd_bitmask64_builder<1> next(simd8<bool> val) { return { _mm512_movepi8_mask(val) }; }
+  }; // struct simd_bitmask64_builder<0>
+
   template<typename T>
   struct simd8x64 {
     static constexpr int NUM_CHUNKS = 64 / sizeof(simd8<T>);


### PR DESCRIPTION
This PR adds a `simd_bitmask64_builder` class, which lets you progressively build a 64-bit bitmask from `simd8<bool>` (the results of `==` and friends on a simd register). It uses it in all `simd8x64<bool>.to_bitmask()` implementations. It is designed to have identical performance to `to_bitmask()` today, but allow it to be called after each SIMD register is processed, throwing away whatever it can on the platform allowed.

For Intel platforms, this just means shifting the bits and or'ing them into a register. For other platforms such as ARM, it's something like a reduce operation, progressively smushing together registers with 16-to-8-bit adds until they end up in a single SIMD-sized registers.

The purpose of this is to move towards a world where we can process one SIMD-sized chunk of bytes at a time before upscaling to 64-bit masks, before upscaling to SIMD-sized masks. We're going to run out of registers if we keep just stashing everything in a `simd8x64` or `simd8x512` and processing them all at once at the end. This lets us be explicit and try to process everything we reasonably can as we process each SIMD register. The next step on that journey will be similar utilities to build a SIMD-sized bitmask progressively, over 8 steps--the savings from doing reduction become much more apparent there, requiring up to a maximum of 4 registers per bitmask if you are doing as few operations as possible with as much parallelism as possible (as we do today in `to_bitmask()`.

I have another draft built on this which allows the UTF-8 checking algorithm to run one SIMD register at a time as well.

DRAFT: I have not yet tested many of the platforms--just Haswell, which was running at the same performance as today on my machine.