### PR TITLE
Add missing include directives to static build targets of simdjson.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ if(SIMDJSON_BUILD_STATIC_LIB)
       TARGETS simdjson_static
       EXPORT simdjson_staticTargets
       ARCHIVE COMPONENT simdjson_Development
+      INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
   install(
       EXPORT simdjson_staticTargets


### PR DESCRIPTION
Fixes issue #2239 whereby a cmake install of the static build, the headers are not included as a property in the simdjson_static target. As a result, when linking against the simdjson_static target in an executable, the compiler can not find the headers.