### PR TITLE
add pdep/pext compress implementation

### DIFF
--- a/include/simdjson/haswell/simd.h
+++ b/include/simdjson/haswell/simd.h
@@ -125,6 +125,30 @@ namespace simd {
     // sensible, but the AVX ISA makes this kind of approach difficult.
     template<typename L>
     simdjson_inline void compress(uint32_t mask, L * output) const {
+#define HAS_FAST_PDEP_AND_PEXT 1
+#if HAS_FAST_PDEP_AND_PEXT == 1
+  const uint64_t nibble_msk = 0x1111111111111111;
+  const uint64_t iota = 0xFEDCBA9876543210;
+
+  // duplicate each bit into a nibble of the same value
+  uint64_t expanded_mask1 = _pdep_u64(~mask, nibble_msk) * 0xF;
+  uint64_t expanded_mask2 = _pdep_u64((~mask) >> 16, nibble_msk) * 0xF;
+
+  // Simulate a 16-wide compaction via `pext`, producing up to 16 nibbles
+  uint64_t wanted_indices1 = _pext_u64(iota, expanded_mask1);
+  uint64_t wanted_indices2 = _pext_u64(iota, expanded_mask2);
+
+  // Move to a vector
+  __m128i nibble_vec1 = _mm_cvtsi64_si128(wanted_indices1);
+  __m128i nibble_vec2 = _mm_cvtsi64_si128(wanted_indices2);
+
+  // Spread each nibble to a byte
+  __m128i byte_vec1 = _mm_and_si128(_mm_unpacklo_epi8(nibble_vec1, _mm_srli_epi16(nibble_vec1, 4)), _mm_set1_epi32(0x0F0F0F0F));
+  __m128i byte_vec2 = _mm_and_si128(_mm_unpacklo_epi8(nibble_vec2, _mm_srli_epi16(nibble_vec2, 4)), _mm_set1_epi32(0x0F0F0F0F));
+
+  _mm_storeu_si128( reinterpret_cast<__m128i *>(output), _mm_shuffle_epi8(_mm256_extracti128_si256(*this, 0), byte_vec1));
+  _mm_storeu_si128( reinterpret_cast<__m128i *>(output + count_ones(~mask & 0xFFFF)), _mm_shuffle_epi8(_mm256_extracti128_si256(*this, 1), byte_vec2));
+#else // !HAS_FAST_PDEP_AND_PEXT
       using internal::thintable_epi8;
       using internal::BitsSetTable256mul2;
       using internal::pshufb_combine_table;
@@ -167,6 +191,7 @@ namespace simd {
       _mm_storeu_si128( reinterpret_cast<__m128i *>(output), v128);
       v128 = _mm256_extractf128_si256(almostthere, 1);
       _mm_storeu_si128( reinterpret_cast<__m128i *>(output + 16 - count_ones(mask & 0xFFFF)), v128);
+#endif // !HAS_FAST_PDEP_AND_PEXT
     }
 
     template<typename L>


### PR DESCRIPTION
Had this idea, but unfortunately I can't get it to compile so I'm a bit stuck.

I get a couple compile errors that look like this:

```
In file included from /usr/lib/gcc/x86_64-linux-gnu/11/include/x86gprintrin.h:43,
                 from /usr/lib/gcc/x86_64-linux-gnu/11/include/x86intrin.h:27,
                 from /home/niles/Documents/github/simdjson/include/simdjson/haswell/intrinsics.h:12,
                 from /home/niles/Documents/github/simdjson/include/simdjson/haswell/begin.h:4,
                 from /home/niles/Documents/github/simdjson/include/simdjson/haswell.h:4,
                 from /home/niles/Documents/github/simdjson/src/haswell.cpp:8,
                 from /home/niles/Documents/github/simdjson/src/simdjson.cpp:27:
/usr/lib/gcc/x86_64-linux-gnu/11/include/bmi2intrin.h: In member function ‘void simdjson::haswell::{anonymous}::simd::base8_numeric<T>::compress(uint32_t, L*) const [with L = unsigned char; T = unsigned char]’:
/usr/lib/gcc/x86_64-linux-gnu/11/include/bmi2intrin.h:76:1: error: inlining failed in call to ‘always_inline’ ‘long long unsigned int _pext_u64(long long unsigned int, long long unsigned int)’: target specific option mismatch
   76 | _pext_u64 (unsigned long long __X, unsigned long long __Y)
      | ^~~~~~~~~
In file included from /home/niles/Documents/github/simdjson/include/simdjson/haswell/begin.h:13,
                 from /home/niles/Documents/github/simdjson/include/simdjson/haswell.h:4,
                 from /home/niles/Documents/github/simdjson/src/haswell.cpp:8,
                 from /home/niles/Documents/github/simdjson/src/simdjson.cpp:27:
/home/niles/Documents/github/simdjson/include/simdjson/haswell/simd.h:139:39: note: called from here
  139 |   uint64_t wanted_indices2 = _pext_u64(iota, expanded_mask2);
      |                              ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```

1. How do I get this to compile?
2. What is the right way to implement this feature? Should `HAS_FAST_PDEP_AND_PEXT` become runtime-dispatched code?