### PR TITLE
investigate adding BMI2 to the haswell kernel

### DIFF
--- a/include/simdjson/haswell/begin.h
+++ b/include/simdjson/haswell/begin.h
@@ -4,7 +4,7 @@
 #include "simdjson/haswell/intrinsics.h"
 
 #if !SIMDJSON_CAN_ALWAYS_RUN_HASWELL
-SIMDJSON_TARGET_REGION("avx2,bmi,pclmul,lzcnt,popcnt")
+SIMDJSON_TARGET_REGION("avx2,bmi,bmi2,pclmul,lzcnt,popcnt")
 #endif
 
 #include "simdjson/haswell/bitmanipulation.h"


### PR DESCRIPTION
As remarked by @Validark, we may add BMI2 as a target for the haswell kernel. This is safe to do but whether it is beneficial remains unclear.


Processor: Intel Ice Lake
Compiler GCC 12

command: `./build/benchmark/dom/parse -a haswell jsonexamples/twitter.json`


Main branch (stage 2):

```
|- Stage 2
|    Speed        :  19.3413 ns per block ( 50.53%) -   0.3022 ns per byte -   3.4537 ns per structural -   3.3088 GB/s
|    Cycles       :  38.6319 per block    ( 51.24%) -   0.6037 per byte    -   6.8984 per structural    -    1.997 GHz est. frequency
|    Instructions : 146.8702 per block    ( 51.63%) -   2.2950 per byte    -  26.2262 per structural    -    3.802 per cycle
|    Misses       :     398 branch misses ( 72.86%) - 7 cache misses ( 37.51%) - 15674.00 cache references
```

This PR (stage 2):
```
|- Stage 2
|    Speed        :  19.5105 ns per block ( 50.86%) -   0.3049 ns per byte -   3.4839 ns per structural -   3.2801 GB/s
|    Cycles       :  38.9602 per block    ( 51.66%) -   0.6088 per byte    -   6.9570 per structural    -    1.997 GHz est. frequency
|    Instructions : 147.2275 per block    ( 51.69%) -   2.3006 per byte    -  26.2901 per structural    -    3.779 per cycle
|    Misses       :     405 branch misses ( 72.86%) - 3 cache misses ( 13.91%) - 16024.00 cache references
```

So the total number of instructions is slightly up when enabling BMI2 on this compiler. The speed may be the same.



Processor: Intel Ice Lake
Compiler LLVM 16

Main branch (stage 2):

```
|- Stage 2
|    Speed        :  19.8465 ns per block ( 54.28%) -   0.3101 ns per byte -   3.5439 ns per structural -   3.2246 GB/s
|    Cycles       :  39.6334 per block    ( 54.72%) -   0.6193 per byte    -   7.0772 per structural    -    1.997 GHz est. frequency
|    Instructions : 140.3376 per block    ( 52.64%) -   2.1929 per byte    -  25.0597 per structural    -    3.541 per cycle
|    Misses       :     316 branch misses ( 73.90%) - 10 cache misses ( 41.97%) - 15570.00 cache references
```

This PR (stage 2):

```
|- Stage 2
|    Speed        :  18.6605 ns per block ( 52.84%) -   0.2916 ns per byte -   3.3322 ns per structural -   3.4295 GB/s
|    Cycles       :  37.2745 per block    ( 53.64%) -   0.5824 per byte    -   6.6560 per structural    -    1.998 GHz est. frequency
|    Instructions : 140.2906 per block    ( 52.63%) -   2.1922 per byte    -  25.0514 per structural    -    3.764 per cycle
|    Misses       :     322 branch misses ( 75.37%) - 11 cache misses ( 45.69%) - 15373.00 cache references
```

The number of instructions is very nearly the same, but LLVM seems to produce faster code (more instructions retired per cycle) with BMI2 enabled.



Overall
------

This change is maybe slightly negative with GCC, but possibly quite beneficial for stage 2 operation (+5% gain).

For stage 1 (results not provided), the results appear neutral.

The expectation is that this change will be neutral for ondemand on both compilers, although we need to verify this.



