### PR TITLE
object::extract: get a bunch of keys in one go

### DIFF
--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -13,15 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {gen: Visual Studio 17 2022, arch: x64, build_type: Debug}
-          - {gen: Visual Studio 17 2022, arch: x64, build_type: Release}
-          - {gen: Visual Studio 17 2022, arch: x64, build_type: RelWithDebInfo}
+          - {gen: Visual Studio 17 2022, arch: x64, build_type: Debug, cxx: 17}
+          - {gen: Visual Studio 17 2022, arch: x64, build_type: Debug, cxx: 20}
+          - {gen: Visual Studio 17 2022, arch: x64, build_type: Release, cxx: 17}
     steps:
     - name: checkout
       uses: actions/checkout@v4
     - name: Configure
       run: |
-        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}}  -T ClangCL -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -B build
+        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDJSON_CXX_STANDARD=${{matrix.cxx}} -T ClangCL -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -B build
     - name: Build
       run: cmake --build build --config ${{matrix.build_type}} --verbose
     - name: Run tests

--- a/benchmark/kostya/simdjson_ondemand.h
+++ b/benchmark/kostya/simdjson_ondemand.h
@@ -24,6 +24,35 @@ struct simdjson_ondemand {
 
 BENCHMARK_TEMPLATE(kostya, simdjson_ondemand)->UseManualTime();
 
+
+#if SIMDJSON_SUPPORTS_EXTRACT
+using namespace simdjson::ondemand;
+
+struct simdjson_ondemand_extract {
+  static constexpr diff_flags DiffFlags = diff_flags::NONE;
+
+  ondemand::parser parser{};
+
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    auto doc = parser.iterate(json);
+    for (ondemand::object object_point : doc.find_field("coordinates")) {
+      point p;
+      auto error = object_point.extract(
+        to{"x", p.x},
+        to{"y", p.y},
+        to{"z", p.z}
+      );
+      if(error) { return false; }
+      result.push_back(p);
+    }
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(kostya, simdjson_ondemand_extract)->UseManualTime();
+
+#endif // SIMDJSON_SUPPORTS_EXTRACT
+
 } // namespace kostya
 
 #endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -73,7 +73,7 @@ struct simdjson_ondemand_extract {
         }},
         to{"retweet_count", t.retweet_count},
         to{"favorite_count", t.favorite_count});
-        if(error) { throw simdjson_error(error); }
+        if(error) { return false; }
         result.push_back(t);
     }
     return true;

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -9,7 +9,7 @@ namespace partial_tweets {
 using namespace simdjson;
 
 struct simdjson_ondemand {
-  using StringType=std::string_view;
+  using StringType = std::string_view;
 
   ondemand::parser parser{};
 
@@ -42,6 +42,48 @@ struct simdjson_ondemand {
 };
 
 BENCHMARK_TEMPLATE(partial_tweets, simdjson_ondemand)->UseManualTime();
+
+
+#if SIMDJSON_SUPPORTS_EXTRACT
+
+using namespace simdjson::ondemand;
+
+struct simdjson_ondemand_extract {
+  using StringType = std::string_view;
+  ondemand::parser parser{};
+  bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
+    // Walk the document, parsing the tweets as we go
+    auto doc = parser.iterate(json);
+    for (ondemand::object tweet_object : doc.find_field("statuses")) {
+      tweet<std::string_view> t;
+      auto error = tweet_object.extract(
+        to{"created_at", t.created_at},
+        to{"id", t.id},
+        to{"text", t.result},
+        to{"in_reply_to_status_id", [&t](auto val) {
+          if(val.is_null()) {
+            t.in_reply_to_status_id = 0;
+          } else {
+            t.in_reply_to_status_id = val;
+          }
+         }},
+        to{"user", sub{
+          to{"id", t.user.id},
+          to{"screen_name", t.user.screen_name},
+        }},
+        to{"retweet_count", t.retweet_count},
+        to{"favorite_count", t.favorite_count});
+        if(error) { throw simdjson_error(error); }
+        result.push_back(t);
+    }
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(partial_tweets, simdjson_ondemand_extract)->UseManualTime();
+
+
+#endif
 
 } // namespace partial_tweets
 

--- a/include/simdjson/fallback/bitmanipulation.h
+++ b/include/simdjson/fallback/bitmanipulation.h
@@ -9,7 +9,7 @@ namespace simdjson {
 namespace fallback {
 namespace {
 
-#if defined(_MSC_VER) && !defined(_M_ARM64) && !defined(_M_X64)
+#if SIMDJSON_REGULAR_VISUAL_STUDIO && !defined(_M_ARM64) && !defined(_M_X64)
 static inline unsigned char _BitScanForward64(unsigned long* ret, uint64_t x) {
   unsigned long x0 = (unsigned long)x, top, bottom;
   _BitScanForward(&top, (unsigned long)(x >> 32));
@@ -28,7 +28,7 @@ static unsigned char _BitScanReverse64(unsigned long* ret, uint64_t x) {
 
 /* result might be undefined when input_num is zero */
 simdjson_inline int leading_zeroes(uint64_t input_num) {
-#ifdef _MSC_VER
+#ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)
   // to least significant bit (LSB) for a set bit (1).
@@ -38,7 +38,7 @@ simdjson_inline int leading_zeroes(uint64_t input_num) {
     return 64;
 #else
   return __builtin_clzll(input_num);
-#endif// _MSC_VER
+#endif// SIMDJSON_REGULAR_VISUAL_STUDIO
 }
 
 } // unnamed namespace

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -24,18 +24,13 @@ simdjson_inline error_code object::extract(Funcs&&... endpoints)
  noexcept((nothrow_endpoint<Funcs> && ...))
 #endif
 {
-  raw_json_string field_key;
-  error_code error = SUCCESS;
-  for(auto pair : *this) {
-    if (error = pair.key().get(field_key); error) {
-      break;
-    }
-    std::ignore = ((field_key.unsafe_is_equal(endpoints.key()) ? (error = endpoints(pair.value())) == SUCCESS : true) && ...);
+  return iter.on_field_raw([&](auto field_key, error_code& error) noexcept {
+    std::ignore = ((field_key.unsafe_is_equal(endpoints.key()) ? (error = endpoints(value(iter.child()))) == SUCCESS : true) && ...);
     if (error) {
-      break;
+      return true;
     }
-  }
-  return error;
+    return false;
+  });
 }
 
 template <typename T>

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -30,7 +30,7 @@ simdjson_inline error_code object::extract(Funcs&&... endpoints)
     if (error = pair.key().get(field_key); error) {
       break;
     }
-    ((field_key.unsafe_is_equal(endpoints.key()) ? (error = endpoints(pair.value())) == SUCCESS : true) && ...);
+    std::ignore = ((field_key.unsafe_is_equal(endpoints.key()) ? (error = endpoints(pair.value())) == SUCCESS : true) && ...);
     if (error) {
       break;
     }

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -18,6 +18,21 @@ namespace ondemand {
 
 #ifdef SIMDJSON_SUPPORTS_EXTRACT
 
+template <endpoint ...Funcs>
+simdjson_inline void object::extract(Funcs&&... endpoints)
+#ifndef _MSC_VER // msvc thinks noexcept is not the same in definition
+ noexcept((nothrow_endpoint<Funcs> && ...))
+#endif
+{
+  raw_json_string field_key;
+  for(auto pair : *this) {
+    if (pair.key().get(field_key)) {
+      break;
+    }
+    ((field_key.unsafe_is_equal(endpoints.key()) && (endpoints(pair.value()), true)), ...);
+  }
+}
+
 template <typename T> struct to {
 private:
   T *pointer;

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -62,8 +62,13 @@ simdjson_inline simdjson_result<value> object::find_field(const std::string_view
 #ifdef SIMDJSON_SUPPORTS_EXTRACT
 template <typename ...T>
 simdjson_inline void object::extract(to<T>... endpoints) & noexcept {
-  for(auto value : *this) {
-    (endpoints.set_value(value) || ...);
+  raw_json_string field_key;
+  for(auto pair : *this) {
+    if (pair.key().get(field_key)) {
+      break;
+    }
+    auto value = pair.value();
+    ((field_key.unsafe_is_equal(endpoints.key) && (endpoints.set_value(value), true)), ...);
   }
 }
 #endif

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -24,7 +24,7 @@ simdjson_inline error_code object::extract(Funcs&&... endpoints)
  noexcept((nothrow_endpoint<Funcs> && ...))
 #endif
 {
-  return iter.on_field_raw([&](auto field_key, error_code& error) noexcept {
+  return iter.on_field_raw([&](auto field_key, error_code& error) noexcept((nothrow_endpoint<Funcs> && ...)) {
     std::ignore = ((field_key.unsafe_is_equal(endpoints.key()) ? (error = endpoints(value(iter.child()))) == SUCCESS : true) && ...);
     if (error) {
       return true;

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -16,6 +16,7 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
 
+#ifdef SIMDJSON_SUPPORTS_EXTRACT
 template <endpoint ...Tos>
 constexpr void sub<Tos...>::operator()(simdjson_result<value> val) noexcept((nothrow_endpoint<Tos> && ...)) {
   object obj;
@@ -26,6 +27,7 @@ constexpr void sub<Tos...>::operator()(simdjson_result<value> val) noexcept((not
    obj.extract(std::forward<T>(app_tos)...);
   }, tos);
 }
+#endif
 
 simdjson_inline simdjson_result<value> object::find_field_unordered(const std::string_view key) & noexcept {
   bool has_value;

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -58,6 +58,17 @@ simdjson_inline simdjson_result<value> object::find_field(const std::string_view
   return value(iter.child());
 }
 
+
+#ifdef SIMDJSON_SUPPORTS_EXTRACT
+template <typename ...T>
+simdjson_inline void object::extract(to<T>... endpoints) & noexcept {
+  for(auto value : *this) {
+    (endpoints.set_value(value) || ...);
+  }
+}
+#endif
+
+
 simdjson_inline simdjson_result<object> object::start(value_iterator &iter) noexcept {
   SIMDJSON_TRY( iter.start_object().error() );
   return object(iter);

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -60,15 +60,15 @@ simdjson_inline simdjson_result<value> object::find_field(const std::string_view
 
 
 #ifdef SIMDJSON_SUPPORTS_EXTRACT
-template <typename ...T>
-simdjson_inline void object::extract(to<T>... endpoints) & noexcept {
+template <endpoint ...Funcs>
+simdjson_inline void object::extract(Funcs&&... endpoints) noexcept((nothrow_endpoint<Funcs> && ...)) {
   raw_json_string field_key;
   for(auto pair : *this) {
     if (pair.key().get(field_key)) {
       break;
     }
     auto value = pair.value();
-    ((field_key.unsafe_is_equal(endpoints.key) && (endpoints.set_value(value), true)), ...);
+    ((field_key.unsafe_is_equal(endpoints.key()) && (endpoints(value), true)), ...);
   }
 }
 #endif

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -19,7 +19,7 @@ namespace ondemand {
 #ifdef SIMDJSON_SUPPORTS_EXTRACT
 
 
-#ifdef _MSC_VER
+#if SIMDJSON_REGULAR_VISUAL_STUDIO
 template <endpoint ...Funcs>
 simdjson_inline error_code object::extract(Funcs&&... endpoints) {
   return iter.on_field_raw([&, eps = std::make_tuple(std::forward<Funcs>(endpoints)...)](auto field_key, error_code& error) mutable {

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -86,7 +86,7 @@ public:
    */
   template <endpoint ...Funcs>
   simdjson_inline error_code extract(Funcs&&... endpoints)
-#ifndef _MSC_VER // msvc thinks noexcept is not the same in definition
+#ifndef SIMDJSON_REGULAR_VISUAL_STUDIO // msvc thinks noexcept is not the same in definition
  noexcept((nothrow_endpoint<Funcs> && ...))
 #endif
  ;

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -15,91 +15,16 @@ namespace ondemand {
 #define SIMDJSON_SUPPORTS_EXTRACT 1
 
 template <typename T>
-concept endpoint = std::is_invocable_v<T, simdjson_result<value>> && std::is_copy_constructible_v<T> && requires (T to) {
- {to.key()} noexcept -> std::convertible_to<std::string_view>;
-};
+concept endpoint = std::is_invocable_v<T, simdjson_result<value>> &&
+                   std::is_copy_constructible_v<T> && requires(T to) {
+                     {
+                       to.key()
+                     } noexcept -> std::convertible_to<std::string_view>;
+                   };
 
 template <typename T>
-concept nothrow_endpoint = endpoint<T> && std::is_nothrow_invocable_v<T, simdjson_result<value>>;
-
-template <typename T>
-struct to {
- private:
-  T* pointer;
-  std::string_view m_key;
- public:
-
- constexpr explicit(false) to(std::string_view const inp_key, T& obj_ref) noexcept :
-  pointer{std::addressof(obj_ref)}, m_key{inp_key} {}
-
- constexpr to(to const&) = default;
- constexpr to(to&&) noexcept = default;
- constexpr to& operator=(to const&) = default;
- constexpr to& operator=(to&&) noexcept = default;
- constexpr ~to() = default;
-
- [[nodiscard]] constexpr std::string_view key() const noexcept {
-  return m_key;
- }
-
- constexpr void operator()(simdjson_result<value> val) noexcept(std::is_nothrow_assignable_v<T, simdjson_result<value>>) {
-    *pointer = val;
- }
-};
-
-template <typename Func>
-  requires (std::is_invocable_v<Func, simdjson_result<value>>)
-struct to<Func> {
- private:
-  Func func;
-  std::string_view m_key;
- public:
-
- constexpr explicit(false) to(std::string_view const inp_key, Func&& inp_func) noexcept(std::is_nothrow_copy_assignable_v<Func>) :
-  func{std::forward<Func>(inp_func)}, m_key{inp_key} {}
-
- constexpr to(to const&) = default;
- constexpr to(to&&) noexcept = default;
- constexpr to& operator=(to const&) = default;
- constexpr to& operator=(to&&) noexcept = default;
- constexpr ~to() = default;
-
- [[nodiscard]] constexpr std::string_view key() const noexcept {
-  return m_key;
- }
-
- constexpr void operator()(simdjson_result<value> val) noexcept(std::is_nothrow_invocable_v<Func, simdjson_result<value>>) {
-    func(val);
- }
-};
-
-
-template <typename Func>
-  requires (std::is_invocable_v<Func, simdjson_result<value>>)
-to(std::string_view, Func&&) -> to<Func>;
-
-template <typename T>
-to(std::string_view, T&) -> to<T>;
-
-
-template <endpoint ...Tos>
-struct sub {
-private:
- using tuple_type = std::tuple<Tos...>;
- tuple_type tos;
-public:
-
- explicit constexpr sub(Tos&&... inp_tos) noexcept(std::is_nothrow_constructible_v<tuple_type, Tos...>) :
-   tos {std::forward<Tos>(inp_tos)...} {}
-
- constexpr sub(sub const&) = default;
- constexpr sub(sub&&) noexcept = default;
- constexpr sub& operator=(sub const&) = default;
- constexpr sub& operator=(sub&&) = default;
- constexpr ~sub() = default;
-
- constexpr void operator()(simdjson_result<value> val) noexcept((nothrow_endpoint<Tos> && ...));
-};
+concept nothrow_endpoint =
+    endpoint<T> && std::is_nothrow_invocable_v<T, simdjson_result<value>>;
 
 #endif
 
@@ -163,8 +88,15 @@ public:
    * Funcs are invocables that take a simdjson_result<value> as input.
    */
   template <endpoint ...Funcs>
-  simdjson_inline void extract(Funcs&&... endpoints) noexcept((nothrow_endpoint<Funcs> && ...));
-
+  simdjson_inline void extract(Funcs&&... endpoints) noexcept((nothrow_endpoint<Funcs> && ...)) {
+    raw_json_string field_key;
+    for(auto pair : *this) {
+      if (pair.key().get(field_key)) {
+        break;
+      }
+      ((field_key.unsafe_is_equal(endpoints.key()) && (endpoints(pair.value()), true)), ...);
+    }
+  }
 #endif
 
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -30,16 +30,8 @@ private:
 private:
  friend class object;
 
- bool set_value(simdjson_result<field> field) noexcept {
-   raw_json_string field_key;
-   if (field.key().get(field_key)) {
-     return false;
-   }
-   if (key == field_key) {
+ void set_value(simdjson_result<value> field) noexcept {
     *pointer = field.value();
-    return true;
-   }
-   return false;
  }
 };
 
@@ -57,16 +49,8 @@ private:
 private:
  friend class object;
 
- bool set_value(simdjson_result<field> field) noexcept {
-   raw_json_string field_key;
-   if (field.key().get(field_key)) {
-     return false;
-   }
-   if (key == field_key) {
+ void set_value(simdjson_result<value> field) noexcept {
     func(field.value());
-    return true;
-   }
-   return false;
  }
 };
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -88,15 +88,11 @@ public:
    * Funcs are invocables that take a simdjson_result<value> as input.
    */
   template <endpoint ...Funcs>
-  simdjson_inline void extract(Funcs&&... endpoints) noexcept((nothrow_endpoint<Funcs> && ...)) {
-    raw_json_string field_key;
-    for(auto pair : *this) {
-      if (pair.key().get(field_key)) {
-        break;
-      }
-      ((field_key.unsafe_is_equal(endpoints.key()) && (endpoints(pair.value()), true)), ...);
-    }
-  }
+  simdjson_inline void extract(Funcs&&... endpoints)
+#ifndef _MSC_VER // msvc thinks noexcept is not the same in definition
+ noexcept((nothrow_endpoint<Funcs> && ...))
+#endif
+ ;
 #endif
 
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -30,8 +30,8 @@ private:
 private:
  friend class object;
 
- void set_value(simdjson_result<value> field) noexcept {
-    *pointer = field.value();
+ void set_value(simdjson_result<value> val) noexcept {
+    *pointer = val;
  }
 };
 
@@ -49,8 +49,8 @@ private:
 private:
  friend class object;
 
- void set_value(simdjson_result<value> field) noexcept {
-    func(field.value());
+ void set_value(simdjson_result<value> val) noexcept {
+    func(val);
  }
 };
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -15,16 +15,13 @@ namespace ondemand {
 #define SIMDJSON_SUPPORTS_EXTRACT 1
 
 template <typename T>
-concept endpoint = std::is_invocable_v<T, simdjson_result<value>> &&
+concept endpoint = std::is_invocable_r_v<error_code, T, simdjson_result<value>> &&
                    std::is_copy_constructible_v<T> && requires(T to) {
-                     {
-                       to.key()
-                     } noexcept -> std::convertible_to<std::string_view>;
+                     { to.key() } noexcept -> std::convertible_to<std::string_view>;
                    };
 
 template <typename T>
-concept nothrow_endpoint =
-    endpoint<T> && std::is_nothrow_invocable_v<T, simdjson_result<value>>;
+concept nothrow_endpoint = endpoint<T> && std::is_nothrow_invocable_r_v<error_code, T, simdjson_result<value>>;
 
 #endif
 
@@ -88,7 +85,7 @@ public:
    * Funcs are invocables that take a simdjson_result<value> as input.
    */
   template <endpoint ...Funcs>
-  simdjson_inline void extract(Funcs&&... endpoints)
+  simdjson_inline error_code extract(Funcs&&... endpoints)
 #ifndef _MSC_VER // msvc thinks noexcept is not the same in definition
  noexcept((nothrow_endpoint<Funcs> && ...))
 #endif

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -1,3 +1,4 @@
+#include <type_traits>
 #ifndef SIMDJSON_GENERIC_ONDEMAND_VALUE_ITERATOR_INL_H
 
 #ifndef SIMDJSON_CONDITIONAL_INCLUDE
@@ -107,6 +108,100 @@ simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::has_n
     default:
       return report_error(TAPE_ERROR, "Missing comma between object fields");
   }
+}
+
+template <typename Func>
+simdjson_warn_unused simdjson_inline error_code value_iterator::on_field_raw(Func&& func) noexcept {
+  static_assert(std::is_nothrow_invocable_r<bool, Func, raw_json_string, error_code&>::value, "Invalid function provided.");
+
+  error_code error = SUCCESS;
+  bool has_value;
+  //
+  // Initially, the object can be in one of a few different places:
+  //
+  // 1. The start of the object, at the first field:
+  //
+  //    ```
+  //    { "a": [ 1, 2 ], "b": [ 3, 4 ] }
+  //      ^ (depth 2, index 1)
+  //    ```
+  if (at_first_field()) {
+    has_value = true;
+
+  //
+  // 2. When a previous search did not yield a value or the object is empty:
+  //
+  //    ```
+  //    { "a": [ 1, 2 ], "b": [ 3, 4 ] }
+  //                                     ^ (depth 0)
+  //    { }
+  //        ^ (depth 0, index 2)
+  //    ```
+  //
+  } else if (!is_open()) {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+    // If we're past the end of the object, we're being iterated out of order.
+    // Note: this is not perfect detection. It's possible the user is inside some other object; if so,
+    // this object iterator will blithely scan that object for fields.
+    if (_json_iter->depth() < depth() - 1) { return OUT_OF_ORDER_ITERATION; }
+#endif
+    return EMPTY;
+
+  // 3. When a previous search found a field or an iterator yielded a value:
+  //
+  //    ```
+  //    // When a field was not fully consumed (or not even touched at all)
+  //    { "a": [ 1, 2 ], "b": [ 3, 4 ] }
+  //           ^ (depth 2)
+  //    // When a field was fully consumed
+  //    { "a": [ 1, 2 ], "b": [ 3, 4 ] }
+  //                   ^ (depth 1)
+  //    // When the last field was fully consumed
+  //    { "a": [ 1, 2 ], "b": [ 3, 4 ] }
+  //                                   ^ (depth 1)
+  //    ```
+  //
+  } else {
+    if ((error = skip_child() )) { abandon(); return error; }
+    if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
+#if SIMDJSON_DEVELOPMENT_CHECKS
+    if (_json_iter->start_position(_depth) != start_position()) { return OUT_OF_ORDER_ITERATION; }
+#endif
+  }
+  while (has_value) {
+    // Get the key and colon, stopping at the value.
+    raw_json_string actual_key;
+    // size_t max_key_length = _json_iter->peek_length() - 2; // -2 for the two quotes
+    // Note: _json_iter->peek_length() - 2 might overflow if _json_iter->peek_length() < 2.
+    // field_key() advances the pointer and checks that '"' is found (corresponding to a key).
+    // The depth is left unchanged by field_key().
+    if ((error = field_key().get(actual_key) )) { abandon(); return error; };
+    // field_value() will advance and check that we find a ':' separating the
+    // key and the value. It will also increment the depth by one.
+    if ((error = field_value() )) { abandon(); return error; }
+    // If it matches, stop and return
+    // We could do it this way if we wanted to allow arbitrary
+    // key content (including escaped quotes).
+    //if (actual_key.unsafe_is_equal(max_key_length, key)) {
+    // Instead we do the following which may trigger buffer overruns if the
+    // user provides an adversarial key (containing a well placed unescaped quote
+    // character and being longer than the number of bytes remaining in the JSON
+    // input).
+    if (func(actual_key, error)) {
+      break;
+    }
+
+    // The call to skip_child is meant to skip over the value corresponding to the key.
+    // After skip_child(), we are right before the next comma (',') or the final brace ('}').
+    SIMDJSON_TRY( skip_child() ); // Skip the value entirely
+    // The has_next_field() advances the pointer and check that either ',' or '}' is found.
+    // It returns true if ',' is found, false otherwise. If anything other than ',' or '}' is found,
+    // then we are in error and we abort.
+    if ((error = has_next_field().get(has_value) )) { abandon(); return error; }
+  }
+
+  // If the loop ended, we're out of fields to look at.
+  return error;
 }
 
 simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::find_field_raw(const std::string_view key) noexcept {

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -111,8 +111,16 @@ simdjson_warn_unused simdjson_inline simdjson_result<bool> value_iterator::has_n
 }
 
 template <typename Func>
-simdjson_warn_unused simdjson_inline error_code value_iterator::on_field_raw(Func&& func) noexcept {
-  static_assert(std::is_nothrow_invocable_r<bool, Func, raw_json_string, error_code&>::value, "Invalid function provided.");
+simdjson_warn_unused simdjson_inline error_code value_iterator::on_field_raw(Func&& func)
+#ifdef __cpp_lib_is_invocable
+  noexcept(std::is_nothrow_invocable_r_v<bool, Func, raw_json_string, error_code&>)
+#else
+  noexcept(false)
+#endif
+{
+#ifdef __cpp_lib_is_invocable
+  static_assert(std::is_invocable_r_v<bool, Func, raw_json_string, error_code&>, "Invalid function provided.");
+#endif
 
   error_code error = SUCCESS;
   bool has_value;

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -198,6 +198,13 @@ public:
    */
   simdjson_warn_unused simdjson_inline simdjson_result<bool> find_field_raw(const std::string_view key) noexcept;
 
+
+  /**
+   * Runs Func on each key found.
+   */
+  template <typename Func>
+  simdjson_warn_unused simdjson_inline error_code on_field_raw(Func&& func) noexcept;
+
   /**
    * Find the field with the given key without regard to order, and *without* unescaping.
    *

--- a/include/simdjson/generic/ondemand/value_iterator.h
+++ b/include/simdjson/generic/ondemand/value_iterator.h
@@ -6,6 +6,12 @@
 #include "simdjson/generic/implementation_simdjson_result_base.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#ifdef __has_include
+#if __has_include (<version>)
+#include <version>
+#endif
+#endif
+
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
@@ -201,9 +207,18 @@ public:
 
   /**
    * Runs Func on each key found.
+   * Almost same as `find_field_raw` but it runs `func` instead of checking the key ourselves.
+   *
+   * @param Func func(raw_json_string key, error_code& error) noexcept
    */
   template <typename Func>
-  simdjson_warn_unused simdjson_inline error_code on_field_raw(Func&& func) noexcept;
+  simdjson_warn_unused simdjson_inline error_code on_field_raw(Func&& func)
+#ifdef __cpp_lib_is_invocable
+  noexcept(std::is_nothrow_invocable_r_v<bool, Func, raw_json_string, error_code&>)
+#else
+  noexcept(false)
+#endif
+  ;
 
   /**
    * Find the field with the given key without regard to order, and *without* unescaping.

--- a/tests/ondemand/CMakeLists.txt
+++ b/tests/ondemand/CMakeLists.txt
@@ -28,6 +28,7 @@ add_cpp_test(ondemand_to_string              LABELS ondemand acceptance per_impl
 add_cpp_test(ondemand_twitter_tests          LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_wrong_type_error_tests LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_iterate_many_csv       LABELS ondemand acceptance per_implementation)
+add_cpp_test(ondemand_extract_tests          LABELS ondemand acceptance per_implementation)
 if(NOT SIMDJSON_SANITIZE)
   add_cpp_test(ondemand_cacheline              LABELS ondemand acceptance per_implementation)
 endif()

--- a/tests/ondemand/ondemand_extract_tests.cpp
+++ b/tests/ondemand/ondemand_extract_tests.cpp
@@ -49,7 +49,7 @@ struct Car {
     //     }
     //
     // we can do this now:
-    obj.extract(
+    error = obj.extract(
       to{"wheels", sub{
         to{"front", car.wheels.front},
         to{"back", car.wheels.back},
@@ -59,6 +59,9 @@ struct Car {
       to{"year", [&car](auto val) {
         car.year = val;
       }});
+    if (error) {
+      return error;
+    }
     return car;
   }
 };

--- a/tests/ondemand/ondemand_extract_tests.cpp
+++ b/tests/ondemand/ondemand_extract_tests.cpp
@@ -1,0 +1,99 @@
+#include "simdjson.h"
+#include "test_ondemand.h"
+
+using namespace simdjson;
+
+namespace multi_get_tests {
+#ifdef __cpp_concepts
+struct Car {
+  std::string_view make;
+  std::string_view model;
+  std::int64_t year = 0;
+
+  static simdjson_result<Car> create(auto& value) {
+    simdjson::ondemand::object obj;
+    auto error = value.get_object().get(obj);
+    if (error) {
+      return error;
+    }
+    Car car{};
+    // Instead of this:
+    //     for (auto field : obj) {
+    //       simdjson::ondemand::raw_json_string key;
+    //       error = field.key().get(key);
+    //       if (error) {
+    //         return error;
+    //       }
+    //       if (key == "make") {
+    //         error = field.value().get_string(car.make);
+    //         if (error) {
+    //           return error;
+    //         }
+    //       } else if (key == "model") {
+    //         error = field.value().get_string(car.model);
+    //         if (error) {
+    //           return error;
+    //         }
+    //       } else if (key == "year") {
+    //         error = field.value().get(car.year);
+    //         if (error) {
+    //           return error;
+    //         }
+    //     }
+    //
+    // we can do this now:
+    obj.extract(
+      ondemand::to{"make", car.make},
+      ondemand::to{"model", car.model},
+      ondemand::to{"year", [&car](auto val) {
+        car.year = val;
+      }});
+    return car;
+  }
+};
+
+bool car_example() {
+  TEST_START();
+  simdjson::padded_string json =
+      R"( [ { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] },
+  { "make": "Kia",    "model": "Soul",   "year": 2012,
+       "tire_pressure": [ 30.1, 31.0 ] },
+  { "make": "Toyota", "model": "Tercel", "year": 1999,
+       "tire_pressure": [ 29.8, 30.0 ] }
+])"_padded;
+
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc = parser.iterate(json);
+  for (auto val : doc) {
+    auto car = Car::create(val);
+    ASSERT_EQUAL(car.error(), SUCCESS);
+    Car const c(car.value());
+    if (c.make != "Toyota" && c.make != "Kia") {
+      return false;
+    }
+    if (c.model != "Camry" && c.model != "Soul" && c.model != "Tercel") {
+      return false;
+    }
+    if (c.year != 2018 && c.year != 2012 && c.year != 1999) {
+      return false;
+    }
+  }
+
+  TEST_SUCCEED();
+}
+
+#endif
+bool run() {
+  return
+#ifdef __cpp_concepts
+      car_example() &&
+#endif
+      true;
+}
+
+} // namespace multi_get_tests
+
+int main(int argc, char *argv[]) {
+  return test_main(argc, argv, multi_get_tests::run);
+}


### PR DESCRIPTION
This is the bare minimum implementation of this idea.

This makes this syntax possible:

```C++
    Car car{};
    error = obj.extract(
      to{"wheels", sub{
        to{"front", car.wheels.front},
        to{"back", car.wheels.back},
      }},
      to{"make", car.make},
      to{"model", car.model},
      to{"year", [&car](auto val) {
        car.year = val;
      }});
    if (error) {
      return error;
    }
```

Its performance is better than #2235, and we're pretty much on par with the traditional way of doing this; but still there are things we could do as well to make it even faster.

```
	findall_consume                              :  0.14821 GB/s  
	findall_consume_sv                           :  0.14996 GB/s  <-- object::find_all
	standard_consume                             :  0.30775 GB/s  <-- traditional way
	findall_extract                              :  0.30347 GB/s  <-- this PR
```

---
I tried to make `to{...}` unnecessary, but it doesn't seem to work. If you have a way that the user wouldn't need to keep typing `to` would be great.