### PR TITLE
Ignore pragma once when amalgamating source files

### DIFF
--- a/singleheader/amalgamate.py
+++ b/singleheader/amalgamate.py
@@ -323,6 +323,10 @@ class Amalgamator:
             for line in fid2:
                 line = line.rstrip('\n')
 
+                # Ignore #pragma once, it causes warnings if it ends up in a .cpp file
+                if re.search(r'^#pragma once$', line):
+                    continue
+
                 # Ignore lines inside #ifndef SIMDJSON_CONDITIONAL_INCLUDE
                 if re.search(r'^#ifndef\s+SIMDJSON_CONDITIONAL_INCLUDE\s*$', line):
                     assert file.is_conditional_include, f"{file} uses #ifndef SIMDJSON_CONDITIONAL_INCLUDE but is not an amalgamated file!"


### PR DESCRIPTION
With gcc it causes an error in `simdjson.cpp`:
```
simdjson.cpp:548:9: warning: #pragma once in main file
  548 | #pragma once
      |         ^~~~
```

It had previously been commented out in: https://github.com/simdjson/simdjson/commit/6ef555e6fb79363fae057a9a46b52cd208d9e305

However, this was lost in an upgrade: https://github.com/simdjson/simdjson/commit/2a4ff7346813b120f2b5b40e95d69352b593cc9c