### PR TITLE
Avoid passing zero to clz builtin due to UB

### DIFF
--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -46,7 +46,7 @@ simdjson_inline int leading_zeroes(uint64_t input_num) {
   else
     return 64;
 #else
-  return __builtin_clzll(input_num);
+  return input_num ? __builtin_clzll(input_num) : 64;
 #endif// SIMDJSON_REGULAR_VISUAL_STUDIO
 }
 

--- a/include/simdjson/fallback/bitmanipulation.h
+++ b/include/simdjson/fallback/bitmanipulation.h
@@ -37,7 +37,7 @@ simdjson_inline int leading_zeroes(uint64_t input_num) {
   else
     return 64;
 #else
-  return __builtin_clzll(input_num);
+  return input_num ? __builtin_clzll(input_num) : 64;
 #endif// _MSC_VER
 }
 

--- a/include/simdjson/lasx/bitmanipulation.h
+++ b/include/simdjson/lasx/bitmanipulation.h
@@ -30,7 +30,7 @@ simdjson_inline uint64_t clear_lowest_bit(uint64_t input_num) {
 
 /* result might be undefined when input_num is zero */
 simdjson_inline int leading_zeroes(uint64_t input_num) {
-  return __builtin_clzll(input_num);
+  return input_num ? __builtin_clzll(input_num) : 64;
 }
 
 /* result might be undefined when input_num is zero */

--- a/include/simdjson/lsx/bitmanipulation.h
+++ b/include/simdjson/lsx/bitmanipulation.h
@@ -30,7 +30,7 @@ simdjson_inline uint64_t clear_lowest_bit(uint64_t input_num) {
 
 /* result might be undefined when input_num is zero */
 simdjson_inline int leading_zeroes(uint64_t input_num) {
-  return __builtin_clzll(input_num);
+  return input_num ? __builtin_clzll(input_num) : 64;
 }
 
 /* result might be undefined when input_num is zero */

--- a/include/simdjson/ppc64/bitmanipulation.h
+++ b/include/simdjson/ppc64/bitmanipulation.h
@@ -45,7 +45,7 @@ simdjson_inline int leading_zeroes(uint64_t input_num) {
   else
     return 64;
 #else
-  return __builtin_clzll(input_num);
+  return input_num ? __builtin_clzll(input_num) : 64;
 #endif // SIMDJSON_REGULAR_VISUAL_STUDIO
 }
 

--- a/include/simdjson/westmere/bitmanipulation.h
+++ b/include/simdjson/westmere/bitmanipulation.h
@@ -46,7 +46,7 @@ simdjson_inline int leading_zeroes(uint64_t input_num) {
   else
     return 64;
 #else
-  return __builtin_clzll(input_num);
+  return input_num ? __builtin_clzll(input_num) : 64;
 #endif// SIMDJSON_REGULAR_VISUAL_STUDIO
 }
 


### PR DESCRIPTION
simdjson internally passes zeroes to `__builtin_clzll`, which is UB.

gcc's documentation on `__builtin_clz` reads as follows:
> Returns the number of leading 0-bits in x, starting at the most significant bit position. If x is 0, the result is undefined.

This is an interesting post I found that is related to this issue: https://stackoverflow.com/a/70015690/9156308. It shows that GCC doesn't seem to optimize the ternary away for x86-64. We use lzcnt anyway directly for those platforms anyway, but I 
don't know if GCC fails to optimize on other platforms, too. It's probably negligible, though.

Also, why don't we provide a default implementation for `leading_zeroes` that can be used on all platforms where the builtin is available?