### PR TITLE
Make document::is_null behavior consistent with documentation

### DIFF
--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -799,6 +799,8 @@ simdjson_inline simdjson_result<bool> value_iterator::is_root_null(bool check_tr
   if(result) { // we have something that looks like a null.
     if (check_trailing && !_json_iter->is_single_token()) { return TRAILING_CONTENT; }
     advance_root_scalar("null");
+  } else if (json[0] == 'n') {
+    return incorrect_type_error("Not a null but starts with n");
   }
   return result;
 }

--- a/tests/ondemand/ondemand_scalar_tests.cpp
+++ b/tests/ondemand/ondemand_scalar_tests.cpp
@@ -373,9 +373,20 @@ namespace scalar_tests {
     TEST_SUCCEED();
   }
 
+  bool nul() {
+    TEST_START();
+    auto json = R"( nul )"_padded;
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    ASSERT_ERROR(doc.is_null(), INCORRECT_TYPE);
+    TEST_SUCCEED();
+  }
+
   bool run() {
     return
            nully() &&
+           nul() &&
            string_with_trailing() &&
            uint64_with_trailing() &&
            int64_with_trailing() &&

--- a/tests/ondemand/ondemand_scalar_tests.cpp
+++ b/tests/ondemand/ondemand_scalar_tests.cpp
@@ -369,9 +369,7 @@ namespace scalar_tests {
     ondemand::parser parser;
     ondemand::document doc;
     ASSERT_SUCCESS(parser.iterate(json).get(doc));
-    bool x;
-    ASSERT_SUCCESS(doc.is_null().get(x));
-    ASSERT_TRUE(!x);
+    ASSERT_ERROR(doc.is_null(), INCORRECT_TYPE);
     TEST_SUCCEED();
   }
 


### PR DESCRIPTION
The function documentation states: `INCORRECT_TYPE If the JSON value begins with 'n'and is not 'null'.`, however, it previously failed to return any error.

The behavior has now been corrected and the unit test updated.