### PR TITLE
Add support for JSONPath with '$' prefix and integrate into dom::at_path

### DIFF
--- a/include/simdjson/dom/array-inl.h
+++ b/include/simdjson/dom/array-inl.h
@@ -7,6 +7,7 @@
 #include "simdjson/dom/array.h"
 #include "simdjson/dom/element.h"
 #include "simdjson/error-inl.h"
+#include "simdjson/jsonpathutil.h"
 #include "simdjson/internal/tape_ref-inl.h"
 
 #include <limits>
@@ -44,6 +45,13 @@ inline simdjson_result<dom::element> simdjson_result<dom::array>::at_pointer(std
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
 }
+
+ inline simdjson_result<dom::element> simdjson_result<dom::array>::at_path(std::string_view json_path) const noexcept {
+  auto json_pointer = json_path_to_pointer_conversion(json_path);
+  if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
+  return at_pointer(json_pointer);
+ }
+
 inline simdjson_result<dom::element> simdjson_result<dom::array>::at(size_t index) const noexcept {
   if (error()) { return error(); }
   return first.at(index);
@@ -111,6 +119,12 @@ inline simdjson_result<element> array::at_pointer(std::string_view json_pointer)
     child = child.at_pointer(json_pointer.substr(i));
   }
   return child;
+}
+
+inline simdjson_result<element> array::at_path(std::string_view json_path) const noexcept {
+  auto json_pointer = json_path_to_pointer_conversion(json_path);
+  if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
+  return at_pointer(json_pointer);
 }
 
 inline simdjson_result<element> array::at(size_t index) const noexcept {

--- a/include/simdjson/dom/array.h
+++ b/include/simdjson/dom/array.h
@@ -109,6 +109,21 @@ public:
   inline simdjson_result<element> at_pointer(std::string_view json_pointer) const noexcept;
 
   /**
+   * Get the value associated with the given JSONPath expression. We only support
+   * JSONPath queries that trivially convertible to JSON Pointer queries: key
+   * names and array indices.
+   *
+   * https://datatracker.ietf.org/doc/html/draft-normington-jsonpath-00
+   *
+   * @return The value associated with the given JSONPath expression, or:
+   *         - INVALID_JSON_POINTER if the JSONPath to JSON Pointer conversion fails
+   *         - NO_SUCH_FIELD if a field does not exist in an object
+   *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length
+   *         - INCORRECT_TYPE if a non-integer is used to access an array
+  */
+  inline simdjson_result<element> at_path(std::string_view json_path) const noexcept;
+
+  /**
    * Get the value at the given index. This function has linear-time complexity and
    * is equivalent to the following:
    *
@@ -152,6 +167,7 @@ public:
   simdjson_inline simdjson_result(error_code error) noexcept; ///< @private
 
   inline simdjson_result<dom::element> at_pointer(std::string_view json_pointer) const noexcept;
+  inline simdjson_result<dom::element> at_path(std::string_view json_path) const noexcept;
   inline simdjson_result<dom::element> at(size_t index) const noexcept;
 
 #if SIMDJSON_EXCEPTIONS

--- a/include/simdjson/dom/element-inl.h
+++ b/include/simdjson/dom/element-inl.h
@@ -9,6 +9,7 @@
 
 #include "simdjson/dom/object-inl.h"
 #include "simdjson/error-inl.h"
+#include "simdjson/jsonpathutil.h"
 
 #include <ostream>
 #include <limits>
@@ -121,6 +122,11 @@ simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::ope
 simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_pointer(const std::string_view json_pointer) const noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
+}
+simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_path(const std::string_view json_path) const noexcept {
+  auto json_pointer = json_path_to_pointer_conversion(json_path);
+  if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
+  return at_pointer(json_pointer);
 }
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
 [[deprecated("For standard compliance, use at_pointer instead, and prefix your pointers with a slash '/', see RFC6901 ")]]
@@ -411,6 +417,11 @@ inline simdjson_result<element> element::at_pointer(std::string_view json_pointe
       return simdjson_result<element>(std::move(copy));
     }
   }
+}
+inline simdjson_result<element> element::at_path(std::string_view json_path) const noexcept {
+  auto json_pointer = json_path_to_pointer_conversion(json_path);
+  if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
+  return at_pointer(json_pointer);
 }
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
 [[deprecated("For standard compliance, use at_pointer instead, and prefix your pointers with a slash '/', see RFC6901 ")]]

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -397,6 +397,21 @@ public:
    */
   inline simdjson_result<element> at_pointer(const std::string_view json_pointer) const noexcept;
 
+  /**
+   * Get the value associated with the given JSONPath expression. We only support
+   * JSONPath queries that trivially convertible to JSON Pointer queries: key
+   * names and array indices.
+   *
+   * https://datatracker.ietf.org/doc/html/draft-normington-jsonpath-00
+   *
+   * @return The value associated with the given JSONPath expression, or:
+   *         - INVALID_JSON_POINTER if the JSONPath to JSON Pointer conversion fails
+   *         - NO_SUCH_FIELD if a field does not exist in an object
+   *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length
+   *         - INCORRECT_TYPE if a non-integer is used to access an array
+  */
+  inline simdjson_result<element> at_path(std::string_view json_path) const noexcept;
+
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
   /**
    *
@@ -526,6 +541,7 @@ public:
   simdjson_inline simdjson_result<dom::element> operator[](std::string_view key) const noexcept;
   simdjson_inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
   simdjson_inline simdjson_result<dom::element> at_pointer(const std::string_view json_pointer) const noexcept;
+  simdjson_inline simdjson_result<dom::element> at_path(const std::string_view json_path) const noexcept;
   [[deprecated("For standard compliance, use at_pointer instead, and prefix your pointers with a slash '/', see RFC6901 ")]]
   simdjson_inline simdjson_result<dom::element> at(const std::string_view json_pointer) const noexcept;
   simdjson_inline simdjson_result<dom::element> at(size_t index) const noexcept;

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -7,6 +7,7 @@
 
 #include "simdjson/dom/element-inl.h"
 #include "simdjson/error-inl.h"
+#include "simdjson/jsonpathutil.h"
 
 #include <cstring>
 
@@ -33,6 +34,11 @@ inline simdjson_result<dom::element> simdjson_result<dom::object>::operator[](co
 inline simdjson_result<dom::element> simdjson_result<dom::object>::at_pointer(std::string_view json_pointer) const noexcept {
   if (error()) { return error(); }
   return first.at_pointer(json_pointer);
+}
+inline simdjson_result<dom::element> simdjson_result<dom::object>::at_path(std::string_view json_path) const noexcept {
+  auto json_pointer = json_path_to_pointer_conversion(json_path);
+  if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
+  return at_pointer(json_pointer);
 }
 inline simdjson_result<dom::element> simdjson_result<dom::object>::at_key(std::string_view key) const noexcept {
   if (error()) { return error(); }
@@ -129,6 +135,12 @@ inline simdjson_result<element> object::at_pointer(std::string_view json_pointer
     child = child.at_pointer(json_pointer.substr(slash));
   }
   return child;
+}
+
+inline simdjson_result<element> object::at_path(std::string_view json_path) const noexcept {
+  auto json_pointer = json_path_to_pointer_conversion(json_path);
+  if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
+  return at_pointer(json_pointer);
 }
 
 inline simdjson_result<element> object::at_key(std::string_view key) const noexcept {

--- a/include/simdjson/dom/object.h
+++ b/include/simdjson/dom/object.h
@@ -172,6 +172,21 @@ public:
   inline simdjson_result<element> at_pointer(std::string_view json_pointer) const noexcept;
 
   /**
+   * Get the value associated with the given JSONPath expression. We only support
+   * JSONPath queries that trivially convertible to JSON Pointer queries: key
+   * names and array indices.
+   *
+   * https://datatracker.ietf.org/doc/html/draft-normington-jsonpath-00
+   *
+   * @return The value associated with the given JSONPath expression, or:
+   *         - INVALID_JSON_POINTER if the JSONPath to JSON Pointer conversion fails
+   *         - NO_SUCH_FIELD if a field does not exist in an object
+   *         - INDEX_OUT_OF_BOUNDS if an array index is larger than an array length
+   *         - INCORRECT_TYPE if a non-integer is used to access an array
+  */
+  inline simdjson_result<element> at_path(std::string_view json_path) const noexcept;
+
+  /**
    * Get the value associated with the given key.
    *
    * The key will be matched against **unescaped** JSON:
@@ -244,6 +259,7 @@ public:
   inline simdjson_result<dom::element> operator[](std::string_view key) const noexcept;
   inline simdjson_result<dom::element> operator[](const char *key) const noexcept;
   inline simdjson_result<dom::element> at_pointer(std::string_view json_pointer) const noexcept;
+  inline simdjson_result<dom::element> at_path(std::string_view json_path) const noexcept;
   inline simdjson_result<dom::element> at_key(std::string_view key) const noexcept;
   inline simdjson_result<dom::element> at_key_case_insensitive(std::string_view key) const noexcept;
 

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -2,6 +2,7 @@
 
 #ifndef SIMDJSON_CONDITIONAL_INCLUDE
 #define SIMDJSON_GENERIC_ONDEMAND_ARRAY_INL_H
+#include "simdjson/jsonpathutil.h"
 #include "simdjson/generic/ondemand/base.h"
 #include "simdjson/generic/ondemand/array.h"
 #include "simdjson/generic/ondemand/array_iterator-inl.h"
@@ -161,53 +162,6 @@ inline simdjson_result<value> array::at_pointer(std::string_view json_pointer) n
     child = child.at_pointer(json_pointer.substr(i));
   }
   return child;
-}
-
-inline std::string json_path_to_pointer_conversion(std::string_view json_path) {
-  if (json_path.empty() || (json_path.front() != '.' &&
-      json_path.front() != '[')) {
-    return "-1"; // This is just a sentinel value, the caller should check for this and return an error.
-  }
-
-  std::string result;
-  // Reserve space to reduce allocations, adjusting for potential increases due
-  // to escaping.
-  result.reserve(json_path.size() * 2);
-
-  size_t i = 0;
-
-  while (i < json_path.length()) {
-    if (json_path[i] == '.') {
-      result += '/';
-    } else if (json_path[i] == '[') {
-      result += '/';
-      ++i; // Move past the '['
-      while (i < json_path.length() && json_path[i] != ']') {
-          if (json_path[i] == '~') {
-            result += "~0";
-          } else if (json_path[i] == '/') {
-            result += "~1";
-          } else {
-            result += json_path[i];
-          }
-          ++i;
-      }
-      if (i == json_path.length() || json_path[i] != ']') {
-          return "-1"; // Using sentinel value that will be handled as an error by the caller.
-      }
-    } else {
-      if (json_path[i] == '~') {
-          result += "~0";
-      } else if (json_path[i] == '/') {
-          result += "~1";
-      } else {
-          result += json_path[i];
-      }
-    }
-    ++i;
-  }
-
-  return result;
 }
 
 inline simdjson_result<value> array::at_path(std::string_view json_path) noexcept {

--- a/include/simdjson/jsonpathutil.h
+++ b/include/simdjson/jsonpathutil.h
@@ -1,0 +1,65 @@
+#ifndef SIMDJSON_JSONPATHUTIL_H
+#define SIMDJSON_JSONPATHUTIL_H
+
+#include <string>
+#include <string_view>
+
+namespace simdjson {
+/**
+ * Converts JSONPath to JSON Pointer.
+ * @param json_path The JSONPath string to be converted.
+ * @return A string containing the equivalent JSON Pointer.
+ * @throws simdjson_error If the conversion fails.
+ */
+inline std::string json_path_to_pointer_conversion(std::string_view json_path) {
+  size_t i = 0;
+
+  // if JSONPath starts with $, skip it
+  if (!json_path.empty() && json_path.front() == '$') {
+    i = 1;
+  }
+  if (json_path.empty() || (json_path[i] != '.' &&
+      json_path[i] != '[')) {
+    return "-1"; // This is just a sentinel value, the caller should check for this and return an error.
+  }
+
+  std::string result;
+  // Reserve space to reduce allocations, adjusting for potential increases due
+  // to escaping.
+  result.reserve(json_path.size() * 2);
+
+  while (i < json_path.length()) {
+    if (json_path[i] == '.') {
+      result += '/';
+    } else if (json_path[i] == '[') {
+      result += '/';
+      ++i; // Move past the '['
+      while (i < json_path.length() && json_path[i] != ']') {
+          if (json_path[i] == '~') {
+            result += "~0";
+          } else if (json_path[i] == '/') {
+            result += "~1";
+          } else {
+            result += json_path[i];
+          }
+          ++i;
+      }
+      if (i == json_path.length() || json_path[i] != ']') {
+          return "-1"; // Using sentinel value that will be handled as an error by the caller.
+      }
+    } else {
+      if (json_path[i] == '~') {
+          result += "~0";
+      } else if (json_path[i] == '/') {
+          result += "~1";
+      } else {
+          result += json_path[i];
+      }
+    }
+    ++i;
+  }
+
+  return result;
+}
+} // namespace simdjson
+#endif // SIMDJSON_JSONPATHUTIL_H

--- a/tests/dom/CMakeLists.txt
+++ b/tests/dom/CMakeLists.txt
@@ -12,6 +12,7 @@ add_cpp_test(errortests                 LABELS dom acceptance per_implementation
 add_cpp_test(extracting_values_example  LABELS dom acceptance per_implementation)
 add_cpp_test(integer_tests              LABELS dom acceptance per_implementation)
 add_cpp_test(jsoncheck                  LABELS dom acceptance per_implementation)
+add_cpp_test(json_path_tests            LABELS dom acceptance per_implementation)
 add_cpp_test(minefieldcheck             LABELS dom acceptance per_implementation)
 add_cpp_test(numberparsingcheck         LABELS dom acceptance per_implementation) # https://tools.ietf.org/html/rfc6901
 add_cpp_test(parse_many_test            LABELS dom acceptance per_implementation)

--- a/tests/dom/json_path_tests.cpp
+++ b/tests/dom/json_path_tests.cpp
@@ -1,0 +1,344 @@
+/**
+ * refer to pathcheck.cpp
+ */
+
+#include <iostream>
+#include <string>
+using namespace std::string_literals;
+
+#include "simdjson.h"
+#include "test_macros.h"
+
+// we define our own asserts to get around NDEBUG
+#ifndef ASSERT
+#define ASSERT(x)                                                              \
+  {                                                                            \
+    if (!(x)) {                                                                \
+      std::cerr << "Failed assertion " << #x << std::endl;                     \
+      return false;                                                            \
+    }                                                                          \
+  }
+#endif
+
+using namespace simdjson;
+
+bool demo() {
+#if SIMDJSON_EXCEPTIONS
+  std::cout << "demo test" << std::endl;
+  auto cars_json = R"( [
+  { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
+  { "make": "Kia",    "model": "Soul",   "year": 2012, "tire_pressure": [ 30.1, 31.0, 28.6, 28.7 ] },
+  { "make": "Toyota", "model": "Tercel", "year": 1999, "tire_pressure": [ 29.8, 30.0, 30.2, 30.5 ] }
+] )"_padded;
+  dom::parser parser;
+  dom::element cars = parser.parse(cars_json);
+  double x = cars.at_path("$[0].tire_pressure[1]");
+  if (x != 39.9)
+    return false;
+  // Iterating through an array of objects
+  std::vector<double> measured;
+  for (dom::element car_element : cars) {
+    dom::object car;
+    simdjson::error_code error;
+    if ((error = car_element.get(car))) {
+      std::cerr << error << std::endl;
+      return false;
+    }
+    double x3 = car.at_path("$.tire_pressure[1]");
+    measured.push_back(x3);
+  }
+  std::vector<double> expected = {39.9, 31, 30};
+  if (measured != expected) {
+    return false;
+  }
+#endif
+  return true;
+}
+
+const padded_string TEST_JSON = R"(
+  {
+    "/~01abc": [
+      0,
+      {
+        "\\\" 0": [
+          "value0",
+          "value1"
+        ]
+      }
+    ],
+    "0": "0 ok",
+    "01": "01 ok",
+    "": "empty ok",
+    "arr": []
+  }
+)"_padded;
+
+const padded_string TEST_RFC_JSON = R"(
+   {
+      "foo": ["bar", "baz"],
+      "": 0,
+      "a/b": 1,
+      "c%d": 2,
+      "e^f": 3,
+      "g|h": 4,
+      "i\\j": 5,
+      "k\"l": 6,
+      " ": 7,
+      "m~n": 8
+   }
+)"_padded;
+
+bool run_success_test(const padded_string &source, const char *json_path,
+                      std::string_view expected_value) {
+  std::cout << "Running successful JSONPath test '" << json_path << "' ..."
+            << std::endl;
+  dom::parser parser;
+  dom::element doc;
+  auto error = parser.parse(source).get(doc);
+  if (error) {
+    std::cerr << "cannot parse: " << error << std::endl;
+    return false;
+  }
+  dom::element answer;
+  error = doc.at_path(json_path).get(answer);
+  if (error) {
+    std::cerr << "cannot access pointer: " << error << std::endl;
+    return false;
+  }
+  std::string str_answer = simdjson::minify(answer);
+  if (str_answer != expected_value) {
+    std::cerr << "They differ!!!" << std::endl;
+    std::cerr << "   found    '" << str_answer << "'" << std::endl;
+    std::cerr << "   expected '" << expected_value << "'" << std::endl;
+  }
+  ASSERT_EQUAL(str_answer, expected_value);
+  return true;
+}
+
+bool run_failure_test(const padded_string &source, const char *json_path,
+                      error_code expected_error) {
+  std::cout << "Running invalid JSONPath test '" << json_path << "' ..."
+            << std::endl;
+  dom::parser parser;
+  ASSERT_ERROR(parser.parse(source).at_path(json_path).error(), expected_error);
+  return true;
+}
+
+bool demo_relative_path() {
+  TEST_START();
+  auto cars_json = R"( [
+        { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
+        { "make": "Kia",    "model": "Soul",   "year": 2012, "tire_pressure": [ 30.1, 31.0, 28.6, 28.7 ] },
+        { "make": "Toyota", "model": "Tercel", "year": 1999, "tire_pressure": [ 29.8, 30.0, 30.2, 30.5 ] }
+        ] )"_padded;
+
+  dom::parser parser;
+  dom::element cars;
+  std::vector<double> measured;
+  auto error = parser.parse(cars_json).get(cars);
+  if (error) {
+    std::cerr << "cannot parse: " << error << std::endl;
+    return false;
+  }
+  for (auto car_element : cars) {
+    double x;
+    ASSERT_SUCCESS(car_element.at_path(".tire_pressure[1]").get(x));
+    measured.push_back(x);
+  }
+
+  std::vector<double> expected = {39.9, 31, 30};
+  if (measured != expected) {
+    return false;
+  }
+  TEST_SUCCEED();
+}
+
+bool many_json_paths() {
+  TEST_START();
+  auto cars_json = R"( [
+        { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
+        { "make": "Kia",    "model": "Soul",   "year": 2012, "tire_pressure": [ 30.1, 31.0, 28.6, 28.7 ] },
+        { "make": "Toyota", "model": "Tercel", "year": 1999, "tire_pressure": [ 29.8, 30.0, 30.2, 30.5 ] }
+        ] )"_padded;
+
+  dom::parser parser;
+  dom::element cars;
+  std::vector<double> measured;
+  ASSERT_SUCCESS(parser.parse(cars_json).get(cars));
+  for (int i = 0; i < 3; i++) {
+    double x;
+    std::string json_path = std::string("$[") + std::to_string(i) +
+                            std::string("].tire_pressure[1]");
+    ASSERT_SUCCESS(cars.at_path(json_path).get(x));
+    measured.push_back(x);
+  }
+
+  std::vector<double> expected = {39.9, 31, 30};
+  if (measured != expected) {
+    return false;
+  }
+  TEST_SUCCEED();
+}
+
+bool many_json_paths_object_array() {
+  TEST_START();
+  auto dogcatpotato =
+      R"( { "dog" : [1,2,3], "cat" : [5, 6, 7], "potato" : [1234]})"_padded;
+
+  dom::parser parser;
+  dom::element doc;
+  ASSERT_SUCCESS(parser.parse(dogcatpotato).get(doc));
+  dom::object obj;
+  ASSERT_SUCCESS(doc.get_object().get(obj));
+  int64_t x;
+  ASSERT_SUCCESS(obj.at_path("$.dog[1]").get(x));
+  ASSERT_EQUAL(x, 2);
+  ASSERT_SUCCESS(obj.at_path("$.potato[0]").get(x));
+  ASSERT_EQUAL(x, 1234);
+  TEST_SUCCEED();
+}
+bool many_json_paths_object() {
+  TEST_START();
+  auto cfoofoo2 =
+      R"( { "c" :{ "foo": { "a": [ 10, 20, 30 ] }}, "d": { "foo2": { "a": [ 10, 20, 30 ] }} , "e": 120 })"_padded;
+  dom::parser parser;
+  dom::element doc;
+  ASSERT_SUCCESS(parser.parse(cfoofoo2).get(doc));
+  dom::object obj;
+  ASSERT_SUCCESS(doc.get_object().get(obj));
+  int64_t x;
+  ASSERT_SUCCESS(obj.at_path("$.c.foo.a[1]").get(x));
+  ASSERT_EQUAL(x, 20);
+  ASSERT_SUCCESS(obj.at_path("$.d.foo2.a.2").get(x));
+  ASSERT_EQUAL(x, 30);
+  ASSERT_SUCCESS(obj.at_path("$.e").get(x));
+  ASSERT_EQUAL(x, 120);
+  TEST_SUCCEED();
+}
+bool many_json_paths_array() {
+  TEST_START();
+  auto cfoofoo2 =
+      R"( [ 111, 2, 3, { "foo": { "a": [ 10, 20, 33 ] }}, { "foo2": { "a": [ 10, 20, 30 ] }}, 1001 ])"_padded;
+  dom::parser parser;
+  dom::element doc;
+  ASSERT_SUCCESS(parser.parse(cfoofoo2).get(doc));
+  dom::array arr;
+  ASSERT_SUCCESS(doc.get_array().get(arr));
+  int64_t x;
+  ASSERT_SUCCESS(arr.at_path("$[3].foo.a[1]").get(x));
+  ASSERT_EQUAL(x, 20);
+  TEST_SUCCEED();
+}
+struct car_type {
+  std::string make;
+  std::string model;
+  uint64_t year;
+  std::vector<double> tire_pressure;
+  car_type(std::string_view _make, std::string_view _model, uint64_t _year,
+           std::vector<double> &&_tire_pressure)
+      : make{_make}, model{_model}, year(_year), tire_pressure(_tire_pressure) {
+  }
+};
+
+bool json_path_invalidation() {
+  TEST_START();
+  auto cars_json = R"( [
+        { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
+        { "make": "Kia",    "model": "Soul",   "year": 2012, "tire_pressure": [ 30.1, 31.0, 28.6, 28.7 ] },
+        { "make": "Toyota", "model": "Tercel", "year": 1999, "tire_pressure": [ 29.8, 30.0, 30.2, 30.5 ] }
+        ] )"_padded;
+
+  dom::parser parser;
+  dom::element cars;
+  std::vector<double> measured;
+  ASSERT_SUCCESS(parser.parse(cars_json).get(cars));
+  std::vector<car_type> content;
+  for (int i = 0; i < 3; i++) {
+    dom::object obj;
+    std::string json_path =
+        std::string("$[") + std::to_string(i) + std::string("]");
+    // Each successive at_path call invalidates
+    // previously parsed values, strings, objects and array.
+    ASSERT_SUCCESS(cars.at_path(json_path).get(obj));
+    // We materialize the object.
+    std::string_view make;
+    ASSERT_SUCCESS(obj["make"].get(make));
+    std::string_view model;
+    ASSERT_SUCCESS(obj["model"].get(model));
+    uint64_t year;
+    ASSERT_SUCCESS(obj["year"].get(year));
+    // We materialize the array.
+    dom::array arr;
+    ASSERT_SUCCESS(obj["tire_pressure"].get(arr));
+    std::vector<double> values;
+    for (auto x : arr) {
+      double value_double;
+      ASSERT_SUCCESS(x.get(value_double));
+      values.push_back(value_double);
+    }
+    content.emplace_back(make, model, year, std::move(values));
+  }
+  std::string expected[] = {"Toyota", "Kia", "Toyota"};
+  int i = 0;
+  for (car_type c : content) {
+    std::cout << c.make << " " << c.model << " " << c.year << "\n";
+    ASSERT_EQUAL(expected[i++], c.make);
+  }
+  TEST_SUCCEED();
+}
+// for 0.5 version and following (standard compliant)
+bool modern_support() {
+#if SIMDJSON_EXCEPTIONS
+  std::cout << "modern test" << std::endl;
+  auto example_json = R"({"key": "value", "array": [0, 1, 2]})"_padded;
+  dom::parser parser;
+  dom::element example = parser.parse(example_json);
+  std::string_view value_str = example.at_path("$.key");
+  ASSERT_EQUAL(value_str, "value");
+  int64_t array0 = example.at_path("$.array[0]");
+  ASSERT_EQUAL(array0, 0);
+  array0 = example.at_path("$.array").at_path("$[0]");
+  ASSERT_EQUAL(array0, 0);
+  ASSERT_ERROR(example.at_path("$.no_such_key").error(), NO_SUCH_FIELD);
+  ASSERT_ERROR(example.at_path("$.array[9]").error(), INDEX_OUT_OF_BOUNDS);
+  ASSERT_ERROR(example.at_path("$.array.not_a_num").error(), INCORRECT_TYPE);
+  ASSERT_ERROR(example.at_path("$.array.").error(), INVALID_JSON_POINTER);
+#endif
+  return true;
+}
+
+int main() {
+  if (true && demo() && modern_support() &&
+      run_success_test(TEST_RFC_JSON, "$.foo", "[\"bar\",\"baz\"]") &&
+      run_success_test(TEST_RFC_JSON, "$.foo[0]", "\"bar\"") &&
+      run_success_test(TEST_RFC_JSON, "$.", "0") &&
+      run_success_test(TEST_RFC_JSON, "$.a/b", "1") &&
+      run_success_test(TEST_RFC_JSON, "$.c%d", "2") &&
+      run_success_test(TEST_RFC_JSON, "$.e^f", "3") &&
+      run_success_test(TEST_RFC_JSON, "$.g|h", "4") &&
+      run_success_test(TEST_RFC_JSON, "$.i\\j", "5") &&
+      run_success_test(TEST_RFC_JSON, "$.k\"l", "6") &&
+      run_success_test(TEST_RFC_JSON, "$. ", "7") &&
+      run_success_test(TEST_RFC_JSON, "$.m~n", "8") &&
+      run_success_test(TEST_JSON, "$./~01abc",
+                       R"([0,{"\\\" 0":["value0","value1"]}])") &&
+      run_success_test(TEST_JSON, "$./~01abc[1]",
+                       R"({"\\\" 0":["value0","value1"]})") &&
+      run_success_test(TEST_JSON, "$./~01abc[1].\\\" 0",
+                       R"(["value0","value1"])") &&
+      run_success_test(TEST_JSON, "$.arr", R"([])") // get array
+      &&
+      run_failure_test(TEST_JSON, R"($./~01abc[1].\\\" 0[2])", NO_SUCH_FIELD) &&
+      run_failure_test(TEST_JSON, "$.arr[0]", INDEX_OUT_OF_BOUNDS) &&
+      run_failure_test(TEST_JSON, "/~01abc", INVALID_JSON_POINTER) &&
+      run_failure_test(TEST_JSON, ".~1abc", NO_SUCH_FIELD) &&
+      run_failure_test(TEST_JSON, "./~01abc.01", INVALID_JSON_POINTER) &&
+      run_failure_test(TEST_JSON, "./~01abc.", INVALID_JSON_POINTER) &&
+      run_failure_test(TEST_JSON, "./~01abc.-", INDEX_OUT_OF_BOUNDS)) {
+    std::cout << "Success!" << std::endl;
+    return 0;
+  } else {
+    std::cerr << "Failed!" << std::endl;
+    return 1;
+  }
+}

--- a/tests/ondemand/ondemand_json_path_tests.cpp
+++ b/tests/ondemand/ondemand_json_path_tests.cpp
@@ -346,6 +346,54 @@ namespace json_path_tests {
         TEST_SUCCEED();
     }
 
+    bool many_json_paths_with_prefix() {
+        TEST_START();
+        // object
+        {
+            auto cfoofoo2 = R"( { "c" :{ "foo": { "a": [ 10, 20, 30 ] }}, "d": { "foo2": { "a": [ 10, 20, 30 ] }} , "e": 120 })"_padded;
+            ondemand::parser parser;
+            ondemand::document doc;
+            ASSERT_SUCCESS(parser.iterate(cfoofoo2).get(doc));
+            ondemand::object obj;
+            ASSERT_SUCCESS(doc.get_object().get(obj));
+            int64_t x;
+            ASSERT_SUCCESS(obj.at_path("$.c.foo.a[1]").get(x));
+            ASSERT_EQUAL(x, 20);
+            ASSERT_SUCCESS(obj.at_path("$.d.foo2.a.2").get(x));
+            ASSERT_EQUAL(x, 30);
+            ASSERT_SUCCESS(obj.at_path("$.e").get(x));
+            ASSERT_EQUAL(x, 120);
+        }
+        // array
+        {
+            auto cfoofoo2 = R"( [ 111, 2, 3, { "foo": { "a": [ 10, 20, 33 ] }}, { "foo2": { "a": [ 10, 20, 30 ] }}, 1001 ])"_padded;
+            ondemand::parser parser;
+            ondemand::document doc;
+            ASSERT_SUCCESS(parser.iterate(cfoofoo2).get(doc));
+            ondemand::array arr;
+            ASSERT_SUCCESS(doc.get_array().get(arr));
+            int64_t x;
+            ASSERT_SUCCESS(arr.at_path("$[3].foo.a[1]").get(x));
+            ASSERT_EQUAL(x, 20);
+        }
+        // onject array
+        {
+            auto dogcatpotato = R"( { "dog" : [1,2,3], "cat" : [5, 6, 7], "potato" : [1234]})"_padded;
+
+            ondemand::parser parser;
+            ondemand::document doc;
+            ASSERT_SUCCESS(parser.iterate(dogcatpotato).get(doc));
+            ondemand::object obj;
+            ASSERT_SUCCESS(doc.get_object().get(obj));
+            int64_t x;
+            ASSERT_SUCCESS(obj.at_path("$.dog[1]").get(x));
+            ASSERT_EQUAL(x, 2);
+            ASSERT_SUCCESS(obj.at_path("$.potato[0]").get(x));
+            ASSERT_EQUAL(x, 1234);
+        }
+        TEST_SUCCEED();
+    }
+
 #if SIMDJSON_EXCEPTIONS
     bool json_path_invalidation_exceptions() {
         TEST_START();
@@ -392,6 +440,7 @@ namespace json_path_tests {
                 many_json_paths_array() &&
                 many_json_paths_object() &&
                 many_json_paths_object_array() &&
+                many_json_paths_with_prefix() &&
                 run_broken_tests() &&
                 json_path_invalidation() &&
                 demo_test() &&


### PR DESCRIPTION
- Updated `json_path_to_pointer_conversion` to support JSONPath starting with the '$' prefix, while maintaining compatibility with the existing implementation.
- Moved `json_path_to_pointer_conversion` to a separate header file for better modularity and to support JSONPath queries in `dom` mode.
- Implemented `at_path` functionality in `dom` mode to enable querying JSON using JSONPath.
- Added unit tests to validate the new JSONPath support in `dom` mode and ensure compatibility with both standard and existing JSONPath formats.

