### PR TITLE
documentation for threading...

### DIFF
--- a/doc/iterate_many.md
+++ b/doc/iterate_many.md
@@ -102,7 +102,12 @@ remove almost entirely its cost and replaces it by the overhead of a thread, whi
 cheaper. Ain't that awesome!
 
 Thread support is only active if thread supported is detected in which case the macro
-SIMDJSON_THREADS_ENABLED is set. Otherwise the library runs in  single-thread mode.
+SIMDJSON_THREADS_ENABLED is set.  You can also manually pass `SIMDJSON_THREADS_ENABLED=1` flag
+to the library. Otherwise the library runs in single-thread mode.
+
+You should be consistent. If you link against the simdjson library built for multithreading
+(i.e., with `SIMDJSON_THREADS_ENABLED`), then you should build your application with multithreading
+system (setting `SIMDJSON_THREADS_ENABLED=1` and linking against a thread library).
 
 A `document_stream` instance uses at most two threads: there is a main thread and a worker thread.
 

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -106,6 +106,10 @@ Thread support is only active if thread supported is detected in which case the 
 SIMDJSON_THREADS_ENABLED is set.  You can also manually pass `SIMDJSON_THREADS_ENABLED=1` flag
 to the library. Otherwise the library runs in single-thread mode.
 
+You should be consistent. If you link against the simdjson library built for multithreading
+(i.e., with `SIMDJSON_THREADS_ENABLED`), then you should build your application with multithreading
+system (setting `SIMDJSON_THREADS_ENABLED=1` and linking against a thread library).
+
 A `document_stream` instance uses at most two threads: there is a main thread and a worker thread.
 You should expect the main thread to be fully occupied while the worker thread is partially busy
 (e.g., 80% of the time).

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -549,9 +549,14 @@ public:
   /**
    * The parser instance can use threads when they are available to speed up some
    * operations. It is enabled by default. Changing this attribute will change the
-   * behavior of the parser for future operations.
+   * behavior of the parser for future operations. Set to true by default.
    */
   bool threaded{true};
+#else
+  /**
+   * When SIMDJSON_THREADS_ENABLED is not defined, the parser instance cannot use threads.
+   */
+  const bool threaded{false};
 #endif
   /** @private Use the new DOM API instead */
   class Iterator;

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -556,7 +556,7 @@ public:
   /**
    * When SIMDJSON_THREADS_ENABLED is not defined, the parser instance cannot use threads.
    */
-  const bool threaded{false};
+  bool threaded{false};
 #endif
   /** @private Use the new DOM API instead */
   class Iterator;

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -282,7 +282,7 @@ public:
   /**
    * When SIMDJSON_THREADS_ENABLED is not defined, the parser instance cannot use threads.
    */
-  const bool threaded{false};
+  bool threaded{false};
   #endif
   /**
    * Unescape this JSON string, replacing \\ with \, \n with newline, etc. to a user-provided buffer.

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -278,8 +278,12 @@ public:
    * behavior of the parser for future operations.
    */
   bool threaded{true};
+  #else
+  /**
+   * When SIMDJSON_THREADS_ENABLED is not defined, the parser instance cannot use threads.
+   */
+  const bool threaded{false};
   #endif
-
   /**
    * Unescape this JSON string, replacing \\ with \, \n with newline, etc. to a user-provided buffer.
    * The result must be valid UTF-8.


### PR DESCRIPTION
Making it explicit that we do not support calling the simdjson library built with multithreading from an application without multithreading support. Users should pick: if multithreading is enabled in the simdjson library, then they need to have multithreading in the their application.

Related to https://github.com/simdjson/simdjson/issues/2275