### PR TITLE
adding pad function

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -209,6 +209,18 @@ std::string data = "my data";
 simdjson::padded_string my_padded_data(data); // copies to a padded buffer
 ```
 
+Whenever you pass an `std::string` reference to `parser::iterate`,
+the parser will access the bytes beyond the end of
+the string but before the end of the allocated memory (`std::string::capacity()`).
+If you are using a sanitizer that checks for reading uninitialized bytes or `std::string`'s
+container-overflow checks, you may encounter sanitizer warnings.
+You can safely ignore these warnings. Or you can call `simdjson::pad(std::string&)` to pad the
+string with `SIMDJSON_PADDING` spaces: this function returns a `simdjson::padding_string_view` which can be be passed to the parser's iterator function:
+
+```c++
+std::string json = "[1]";
+ondemand::document doc = parser.iterate(simdjson::pad(json));
+```
 
 We recommend against creating many `std::string` or many `std::padding_string` instances in your application to store your JSON data.
 Consider reusing the same buffers and limiting memory allocations.

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -60,6 +60,19 @@ std::string data = "my data";
 simdjson::padded_string my_padded_data(data); // copies to a padded buffer
 ```
 
+Whenever you pass an `std::string` reference to `parser::parse`,
+the parser will access the bytes beyond the end of
+the string but before the end of the allocated memory (`std::string::capacity()`).
+If you are using a sanitizer that checks for reading uninitialized bytes or `std::string`'s
+container-overflow checks, you may encounter sanitizer warnings.
+You can safely ignore these warnings. Or you can call `simdjson::pad(std::string&)` to pad the
+string with `SIMDJSON_PADDING` spaces: this function returns a `simdjson::padding_string_view` which can be be passed to the parser's iterator function:
+
+```c++
+std::string json = "[1]";
+dom::element doc = parser.parse(simdjson::pad(json));
+```
+
 The parsed document resulting from the `parser.load` and `parser.parse` calls depends on the `parser` instance. Thus the `parser` instance must remain in scope. Furthermore, you must have at most one parsed document in play per `parser` instance.
 You cannot copy a `parser` instance, you may only move it.
 

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -202,6 +202,22 @@ public:
    *   simdjson::dom::parser parser;
    *   simdjson::dom::element element = parser.parse(padded_json_copy.get(), json_len, false);
    *
+   * ### std::string references
+   *
+   * If you pass a mutable std::string reference (std::string&), the parser will seek to extend
+   * its capacity to SIMDJSON_PADDING bytes beyond the end of the string.
+   *
+   * Whenever you pass an std::string reference, the parser will access the bytes beyond the end of
+   * the string but before the end of the allocated memory (std::string::capacity()).
+   * If you are using a sanitizer that checks for reading uninitialized bytes or std::string's
+   * container-overflow checks, you may encounter sanitizer warnings.
+   * You can safely ignore these warnings. Or you can call simdjson::pad(std::string&) to pad the
+   * string with SIMDJSON_PADDING spaces: this function returns a simdjson::padding_string_view
+   * which can be be passed to the parser's parse function:
+   *
+   *    std::string json = R"({ "foo": 1 } { "foo": 2 } { "foo": 3 } )";
+   *    element doc = parser.parse(simdjson::pad(json));
+   *
    * ### Parser Capacity
    *
    * If the parser's current capacity is less than len, it will allocate enough capacity

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -84,6 +84,22 @@ public:
    * using a sanitizer that verifies that no uninitialized byte is read, then you should initialize the
    * SIMDJSON_PADDING bytes to avoid runtime warnings.
    *
+   * ### std::string references
+   *
+   * If you pass a mutable std::string reference (std::string&), the parser will seek to extend
+   * its capacity to SIMDJSON_PADDING bytes beyond the end of the string.
+   *
+   * Whenever you pass an std::string reference, the parser will access the bytes beyond the end of
+   * the string but before the end of the allocated memory (std::string::capacity()).
+   * If you are using a sanitizer that checks for reading uninitialized bytes or std::string's
+   * container-overflow checks, you may encounter sanitizer warnings.
+   * You can safely ignore these warnings. Or you can call simdjson::pad(std::string&) to pad the
+   * string with SIMDJSON_PADDING spaces: this function returns a simdjson::padding_string_view
+   * which can be be passed to the parser's iterate function:
+   *
+   *    std::string json = R"({ "foo": 1 } { "foo": 2 } { "foo": 3 } )";
+   *    document doc = parser.iterate(simdjson::pad(json));
+   *
    * @param json The JSON to parse.
    * @param len The length of the JSON.
    * @param capacity The number of bytes allocated in the JSON (must be at least len+SIMDJSON_PADDING).

--- a/include/simdjson/padded_string_view-inl.h
+++ b/include/simdjson/padded_string_view-inl.h
@@ -53,6 +53,11 @@ inline bool padded_string_view::remove_utf8_bom() noexcept {
 inline std::ostream& operator<<(std::ostream& out, simdjson_result<padded_string_view> &s) noexcept(false) { return out << s.value(); }
 #endif
 
+inline padded_string_view pad(std::string& s) noexcept {
+  const auto len = s.size();
+  s.append(SIMDJSON_PADDING, ' ');
+  return padded_string_view(s.data(), len, s.size());
+}
 } // namespace simdjson
 
 

--- a/include/simdjson/padded_string_view.h
+++ b/include/simdjson/padded_string_view.h
@@ -83,6 +83,15 @@ public:
 inline std::ostream& operator<<(std::ostream& out, simdjson_result<padded_string_view> &s) noexcept(false);
 #endif
 
+/**
+ * Create a padded_string_view from a string. The string will be padded with SIMDJSON_PADDING
+ * space characters. The resulting padded_string_view will have a length equal to the original
+ * string.
+ *
+ * @param s The string.
+ * @return The padded string.
+ */
+inline padded_string_view pad(std::string& s) noexcept;
 } // namespace simdjson
 
 #endif // SIMDJSON_PADDED_STRING_VIEW_H

--- a/tests/dom/readme_examples.cpp
+++ b/tests/dom/readme_examples.cpp
@@ -461,6 +461,13 @@ void parse_documentation_lowlevel() {
   (void)element;
 }
 
+void simplepad() {
+  std::string json = "[1]";
+  dom::parser parser;
+  dom::element doc;
+  auto error = parser.parse(simdjson::pad(json)).get(doc);
+  if(error) { exit(-1); }
+}
 
 void jsondollar() {
   dom::parser parser;
@@ -497,6 +504,7 @@ void jsonpath() {
 }
 
 int main() {
+  simplepad();
   jsonpath();
   jsondollar();
   basics_dom_1();

--- a/tests/ondemand/ondemand_readme_examples.cpp
+++ b/tests/ondemand/ondemand_readme_examples.cpp
@@ -8,7 +8,15 @@
 #endif
 using namespace std;
 using namespace simdjson;
-using error_code=simdjson::error_code;
+using error_code = simdjson::error_code;
+
+bool simplepad() {
+  std::string json = "[1]";
+  ondemand::parser parser;
+  ondemand::document doc;
+  auto error = parser.iterate(simdjson::pad(json)).get(doc);
+  return error == SUCCESS;
+}
 
 bool string1() {
   const char * data = "my data"; // 7 bytes
@@ -1918,6 +1926,7 @@ bool run() {
     && using_the_parsed_json_4()
     && using_the_parsed_json_5()
 #endif
+    && simplepad()
     && using_the_parsed_json_6()
     && json_pointer_simple()
     && json_pointer_unicode()


### PR DESCRIPTION
For convenience, we allow people to pass an `std::string` instance to our parsing functions. When needed, these function increase the capacity of the string to provide padding. Sadly, some recently introduced sanity checkers spot the fact that we access data beyond the string and they flag it as an error. It is a false positive, but it leaves our users with a warning to ignore.

To make life easier, this PR introduce a 'pad' function which grows the string and returns a `padding_string_view`.
