### PR TITLE
fix: fix deprecation from -Wdeprecated-literal-operator

### DIFF
--- a/include/simdjson/padded_string-inl.h
+++ b/include/simdjson/padded_string-inl.h
@@ -187,11 +187,11 @@ inline simdjson_result<padded_string> padded_string::load(std::string_view filen
 
 } // namespace simdjson
 
-inline simdjson::padded_string operator "" _padded(const char *str, size_t len) {
+inline simdjson::padded_string operator ""_padded(const char *str, size_t len) {
   return simdjson::padded_string(str, len);
 }
 #ifdef __cpp_char8_t
-inline simdjson::padded_string operator "" _padded(const char8_t *str, size_t len) {
+inline simdjson::padded_string operator ""_padded(const char8_t *str, size_t len) {
   return simdjson::padded_string(reinterpret_cast<const char8_t *>(str), len);
 }
 #endif

--- a/include/simdjson/padded_string.h
+++ b/include/simdjson/padded_string.h
@@ -161,9 +161,9 @@ inline std::ostream& operator<<(std::ostream& out, simdjson_result<padded_string
 } // namespace simdjson
 
 // This is deliberately outside of simdjson so that people get it without having to use the namespace
-inline simdjson::padded_string operator "" _padded(const char *str, size_t len);
+inline simdjson::padded_string operator ""_padded(const char *str, size_t len);
 #ifdef __cpp_char8_t
-inline simdjson::padded_string operator "" _padded(const char8_t *str, size_t len);
+inline simdjson::padded_string operator ""_padded(const char8_t *str, size_t len);
 #endif
 
 namespace simdjson {


### PR DESCRIPTION
Otherwise simdjson doesn't build with V8's Node.js fork, which uses -Werror,-Wdeprecated-literal-operator and latest version of clang.

