### PR TITLE
let us be more careful with concepts, we require __cpp_concepts >= 201907L and check for old versions of Apple clang

### DIFF
--- a/include/simdjson/compiler_check.h
+++ b/include/simdjson/compiler_check.h
@@ -56,11 +56,13 @@
 #endif
 #endif
 
-#if defined(__APPLE__) && defined(__clang__)
-#if __clang_major__ <= 13
+#endif
+#if defined(__apple_build_version__)
+#if __apple_build_version__ < 14000000
 #define SIMDJSON_CONCEPT_DISABLED 1 // apple-clang/13 doesn't support std::convertible_to
 #endif
 #endif
+
 
 #if defined(__cpp_concepts) && !defined(SIMDJSON_CONCEPT_DISABLED)
 #if __cpp_concepts >= 201907L

--- a/include/simdjson/compiler_check.h
+++ b/include/simdjson/compiler_check.h
@@ -57,8 +57,12 @@
 #endif
 
 #if defined(__cpp_concepts) && !defined(SIMDJSON_CONCEPT_DISABLED)
+#if __cpp_concepts >= 202002L
 #include <utility>
 #define SIMDJSON_SUPPORTS_DESERIALIZATION 1
+#else
+#define SIMDJSON_SUPPORTS_DESERIALIZATION 0
+#endif
 #else // defined(__cpp_concepts) && !defined(SIMDJSON_CONCEPT_DISABLED)
 #define SIMDJSON_SUPPORTS_DESERIALIZATION 0
 #endif // defined(__cpp_concepts) && !defined(SIMDJSON_CONCEPT_DISABLED)

--- a/include/simdjson/compiler_check.h
+++ b/include/simdjson/compiler_check.h
@@ -56,7 +56,6 @@
 #endif
 #endif
 
-#endif
 #if defined(__apple_build_version__)
 #if __apple_build_version__ < 14000000
 #define SIMDJSON_CONCEPT_DISABLED 1 // apple-clang/13 doesn't support std::convertible_to

--- a/include/simdjson/compiler_check.h
+++ b/include/simdjson/compiler_check.h
@@ -56,8 +56,14 @@
 #endif
 #endif
 
+#if defined(__APPLE__) && defined(__clang__)
+#if __clang_major__ <= 13
+#define SIMDJSON_CONCEPT_DISABLED 1 // apple-clang/13 doesn't support std::convertible_to
+#endif
+#endif
+
 #if defined(__cpp_concepts) && !defined(SIMDJSON_CONCEPT_DISABLED)
-#if __cpp_concepts >= 202002L
+#if __cpp_concepts >= 201907L
 #include <utility>
 #define SIMDJSON_SUPPORTS_DESERIALIZATION 1
 #else


### PR DESCRIPTION
See https://github.com/nodejs/node/pull/56250