### PR TITLE
fixing performance issue under Zen 4 processors

### DIFF
--- a/include/simdjson/icelake/simd.h
+++ b/include/simdjson/icelake/simd.h
@@ -148,14 +148,18 @@ namespace simd {
 
     // Copies to 'output" all bytes corresponding to a 0 in the mask (interpreted as a bitset).
     // Passing a 0 value for mask would be equivalent to writing out every byte to output.
-    // Only the first 32 - count_ones(mask) bytes of the result are significant but 32 bytes
+    // Only the first 64 - count_ones(mask) bytes of the result are significant but 64 bytes
     // get written.
     // Design consideration: it seems like a function with the
     // signature simd8<L> compress(uint32_t mask) would be
     // sensible, but the AVX ISA makes this kind of approach difficult.
     template<typename L>
     simdjson_inline void compress(uint64_t mask, L * output) const {
-      _mm512_mask_compressstoreu_epi8 (output,~mask,*this);
+      // we deliberately avoid _mm512_mask_compressstoreu_epi8 for portability
+      // (AMD Zen4 has terrible performance with it, it is effectively broken)
+      // _mm512_mask_compressstoreu_epi8 (output,~mask,*this);
+      __m512i compressed = _mm512_maskz_compress_epi8(~mask, *this);
+      _mm512_storeu_epi8(output, compressed); // could use a mask
     }
 
     template<typename L>

--- a/include/simdjson/icelake/simd.h
+++ b/include/simdjson/icelake/simd.h
@@ -159,7 +159,7 @@ namespace simd {
       // (AMD Zen4 has terrible performance with it, it is effectively broken)
       // _mm512_mask_compressstoreu_epi8 (output,~mask,*this);
       __m512i compressed = _mm512_maskz_compress_epi8(~mask, *this);
-      _mm512_storeu_epi8(output, compressed); // could use a mask
+      _mm512_storeu_si512(output, compressed); // could use a mask
     }
 
     template<typename L>


### PR DESCRIPTION
On a Zen 4 processor:

Before:

```
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
fast_minify_twitter/repeats:10_mean       505635 ns       505492 ns           10 Gigabytes=1.24931G/s docs=1.97828k/s
```

After:

```
------------------------------------------------------------------------------------------------
Benchmark                                      Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------------
fast_minify_twitter/repeats:10_mean        29382 ns        29374 ns           10 Gigabytes=21.5023G/s docs=34.0488k/s
```


Fixes  https://github.com/simdjson/simdjson/issues/2334
