### PR TITLE
doc: replace ndjson[dot]org with ndjson spec

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1986,7 +1986,7 @@ serialize data into streams of multiple JSON documents. That is, instead of one 
 write out multiple records as independent JSON documents, to be read one-by-one.
 
 The simdjson library also supports multithreaded JSON streaming through a large file
-containing many smaller JSON documents in either [ndjson](http://ndjson.org)
+containing many smaller JSON documents in either [ndjson](https://github.com/ndjson/ndjson-spec)
 or [JSON lines](http://jsonlines.org) format. If your JSON documents all contain arrays
 or objects, we even support direct file concatenation without whitespace. However, if there
 is content between your JSON documents, it should be exclusively ASCII white-space characters.

--- a/doc/iterate_many.md
+++ b/doc/iterate_many.md
@@ -130,7 +130,7 @@ If your documents are all objects or arrays, then you may even have nothing betw
 E.g., `[1,2]{"32":1}` is recognized as two documents.
 
 Some official formats **(non-exhaustive list)**:
-- [Newline-Delimited JSON (NDJSON)](http://ndjson.org/)
+- [Newline-Delimited JSON (NDJSON)](https://github.com/ndjson/ndjson-spec/)
 - [JSON lines (JSONL)](http://jsonlines.org/)
 - [Record separator-delimited JSON (RFC 7464)](https://tools.ietf.org/html/rfc7464) <- Not supported by JsonStream!
 - [More on Wikipedia...](https://en.wikipedia.org/wiki/JSON_streaming)


### PR DESCRIPTION
the `ndjson[dot]org` expired, and point to incorrect website with malware. more in https://github.com/ndjson/ndjson.github.io/issues/24

follow up #2234

