### PR TITLE
Add link to zimdjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ We distinguish between "bindings" (which just wrap the C++ code) and a port to a
 - [simdjsone](https://github.com/saleyn/simdjsone): erlang bindings.
 - [lua-simdjson](https://github.com/FourierTransformer/lua-simdjson): lua bindings.
 - [hermes-json](https://hackage.haskell.org/package/hermes-json): haskell bindings.
-- [simdjzon](https://github.com/travisstaloch/simdjzon): zig port.
+- [zimdjson](https://github.com/EzequielRamis/zimdjson): Zig port.
+- [simdjzon](https://github.com/travisstaloch/simdjzon): Zig port.
 - [JSON-Simd](https://github.com/rawleyfowler/JSON-simd): Raku bindings.
 - [JSON::SIMD](https://metacpan.org/pod/JSON::SIMD): Perl bindings; fully-featured JSON module that uses simdjson for decoding.
 - [gemmaJSON](https://github.com/sainttttt/gemmaJSON): Nim JSON parser based on simdjson bindings.


### PR DESCRIPTION
Hi Daniel, I'm writting to you because I'm excited to show you [zimdjson](https://github.com/EzequielRamis/zimdjson), a Zig port of simdjson that took me a year and a half to develop. Besides it is a "port", I've added to it new features and resolved some open issues you have here, which may fit in the C++ implementation.

- I've removed the padding requirement following ideas from https://github.com/simdjson/simdjson/issues/1686, now the parser handles the end of the input with an internal buffer. In very old commits I've managed to have the DOM parser to have a constant-size buffer (because of inlining) but the code was horrible, so I've decided to opt-in with a variable-size buffer which On-Demand can also utilize. The good news is that this buffer has not an average O(n) of memory, being n the input size, but an average O(k), where k is the largest JSON literal / whitespace located at the end of the input, something insignificant in comparison. This solution is good enough for day-to-day documents, except for large single-element documents, but that's a peeky problem. In terms of performance, it bound checks per token instead of checking inside the element parsers like what happens in this PR https://github.com/simdjson/simdjson/pull/1665, so there is not a lot of performance regression.

- In the above issue and in this https://github.com/simdjson/simdjson/issues/128 is recurrent the talk about some streaming feature and about being able to support very large files. These ideas converged to a general streaming parser (not to be confused with `iterate_many`) which can handle large monolithic documents with O(1) of memory usage. In this mode, the DOM is able to handle up to ~34GB files. Better than that, the On-Demand got lazier and has practically no limit. The only cost you have to pay is that the distance between each token doesn't exceed the chunk length, but that cost is similar to `iterate_many`, where you must make sure the documents fit in the buffer. In my README below there are some benchmarks showing how the streaming parser performs.

- Finally I want to mention that I could integrate reflection inside On-Demand nicely (only deserialization), something you are trying to achieve until C++26 is released https://github.com/simdjson/simdjson/pull/2282. In summary, it behaves like [Serde](https://serde.rs), but I don't know if you have different thoughts about it.

That's all for now, I hope you can find something useful of my work.