### PR TITLE
Map proto

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1243,7 +1243,6 @@ int main() {
 You may also conditionally fill in `std::optional` values.
 
 ```C++
-
   padded_string json =
       R"( { "car1": { "make": "Toyota", "model": "Camry",  "year": 2018,
        "tire_pressure": [ 40.1, 39.9 ] }
@@ -1255,6 +1254,23 @@ You may also conditionally fill in `std::optional` values.
   // car has no value, error != simdjson::SUCCESS
   error = doc["car1"].get<std::optional<Car>>().get(car);
   // car has value Car{"Toyota", "Camry", 2018, {40.1f, 39.9f}}
+  // error is simdjson::SUCCESS
+```
+
+You can also deserialized to map-like types with keys that can be constructed
+from `std::string_view` instances:
+
+
+```C++
+  padded_string json =
+      R"( { "car1": { "make": "Toyota", "model": "Camry",  "year": 2018,
+       "tire_pressure": [ 40.1, 39.9 ] }
+})"_padded;
+  ondemand::parser parser;
+  ondemand::document doc = parser.iterate(json);
+  std:map<std::string,Car> cars;
+  error = doc.get<std:map<std::string,Car>>().get(cars);
+  // car has value car1->Car{"Toyota", "Camry", 2018, {40.1f, 39.9f}}
   // error is simdjson::SUCCESS
 ```
 

--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -32,14 +32,30 @@ SIMDJSON_IMPL_CONCEPT(op_append, operator+=)
 #undef SIMDJSON_IMPL_CONCEPT
 } // namespace details
 
+
+template <typename T>
+concept string_view_like = std::is_convertible_v<T, std::string_view> &&
+                           !std::is_convertible_v<T, const char*>;
+
+template<typename T>
+concept constructible_from_string_view = std::is_constructible_v<T, std::string_view>
+                                        && !std::is_same_v<T, std::string_view>
+                                        && std::is_default_constructible_v<T>;
+
+template<typename M>
+concept string_view_keyed_map = string_view_like<typename M::key_type>
+              && requires(std::remove_cvref_t<M>& m, typename M::key_type sv, typename M::mapped_type v) {
+    { m.emplace(sv, v) } -> std::same_as<std::pair<typename M::iterator, bool>>;
+};
+
 /// Check if T is a container that we can append to, including:
 ///   std::vector, std::deque, std::list, std::string, ...
 template <typename T>
 concept appendable_containers =
-    details::supports_emplace_back<T> || details::supports_emplace<T> ||
+    (details::supports_emplace_back<T> || details::supports_emplace<T> ||
     details::supports_push_back<T> || details::supports_push<T> ||
     details::supports_add<T> || details::supports_append<T> ||
-    details::supports_insert<T>;
+    details::supports_insert<T>) && !string_view_keyed_map<T>;
 
 /// Insert into the container however possible
 template <appendable_containers T, typename... Args>
@@ -107,20 +123,6 @@ concept optional_type = requires(std::remove_cvref_t<T> obj) {
   { static_cast<bool>(obj) } -> std::same_as<bool>; // convertible to bool
 };
 
-template <typename T>
-concept string_view_like = std::is_convertible_v<T, std::string_view> &&
-                           !std::is_convertible_v<T, const char*>;
-
-template<typename T, typename U>
-concept constructible_from_string_view = string_view_like<U> && requires(T t, U sv) {
-    T{sv};
-};
-
-template<typename M, typename U>
-concept string_view_keyed_map = string_view_like<U> && requires(M m, U sv,
-                                              typename M::mapped_type v) {
-    { m.emplace(sv, v) } -> std::same_as<std::pair<typename M::iterator, bool>>;
-};
 
 
 } // namespace concepts

--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -107,6 +107,22 @@ concept optional_type = requires(std::remove_cvref_t<T> obj) {
   { static_cast<bool>(obj) } -> std::same_as<bool>; // convertible to bool
 };
 
+template <typename T>
+concept string_view_like = std::is_convertible_v<T, std::string_view> &&
+                           !std::is_convertible_v<T, const char*>;
+
+template<typename T, typename U>
+concept constructible_from_string_view = string_view_like<U> && requires(T t, U sv) {
+    T{sv};
+};
+
+template<typename M, typename U>
+concept string_view_keyed_map = string_view_like<U> && requires(M m, U sv,
+                                              typename M::mapped_type v) {
+    { m.emplace(sv, v) } -> std::same_as<std::pair<typename M::iterator, bool>>;
+};
+
+
 } // namespace concepts
 } // namespace simdjson
 #endif // SIMDJSON_SUPPORTS_DESERIALIZATION

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -239,20 +239,27 @@ public:
     if constexpr (custom_deserializable<T, document>) {
         return deserialize(*this, out);
     } else {
-#endif // SIMDJSON_SUPPORTS_DESERIALIZATION
-      // Unless the simdjson library or the user provides an inline implementation, calling this method should
-      // immediately fail.
-      static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
-        "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
-        "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
-        " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template."
-        " You may also add support for custom types, see our documentation.");
+      static_assert(!sizeof(T), "The get<T> method with type T is not implemented by the simdjson library. "
+        "And you do not seem to have added support for it. Indeed, we have that "
+        "simdjson::custom_deserializable<T> is false and the type T is not a default type "
+        "such as ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+        "int64_t, double, or bool.");
       static_cast<void>(out); // to get rid of unused errors
       return UNINITIALIZED;
-#if SIMDJSON_SUPPORTS_DESERIALIZATION
     }
-#endif
+#else // SIMDJSON_SUPPORTS_DESERIALIZATION
+    // Unless the simdjson library or the user provides an inline implementation, calling this method should
+    // immediately fail.
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
+      "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template."
+      " You may also add support for custom types, see our documentation.");
+    static_cast<void>(out); // to get rid of unused errors
+    return UNINITIALIZED;
+#endif // SIMDJSON_SUPPORTS_DESERIALIZATION
   }
+
   /** @overload template<typename T> error_code get(T &out) & noexcept */
   template<typename T> simdjson_deprecated simdjson_inline error_code get(T &out) && noexcept;
 
@@ -814,20 +821,27 @@ public:
     if constexpr (custom_deserializable<T, document_reference>) {
         return deserialize(*this, out);
     } else {
-#endif // SIMDJSON_SUPPORTS_DESERIALIZATION
-      // Unless the simdjson library or the user provides an inline implementation, calling this method should
-      // immediately fail.
-      static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
-        "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
-        "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
-        " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template."
-        " You may also add support for custom types, see our documentation.");
+      static_assert(!sizeof(T), "The get<T> method with type T is not implemented by the simdjson library. "
+        "And you do not seem to have added support for it. Indeed, we have that "
+        "simdjson::custom_deserializable<T> is false and the type T is not a default type "
+        "such as ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+        "int64_t, double, or bool.");
       static_cast<void>(out); // to get rid of unused errors
       return UNINITIALIZED;
-#if SIMDJSON_SUPPORTS_DESERIALIZATION
     }
-#endif
+#else // SIMDJSON_SUPPORTS_DESERIALIZATION
+    // Unless the simdjson library or the user provides an inline implementation, calling this method should
+    // immediately fail.
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
+      "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template."
+      " You may also add support for custom types, see our documentation.");
+    static_cast<void>(out); // to get rid of unused errors
+    return UNINITIALIZED;
+#endif // SIMDJSON_SUPPORTS_DESERIALIZATION
   }
+
   /** @overload template<typename T> error_code get(T &out) & noexcept */
   template<typename T> simdjson_inline error_code get(T &out) && noexcept;
   simdjson_inline simdjson_result<std::string_view> raw_json() noexcept;

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -70,22 +70,28 @@ public:
     noexcept
 #endif
  {
-#if SIMDJSON_SUPPORTS_DESERIALIZATION
-    if constexpr (custom_deserializable<T, value>) {
+  #if SIMDJSON_SUPPORTS_DESERIALIZATION
+  if constexpr (custom_deserializable<T, value>) {
       return deserialize(*this, out);
-    } else {
-#endif // SIMDJSON_SUPPORTS_DESERIALIZATION
-      // Unless the simdjson library or the user provides an inline implementation, calling this method should
-      // immediately fail.
-      static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
-        "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
-        "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
-        " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template."
-        " You may also add support for custom types, see our documentation.");
-      static_cast<void>(out); // to get rid of unused errors
-      return UNINITIALIZED;
-#if SIMDJSON_SUPPORTS_DESERIALIZATION
-    }
+  } else {
+    static_assert(!sizeof(T), "The get<T> method with type T is not implemented by the simdjson library. "
+      "And you do not seem to have added support for it. Indeed, we have that "
+      "simdjson::custom_deserializable<T> is false and the type T is not a default type "
+      "such as ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      "int64_t, double, or bool.");
+    static_cast<void>(out); // to get rid of unused errors
+    return UNINITIALIZED;
+  }
+#else // SIMDJSON_SUPPORTS_DESERIALIZATION
+    // Unless the simdjson library or the user provides an inline implementation, calling this method should
+    // immediately fail.
+    static_assert(!sizeof(T), "The get method with given type is not implemented by the simdjson library. "
+      "The supported types are ondemand::object, ondemand::array, raw_json_string, std::string_view, uint64_t, "
+      "int64_t, double, and bool. We recommend you use get_double(), get_bool(), get_uint64(), get_int64(), "
+      " get_object(), get_array(), get_raw_json_string(), or get_string() instead of the get template."
+      " You may also add support for custom types, see our documentation.");
+    static_cast<void>(out); // to get rid of unused errors
+    return UNINITIALIZED;
 #endif
   }
 


### PR DESCRIPTION
You can now do:

```cpp
  padded_string json =
      R"( { "car1": { "make": "Toyota", "model": "Camry",  "year": 2018,
       "tire_pressure": [ 40.1, 39.9 ] }
})"_padded;
  ondemand::parser parser;
  ondemand::document doc = parser.iterate(json);
  std:map<std::string,Car> cars =  doc.get<std:map<std::string,Car>>();
```