### PR TITLE
adding docker config and instructions so that our users can test the static reflection

### DIFF
--- a/benchmark/static_reflect/citm_catalog_benchmark/CMakeLists.txt
+++ b/benchmark/static_reflect/citm_catalog_benchmark/CMakeLists.txt
@@ -8,7 +8,6 @@ if(TARGET serde-benchmark)
 endif()
 
 target_link_libraries(benchmark_serialization_citm_catalog PRIVATE simdjson::simdjson nlohmann_json)
-target_link_libraries(benchmark_serialization_citm_catalog PRIVATE profiler)
 target_link_libraries(benchmark_serialization_citm_catalog PRIVATE reflectcpp)
 target_compile_definitions(benchmark_serialization_citm_catalog PRIVATE SIMDJSON_BENCH_CPP_REFLECT=1)
 

--- a/benchmark/static_reflect/twitter_benchmark/CMakeLists.txt
+++ b/benchmark/static_reflect/twitter_benchmark/CMakeLists.txt
@@ -8,7 +8,6 @@ add_executable(benchmark_serialization_twitter benchmark_serialization_twitter.c
     target_compile_definitions(benchmark_serialization_twitter PRIVATE SIMDJSON_RUST_VERSION="${Rust_VERSION}")
 endif()
 target_link_libraries(benchmark_serialization_twitter PRIVATE simdjson::simdjson nlohmann_json)
-target_link_libraries(benchmark_serialization_twitter PRIVATE profiler)
 target_link_libraries(benchmark_serialization_twitter PRIVATE reflectcpp)
 target_compile_definitions(benchmark_serialization_twitter PRIVATE SIMDJSON_BENCH_CPP_REFLECT=1)
 

--- a/p2996/Dockerfile
+++ b/p2996/Dockerfile
@@ -1,0 +1,42 @@
+# Stage 1. Check out LLVM source code and run the build.
+FROM debian:12 AS builder
+# First, Update the apt's source list and include the sources of the packages.
+RUN grep deb /etc/apt/sources.list | \
+    sed 's/^deb/deb-src /g' >> /etc/apt/sources.list
+# Install compiler, python and subversion.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates gnupg \
+           build-essential cmake make python3 zlib1g wget subversion unzip ninja-build git linux-perf && \
+    rm -rf /var/lib/apt/lists/*
+RUN git clone --depth=1 --branch p2996  https://github.com/bloomberg/clang-p2996.git /tmp/clang-source
+RUN cmake -S /tmp/clang-source/llvm -B /tmp/clang-source/build-llvm -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DLLVM_UNREACHABLE_OPTIMIZE=ON \
+    -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;libunwind" \
+    -DCLANG_DEFAULT_CXX_STDLIB=libc++ \
+    -DLLVM_ENABLE_PROJECTS=clang -G Ninja
+RUN cmake --build /tmp/clang-source/build-llvm -j
+RUN cmake --install /tmp/clang-source/build-llvm --prefix /tmp/clang-install
+
+
+# Stage 2. Produce a minimal release image with build results.
+FROM debian:12
+ARG USER_NAME
+ARG USER_ID
+ARG GROUP_ID
+LABEL maintainer "LLVM Developers"
+# Install packages for minimal useful image.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential  ca-certificates rust-all libcurl4-openssl-dev cmake make wget python3 python3-dev sudo curl ninja-build vim git binutils && \
+    rm -rf /var/lib/apt/lists/*
+# Copy build results of stage 1 to /usr/local.
+COPY --from=builder /tmp/clang-install/ /usr/local/
+RUN P=`/usr/local/bin/clang++ -v 2>&1 | grep Target | cut -d' ' -f2-`; echo /usr/local/lib/$P > /etc/ld.so.conf.d/$P.conf
+RUN ldconfig
+RUN addgroup --gid $GROUP_ID user; exit 0
+RUN adduser --disabled-password --gecos '' --uid $USER_ID --gid $GROUP_ID $USER_NAME; exit 0
+RUN echo "$USER_NAME:$USER_NAME" | chpasswd && adduser $USER_NAME sudo
+RUN echo '----->'
+RUN echo 'root:Docker!' | chpasswd
+ENV TERM xterm-256color
+USER $USER_NAME

--- a/p2996/README.md
+++ b/p2996/README.md
@@ -4,12 +4,12 @@ The simdjson has experimental support for static reflection, when the compiler s
 We focus on the [latest p2996 paper](https://isocpp.org/files/papers/P2996R10.html) that is targeting C++26.
 
 ## Current status
-There are 2 versions of compiler that aim to support the C++26 reflection paper ([p2996](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2996r4.html)).
+There are 2 versions of compiler that aim to support the C++26 reflection paper ([p2996](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2996r10.html)).
 
 1. [Clang-p2996 llvm branch](https://github.com/bloomberg/clang-p2996/tree/p2996) that open-source and available in the [Compiler Explorer](https://godbolt.org/z/eoEej3E6j).
 2. EDG reflection branch that is only publicly available in the [Compiler Explorer](https://godbolt.org).
 
-For now, we will resort to #1, since it is open-source. 
+For now, we will resort to #1, since it is open-source.
 
 We are excited to hear that this reflection proposal seems to be on-track for C++26. [As per Herb Sutter](https://herbsutter.com/2024/03/22/trip-report-winter-iso-c-standards-meeting-tokyo-japan/).
 
@@ -29,7 +29,7 @@ cd simdjson
 As of March 2025, support for static reflection is available only in the `json_builder_init` branch, so you should switch:
 
 ```bash
-git checkout -B json_builder_init 
+git checkout -B json_builder_init
 ```
 
 2. Make sure that you have [docker installed and running](https://docs.docker.com/engine/install/) on your system. Most Linux distributions support docker though some (like RedHat) have the equivalent (Podman). Users of Apple systems may want to [consider OrbStack](https://orbstack.dev). You do not need to familiar with docker, you just need to make sure that you are have it running.
@@ -40,20 +40,25 @@ git checkout -B json_builder_init
 bash ./p2996/run_docker.sh bash
 ```
 
-This will enter a bash shell with access to the repo directory. Note that this will take some time when running it for the first time, since the specific container image has to be built. 
+This will enter a bash shell with access to the repo directory. Note that this will take some time when running it for the first time, since the specific container image has to be built.
 
 This step builds and executes a docker container defined by our Dockerfile which provides the necessary environment.
+
+Importantly, we build the experimental LLVM compiler based on the current state of the
+`p2996` branch of the `https://github.com/bloomberg/clang-p2996.git` repository. It is possible that the build could fail. Furthermore, you may need to refresh the build from time to time. We provide a script which allows you to delete the docker image you have built (`bash ./p2996/remove_docker.sh`) so you can start anew.
+
+
 
 
 4. While inside the docker shell, configure the build system with cmake:
 ```bash
-CXX=clang++ cmake -B buildreflect -D SIMDJSON_STATIC_REFLECTION=ON
+CXX=clang++ cmake -B buildreflect -D SIMDJSON_STATIC_REFLECTION=ON -DSIMDJSON_DEVELOPER_MODE=ON
 ```
 This only needs to be done once.
 
 5. Build the code...
 ```bash
-cmake --build buildreflect
+cmake --build buildreflect --target benchmark_serialization_citm_catalog benchmark_serialization_twitter
 ```
 
 
@@ -62,9 +67,10 @@ cmake --build buildreflect
 ctest --test-dir buildreflect --output-on-failure
 ```
 
-7. Run the benchmark.
+7. Run the benchmarks.
 ```bash
-./buildreflect/benchmark/static_reflect/twitter_data/benchmark_serialization_twitter
+./buildreflect/benchmark/static_reflect/citm_catalog_benchmark/benchmark_serialization_citm_catalog
+./buildreflect/benchmark/static_reflect/twitter_benchmark/benchmark_serialization_twitter
 ```
 
 You can modify the source code with your favorite editor and run again steps 5 (Build the code) and 6 (Run the tests) and 7 (Run the benchmark). Importantly, you should remain in the docker shell.

--- a/p2996/README.md
+++ b/p2996/README.md
@@ -1,0 +1,73 @@
+# Building the experimental LLVM compiler for static reflection
+
+The simdjson has experimental support for static reflection, when the compiler supports it.
+We focus on the [latest p2996 paper](https://isocpp.org/files/papers/P2996R10.html) that is targeting C++26.
+
+## Current status
+There are 2 versions of compiler that aim to support the C++26 reflection paper ([p2996](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2996r4.html)).
+
+1. [Clang-p2996 llvm branch](https://github.com/bloomberg/clang-p2996/tree/p2996) that open-source and available in the [Compiler Explorer](https://godbolt.org/z/eoEej3E6j).
+2. EDG reflection branch that is only publicly available in the [Compiler Explorer](https://godbolt.org).
+
+For now, we will resort to #1, since it is open-source. 
+
+We are excited to hear that this reflection proposal seems to be on-track for C++26. [As per Herb Sutter](https://herbsutter.com/2024/03/22/trip-report-winter-iso-c-standards-meeting-tokyo-japan/).
+
+## Instructions for building simdjson for static reflection (using docker)
+
+We are assuming that you are running Linux or macOS. We recommend that Windows users rely on WSL.
+
+Follow the following two steps:
+
+1. Clone the project
+
+```bash
+git clone https://github.com/simdjson/simdjson.git
+cd simdjson
+```
+
+As of March 2025, support for static reflection is available only in the `json_builder_init` branch, so you should switch:
+
+```bash
+git checkout -B json_builder_init 
+```
+
+2. Make sure that you have [docker installed and running](https://docs.docker.com/engine/install/) on your system. Most Linux distributions support docker though some (like RedHat) have the equivalent (Podman). Users of Apple systems may want to [consider OrbStack](https://orbstack.dev). You do not need to familiar with docker, you just need to make sure that you are have it running.
+
+3. While inside the `simdjson` repository, run the following bash script:
+
+```bash
+bash ./p2996/run_docker.sh bash
+```
+
+This will enter a bash shell with access to the repo directory. Note that this will take some time when running it for the first time, since the specific container image has to be built. 
+
+This step builds and executes a docker container defined by our Dockerfile which provides the necessary environment.
+
+
+4. While inside the docker shell, configure the build system with cmake:
+```bash
+CXX=clang++ cmake -B buildreflect -D SIMDJSON_STATIC_REFLECTION=ON
+```
+This only needs to be done once.
+
+5. Build the code...
+```bash
+cmake --build buildreflect
+```
+
+
+6. Run the tests...
+```bash
+ctest --test-dir buildreflect --output-on-failure
+```
+
+7. Run the benchmark.
+```bash
+./buildreflect/benchmark/static_reflect/twitter_data/benchmark_serialization_twitter
+```
+
+You can modify the source code with your favorite editor and run again steps 5 (Build the code) and 6 (Run the tests) and 7 (Run the benchmark). Importantly, you should remain in the docker shell.
+
+You can create a new docker shell at any time by running step 3 (bash script).
+

--- a/p2996/remove_docker.sh
+++ b/p2996/remove_docker.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+tuser=$(echo $USER | tr -dc 'a-z')
+container_name=${CONTAINER_NAME:-"debian12-clang-p2996-programming_station-for-$tuser-simdjson"}
+echo $container_name
+echo " Removing the container "
+docker ps -a | awk '{ print $1,$2 }' | grep $container_name| awk '{print $1 }' | xargs -I {} docker stop -t 1 {} | xargs docker rm 
+# removing image
+docker image rm $container_name

--- a/p2996/remove_docker.sh
+++ b/p2996/remove_docker.sh
@@ -3,6 +3,6 @@ tuser=$(echo $USER | tr -dc 'a-z')
 container_name=${CONTAINER_NAME:-"debian12-clang-p2996-programming_station-for-$tuser-simdjson"}
 echo $container_name
 echo " Removing the container "
-docker ps -a | awk '{ print $1,$2 }' | grep $container_name| awk '{print $1 }' | xargs -I {} docker stop -t 1 {} | xargs docker rm 
+docker ps -a | awk '{ print $1,$2 }' | grep $container_name| awk '{print $1 }' | xargs -I {} docker stop -t 1 {} | xargs docker rm
 # removing image
 docker image rm $container_name

--- a/p2996/run_docker.sh
+++ b/p2996/run_docker.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+if [ -z "$1" ]
+  then
+    echo "The run-docker-station script takes a command as a argument. E.g., try ./run-docker-station 'ls' "
+    exit 1
+fi
+
+set -o noglob
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+COMMAND=$@
+
+tuser=$(echo $USER | tr -dc 'a-z')
+
+container_name=${CONTAINER_NAME:-"debian12-clang-p2996-programming_station-for-$tuser-simdjson"}
+
+command -v docker >/dev/null 2>&1 || { echo >&2 "Please install docker. E.g., go to https://www.docker.com/products/docker-desktop Type 'docker' to diagnose the problem."; exit 1; }
+
+docker info >/dev/null 2>&1 || { echo >&2 "Docker server is not running? type 'docker info'."; exit 1; }
+
+SSHPARAM=""
+[ -e "${SSH_AUTH_SOCK}" ] && SSHPARAM="--volume /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock  --env SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock"
+[ -e "${HOME}/.ssh" ] && SSHPARAM="--volume ${HOME}/.ssh:/home/$tuser/.ssh:ro"  
+
+
+docker image inspect $container_name >/dev/null 2>&1 || ( echo "instantiating the container" ; docker build --no-cache -t $container_name -f $SCRIPTPATH/Dockerfile --build-arg USER_NAME="$tuser"  --build-arg USER_ID=$(id -u)  --build-arg GROUP_ID=$(id -g) .  )
+
+if [ -t 0 ]; then DOCKER_ARGS=-it; fi
+docker run --rm $DOCKER_ARGS -h $container_name $SSHPARAM -v $(pwd):$(pwd):Z --privileged  -w $(pwd)  $container_name sh -c "$COMMAND"

--- a/p2996/run_docker.sh
+++ b/p2996/run_docker.sh
@@ -21,7 +21,7 @@ docker info >/dev/null 2>&1 || { echo >&2 "Docker server is not running? type 'd
 
 SSHPARAM=""
 [ -e "${SSH_AUTH_SOCK}" ] && SSHPARAM="--volume /run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock  --env SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock"
-[ -e "${HOME}/.ssh" ] && SSHPARAM="--volume ${HOME}/.ssh:/home/$tuser/.ssh:ro"  
+[ -e "${HOME}/.ssh" ] && SSHPARAM="--volume ${HOME}/.ssh:/home/$tuser/.ssh:ro"
 
 
 docker image inspect $container_name >/dev/null 2>&1 || ( echo "instantiating the container" ; docker build --no-cache -t $container_name -f $SCRIPTPATH/Dockerfile --build-arg USER_NAME="$tuser"  --build-arg USER_ID=$(id -u)  --build-arg GROUP_ID=$(id -g) .  )


### PR DESCRIPTION
Currently, we have added to the json_builder_init branch support for C++26 static reflection. Unfortunately, it is not easy for most people to test out this feature.

This PR adds a tested and documented procedure to do so.