### PR TITLE
do not try to include <string_view> without C++17 for MSVC

### DIFF
--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -232,6 +232,7 @@ double from_chars(const char *first, const char* end) noexcept;
 // and even if __cpp_lib_string_view is undefined, it is the case
 // with Apple clang version 11.
 // We must handle it. *This is important.*
+#ifndef _MSC_VER
 #ifndef SIMDJSON_HAS_STRING_VIEW
 #if defined __has_include
 // do not combine the next #if with the previous one (unsafe)
@@ -247,6 +248,7 @@ double from_chars(const char *first, const char* end) noexcept;
 #endif // __has_include (<string_view>)
 #endif // defined __has_include
 #endif // def SIMDJSON_HAS_STRING_VIEW
+#endif // def _MSC_VER
 // end of complicated but important routine to try to detect string_view.
 
 //

--- a/include/simdjson/jsonpathutil.h
+++ b/include/simdjson/jsonpathutil.h
@@ -2,7 +2,7 @@
 #define SIMDJSON_JSONPATHUTIL_H
 
 #include <string>
-#include <string_view>
+#include "simdjson/common_defs.h"
 
 namespace simdjson {
 /**


### PR DESCRIPTION
Doing that will emit warning at https://github.com/microsoft/STL/blob/vs-2022-17.13/stl/inc/string_view#L12.

