### PR TITLE
JSON builder optimizations

### DIFF
--- a/include/simdjson/generic/ondemand/json_string_builder-inl.h
+++ b/include/simdjson/generic/ondemand/json_string_builder-inl.h
@@ -421,7 +421,10 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
     if (capacity_check(max_number_size)) {
       using unsigned_type = typename std::make_unsigned<number_type>::type;
       bool negative = v < 0;
-      unsigned_type pv = static_cast<unsigned_type>(negative ? -v : v);
+      unsigned_type pv = static_cast<unsigned_type>(v);
+      if (negative) {
+        pv = 0 - pv; // the 0 is for Microsoft
+      }
       size_t dc = internal::digit_count(pv);
       if (negative) {
         buffer.get()[position++] = '-';

--- a/include/simdjson/generic/ondemand/json_string_builder-inl.h
+++ b/include/simdjson/generic/ondemand/json_string_builder-inl.h
@@ -61,14 +61,17 @@ A possible SWAR implementation of has_json_escapable_byte. It is not used becaus
 it is slower than the current implementation. It is kept here for reference (to show
 that we tried it).
 
-constexpr bool has_json_escapable_byte(uint64_t x) {
-    uint64_t lt32 = (x - 0x2020202020202020ULL) & ~x & 0x8080808080808080ULL;
+ bool fast2_has_json_escapable_byte(uint64_t x) {
+    uint64_t is_ascii = 0x8080808080808080ULL & ~x;
+    uint64_t lt32 =
+        (x - 0x2020202020202020ULL);
     uint64_t sub34 = x ^ 0x2222222222222222ULL;
-    uint64_t eq34 = (sub34 - 0x0101010101010101ULL) & ~sub34 & 0x8080808080808080ULL;
+    uint64_t eq34 = (sub34 - 0x0101010101010101ULL);
     uint64_t sub92 = x ^ 0x5C5C5C5C5C5C5C5CULL;
-    uint64_t eq92 = (sub92 - 0x0101010101010101ULL) & ~sub92 & 0x8080808080808080ULL;
-    return (lt32 | eq34 | eq92) != 0;
-}
+    uint64_t eq92 = (sub92 - 0x0101010101010101ULL);
+    return ((lt32 | eq34 | eq92) & is_ascii) != 0;
+  }
+
 **/
 
 SIMDJSON_CONSTEXPR_LAMBDA simdjson_inline bool

--- a/include/simdjson/generic/ondemand/json_string_builder-inl.h
+++ b/include/simdjson/generic/ondemand/json_string_builder-inl.h
@@ -42,10 +42,40 @@ namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace builder {
 
+static SIMDJSON_CONSTEXPR_LAMBDA std::array<uint8_t, 256> json_quotable_character = {
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+
+/**
+
+A possible SWAR implementation of has_json_escapable_byte. It is not used because
+it is slower than the current implementation. It is kept here for reference (to show
+that we tried it).
+
+constexpr bool has_json_escapable_byte(uint64_t x) {
+    uint64_t lt32 = (x - 0x2020202020202020ULL) & ~x & 0x8080808080808080ULL;
+    uint64_t sub34 = x ^ 0x2222222222222222ULL;
+    uint64_t eq34 = (sub34 - 0x0101010101010101ULL) & ~sub34 & 0x8080808080808080ULL;
+    uint64_t sub92 = x ^ 0x5C5C5C5C5C5C5C5CULL;
+    uint64_t eq92 = (sub92 - 0x0101010101010101ULL) & ~sub92 & 0x8080808080808080ULL;
+    return (lt32 | eq34 | eq92) != 0;
+}
+**/
+
 SIMDJSON_CONSTEXPR_LAMBDA simdjson_inline bool
 simple_needs_escaping(std::string_view v) {
   for (char c : v) {
-    if ((uint8_t(c) < 32) | (c == '"') | (c == '\\')) {
+    // a table lookup is faster than a series of comparisons
+    if(json_quotable_character[static_cast<uint8_t>(c)]) {
       return true;
     }
   }
@@ -110,18 +140,6 @@ simdjson_inline bool fast_needs_escaping(std::string_view view) {
 }
 #endif
 
-static SIMDJSON_CONSTEXPR_LAMBDA std::array<uint8_t, 256> json_quotable_character = {
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 SIMDJSON_CONSTEXPR_LAMBDA inline size_t
 find_next_json_quotable_character(const std::string_view view,
@@ -333,7 +351,25 @@ simdjson_inline size_t digit_count(number_type v) noexcept {
                 "We only support 8-bit, 16-bit, 32-bit and 64-bit numbers");
   return fast_digit_count(v);
 }
-
+static const char decimal_table[200] = {
+  0x30, 0x30, 0x30, 0x31, 0x30, 0x32, 0x30, 0x33, 0x30, 0x34, 0x30, 0x35,
+  0x30, 0x36, 0x30, 0x37, 0x30, 0x38, 0x30, 0x39, 0x31, 0x30, 0x31, 0x31,
+  0x31, 0x32, 0x31, 0x33, 0x31, 0x34, 0x31, 0x35, 0x31, 0x36, 0x31, 0x37,
+  0x31, 0x38, 0x31, 0x39, 0x32, 0x30, 0x32, 0x31, 0x32, 0x32, 0x32, 0x33,
+  0x32, 0x34, 0x32, 0x35, 0x32, 0x36, 0x32, 0x37, 0x32, 0x38, 0x32, 0x39,
+  0x33, 0x30, 0x33, 0x31, 0x33, 0x32, 0x33, 0x33, 0x33, 0x34, 0x33, 0x35,
+  0x33, 0x36, 0x33, 0x37, 0x33, 0x38, 0x33, 0x39, 0x34, 0x30, 0x34, 0x31,
+  0x34, 0x32, 0x34, 0x33, 0x34, 0x34, 0x34, 0x35, 0x34, 0x36, 0x34, 0x37,
+  0x34, 0x38, 0x34, 0x39, 0x35, 0x30, 0x35, 0x31, 0x35, 0x32, 0x35, 0x33,
+  0x35, 0x34, 0x35, 0x35, 0x35, 0x36, 0x35, 0x37, 0x35, 0x38, 0x35, 0x39,
+  0x36, 0x30, 0x36, 0x31, 0x36, 0x32, 0x36, 0x33, 0x36, 0x34, 0x36, 0x35,
+  0x36, 0x36, 0x36, 0x37, 0x36, 0x38, 0x36, 0x39, 0x37, 0x30, 0x37, 0x31,
+  0x37, 0x32, 0x37, 0x33, 0x37, 0x34, 0x37, 0x35, 0x37, 0x36, 0x37, 0x37,
+  0x37, 0x38, 0x37, 0x39, 0x38, 0x30, 0x38, 0x31, 0x38, 0x32, 0x38, 0x33,
+  0x38, 0x34, 0x38, 0x35, 0x38, 0x36, 0x38, 0x37, 0x38, 0x38, 0x38, 0x39,
+  0x39, 0x30, 0x39, 0x31, 0x39, 0x32, 0x39, 0x33, 0x39, 0x34, 0x39, 0x35,
+  0x39, 0x36, 0x39, 0x37, 0x39, 0x38, 0x39, 0x39,
+};
 } // namespace internal
 
 template <typename number_type, typename>
@@ -367,7 +403,11 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
       unsigned_type pv = static_cast<unsigned_type>(v);
       size_t dc = internal::digit_count(pv);
       char *write_pointer = buffer.get() + position + dc - 1;
-      // optimization opportunity: if v is large, we can do better.
+      while (pv >= 100) {
+        memcpy(write_pointer - 1, &internal::decimal_table[(pv % 100)*2], 2);
+        write_pointer -= 2;
+        pv /= 100;
+      }
       while (pv >= 10) {
         *write_pointer-- = char('0' + (pv % 10));
         pv /= 10;
@@ -387,7 +427,11 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
         buffer.get()[position++] = '-';
       }
       char *write_pointer = buffer.get() + position + dc - 1;
-      // optimization opportunity: if v is large, we can do better.
+      while (pv >= 100) {
+        memcpy(write_pointer - 1, &internal::decimal_table[(pv % 100)*2], 2);
+        write_pointer -= 2;
+        pv /= 100;
+      }
       while (pv >= 10) {
         *write_pointer-- = char('0' + (pv % 10));
         pv /= 10;

--- a/tests/builder/builder_string_builder_tests.cpp
+++ b/tests/builder/builder_string_builder_tests.cpp
@@ -107,6 +107,65 @@ namespace builder_tests {
         TEST_SUCCEED();
     }
 
+    bool various_integers() {
+        TEST_START();
+        std::vector<std::pair<int64_t, std::string_view>> test_cases = {
+            {0, "0"},
+            {1, "1"},
+            {-1, "-1"},
+            {42, "42"},
+            {-42, "-42"},
+            {100, "100"},
+            {-100, "-100"},
+            {999, "999"},
+            {-999, "-999"},
+            {2147483647, "2147483647"},  // max 32-bit integer
+            {-2147483648, "-2147483648"}, // min 32-bit integer
+            {4294967296ULL, "4294967296"}, // 2^32
+            {-4294967296LL, "-4294967296"},
+            {10000000000LL, "10000000000"}, // 10 billion
+            {-10000000000LL, "-10000000000"},
+            {9223372036854775807LL, "9223372036854775807"}, // max 64-bit integer
+            {-9223372036854775807LL-1, "-9223372036854775808"}, // min 64-bit integer
+            {1234567890123LL, "1234567890123"},
+            {-1234567890123LL, "-1234567890123"},
+        };
+        for (const auto& [value, expected] : test_cases) {
+            simdjson::builder::string_builder sb;
+            sb.append(value);
+            std::string_view p;
+            auto result = sb.view().get(p);
+            ASSERT_SUCCESS(result);
+            ASSERT_EQUAL(p, expected);
+        }
+        TEST_SUCCEED();
+    }
+
+    bool various_unsigned_integers() {
+        TEST_START();
+        std::vector<std::pair<uint64_t, std::string_view>> test_cases = {
+            {0, "0"},
+            {1, "1"},
+            {42, "42"},
+            {100, "100"},
+            {999, "999"},
+            {2147483647, "2147483647"},  // max 32-bit integer
+            {4294967296ULL, "4294967296"}, // 2^32
+            {10000000000LL, "10000000000"}, // 10 billion
+            {9223372036854775807LL, "9223372036854775807"}, // max 64-bit integer
+            {1234567890123LL, "1234567890123"},
+        };
+        for (const auto& [value, expected] : test_cases) {
+            simdjson::builder::string_builder sb;
+            sb.append(value);
+            std::string_view p;
+            auto result = sb.view().get(p);
+            ASSERT_SUCCESS(result);
+            ASSERT_EQUAL(p, expected);
+        }
+        TEST_SUCCEED();
+    }
+
     bool append_raw() {
         TEST_START();
         simdjson::builder::string_builder sb;
@@ -213,6 +272,8 @@ namespace builder_tests {
 
     bool run() {
         return
+            various_integers() &&
+            various_unsigned_integers() &&
             car_test() &&
     #if SIMDJSON_EXCEPTIONS
             string_convertion_except() &&


### PR DESCRIPTION
These a tiny optimizations on top of `json_builder_init`. On one system and one benchmark, it reduces the number of instructions by about 7% and it improves the speed by about 5%.

Before:
```
$ ./buildreflect/benchmark/static_reflect/twitter_benchmark/benchmark_serialization_twitter
bench_simdjson_static_reflection                             :  1848.61 MB/s   0.42 Ms/s   3.19 GHz   1.73 c/b   5.40 i/b   3.13 i/c
```

After:
```
$ ./buildreflect/benchmark/static_reflect/twitter_benchmark/benchmark_serialization_twitter
bench_simdjson_static_reflection                             :  1945.19 MB/s   0.44 Ms/s   3.19 GHz   1.64 c/b   5.04 i/b   3.07 i/c
```