### PR TITLE
Treat -0 as -0.0 when SIMDJSON_MINUS_ZERO_AS_FLOAT is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,12 @@ if(
   )
 endif()
 
+option(SIMDJSON_MINUS_ZERO_AS_FLOAT "Treat -0 as a floating-point value" OFF)
+
+if(SIMDJSON_MINUS_ZERO_AS_FLOAT)
+  simdjson_add_props(target_compile_definitions PRIVATE SIMDJSON_MINUS_ZERO_AS_FLOAT=1)
+endif(SIMDJSON_MINUS_ZERO_AS_FLOAT)
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(loongarch64)$")
     option(SIMDJSON_PREFER_LSX "Prefer LoongArch SX" ON)
     include(CheckCXXCompilerFlag)

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -2246,6 +2246,11 @@ Thus it is a dynamically typed number. Before accessing the value, you must dete
 such a number of `get_number()`, you get the error `BIGINT_ERROR`. You can access the underlying string of digits with the function `raw_json_token()` which returns a `std::string_view` instance starting at the beginning of the digit. You can also call `get_double()` to get a floating-point approximation.
 
 
+  By default, the string `-0` is parsed as the integer 0 as in Python or C++. If you set the macro
+  `SIMDJSON_MINUS_ZERO_AS_FLOAT` to `1` when building simdjson, you can get that `-0` is mapped to `-0.0`
+  as in JavaScript. You can get the desired effect by building simdjson with cmake setting the
+  `SIMDJSON_MINUS_ZERO_AS_FLOAT` to on: `cmake -B build -D SIMDJSON_MINUS_ZERO_AS_FLOAT=ON`.
+
 You must check the type before accessing the value: it is an error to call `get_int64()` when `number.get_number_type()` is not `number_type::signed_integer` and when `number.is_int64()` is false. You are responsible for this check as the user of the library.
 
 The `get_number()` function is designed with performance in mind. When calling `get_number()`, you scan the number string only once, determining efficiently the type and storing it in an efficient manner.

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -119,6 +119,12 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   std::cout << "I parsed " << value << " from " << numberstring.data() << std::endl;
   ```
   The strings contain unescaped valid UTF-8 strings: no unmatched surrogate is allowed.
+  Internally, numbers are stored as either 64-bit integers or 64-bit floating-point numbers.
+  Thus it is possible to get the full 64-bit integer range (either signed or  unsigned).
+  By default, the string `-0` is parsed as the integer 0 as in Pytho or C++. If you set the macro
+  `SIMDJSON_MINUS_ZERO_AS_FLOAT` to `1` when building simdjson, you can get that `-0` is mapped to `-0.0`
+  as in JavaScript. You can get the desired effect by building simdjson with cmake setting the
+  `SIMDJSON_MINUS_ZERO_AS_FLOAT` to on: `cmake -B build -D SIMDJSON_MINUS_ZERO_AS_FLOAT=ON`.
 * **Field Access:** To get the value of the "foo" field in an object, use `object["foo"]`.
 * **Array Iteration:** To iterate through an array, use `for (auto value : array) { ... }`. If you
   know the type of the value, you can cast it right there, too! `for (double value : array) { ... }`

--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -647,12 +647,16 @@ simdjson_inline error_code parse_number(const uint8_t *const src, W &writer) {
   if (i > uint64_t(INT64_MAX)) {
     WRITE_UNSIGNED(i, src, writer);
   } else {
+#if SIMDJSON_MINUS_ZERO_AS_FLOAT
     if(i == 0 && negative) {
       // We have to write -0.0 instead of 0
       WRITE_DOUBLE(-0.0, src, writer);
     } else {
       WRITE_INTEGER(negative ? (~i+1) : i, src, writer);
     }
+#else
+  WRITE_INTEGER(negative ? (~i+1) : i, src, writer);
+#endif
   }
   if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return INVALID_NUMBER(src); }
   return SUCCESS;

--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -647,7 +647,12 @@ simdjson_inline error_code parse_number(const uint8_t *const src, W &writer) {
   if (i > uint64_t(INT64_MAX)) {
     WRITE_UNSIGNED(i, src, writer);
   } else {
-    WRITE_INTEGER(negative ? (~i+1) : i, src, writer);
+    if(i == 0 && negative) {
+      // We have to write -0.0 instead of 0
+      WRITE_DOUBLE(-0.0, src, writer);
+    } else {
+      WRITE_INTEGER(negative ? (~i+1) : i, src, writer);
+    }
   }
   if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return INVALID_NUMBER(src); }
   return SUCCESS;

--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -1117,6 +1117,12 @@ simdjson_unused simdjson_inline simdjson_result<number_type> get_number_type(con
       if (simdjson_unlikely(digit_count == 19 && memcmp(src, smaller_big_integer, 19) > 0)) {
         return number_type::big_integer;
       }
+#if SIMDJSON_MINUS_ZERO_AS_FLOAT
+      if(digit_count == 1 && src[0] == '0') {
+        // We have to write -0.0 instead of 0
+        return number_type::floating_point_number;
+      }
+#endif
       return number_type::signed_integer;
     }
     // Let us check if we have a big integer (>=2**64).

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -399,7 +399,8 @@ namespace number_tests {
 
   bool specific_tests() {
     std::cout << __func__ << std::endl;
-    return basic_test_64bit("-1e-999", -0.0) &&
+    return basic_test_64bit("-0", -0.0) &&
+           basic_test_64bit("-1e-999", -0.0) &&
            basic_test_64bit("-2402844368454405395.2",-2402844368454405395.2) &&
            basic_test_64bit("4503599627370496.5", 4503599627370496.5) &&
            basic_test_64bit("4503599627475352.5", 4503599627475352.5) &&
@@ -1245,7 +1246,6 @@ namespace dom_api_tests {
   bool numeric_values_exception() {
     std::cout << "Running " << __func__ << std::endl;
     dom::parser parser;
-
     ASSERT_EQUAL( uint64_t(parser.parse("0"_padded)), 0);
     ASSERT_EQUAL( int64_t(parser.parse("0"_padded)), 0);
     ASSERT_EQUAL( double(parser.parse("0"_padded)), 0);

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -399,7 +399,10 @@ namespace number_tests {
 
   bool specific_tests() {
     std::cout << __func__ << std::endl;
-    return basic_test_64bit("-0", -0.0) &&
+    return
+    #if SIMDJSON_MINUS_ZERO_AS_FLOAT
+           basic_test_64bit("-0", -0.0) &&
+    #endif // SIMDJSON_MINUS_ZERO_AS_FLOAT
            basic_test_64bit("-1e-999", -0.0) &&
            basic_test_64bit("-2402844368454405395.2",-2402844368454405395.2) &&
            basic_test_64bit("4503599627370496.5", 4503599627370496.5) &&

--- a/tests/ondemand/ondemand_number_tests.cpp
+++ b/tests/ondemand/ondemand_number_tests.cpp
@@ -184,20 +184,6 @@ namespace number_tests {
     TEST_SUCCEED();
   }
 
-  bool issue_1532() {
-    TEST_START();
-    padded_string negative_zero_string(std::string_view("-0"));
-    simdjson::ondemand::parser parser;
-    ondemand::document doc;
-    ASSERT_SUCCESS(parser.iterate(negative_zero_string).get(doc));
-    double x;
-    ASSERT_SUCCESS(doc.get(x));
-    // should be minus 0
-    ASSERT_TRUE(std::signbit(x));
-    ASSERT_TRUE(x == -0);
-    TEST_SUCCEED();
-  }
-
   bool old_crashes() {
     TEST_START();
     github_issue_1273();
@@ -518,8 +504,7 @@ namespace number_tests {
   }
 
   bool run() {
-    return issue_1532() &&
-           gigantic_big_int() &&
+    return gigantic_big_int() &&
            big_int_not_zero() &&
            negative_big_int() &&
            issue2099() &&

--- a/tests/ondemand/ondemand_number_tests.cpp
+++ b/tests/ondemand/ondemand_number_tests.cpp
@@ -312,7 +312,30 @@ namespace number_tests {
     ASSERT_EQUAL(number.get_number_type(), ondemand::number_type::floating_point_number);
     ASSERT_EQUAL(number.get_double(), 1e9);
     TEST_SUCCEED();
-}
+  }
+
+  bool minus_zero() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "-0"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    ondemand::number number;
+    ASSERT_SUCCESS(doc.get_number().get(number));
+    #if SIMDJSON_MINUS_ZERO_AS_FLOAT
+    ASSERT_EQUAL(number.get_number_type(), ondemand::number_type::floating_point_number);
+    #else
+    ASSERT_EQUAL(number.get_number_type(), ondemand::number_type::signed_integer);
+    #endif
+    ondemand::number_type nt{};
+    ASSERT_SUCCESS(doc.get_number_type().get(nt));
+    #if SIMDJSON_MINUS_ZERO_AS_FLOAT
+    ASSERT_EQUAL(nt, ondemand::number_type::floating_point_number);
+    #else
+    ASSERT_EQUAL(nt, ondemand::number_type::signed_integer);
+    #endif
+    TEST_SUCCEED();
+  }
 
   bool issue1878() {
     TEST_START();
@@ -504,7 +527,8 @@ namespace number_tests {
   }
 
   bool run() {
-    return gigantic_big_int() &&
+    return minus_zero() &&
+           gigantic_big_int() &&
            big_int_not_zero() &&
            negative_big_int() &&
            issue2099() &&

--- a/tests/ondemand/ondemand_number_tests.cpp
+++ b/tests/ondemand/ondemand_number_tests.cpp
@@ -184,6 +184,20 @@ namespace number_tests {
     TEST_SUCCEED();
   }
 
+  bool issue_1532() {
+    TEST_START();
+    padded_string negative_zero_string(std::string_view("-0"));
+    simdjson::ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(negative_zero_string).get(doc));
+    double x;
+    ASSERT_SUCCESS(doc.get(x));
+    // should be minus 0
+    ASSERT_TRUE(std::signbit(x));
+    ASSERT_TRUE(x == -0);
+    TEST_SUCCEED();
+  }
+
   bool old_crashes() {
     TEST_START();
     github_issue_1273();
@@ -504,7 +518,8 @@ namespace number_tests {
   }
 
   bool run() {
-    return gigantic_big_int() &&
+    return issue_1532() &&
+           gigantic_big_int() &&
            big_int_not_zero() &&
            negative_big_int() &&
            issue2099() &&


### PR DESCRIPTION
Currently, in simdjson, -0 in the DOM API gets materialized as the integer 0. We would now interpret it as the double value -0.0 when the macro SIMDJSON_MINUS_ZERO_AS_FLOAT is set. The string 0 is still interpreted as the integer 0.

The same would apply with `get_number()` and  `get_number_type()` in the On-Demand API.

There is no perfect solution here. In most programming languages (e.g., C or Python), the string `-0` is interpreted as a integer. Here is what you get in Python...

```Python
>>> x = -0
>>> x.is_integer()
True
>>> x
0
```

The motivation for this change is that, in JavaScript, -0 becomes -0.0.


Fixes https://github.com/simdjson/simdjson/issues/1532