### PR TITLE
chore: add greptimedb to the real-world usage list

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Real-world usage
 - [fastgron](https://github.com/adamritter/fastgron)
 - [WasmEdge](https://wasmedge.org)
 - [RonDB](https://github.com/logicalclocks/rondb)
+- [GreptimeDB](https://github.com/GreptimeTeam/greptimedb)
 
 
 If you are planning to use simdjson in a product, please work from one of our releases.


### PR DESCRIPTION
This PR adds [GreptimeDB](https://github.com/GreptimeTeam/greptimedb) to the real-world usage list.
Starting from the `v0.14` release, GreptimeDB uses [`simd-json`](https://crates.io/crates/simd-json) to speed up parsing JSON strings. The performance is compelling, see the original PR [here](https://github.com/GreptimeTeam/greptimedb/pull/5794).

Thanks for the awesome lib. 🚀 