### PR TITLE
Fixing MSYS2 issue

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -5,9 +5,9 @@ option(SIMDJSON_ALLOW_DOWNLOADS
         ON)
 
 cmake_dependent_option(SIMDJSON_COMPETITION "Compile competitive benchmarks" ON
-        SIMDJSON_ALLOW_DOWNLOADS OFF)
+        "SIMDJSON_ALLOW_DOWNLOADS OR MINGW" OFF)
 cmake_dependent_option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" ON
-        SIMDJSON_ALLOW_DOWNLOADS OFF)
+        "SIMDJSON_ALLOW_DOWNLOADS OR MINGW" OFF)
 
 if(SIMDJSON_GOOGLE_BENCHMARKS)
   CPMAddPackage(

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -5,7 +5,7 @@ option(SIMDJSON_ALLOW_DOWNLOADS
         ON)
 
 cmake_dependent_option(SIMDJSON_COMPETITION "Compile competitive benchmarks" ON
-        "SIMDJSON_ALLOW_DOWNLOADS OR MINGW" OFF)
+        SIMDJSON_ALLOW_DOWNLOADS OFF)
 cmake_dependent_option(SIMDJSON_GOOGLE_BENCHMARKS "compile the Google Benchmark benchmarks" ON
         "SIMDJSON_ALLOW_DOWNLOADS OR MINGW" OFF)
 


### PR DESCRIPTION

Google Benchmarks does not support MSYS2. Disable Google Benchmark when something like MSYS2 is detected.