### PR TITLE
guarding the POSITION_INDEPENDENT_CODE

### DIFF
--- a/cmake/developer-options.cmake
+++ b/cmake/developer-options.cmake
@@ -2,7 +2,10 @@
 # Flags used by exes and by the simdjson library (project-wide flags)
 #
 add_library(simdjson-internal-flags INTERFACE)
-set_target_properties(simdjson-internal-flags PROPERTIES POSITION_INDEPENDENT_CODE ON)
+if(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
+  # We default to ON for all targets, so that we can use the library in shared libraries.
+  set_target_properties(simdjson-internal-flags PROPERTIES POSITION_INDEPENDENT_CODE ON)
+endif(NOT DEFINED CMAKE_POSITION_INDEPENDENT_CODE)
 
 option(SIMDJSON_CHECK_EOF "Check for the end of the input buffer. The setting is unnecessary since we require padding of the inputs. You should expect tests to fail with this option turned on." OFF)
 if(SIMDJSON_CHECK_EOF)


### PR DESCRIPTION
Follow up to https://github.com/simdjson/simdjson/pull/2383 by @xkszltl 


We obey CMAKE_POSITION_INDEPENDENT_CODE if it is set. 

Fixes https://github.com/simdjson/simdjson/issues/2384