### PR TITLE
Fix linker errors for downstream users caused by non-inline symbols in header

### DIFF
--- a/include/simdjson/generic/ondemand/json_string_builder-inl.h
+++ b/include/simdjson/generic/ondemand/json_string_builder-inl.h
@@ -303,9 +303,9 @@ simdjson_inline void string_builder::clear() noexcept {
 namespace internal {
 
 // We could specialize further for 32-bit integers.
-int int_log2(uint32_t x) { return (63 - leading_zeroes(x | 1)); }
+inline int int_log2(uint32_t x) { return (63 - leading_zeroes(x | 1)); }
 
-int fast_digit_count(uint32_t x) {
+inline int fast_digit_count(uint32_t x) {
   static uint64_t table[] = {
       4294967296,  8589934582,  8589934582,  8589934582,  12884901788,
       12884901788, 12884901788, 17179868184, 17179868184, 17179868184,
@@ -317,9 +317,9 @@ int fast_digit_count(uint32_t x) {
   return uint32_t((x + table[int_log2(x)]) >> 32);
 }
 
-int int_log2(uint64_t x) { return 63 - leading_zeroes(x | 1); }
+inline int int_log2(uint64_t x) { return 63 - leading_zeroes(x | 1); }
 
-int fast_digit_count(uint64_t x) {
+inline int fast_digit_count(uint64_t x) {
   static uint64_t table[] = {9,
                              99,
                              999,


### PR DESCRIPTION
This addresses non-inlined symbols leaking into public headers after a recent update. Adding an inline specifier to these symbols fixes linker errors for downstream users.

 Fixes #2402 