### PR TITLE
remove cmake_policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ cmake-build-release/
 .history/
 
 # Visual Studio artifacts
-/VS/
+/.vs/
 
 # C/C++ build outputs
 .build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
-cmake_policy(VERSION 3.5) # For doctest
-
 
 project(
     simdjson


### PR DESCRIPTION
`cmake_policy` was added in https://github.com/simdjson/simdjson/commit/d7d19db6aefdec1db1b8345f9b23ed5b052e4966 with a cryptic comment. Removing it doesn't seem to make a difference, but its presence leads to warnings CMake warnings with modern CMake versions (as CMake <3.10 was deprecated). Example of such a warning can be found here: https://github.com/simdjson/simdjson/actions/runs/16573693121/job/46872474324#step:4:10

Thus all projects using simdjson with CMake > 3.28 get riddled with CMake warnings.

A minor unrelated additional commit in this PR is properly "gitignoring" the Visual Studio IDE artifact directory.

