### PR TITLE
Ignorant operator>>

### DIFF
--- a/include/simdjson/generic/implementation_simdjson_result_base-inl.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base-inl.h
@@ -28,6 +28,23 @@ simdjson_warn_unused simdjson_inline error_code implementation_simdjson_result_b
   return error;
 }
 
+template<typename T> template <typename OutT> simdjson_inline simdjson_result<T>& implementation_simdjson_result_base<T>::operator>>(OutT &out) {
+  auto& self = static_cast<simdjson_result<T>&>(*this);
+  if (error()) { return self; } // ignore errors, don't even throw
+  if constexpr (requires (simdjson_result<T>& res) {res.get(out);}) {
+    self.get(out);
+  } else {
+    out = std::forward<implementation_simdjson_result_base>(*this).first;
+  }
+  return self;
+}
+
+template <typename T> simdjson_inline simdjson_result<T>& implementation_simdjson_result_base<T>::operator>>(error_code &out) noexcept {
+  auto& self = static_cast<simdjson_result<T>&>(*this);
+  if (error()) { out = error(); }
+  return self;
+}
+
 template<typename T>
 simdjson_inline error_code implementation_simdjson_result_base<T>::error() const noexcept {
   return this->second;

--- a/include/simdjson/generic/implementation_simdjson_result_base.h
+++ b/include/simdjson/generic/implementation_simdjson_result_base.h
@@ -69,6 +69,10 @@ struct implementation_simdjson_result_base {
    */
   simdjson_inline error_code get(T &value) && noexcept;
 
+
+  template<typename OutT> simdjson_inline simdjson_result<T>& operator>>(OutT &out);
+  simdjson_inline simdjson_result<T>& operator>>(error_code&) noexcept;
+
   /**
    * The error.
    */

--- a/tests/ondemand/ondemand_convert_tests.cpp
+++ b/tests/ondemand/ondemand_convert_tests.cpp
@@ -19,7 +19,7 @@ struct Car {
 
   friend error_code tag_invoke(simdjson::deserialize_tag, auto &val, Car &car) {
     simdjson::ondemand::object obj;
-    error_code error;
+    error_code error{};
     val.get_object() >> obj >> error;
     if (error) {
       return error;

--- a/tests/ondemand/ondemand_convert_tests.cpp
+++ b/tests/ondemand/ondemand_convert_tests.cpp
@@ -17,10 +17,10 @@ struct Car {
   int year{};
   std::vector<double> tire_pressure{};
 
-  friend simdjson::error_code tag_invoke(simdjson::deserialize_tag, auto &val,
-                                         Car &car) {
+  friend error_code tag_invoke(simdjson::deserialize_tag, auto &val, Car &car) {
     simdjson::ondemand::object obj;
-    auto error = val.get_object().get(obj);
+    error_code error;
+    val.get_object() >> obj >> error;
     if (error) {
       return error;
     }
@@ -28,30 +28,18 @@ struct Car {
     // which we expect to be faster.
     for (auto field : obj) {
       simdjson::ondemand::raw_json_string key;
-      error = field.key().get(key);
+      field.key() >> key >> error;
+      if (key == "make") {
+         field.value() >> car.make >> error;
+      } else if (key == "model") {
+        field.value() >> car.model >> error;
+      } else if (key == "year") {
+        field.value() >> car.year >> error;
+      } else if (key == "tire_pressure") {
+        field.value() >> car.tire_pressure >> error;
+      }
       if (error) {
         return error;
-      }
-      if (key == "make") {
-        error = field.value().get_string(car.make);
-        if (error) {
-          return error;
-        }
-      } else if (key == "model") {
-        error = field.value().get_string(car.model);
-        if (error) {
-          return error;
-        }
-      } else if (key == "year") {
-        error = field.value().get(car.year);
-        if (error) {
-          return error;
-        }
-      } else if (key == "tire_pressure") {
-        error = field.value().get(car.tire_pressure);
-        if (error) {
-          return error;
-        }
       }
     }
     return simdjson::SUCCESS;


### PR DESCRIPTION
This is essentially the same as `.get(output) -> error_code`, but with one different, it does not throw when there's an error, and simply sets the error when a reference to it is given.

So this becomes possible:

```cpp
.value() >> car.model >> error;
```

It doesn't change much more than that, it's a syntactic sugar.

```cpp
struct Car {
  std::string make{};
  std::string model{};
  int year{};
  std::vector<double> tire_pressure{};

  friend error_code tag_invoke(simdjson::deserialize_tag, auto &val, Car &car) {
    simdjson::ondemand::object obj;
    error_code error;
    val.get_object() >> obj >> error;
    if (error) {
      return error;
    }
    // Instead of repeatedly obj["something"], we iterate through the object
    // which we expect to be faster.
    for (auto field : obj) {
      simdjson::ondemand::raw_json_string key;
      field.key() >> key >> error;
      if (key == "make") {
         field.value() >> car.make >> error;
      } else if (key == "model") {
        field.value() >> car.model >> error;
      } else if (key == "year") {
        field.value() >> car.year >> error;
      } else if (key == "tire_pressure") {
        field.value() >> car.tire_pressure >> error;
      }
      if (error) {
        return error;
      }
    }
    return simdjson::SUCCESS;
  }
};
```

We can't do the same with `document` and `object` and others that have `.get(output)` because they don't hold the error in themselves, but they return it after trying to set things.

So, no `val >> obj >> error` (in above example) for us.