### PR TITLE
doing more to discourage value_unsafe();

### DIFF
--- a/benchmark/dom/parse_stream.cpp
+++ b/benchmark/dom/parse_stream.cpp
@@ -25,12 +25,11 @@ int main(int argc, char *argv[]) {
     exit(1);
   }
   const char *filename = argv[1];
-  auto v = simdjson::padded_string::load(filename);
-  if (v.error()) {
+  simdjson::padded_string p;
+  if (simdjson::padded_string::load(filename).get(p)) {
     std::cerr << "Could not load the file " << filename << std::endl;
     return EXIT_FAILURE;
   }
-  const simdjson::padded_string& p = v.value_unsafe();
   if (test_baseline) {
     std::wclog << "Baseline: Getline + normal parse... " << std::endl;
     std::cout << "Gigabytes/second\t"

--- a/benchmark/get_corpus_benchmark.cpp
+++ b/benchmark/get_corpus_benchmark.cpp
@@ -9,7 +9,11 @@ simdjson_never_inline
 double bench(std::string filename, simdjson::padded_string& p) {
   std::chrono::time_point<std::chrono::steady_clock> start_clock =
       std::chrono::steady_clock::now();
-  simdjson::padded_string::load(filename).value_unsafe().swap(p);
+  auto error = simdjson::padded_string::load(filename).get(p);
+  if(error) {
+    std::cerr << simdjson::error_message(error) << std::endl;
+    std::abort();
+  }
   std::chrono::time_point<std::chrono::steady_clock> end_clock =
       std::chrono::steady_clock::now();
   std::chrono::duration<double> elapsed = end_clock - start_clock;

--- a/include/simdjson/error.h
+++ b/include/simdjson/error.h
@@ -203,12 +203,42 @@ struct simdjson_result_base : protected std::pair<T, error_code> {
   /**
    * Get the result value. This function is safe if and only
    * the error() method returns a value that evaluates to false.
+   * We discourage the use of value_unsafe().
+   *
+   * The recommended pattern is:
+   *
+   * T value; // where T is the type
+   * auto error = result.get(value);
+   * if (error) {
+   *   // handle error
+   * }
+   *
+   * Or you may call 'value()' which will raise an exception
+   * in case of error:
+   *
+   * T value = result.value();
    */
   simdjson_inline const T& value_unsafe() const& noexcept;
 
   /**
    * Take the result value (move it). This function is safe if and only
    * the error() method returns a value that evaluates to false.
+   * We discourage the use of value_unsafe().
+   *
+   * The recommended pattern is:
+   *
+   * T value; // where T is the type
+   * auto error = result.get(value);
+   * if (error) {
+   *   // handle error, return, exit, abort
+   * } else {
+   *   // use value here.
+   * }
+   *
+   * Or you may call 'value()' which will raise an exception
+   * in case of error:
+   *
+   * T value = result.value();
    */
   simdjson_inline T&& value_unsafe() && noexcept;
 


### PR DESCRIPTION
- Removes value_unsafe at two places in our benchmarks.
- Document more thoroughly value_unsafe and propose an alternative.
