### PR TITLE
Improve DOM implementation

### DIFF
--- a/include/simdjson/arm64/stringparsing_defs.h
+++ b/include/simdjson/arm64/stringparsing_defs.h
@@ -17,7 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
   simdjson_inline bool has_backslash() { return bs_bits != 0; }

--- a/include/simdjson/fallback/stringparsing_defs.h
+++ b/include/simdjson/fallback/stringparsing_defs.h
@@ -13,7 +13,7 @@ namespace {
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 1;
-  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return c == '"'; }
   simdjson_inline bool has_backslash() { return c == '\\'; }

--- a/include/simdjson/haswell/stringparsing_defs.h
+++ b/include/simdjson/haswell/stringparsing_defs.h
@@ -17,7 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
   simdjson_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }

--- a/include/simdjson/icelake/stringparsing_defs.h
+++ b/include/simdjson/icelake/stringparsing_defs.h
@@ -17,7 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 64;
-  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
   simdjson_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }

--- a/include/simdjson/lasx/stringparsing_defs.h
+++ b/include/simdjson/lasx/stringparsing_defs.h
@@ -17,7 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
   simdjson_inline bool has_backslash() { return bs_bits != 0; }

--- a/include/simdjson/lsx/stringparsing_defs.h
+++ b/include/simdjson/lsx/stringparsing_defs.h
@@ -17,7 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
   simdjson_inline bool has_backslash() { return bs_bits != 0; }

--- a/include/simdjson/ppc64/stringparsing_defs.h
+++ b/include/simdjson/ppc64/stringparsing_defs.h
@@ -17,7 +17,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_inline static backslash_and_quote
+  simdjson_inline backslash_and_quote
   copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() {

--- a/include/simdjson/westmere/stringparsing_defs.h
+++ b/include/simdjson/westmere/stringparsing_defs.h
@@ -14,7 +14,7 @@ using namespace simd;
 struct backslash_and_quote {
 public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
-  simdjson_inline static backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
+  simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
   simdjson_inline bool has_backslash() { return bs_bits != 0; }

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -151,7 +151,8 @@ simdjson_inline bool handle_unicode_codepoint_wobbly(const uint8_t **src_ptr,
 simdjson_warn_unused simdjson_inline uint8_t *parse_string(const uint8_t *src, uint8_t *dst, bool allow_replacement) {
   while (1) {
     // Copy the next n bytes, and find the backslash and quote in them.
-    auto bs_quote = backslash_and_quote::copy_and_find(src, dst);
+    auto b = backslash_and_quote{};
+    auto bs_quote = b.copy_and_find(src, dst);
     // If the next thing is the end quote, copy and return
     if (bs_quote.has_quote_first()) {
       // we encountered quotes first. Move dst to point to quotes and exit
@@ -196,7 +197,8 @@ simdjson_warn_unused simdjson_inline uint8_t *parse_wobbly_string(const uint8_t 
   // It is not ideal that this function is nearly identical to parse_string.
   while (1) {
     // Copy the next n bytes, and find the backslash and quote in them.
-    auto bs_quote = backslash_and_quote::copy_and_find(src, dst);
+    auto b = backslash_and_quote{};
+    auto bs_quote = b.copy_and_find(src, dst);
     // If the next thing is the end quote, copy and return
     if (bs_quote.has_quote_first()) {
       // we encountered quotes first. Move dst to point to quotes and exit


### PR DESCRIPTION
By removing stage1 and implementing yyjson's DOM parser. Running `benchmark\bench_parse_call --benchmark_filter="parse_twitter|parse_gsoc"` on an AMD Ryzen 3600 gets the following results:

| GB/s | MSVC before | MSVC after | Clang-CL before | Clang-CL after |
| --- | --- | --- | --- | --- |
| parse_twitter - haswell | 1.49004 | 2.80757 | 2.93942 | 3.09504 |
| parse_gsoc - haswell | 2.06389 | 5.30087 | 4.1485G | 6.45398 |
| parse_twitter - westmere | 1.82864 | 2.42042 | 2.14038 | 2.93942 |
| parse_gsoc - westmere | 2.65043 | 3.97565 | 2.83975 | 5.18563 |
| parse_twitter - fallback | 0.70212 | 1.05272 | 0.74675 | 1.13167 |
| parse_gsoc - fallback | 0.82877 | 1.22233 | 0.79636 | 1.24949 |