### PR TITLE
This PR introduces comprehensive support for C++ std::chrono types

### DIFF
--- a/include/simdjson/generic/ondemand/json_builder.h
+++ b/include/simdjson/generic/ondemand/json_builder.h
@@ -12,6 +12,7 @@
 #if SIMDJSON_STATIC_REFLECTION
 
 #include <charconv>
+#include <chrono>
 #include <cstring>
 #include <meta>
 #include <memory>
@@ -88,6 +89,20 @@ template<typename number_type,
          typename = typename std::enable_if<std::is_arithmetic<number_type>::value && !std::is_same_v<number_type, char>>::type>
 constexpr void atom(string_builder &b, const number_type t) {
   b.append(t);
+}
+
+// Support for std::chrono::duration - serialize as milliseconds
+template <typename Rep, typename Period>
+void atom(string_builder &b, const std::chrono::duration<Rep, Period> &duration) {
+  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+  b.append(ms);
+}
+
+// Support for std::chrono::time_point - serialize as milliseconds since epoch
+template <typename Clock, typename Duration>
+void atom(string_builder &b, const std::chrono::time_point<Clock, Duration> &time_point) {
+  auto ms_since_epoch = std::chrono::duration_cast<std::chrono::milliseconds>(time_point.time_since_epoch()).count();
+  b.append(ms_since_epoch);
 }
 
 template <class T>

--- a/include/simdjson/generic/ondemand/json_string_builder-inl.h
+++ b/include/simdjson/generic/ondemand/json_string_builder-inl.h
@@ -332,7 +332,11 @@ simdjson_really_inline size_t digit_count(number_type v) noexcept {
   static_assert(sizeof(number_type) == 8 || sizeof(number_type) == 4 ||
                     sizeof(number_type) == 2 || sizeof(number_type) == 1,
                 "We only support 8-bit, 16-bit, 32-bit and 64-bit numbers");
-  return fast_digit_count(v);
+  if (sizeof(number_type) <= 4) {
+    return fast_digit_count(static_cast<uint32_t>(v));
+  } else {
+    return fast_digit_count(static_cast<uint64_t>(v));
+  }
 }
 static const char decimal_table[200] = {
   0x30, 0x30, 0x30, 0x31, 0x30, 0x32, 0x30, 0x33, 0x30, 0x34, 0x30, 0x35,

--- a/include/simdjson/generic/ondemand/std_deserialize.h
+++ b/include/simdjson/generic/ondemand/std_deserialize.h
@@ -8,6 +8,7 @@
 #include "simdjson/generic/ondemand/base.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#include <chrono>
 #include <concepts>
 #include <limits>
 #if SIMDJSON_STATIC_REFLECTION
@@ -43,6 +44,25 @@ error_code tag_invoke(deserialize_tag, auto &val, T &out) noexcept {
   double x;
   SIMDJSON_TRY(val.get_double().get(x));
   out = static_cast<T>(x);
+  return SUCCESS;
+}
+
+// Support for std::chrono::duration - deserialize from milliseconds
+template <typename Rep, typename Period, typename ValT>
+error_code tag_invoke(deserialize_tag, ValT &val, std::chrono::duration<Rep, Period> &out) noexcept {
+  int64_t ms;
+  SIMDJSON_TRY(val.get_int64().get(ms));
+  out = std::chrono::duration_cast<std::chrono::duration<Rep, Period>>(std::chrono::milliseconds(ms));
+  return SUCCESS;
+}
+
+// Support for std::chrono::time_point - deserialize from milliseconds since epoch
+template <typename Clock, typename Duration, typename ValT>
+error_code tag_invoke(deserialize_tag, ValT &val, std::chrono::time_point<Clock, Duration> &out) noexcept {
+  int64_t ms_since_epoch;
+  SIMDJSON_TRY(val.get_int64().get(ms_since_epoch));
+  auto duration = std::chrono::milliseconds(ms_since_epoch);
+  out = std::chrono::time_point<Clock, Duration>(std::chrono::duration_cast<Duration>(duration));
   return SUCCESS;
 }
 

--- a/tests/builder/static_reflection_chrono_test.cpp
+++ b/tests/builder/static_reflection_chrono_test.cpp
@@ -1,0 +1,176 @@
+#include "simdjson.h"
+#include "test_builder.h"
+#include <chrono>
+#include <string>
+#include <vector>
+#include <optional>
+#include <iostream>
+
+using namespace simdjson;
+
+namespace builder_tests {
+
+struct Meeting {
+    std::string title;
+    std::chrono::system_clock::time_point start_time;
+    std::vector<std::string> attendees;
+    std::optional<std::string> location;
+    bool is_recurring;
+};
+
+bool test_meeting_roundtrip() {
+    TEST_START();
+#if SIMDJSON_STATIC_REFLECTION
+    // Create a Meeting instance with current time
+    auto now = std::chrono::system_clock::now();
+    Meeting original{
+        .title = "CppCon Planning",
+        .start_time = now,
+        .attendees = {"Alice", "Bob", "Charlie"},
+        .location = "Denver",
+        .is_recurring = true
+    };
+
+    // Serialize to JSON
+    auto json_result = builder::to_json_string(original);
+    ASSERT_SUCCESS(json_result);
+    std::string json = json_result.value();
+
+    std::cout << "Serialized JSON: " << json << std::endl;
+
+    // Parse back from JSON
+    ondemand::parser parser;
+    auto doc_result = parser.iterate(pad(json));
+    ASSERT_SUCCESS(doc_result);
+
+    auto get_result = doc_result.value().get<Meeting>();
+    ASSERT_SUCCESS(get_result);
+
+    Meeting deserialized = std::move(get_result.value());
+
+    // Verify round-trip
+    ASSERT_EQUAL(deserialized.title, original.title);
+    ASSERT_EQUAL(deserialized.is_recurring, original.is_recurring);
+    ASSERT_TRUE(deserialized.location.has_value());
+    ASSERT_EQUAL(deserialized.location.value(), original.location.value());
+    ASSERT_EQUAL(deserialized.attendees.size(), original.attendees.size());
+    for(size_t i = 0; i < original.attendees.size(); i++) {
+        ASSERT_EQUAL(deserialized.attendees[i], original.attendees[i]);
+    }
+
+    // Check that the time point is correctly deserialized with millisecond precision
+    auto original_ms = std::chrono::duration_cast<std::chrono::milliseconds>(original.start_time.time_since_epoch()).count();
+    auto deserialized_ms = std::chrono::duration_cast<std::chrono::milliseconds>(deserialized.start_time.time_since_epoch()).count();
+
+    std::cout << "Original time: " << original_ms << "ms since epoch" << std::endl;
+    std::cout << "Deserialized time: " << deserialized_ms << "ms since epoch" << std::endl;
+
+    // Verify exact equality at millisecond precision
+    ASSERT_EQUAL(deserialized_ms, original_ms);
+
+#endif
+    TEST_SUCCEED();
+}
+
+bool test_duration_roundtrip() {
+    TEST_START();
+#if SIMDJSON_STATIC_REFLECTION
+    struct Task {
+        std::string name;
+        std::chrono::milliseconds duration_ms;
+        std::chrono::seconds duration_s;
+        std::chrono::minutes duration_min;
+    };
+
+    Task original{
+        .name = "Build Project",
+        .duration_ms = std::chrono::milliseconds(5432),
+        .duration_s = std::chrono::seconds(300),
+        .duration_min = std::chrono::minutes(45)
+    };
+
+    // Serialize to JSON
+    auto json_result = builder::to_json_string(original);
+    ASSERT_SUCCESS(json_result);
+    std::string json = json_result.value();
+
+    std::cout << "Duration test JSON: " << json << std::endl;
+
+    // Parse back from JSON
+    ondemand::parser parser;
+    auto doc_result = parser.iterate(pad(json));
+    ASSERT_SUCCESS(doc_result);
+
+    auto get_result = doc_result.value().get<Task>();
+    ASSERT_SUCCESS(get_result);
+
+    Task deserialized = std::move(get_result.value());
+
+    // Verify round-trip
+    ASSERT_EQUAL(deserialized.name, original.name);
+    ASSERT_EQUAL(deserialized.duration_ms.count(), original.duration_ms.count());
+    ASSERT_EQUAL(deserialized.duration_s.count(), original.duration_s.count());
+    ASSERT_EQUAL(deserialized.duration_min.count(), original.duration_min.count());
+
+#endif
+    TEST_SUCCEED();
+}
+
+bool test_different_clock_types() {
+    TEST_START();
+#if SIMDJSON_STATIC_REFLECTION
+    struct Schedule {
+        std::string event;
+        std::chrono::system_clock::time_point system_time;
+        std::chrono::steady_clock::time_point steady_time;
+    };
+
+    Schedule original{
+        .event = "Conference",
+        .system_time = std::chrono::system_clock::now(),
+        .steady_time = std::chrono::steady_clock::now()
+    };
+
+    // Serialize to JSON
+    auto json_result = builder::to_json_string(original);
+    ASSERT_SUCCESS(json_result);
+    std::string json = json_result.value();
+
+    std::cout << "Clock types test JSON: " << json << std::endl;
+
+    // Parse back from JSON
+    ondemand::parser parser;
+    auto doc_result = parser.iterate(pad(json));
+    ASSERT_SUCCESS(doc_result);
+
+    auto get_result = doc_result.value().get<Schedule>();
+    ASSERT_SUCCESS(get_result);
+
+    Schedule deserialized = std::move(get_result.value());
+
+    // Verify round-trip - check millisecond precision
+    ASSERT_EQUAL(deserialized.event, original.event);
+
+    auto orig_sys_ms = std::chrono::duration_cast<std::chrono::milliseconds>(original.system_time.time_since_epoch()).count();
+    auto deser_sys_ms = std::chrono::duration_cast<std::chrono::milliseconds>(deserialized.system_time.time_since_epoch()).count();
+    ASSERT_EQUAL(deser_sys_ms, orig_sys_ms);
+
+    auto orig_steady_ms = std::chrono::duration_cast<std::chrono::milliseconds>(original.steady_time.time_since_epoch()).count();
+    auto deser_steady_ms = std::chrono::duration_cast<std::chrono::milliseconds>(deserialized.steady_time.time_since_epoch()).count();
+    ASSERT_EQUAL(deser_steady_ms, orig_steady_ms);
+
+#endif
+    TEST_SUCCEED();
+}
+
+bool run() {
+    return test_meeting_roundtrip() &&
+           test_duration_roundtrip() &&
+           test_different_clock_types();
+}
+
+} // namespace builder_tests
+
+int main(int argc, char *argv[]) {
+    return builder_tests::run() ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
## Summary

  This PR introduces comprehensive support for C++ std::chrono types (durations and time_points) in simdjson's static reflection API,
  enabling automatic JSON serialization and deserialization of temporal data.

## Problem Solved

  Previously, structs containing std::chrono::duration or std::chrono::time_point members could not be serialized/deserialized using
  simdjson's static reflection features. This limitation forced users to manually convert temporal data or create custom serialization
  logic.

## Implementation Details

  1. Serialization Support (include/simdjson/generic/ondemand/json_builder.h)

  - Added template specializations for std::chrono::duration<Rep, Period>
  - Added template specializations for std::chrono::time_point<Clock, Duration>
  - Both types serialize to milliseconds as JSON integers for precision and compatibility

  2. Deserialization Support (include/simdjson/generic/ondemand/std_deserialize.h)

  - Added tag_invoke overloads for deserializing durations from milliseconds
  - Added tag_invoke overloads for deserializing time_points from milliseconds since epoch
  - Properly handles conversion between different duration units and clock types

  3. Template Instantiation Fix (include/simdjson/generic/ondemand/json_string_builder-inl.h)

  - Fixed digit_count() function to explicitly cast to uint32_t or uint64_t
  - Resolves compilation errors when serializing chrono types with various integer representations

  4. Comprehensive Testing (tests/builder/static_reflection_chrono_test.cpp)

  - Round-trip tests for structs containing time_point members
  - Tests for multiple duration types (milliseconds, seconds, minutes)
  - Validation of different clock types (system_clock, steady_clock)
  - Ensures millisecond precision is maintained through serialization

## Key Design Decisions

  - Milliseconds as standard unit: Provides good balance between precision and JSON number range
  - Integer representation: More efficient and portable than ISO 8601 strings
  - Non-intrusive design: No modifications needed to user structs
  - Template-based approach: Works automatically with any chrono duration/time_point type

## Example Usage
```c++
  struct Meeting {
      std::string title;
      std::chrono::system_clock::time_point start_time;
      std::chrono::minutes duration;
  };

  // Automatically serializes to:
  // {"title":"Team Standup","start_time":1736951234567,"duration":30000}

  Meeting m = doc.get<Meeting>(); // Deserializes seamlessly
```

## Testing

  All tests pass with reflection-enabled clang compiler. The implementation maintains exact millisecond precision through round-trip
  serialization.