### PR TITLE
remove trailing whitespace + fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Some users may want to browse code along with the compiled assembly. You want to
 * [C++26 reflection example](https://godbolt.org/z/K3Px64TqK)
 * [simdjson examples with errors handled through exceptions](https://godbolt.org/z/7G5qE4sr9)
 * [simdjson examples with errors without exceptions](https://godbolt.org/z/e9dWb9E4v)
- 
 
 Performance results
 -------------------

--- a/include/simdjson/generic/ondemand/std_deserialize.h
+++ b/include/simdjson/generic/ondemand/std_deserialize.h
@@ -291,7 +291,7 @@ error_code tag_invoke(deserialize_tag, ValT &val, T &out) noexcept {
     if constexpr (!std::meta::is_const(mem) && std::meta::is_public(mem)) {
       constexpr std::string_view key = std::define_static_string(std::meta::identifier_of(mem));
       // Note: removed static assert as optional types are now handled generically
-      // as long we are succesful or the field is not found, we continue
+      // as long we are successful or the field is not found, we continue
       if(e == simdjson::SUCCESS || e == simdjson::NO_SUCH_FIELD) {
         e = obj[key].get(out.[:mem:]);
       }

--- a/tests/dom/CMakeLists.txt
+++ b/tests/dom/CMakeLists.txt
@@ -123,7 +123,7 @@ endif()
 
 # Add the tests if we're on:
 #   1. Visual Studio 2022 v17.6 or later
-#   2. GCC v14.0.0 or later (GCC v13.0.0 cannot handle pipe oprator of lambda)
+#   2. GCC v14.0.0 or later (GCC v13.0.0 cannot handle pipe operator of lambda)
 #   3. Clang v15.0.0 or later (certain version C++ headers occur error when compiling)
 if(
   (MSVC AND MSVC_VERSION LESS 1930) OR


### PR DESCRIPTION
This pull request removes the trailing whitespace from the readme file so that the whitespace test in CI passes again.
Furthermore, some typos are fixed.