### PR TITLE
Fix yyjson leaks when running `./bench_ondemand`

### DIFF
--- a/benchmark/distinct_user_id/yyjson.h
+++ b/benchmark/distinct_user_id/yyjson.h
@@ -44,7 +44,10 @@ struct yyjson_base {
 
 struct yyjson : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
-    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), result);
+    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, yyjson)->UseManualTime();
@@ -52,11 +55,15 @@ BENCHMARK_TEMPLATE(distinct_user_id, yyjson)->UseManualTime();
 #if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<uint64_t> &result) {
-    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
+    yyjson_doc *doc = yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(distinct_user_id, yyjson_insitu)->UseManualTime();
 #endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
+
 } // namespace distinct_user_id
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/find_tweet/yyjson.h
+++ b/benchmark/find_tweet/yyjson.h
@@ -36,18 +36,26 @@ struct yyjson_base {
 
 struct yyjson : yyjson_base {
   bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
-    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), find_id, result);
+    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+    bool b = yyjson_base::run(doc, find_id, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, yyjson)->UseManualTime();
+
 #if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, uint64_t find_id, std::string_view &result) {
-    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), find_id, result);
+    yyjson_doc *doc = yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
+    bool b = yyjson_base::run(doc, find_id, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(find_tweet, yyjson_insitu)->UseManualTime();
 #endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
+
 } // namespace find_tweet
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/json2msgpack/yyjson.h
+++ b/benchmark/json2msgpack/yyjson.h
@@ -100,6 +100,7 @@ struct yyjson : yyjson2msgpack {
            std::string_view &result) {
     yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
     result = to_msgpack(doc, reinterpret_cast<uint8_t*>(buffer));
+    yyjson_doc_free(doc);
     return true;
   }
 };
@@ -113,6 +114,7 @@ struct yyjson_insitu : yyjson2msgpack {
     yyjson_doc *doc =
         yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
     result = to_msgpack(doc, reinterpret_cast<uint8_t*>(buffer));
+    yyjson_doc_free(doc);
     return true;
   }
 };

--- a/benchmark/kostya/yyjson.h
+++ b/benchmark/kostya/yyjson.h
@@ -49,18 +49,26 @@ struct yyjson_base {
 
 struct yyjson : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), result);
+    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(kostya, yyjson)->UseManualTime();
+
 #if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
+    yyjson_doc *doc = yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(kostya, yyjson_insitu)->UseManualTime();
 #endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
+
 } // namespace kostya
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/large_random/yyjson.h
+++ b/benchmark/large_random/yyjson.h
@@ -47,18 +47,26 @@ struct yyjson_base {
 
 struct yyjson : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), result);
+    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(large_random, yyjson)->UseManualTime();
+
 #if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<point> &result) {
-    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
+    yyjson_doc *doc = yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(large_random, yyjson_insitu)->UseManualTime();
 #endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
+
 } // namespace large_random
 
 #endif // SIMDJSON_COMPETITION_YYJSON

--- a/benchmark/partial_tweets/yyjson.h
+++ b/benchmark/partial_tweets/yyjson.h
@@ -62,19 +62,26 @@ struct yyjson_base {
 
 struct yyjson : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
-    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), result);
+    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, yyjson)->UseManualTime();
+
 #if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
-    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), result);
+    yyjson_doc *doc = yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
+    bool b = yyjson_base::run(doc, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(partial_tweets, yyjson_insitu)->UseManualTime();
 #endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
+
 } // namespace partial_tweets
 
 #endif // SIMDJSON_COMPETITION_YYJSON
-

--- a/benchmark/top_tweet/yyjson.h
+++ b/benchmark/top_tweet/yyjson.h
@@ -51,18 +51,26 @@ struct yyjson_base {
 
 struct yyjson : yyjson_base {
   bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
-    return yyjson_base::run(yyjson_read(json.data(), json.size(), 0), max_retweet_count, result);
+    yyjson_doc *doc = yyjson_read(json.data(), json.size(), 0);
+    bool b = yyjson_base::run(doc, max_retweet_count, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(top_tweet, yyjson)->UseManualTime();
+
 #if SIMDJSON_COMPETITION_ONDEMAND_INSITU
 struct yyjson_insitu : yyjson_base {
   bool run(simdjson::padded_string &json, int64_t max_retweet_count, top_tweet_result<StringType> &result) {
-    return yyjson_base::run(yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0), max_retweet_count, result);
+    yyjson_doc *doc = yyjson_read_opts(json.data(), json.size(), YYJSON_READ_INSITU, 0, 0);
+    bool b = yyjson_base::run(doc, max_retweet_count, result);
+    yyjson_doc_free(doc);
+    return b;
   }
 };
 BENCHMARK_TEMPLATE(top_tweet, yyjson_insitu)->UseManualTime();
 #endif // SIMDJSON_COMPETITION_ONDEMAND_INSITU
+
 } // namespace top_tweet
 
 #endif // SIMDJSON_COMPETITION_YYJSON


### PR DESCRIPTION
Short title (summary): Fix memory leaks in yyjson benchmarks (missing yyjson_doc_free)

Description
- Some yyjson-based benchmarks did not call yyjson_doc_free, causing large memory leaks when running multiple tests (e.g., ./bench_ondemand without filters could exhaust 32 GB RAM).
- Fixed by ensuring every yyjson_doc created in the benchmarks is properly freed. After this change, Valgrind reports no leaks on affected benchmarks.

Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to verify / test
- Run benchmarks with Valgrind: `valgrind --leak-check=full --trace-children=yes build/benchmark/bench_ondemand`
- No more “definitely lost” reports after the changes in this PR.