### PR TITLE
minor suggested changes.

### DIFF
--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -143,6 +143,24 @@ concept container_but_not_string =
   std::ranges::input_range<T> && !string_like<T> && !concepts::string_view_keyed_map<T>;
 
 
+// Concept: Indexable container that is not a string or associative container
+// Accepts: std::vector, std::array, std::deque (have operator[], value_type, not string_like)
+// Rejects: std::string (string_like), std::list (no operator[]), std::map (has key_type)
+template<typename Container>
+concept indexable_container = requires {
+  typename Container::value_type;
+  requires !concepts::string_like<Container>;
+  requires !requires { typename Container::key_type; };  // Reject maps/sets
+  requires requires(Container& c, std::size_t i) {
+    { c[i] } -> std::convertible_to<typename Container::value_type>;
+  };
+};
+
+// Variable template to use with std::meta::substitute
+template<typename Container>
+constexpr bool indexable_container_v = indexable_container<Container>;
+
+
 } // namespace concepts
 
 


### PR DESCRIPTION
There are minor suggestions for francisco/json_path_reflection https://github.com/simdjson/simdjson/pull/2483

And yes, the official name is JSONPath, not JSON Path as one might imagine.