### PR TITLE
fix: cmake error when CMAKE_CXX_FLAGS is empty

### DIFF
--- a/cmake/exception-flags.cmake
+++ b/cmake/exception-flags.cmake
@@ -17,8 +17,9 @@ editing CMAKE_CXX_FLAGS")
     # /EHc used in conjection with /EHs indicates that extern "C" functions
     # never throw (terminate-on-throw)
     # Here, we disable both with the - argument negation operator
-    string(REPLACE "/EHsc" "/EHs-c-" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-
+    if(CMAKE_CXX_FLAGS)
+        string(REPLACE "/EHsc" "/EHs-c-" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+    endif()
     # Because we cannot change the flag above on an individual target (yet), the
     # definition below must similarly be added globally
     add_definitions(-D_HAS_EXCEPTIONS=0)


### PR DESCRIPTION
Description
- fixes the error when CMAKE_CXX_FLAGS is empty.
- related to issue #2510 .

Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to test
```bash
> mkdir build
> cd build
> cmake -G "Visual Studio 17 2022" -A x64 -DSIMDJSON_DEVELOPER_MODE=OFF -DCMAKE_CXX_FLAGS="" ..
```
After fix there's no error.


