### PR TITLE
Make it possible to provide custom serializers for range types

### DIFF
--- a/include/simdjson/generic/ondemand/json_string_builder-inl.h
+++ b/include/simdjson/generic/ondemand/json_string_builder-inl.h
@@ -534,7 +534,7 @@ simdjson_inline void string_builder::append(const T &value) {
 #if SIMDJSON_SUPPORTS_RANGES && SIMDJSON_SUPPORTS_CONCEPTS
 // Support for range-based appending (std::ranges::view, etc.)
 template <std::ranges::range R>
-  requires(!std::is_convertible<R, std::string_view>::value)
+  requires(!std::is_convertible<R, std::string_view>::value && !require_custom_serialization<R>)
 simdjson_inline void string_builder::append(const R &range) noexcept {
   auto it = std::ranges::begin(range);
   auto end = std::ranges::end(range);

--- a/include/simdjson/generic/ondemand/json_string_builder.h
+++ b/include/simdjson/generic/ondemand/json_string_builder.h
@@ -176,7 +176,7 @@ public:
 #if SIMDJSON_SUPPORTS_RANGES && SIMDJSON_SUPPORTS_CONCEPTS
   // Support for range-based appending (std::ranges::view, etc.)
   template <std::ranges::range R>
-requires (!std::is_convertible<R, std::string_view>::value)
+requires (!std::is_convertible<R, std::string_view>::value && !require_custom_serialization<R>)
   simdjson_inline void append(const R &range) noexcept;
 #endif
   /**


### PR DESCRIPTION
If you provide a custom serializer for range types it is currently never used because the requires clause for string_builder::append with ranges is overly broad