### PR TITLE
oss-fuzz: Add unit testing build to oss-fuzz build script

### DIFF
--- a/fuzz/ossfuzz.sh
+++ b/fuzz/ossfuzz.sh
@@ -35,7 +35,7 @@ cmake .. \
 -DSIMDJSON_DISABLE_DEPRECATED_API=On \
 -DSIMDJSON_FUZZ_LDFLAGS=$LIB_FUZZING_ENGINE
 
-cmake --build . --target all_fuzzers
+cmake --build . --target all_fuzzers all_tests
 
 cp fuzz/fuzz_* $OUT
 


### PR DESCRIPTION
OSS-Fuzz has a new Chronos feature that allows fast rebuilding of OSS-Fuzz-integrated projects and checks whether the project code or fuzzers still pass their unit tests after patching. To enable this feature, the unit tests of integrated projects need to be built. Therefore, this PR modifies the build script used by OSS-Fuzz to also build the unit tests for this project. The OSS-Fuzz-side changes for this project's integration can be found here: https://github.com/google/oss-fuzz/pull/14714.