### PR TITLE
when calling get_string with a mutable string parameter, we want to only use the string buffer as scratch space

### DIFF
--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -515,9 +515,13 @@ simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> value_ite
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code value_iterator::get_string(string_type& receiver, bool allow_replacement) noexcept {
   std::string_view content;
+  // Save the string buffer location so that we can restore it after get_string
+  auto saved_string_buf_loc = _json_iter->string_buf_loc();
   auto err = get_string(allow_replacement).get(content);
   if (err) { return err; }
   receiver = content;
+  // Restore the string buffer location, effectively discarding any temporary string storage
+  _json_iter->string_buf_loc() = saved_string_buf_loc;
   return SUCCESS;
 }
 simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> value_iterator::get_wobbly_string() noexcept {
@@ -657,9 +661,13 @@ simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> value_ite
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code value_iterator::get_root_string(string_type& receiver, bool check_trailing, bool allow_replacement) noexcept {
   std::string_view content;
+  // Save the string buffer location so that we can restore it after get_string
+  auto saved_string_buf_loc = _json_iter->string_buf_loc();
   auto err = get_root_string(check_trailing, allow_replacement).get(content);
   if (err) { return err; }
   receiver = content;
+  // Restore the string buffer location, effectively discarding any temporary string storage
+  _json_iter->string_buf_loc() = saved_string_buf_loc;
   return SUCCESS;
 }
 simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> value_iterator::get_root_wobbly_string(bool check_trailing) noexcept {


### PR DESCRIPTION
The new behaviour will be closer to how we document these functions.
