### PR TITLE
implementing the backslash-free string optimization

### DIFF
--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -162,16 +162,7 @@ simdjson_unused simdjson_inline bool operator!=(std::string_view c, const raw_js
 
 
 simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> raw_json_string::unescape(json_iterator &iter, bool allow_replacement) const noexcept {
-  // This function is called by field::unescaped_key(), and so we expect tiny strings, usually without escapes.
-  const char * r{raw()};
-  while(*r != '"') {
-    if(*r == '\\') {
-      return iter.unescape(*this, allow_replacement);
-    }
-    r++;
-  }
-  // No escapes: we can just return a string_view into the original JSON buffer.
-  return std::string_view(raw(), r - raw() );
+  return iter.unescape(*this, allow_replacement);
 }
 
 simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> raw_json_string::unescape_wobbly(json_iterator &iter) const noexcept {

--- a/include/simdjson/generic/ondemand/raw_json_string.h
+++ b/include/simdjson/generic/ondemand/raw_json_string.h
@@ -149,13 +149,9 @@ private:
    * Unescape this JSON string, replacing \\ with \, \n with newline, etc.
    * The result will be a valid UTF-8.
    *
-   * When the string does not contain any escape sequences, this function
-   * will simply return a string_view into the original JSON buffer.
-   *
    * ## IMPORTANT: string_view lifetime
    *
-   * The string_view is only valid until the next parse() call on the parser when escaping
-   * was needed.
+   * The string_view is only valid until the next parse() call on the parser.
    *
    * @param iter A json_iterator, which contains a buffer where the string will be written.
    * @param allow_replacement Whether we allow replacement of invalid surrogate pairs.

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -520,14 +520,18 @@ simdjson_warn_unused simdjson_inline simdjson_result<std::string_view> value_ite
   // backslash is found early. However, we expect that in most strings there will be no backslash,
   // so we optimize for that case. The compiler knows to expect a full scan and it can optimize for it.
   auto has_backslash_fast = [](std::string_view s) noexcept {
-    bool has_backslash = false;
-    for( const char c : s) { has_backslash |= (c == '\\'); }
-    return has_backslash;
+    for(const char c : s) {
+      if(c == '\\') {
+        return true;
+      }
+    }
+    return false;
   };
   std::string_view string_with_quotes(reinterpret_cast<const char*>(peek_start()), peek_start_length());
   if(string_with_quotes.front() != '"') {
     return incorrect_type_error("Not a string");
   }
+
   if(!has_backslash_fast(string_with_quotes)) {
     // Find the ending quote
     size_t len = string_with_quotes.size();


### PR DESCRIPTION
This builds on top of a PR by  @CarlosEduR. https://github.com/simdjson/simdjson/pull/2211

Fixes https://github.com/simdjson/simdjson/issues/1470


It looks like the proper design to me right now, but we need to run benchmarks to see if it is at least performance neutral.