### PR TITLE
Fix incomplete ABLATION_NO_CONSTEVAL guards

### DIFF
--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -94,8 +94,12 @@ constexpr void atom(string_builder &b, const T &t) {
   template for (constexpr auto dm : std::define_static_array(std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked()))) {
     if (i != 0)
       b.append(',');
+#if ABLATION_NO_CONSTEVAL
+    b.escape_and_append_with_quotes(std::meta::identifier_of(dm));
+#else
     constexpr auto key = std::define_static_string(constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)));
     b.append_raw(key);
+#endif
     b.append(':');
     atom(b, t.[:dm:]);
     i++;
@@ -132,9 +136,13 @@ void atom(string_builder &b, const T &e) {
 #if SIMDJSON_STATIC_REFLECTION
   constexpr auto enumerators = std::define_static_array(std::meta::enumerators_of(^^T));
   template for (constexpr auto enum_val : enumerators) {
-    constexpr auto enum_str = std::define_static_string(constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(enum_val)));
     if (e == [:enum_val:]) {
+#if ABLATION_NO_CONSTEVAL
+      b.escape_and_append_with_quotes(std::meta::identifier_of(enum_val));
+#else
+      constexpr auto enum_str = std::define_static_string(constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(enum_val)));
       b.append_raw(enum_str);
+#endif
       return;
     }
   };


### PR DESCRIPTION
## Summary

- Add missing `ABLATION_NO_CONSTEVAL` guards to `atom()` for structs (line 94-102)
- Add missing `ABLATION_NO_CONSTEVAL` guards to `atom()` for enums (line 136-150)

## Problem

The ablation study was showing inconsistent results for the consteval optimization because the `ABLATION_NO_CONSTEVAL` flag only affected the `append()` functions but not the `atom()` functions. This meant some code paths still used consteval even when ablation was enabled.

**Before fix:**
| Config | CITM | Twitter |
|--------|------|---------|
| NO_CONSTEVAL | -9% | -1% |

**After fix:**
| Config | CITM | Twitter |
|--------|------|---------|
| NO_CONSTEVAL | -47% | -38% |

## Full Ablation Results (with fix)

| Configuration | CITM (MB/s) | Impact | Twitter (MB/s) | Impact |
|---------------|-------------|--------|----------------|--------|
| Baseline | 3114.22 | - | 5751.85 | - |
| NO_BRANCH_HINTS | 2436.44 | -22% | 4991.61 | -13% |
| NO_SIMD_ESCAPING | 2675.11 | -14% | 1419.44 | -75% |
| NO_CONSTEVAL | 1647.66 | -47% | 3565.21 | -38% |

## Conclusion

The consteval optimization (`std::define_static_string` with `consteval_to_quoted_escaped`) provides ~2x performance improvement by pre-computing escaped/quoted field names and enum strings at compile time.