### PR TITLE
Fix wrong branch hint and missing consteval guard in extract_from

### DIFF
--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -329,8 +329,12 @@ void extract_from(string_builder &b, const T &obj) {
         first = false;
 
         // Serialize the key
+#if ABLATION_NO_CONSTEVAL
+        b.escape_and_append_with_quotes(std::meta::identifier_of(mem));
+#else
         constexpr auto quoted_key = std::define_static_string(constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(mem)));
         b.append_raw(quoted_key);
+#endif
         b.append(':');
 
         // Serialize the value

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -362,7 +362,7 @@ simdjson_inline bool string_builder::capacity_check(size_t upcoming_bytes) {
     return true;
   }
   // check for overflow, most of the time there is no overflow
-  if (simdjson_likely(position + upcoming_bytes < position)) {
+  if (simdjson_unlikely(position + upcoming_bytes < position)) {
     return false;
   }
 #endif


### PR DESCRIPTION
## Summary

- Fix incorrect `simdjson_likely` → `simdjson_unlikely` on overflow check in `capacity_check()` (`json_string_builder-inl.h:365`)
- Add missing `ABLATION_NO_CONSTEVAL` guard in `extract_from()` (`json_builder.h:332`)

## Details

### 1. Wrong branch hint (bug)

The overflow check in `capacity_check()` used `simdjson_likely` but the comment says "most of the time there is no overflow". This was telling the branch predictor to optimize for the overflow path, which is the opposite of what we want:

```cpp
// BEFORE (wrong):
if (simdjson_likely(position + upcoming_bytes < position)) { return false; }

// AFTER (correct):
if (simdjson_unlikely(position + upcoming_bytes < position)) { return false; }
```

This improved the branch hints ablation impact from -13% to **-18%** on Twitter.

### 2. Missing consteval guard in extract_from (completeness)

`extract_from()` used `consteval_to_quoted_escaped` without an `ABLATION_NO_CONSTEVAL` guard. Not used in benchmarks, but added for consistency with all other call sites.

## Updated Ablation Results (with all fixes)

| Configuration | CITM (MB/s) | Impact | Twitter (MB/s) | Impact |
|---------------|-------------|--------|----------------|--------|
| Baseline | 3001.10 | - | 5651.89 | - |
| NO_BRANCH_HINTS | 2443.67 | -19% | 4651.78 | -18% |
| NO_SIMD_ESCAPING | 2904.34 | -3% | 1403.36 | -75% |
| NO_CONSTEVAL | 1796.05 | -40% | 3542.77 | -37% |