### PR TITLE
add mruby-fast-json binding to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ We distinguish between "bindings" (which just wrap the C++ code) and a port to a
 - [JSON::SIMD](https://metacpan.org/pod/JSON::SIMD): Perl bindings; fully-featured JSON module that uses simdjson for decoding.
 - [gemmaJSON](https://github.com/sainttttt/gemmaJSON): Nim JSON parser based on simdjson bindings.
 - [simdjson-java](https://github.com/simdjson/simdjson-java): Java port.
+- [mruby-fast-json](https://github.com/Asmod4n/mruby-fast-json): mruby binding with high API coverage.
 
 About simdjson
 --------------


### PR DESCRIPTION
Short title (summary): Add mruby binding to README.

Description
I took simdjson as a learning opportunity to learn more about c++, as such i have covered most of the public API Surface simdjson got for the binding.

Type of change
- [x] Other (please describe): binding addition.

Checklist before submitting
- [x] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear

Have fun :)