### PR TITLE
bench: added microbenchmarks for on-demand get_int64() and get_double()

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -610,34 +610,4 @@ static void parse_surrogate_pairs(State& state) {
 }
 BENCHMARK(parse_surrogate_pairs);
 
-static void bench_get_int64(State &state) {
-  ondemand::parser parser;
-  const std::string_view number = "123456789";
-  padded_string json{number};
-
-  for (simdjson_unused auto _ : state) {
-    auto doc = parser.iterate(json);
-    int64_t x = doc.get_int64();
-
-    benchmark::DoNotOptimize(x);
-    benchmark::ClobberMemory();
-  }
-}
-BENCHMARK(bench_get_int64);
-
-static void bench_get_double(State &state) {
-  ondemand::parser parser;
-  const std::string_view number = "123456789.0";
-  padded_string json{number};
-
-  for (simdjson_unused auto _ : state) {
-    auto doc = parser.iterate(json);
-    double d = doc.get_double();
-
-    benchmark::DoNotOptimize(d);
-    benchmark::ClobberMemory();
-  }
-}
-BENCHMARK(bench_get_double);
-
 BENCHMARK_MAIN();


### PR DESCRIPTION
Short title (summary) : 

Added two small microbenchmarks to measure top-level number parsing using the OnDemand API to address issue #2186 (investigate whether 'get_int64()' can be slower than 'get_double()').

Description :

- Added two microbenchmarks in `benchmark/bench_dom_api.cpp` (keeps the repo's existing benchmark binary and style).
-- Functions: 'bench_get_int64' andd 'bench_get_double'
-- Followed the repo’s existing benchmark template

- Related Issue : https://github.com/simdjson/simdjson/issues/2186

Type of change :

- Benchmark

Results :

- Machine :-
--CPU : Intel(R) Core(TM) i5-13420H (13th Gen)
--OS : Windows 11 (MSVC 19.43.34808)
--Architecture : x64
--Build Type : Release

<img width="716" height="252" alt="image" src="https://github.com/user-attachments/assets/24145464-8454-45c2-8595-457d544dfc75" />

I also tested different string lengths. The only time get_double() appeared faster was when the double test string was shorter than the integer test string. When input lengths were equal, results were essentially the same.

Conclusion : on my machine I could not reproduce a case where get_int64() was meaningfully slower than get_double(). Observed variations correlate with input digit length rather than numeric type.