### PR TITLE
fix failing CI and rename misleading workflow name

### DIFF
--- a/.github/workflows/ubuntu24-checkperf.yml
+++ b/.github/workflows/ubuntu24-checkperf.yml
@@ -1,4 +1,4 @@
-name: Performance check on Ubuntu 20.04 CI (GCC 9)
+name: Performance check on Ubuntu 24.04 CI (GCC 13)
 
 on:
   push:

--- a/.github/workflows/ubuntu24-noexcept.yml
+++ b/.github/workflows/ubuntu24-noexcept.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 20.04 CI (GCC 9) without exceptions
+name: Ubuntu 24.04 CI (GCC 13) without exceptions
 
 on: [push, pull_request]
 
@@ -24,7 +24,7 @@ jobs:
           cd .. &&
           mkdir build &&
           cd build &&
-          cmake  -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DSIMDJSON_EXCEPTIONS=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
+          cmake  -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_GOOGLE_BENCHMARKS=ON -DSIMDJSON_EXCEPTIONS=OFF -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX:PATH=destination ..  &&
           cmake --build .   &&
           ctest --output-on-failure -LE explicitonly -j   &&
           make install  &&

--- a/.github/workflows/ubuntu24-nothread.yml
+++ b/.github/workflows/ubuntu24-nothread.yml
@@ -1,4 +1,4 @@
-name: Ubuntu 20.04 CI (GCC 9) Without Threads
+name: Ubuntu 24.04 CI (GCC 13) Without Threads
 
 on: [push, pull_request]
 

--- a/.github/workflows/ubuntu24-sani.yml
+++ b/.github/workflows/ubuntu24-sani.yml
@@ -1,9 +1,9 @@
-name: Ubuntu 20.04 CI (GCC 9) With Memory Sanitizer
+name: Ubuntu 24.04 CI (GCC 13) With Memory Sanitizer
 
 on: [push, pull_request]
 
 jobs:
-  ubuntu-build-address-sanitizier:
+  ubuntu-build-address-sanitizer:
     if: >-
       ! contains(toJSON(github.event.commits.*.message), '[skip ci]') &&
       ! contains(toJSON(github.event.commits.*.message), '[skip github]')

--- a/include/simdjson/padded_string-inl.h
+++ b/include/simdjson/padded_string-inl.h
@@ -387,7 +387,7 @@ simdjson_inline padded_memory_map::padded_memory_map(const char *filename) noexc
       close(fd);
       return; // failed to get file size, data will be nullptr
     }
-    size = (size_t)st.st_size;
+    size = static_cast<size_t>(st.st_size);
     size_t total_size = size + simdjson::SIMDJSON_PADDING;
     void *anon_map =
         mmap(NULL, total_size, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
@@ -402,13 +402,13 @@ simdjson_inline padded_memory_map::padded_memory_map(const char *filename) noexc
       close(fd);
       return; // failed to mmap file, data will be nullptr
     }
-    data = (const char *)file_map;
+    data = static_cast<const char *>(file_map);
     close(fd); // no longer needed after mapping
 }
 
 simdjson_inline padded_memory_map::~padded_memory_map() noexcept {
   if (data != nullptr) {
-    munmap((void *)data, size + simdjson::SIMDJSON_PADDING);
+    munmap(const_cast<char *>(data), size + simdjson::SIMDJSON_PADDING);
   }
 }
 


### PR DESCRIPTION
I noticed the `Performance check on Ubuntu 20.04 CI (GCC 9)` workflow was not passing due to a cast warning and the use of `-Werror` in the workflow. This PR:

- Fix the casts in the code that were triggering the warning and crashing the workflow.
- Rename the misleading workflow names (they're called `Ubuntu 20.04 CI (GCC 9)`, but actually run on `Ubuntu 24.04 (GCC 13)`.

Type of change
- [ ] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [x] Other (please describe): CI
