### PR TITLE
Add guard for depth overflow in ondemand parser

### DIFF
--- a/include/simdjson/generic/ondemand/json_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/json_iterator-inl.h
@@ -158,6 +158,7 @@ simdjson_warn_unused simdjson_inline error_code json_iterator::skip_child(depth_
     switch (*return_current_and_advance()) {
       case '[': case '{':
         logger::log_start_value(*this, "skip");
+        if (simdjson_unlikely(_depth == INT32_MAX)) { return report_error(DEPTH_ERROR, "Depth overflow in skip_child"); }
         _depth++;
         break;
       // TODO consider whether matching braces is a requirement: if non-matching braces indicates


### PR DESCRIPTION
Adds a check in skip_child() to avoid overflow in depth tracking.

In extreme cases, the depth counter can overflow when parsing
deeply nested input. This adds a guard before incrementing it
and returns an error if the limit is reached.

