### PR TITLE
Use CAPACITY for inputs exceeding DOM size limit

### DIFF
--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -33,6 +33,11 @@ inline error_code document::allocate(size_t capacity) noexcept {
     allocated_capacity = 0;
     return SUCCESS;
   }
+  // Unsupported size is a capacity-limit violation, not an allocation failure.
+  // MEMALLOC remains reserved for failed allocations below.
+  if (capacity > SIMDJSON_MAXSIZE_BYTES) {
+    return CAPACITY;
+  }
 
   // a pathological input like "[[[[..." would generate capacity tape elements, so
   // need a capacity of at least capacity + 1, but it is also possible to do

--- a/tests/dom/errortests.cpp
+++ b/tests/dom/errortests.cpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <cmath>
 #include <set>
+#include <limits>
 #include <unistd.h>
 
 #include "simdjson.h"
@@ -35,6 +36,21 @@ namespace parser_load {
       TEST_SUCCEED();
     }
     TEST_FAIL("No documents returned");
+  }
+
+  bool parser_parse_huge_declared_length_capacity() {
+    TEST_START();
+    // Use a non-trivial string to avoid compiler object-size warnings with huge declared lengths.
+    // This test validates declared-length capacity handling, not source-buffer size.
+    std::string json = "0000000000000000000000000000000000000000000000000000000000000000";
+    size_t huge_size = SIMDJSON_MAXSIZE_BYTES;
+    if (huge_size == (std::numeric_limits<size_t>::max)()) {
+      TEST_SUCCEED();
+    }
+    huge_size += 1;
+    dom::parser parser{huge_size};
+    ASSERT_ERROR(parser.parse(json.c_str(), huge_size, true).error(), CAPACITY);
+    TEST_SUCCEED();
   }
 
   bool parser_parse_many_documents_error_in_the_middle() {
@@ -147,6 +163,7 @@ namespace parser_load {
     return true
         && parser_load_capacity()
         && parser_load_many_capacity()
+        && parser_parse_huge_declared_length_capacity()
         && parser_load_nonexistent()
         && parser_load_many_nonexistent()
         && padded_string_load_nonexistent()


### PR DESCRIPTION
### Short title (summary)
Return CAPACITY for oversize DOM allocation in parse flow

---

### Description
- Added an explicit bound check in `document::allocate` to return `CAPACITY` when the requested size exceeds `SIMDJSON_MAXSIZE_BYTES`.
- Previously, oversized declared input lengths could reach allocation and return `MEMALLOC`, which misclassifies a capacity-limit violation as an allocation failure.
- This ensures consistent error semantics: invalid sizes return `CAPACITY`, while real allocation failures continue to return `MEMALLOC`.

- Issue reproduced: parsing with a declared length larger than the supported DOM capacity returns incorrect error classification.

---

### Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

---

### How to verify / test
- Added regression test: `parser_parse_huge_declared_length_capacity`
  - Uses `parser.parse(...)` with declared length `SIMDJSON_MAXSIZE_BYTES + 1`
  - Verifies that the parser returns `CAPACITY`
- Test exercises real parse flow (`parse → ensure_capacity → document::allocate`)
- Designed to be CI-safe:
  - Uses `std::string` input to avoid compiler object-size warnings (`-Werror`)
  - Includes guard to prevent overflow on 32-bit platforms

Run locally:
```bash
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build

Checklist before submitting
- [x] I added/updated tests covering my change (if applicable)
- [x] Code builds locally and passes my check
- [ ] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear
- [ ] I linked the related issue (if applicable)

Final notes
- Change is intentionally minimal and limited to error classification for oversized inputs.
-No impact on valid parsing behaviour.
-Test is structured to be portable and stable across compilers and architectures.