### PR TITLE
literals should be guarded

### DIFF
--- a/doc/compile_time.md
+++ b/doc/compile_time.md
@@ -32,6 +32,21 @@ your code with the `SIMDJSON_STATIC_REFLECTION` macro set:
 The `simdjson::compile_time::parse_json` function parses a JSON document at **compile time** and returns a `constexpr` structure reflecting its content. We support the full range of JSON values, which are mapped to C++ types as in
 the following table.
 
+For convenience, you can also use the `""_json` user-defined literal operator, which is available in the `simdjson::literals` namespace:
+
+```cpp
+using namespace simdjson::literals;
+
+constexpr auto cfg = R"(
+{
+    "port": 8080,
+    "host": "localhost"
+}
+)"_json;
+```
+
+Alternatively, you can use the qualified name `simdjson::literals::operator""_json`.
+
 
 | JSON type      | C++ type                         |
 |----------------|----------------------------------|
@@ -61,6 +76,8 @@ You can do so, at compile-time, as follows:
 
 
 ```cpp
+using namespace simdjson::literals;
+
 constexpr auto cfg = R"(
 
 {
@@ -79,6 +96,8 @@ constexpr auto cfg = R"(
 You can nest objects and arrays:
 
 ```cpp
+using namespace simdjson::literals;
+
 constexpr auto data = R"(
 
 {
@@ -98,6 +117,8 @@ constexpr auto data = R"(
 Top-level arrays are allowed:
 
 ```cpp
+using namespace simdjson::literals;
+
 constexpr auto arr = R"(
 
 [1, 2, 3]
@@ -116,6 +137,8 @@ want to check that it conforms to your expectation. You can do so with concepts.
 Let us consider this example:
 
 ```cpp
+    using namespace simdjson::literals;
+
     constexpr auto config = R"(
 
     [

--- a/include/simdjson/compile_time_json.h
+++ b/include/simdjson/compile_time_json.h
@@ -63,13 +63,16 @@ namespace compile_time {
 template <constevalutil::fixed_string json_str> consteval auto parse_json();
 
 } // namespace compile_time
-} // namespace simdjson
 
+inline namespace literals {
 
 template <simdjson::constevalutil::fixed_string str>
 consteval auto operator ""_json() {
   return simdjson::compile_time::parse_json<str>();
 }
+
+} // namespace literals
+} // namespace simdjson
 
 #endif // SIMDJSON_STATIC_REFLECTION
 #endif // SIMDJSON_GENERIC_COMPILE_TIME_JSON_H

--- a/tests/compile_time/compile_time_json_tests.cpp
+++ b/tests/compile_time/compile_time_json_tests.cpp
@@ -10,6 +10,7 @@
 
 using namespace std::string_view_literals;
 using namespace simdjson;
+using namespace simdjson::literals;
 
 namespace compile_time_json_tests {
 /**


### PR DESCRIPTION
We should require that people call  `using namespace simdjson::literals` to avoid conflicts.

```cpp
using namespace simdjson::literals;

constexpr auto cfg = R"(
{
    "port": 8080,
    "host": "localhost"
}
)"_json;
```
