### PR TITLE
Fix integer overflow in allocation sizing to prevent OOB writes

### DIFF
--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -10,6 +10,7 @@
 #include "simdjson/internal/jsonformatutils.h"
 
 #include <cstring>
+#include <limits>
 
 namespace simdjson {
 namespace dom {
@@ -37,15 +38,41 @@ inline error_code document::allocate(size_t capacity) noexcept {
     return CAPACITY;
   }
 
+  auto checked_roundup64 = [](size_t value, size_t &out) noexcept -> bool {
+    constexpr size_t roundup_mask = 64 - 1;
+    if (value > (std::numeric_limits<size_t>::max)() - roundup_mask) {
+      return false;
+    }
+    out = SIMDJSON_ROUNDUP_N(value, 64);
+    return true;
+  };
+
   // a pathological input like "[[[[..." would generate capacity tape elements, so
   // need a capacity of at least capacity + 1, but it is also possible to do
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
   // generated, see issue https://github.com/simdjson/simdjson/issues/345
-  size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
+  size_t tape_capacity;
+  if (capacity > (std::numeric_limits<size_t>::max)() - 3 ||
+      !checked_roundup64(capacity + 3, tape_capacity)) {
+    return CAPACITY;
+  }
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * capacity / 3 + SIMDJSON_PADDING, 64);
+  // Compute floor(5 * capacity / 3) without overflow: (capacity/3)*5 + ((capacity%3)*5)/3.
+  const size_t capacity_div3 = capacity / 3;
+  const size_t capacity_mod3 = capacity % 3;
+  if (capacity_div3 > (std::numeric_limits<size_t>::max)() / 5) {
+    return CAPACITY;
+  }
+  const size_t scaled_capacity = capacity_div3 * 5 + ((capacity_mod3 * 5) / 3);
+  if (scaled_capacity > (std::numeric_limits<size_t>::max)() - SIMDJSON_PADDING) {
+    return CAPACITY;
+  }
+  size_t string_capacity;
+  if (!checked_roundup64(scaled_capacity + SIMDJSON_PADDING, string_capacity)) {
+    return CAPACITY;
+  }
   string_buf.reset( new (std::nothrow) uint8_t[string_capacity]);
   tape.reset(new (std::nothrow) uint64_t[tape_capacity]);
   if(!(string_buf && tape)) {

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -6,6 +6,8 @@
 #include "simdjson/internal/dom_parser_implementation.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#include <limits>
+
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 
@@ -63,7 +65,15 @@ inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parse
 inline simdjson_warn_unused error_code dom_parser_implementation::set_capacity(size_t capacity) noexcept {
   if(capacity > SIMDJSON_MAXSIZE_BYTES) { return CAPACITY; }
   // Stage 1 index output
-  size_t max_structures = SIMDJSON_ROUNDUP_N(capacity, 64) + 2 + 7;
+  constexpr size_t roundup_mask = 64 - 1;
+  if (capacity > (std::numeric_limits<size_t>::max)() - roundup_mask) {
+    return CAPACITY;
+  }
+  size_t rounded_capacity = SIMDJSON_ROUNDUP_N(capacity, 64);
+  if (rounded_capacity > (std::numeric_limits<size_t>::max)() - 9) {
+    return CAPACITY;
+  }
+  size_t max_structures = rounded_capacity + 2 + 7;
   structural_indexes.reset( new (std::nothrow) uint32_t[max_structures] );
   if (!structural_indexes) { _capacity = 0; return MEMALLOC; }
   structural_indexes[0] = 0;

--- a/tests/dom/errortests.cpp
+++ b/tests/dom/errortests.cpp
@@ -37,6 +37,16 @@ namespace parser_load {
     TEST_FAIL("No documents returned");
   }
 
+  bool parser_allocate_capacity_overflow_32bit() {
+    TEST_START();
+    if (sizeof(size_t) != 4) {
+      TEST_SUCCEED();
+    }
+    dom::parser parser;
+    ASSERT_ERROR(parser.allocate(SIMDJSON_MAXSIZE_BYTES, DEFAULT_MAX_DEPTH), CAPACITY);
+    TEST_SUCCEED();
+  }
+
   bool parser_parse_many_documents_error_in_the_middle() {
     TEST_START();
     const padded_string DOC = "1 2 [} 3"_padded;
@@ -147,6 +157,7 @@ namespace parser_load {
     return true
         && parser_load_capacity()
         && parser_load_many_capacity()
+        && parser_allocate_capacity_overflow_32bit()
         && parser_load_nonexistent()
         && parser_load_many_nonexistent()
         && padded_string_load_nonexistent()


### PR DESCRIPTION
This PR hardens allocation size computations in the parser to prevent integer overflow during capacity scaling and rounding operations.

The change ensures that all size calculations fail safely instead of silently wrapping on overflow.

-Introduced overflow-checked arithmetic for all allocation size computations
-Added guards before:
  - capacity scaling
  - padding addition
  - rounding operations
 
-Return `CAPACITY` error when overflow is detected (fail-closed behavior)
