### PR TITLE
Fix undefined behavior in document_stream parsing

### DIFF
--- a/include/simdjson/dom/document_stream-inl.h
+++ b/include/simdjson/dom/document_stream-inl.h
@@ -234,7 +234,7 @@ simdjson_inline std::string_view document_stream::iterator::source() const noexc
     // cannot legally appear in a JSON value at the source level (control
     // characters in strings must be escaped as \u001E), so stripping it is
     // safe in every stream_format.
-    while(svlen > 1 && (std::isspace(start[svlen-1]) || start[svlen-1] == '\0' || static_cast<uint8_t>(start[svlen-1]) == 0x1E)) {
+    while(svlen > 1 && (std::isspace(static_cast<unsigned char>(start[svlen-1])) || start[svlen-1] == '\0' || static_cast<uint8_t>(start[svlen-1]) == 0x1E)) {
       svlen--;
     }
     return std::string_view(start, svlen);

--- a/include/simdjson/generic/ondemand/document_stream-inl.h
+++ b/include/simdjson/generic/ondemand/document_stream-inl.h
@@ -398,7 +398,7 @@ simdjson_inline std::string_view document_stream::iterator::source() const noexc
           // legally appear in a JSON value at the source level (control
           // characters in strings must be escaped as \u001E), so stripping
           // it is safe in every stream_format.
-          while(svlen > 1 && (std::isspace(start[svlen-1]) || start[svlen-1] == '\0' || static_cast<uint8_t>(start[svlen-1]) == 0x1E)) {
+          while(svlen > 1 && (std::isspace(static_cast<unsigned char>(start[svlen-1])) || start[svlen-1] == '\0' || static_cast<uint8_t>(start[svlen-1]) == 0x1E)) {
             svlen--;
           }
           return std::string_view(start, svlen);

--- a/tests/dom/document_stream_tests.cpp
+++ b/tests/dom/document_stream_tests.cpp
@@ -270,6 +270,25 @@ namespace document_stream_tests {
       }
       TEST_SUCCEED();
   }
+
+  bool issue_non_ascii_separator_source() {
+      TEST_START();
+      std::string bytes = "1 ";
+      bytes.push_back(char(0xFF));
+      bytes += " 2";
+      simdjson::padded_string json(bytes);
+
+      simdjson::dom::parser parser;
+      simdjson::dom::document_stream stream;
+      ASSERT_SUCCESS(parser.parse_many(json).get(stream));
+
+      auto i = stream.begin();
+      ASSERT_TRUE(i != stream.end());
+      std::string_view source = i.source();
+      ASSERT_TRUE(!source.empty());
+      ASSERT_EQUAL(source.front(), '1');
+      TEST_SUCCEED();
+  }
   bool issue1310() {
     std::cout << "Running " << __func__ << std::endl;
     // hex  : 20 20 5B 20 33 2C 31 5D 20 22 22 22 22 22 22 22 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20 20
@@ -2097,6 +2116,7 @@ namespace document_stream_tests {
            comma_delimited_tests() &&
            issue2181() &&
            issue2170() &&
+          issue_non_ascii_separator_source() &&
            skipbom() &&
            fuzzaccess() &&
            baby_fuzzer() &&

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -238,6 +238,25 @@ namespace document_stream_tests {
         TEST_SUCCEED();
     }
 
+    bool issue_non_ascii_separator_source() {
+        TEST_START();
+        std::string bytes = "1 ";
+        bytes.push_back(char(0xFF));
+        bytes += " 2";
+        simdjson::padded_string json(bytes);
+
+        ondemand::parser parser;
+        ondemand::document_stream stream;
+        ASSERT_SUCCESS(parser.iterate_many(json).get(stream));
+
+        auto i = stream.begin();
+        ASSERT_TRUE(i != stream.end());
+        std::string_view source = i.source();
+        ASSERT_TRUE(!source.empty());
+        ASSERT_EQUAL(source.front(), '1');
+        TEST_SUCCEED();
+    }
+
     bool issue1977() {
         TEST_START();
         std::string json = R"( 1111 })";
@@ -2345,6 +2364,7 @@ namespace document_stream_tests {
             comma_delimited_tests() &&
             issue2181() &&
             issue2170() &&
+            issue_non_ascii_separator_source() &&
             issue2137() &&
             skipbom() &&
             issue1977() &&


### PR DESCRIPTION
This fixes undefined behavior in stream parsing caused by passing potentially negative char values directly to `std::isspace`

All calls to std::isspace in the affected code paths have been updated to safely cast the input:

          std::isspace(static_cast<unsigned char>(...))

This follows the standard and recommended pattern for safe usage of C character classification functions.