### PR TITLE
Prevent integer overflow in string buffer size computation

### DIFF
--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -13,6 +13,8 @@
 #include "simdjson/generic/ondemand/raw_json_string.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#include <limits>
+
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
@@ -25,9 +27,14 @@ simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capa
   if (new_capacity > max_capacity()) { return CAPACITY; }
   if (string_buf && new_capacity == capacity() && new_max_depth == max_depth()) { return SUCCESS; }
 
+  const size_t quotient = new_capacity / 3;
+  // Keep room for the remainder term and the padding addition below.
+  const size_t maximum_quotient = ((std::numeric_limits<size_t>::max)() - SIMDJSON_PADDING - 3) / 5;
+  if (quotient > maximum_quotient) { return CAPACITY; }
+
   // string_capacity copied from document::allocate
   _capacity = 0;
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * new_capacity / 3 + SIMDJSON_PADDING, 64);
+  size_t string_capacity = SIMDJSON_ROUNDUP_N((quotient * 5) + ((new_capacity % 3) * 5) / 3 + SIMDJSON_PADDING, 64);
   string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
 #if SIMDJSON_DEVELOPMENT_CHECKS
   start_positions.reset(new (std::nothrow) token_position[new_max_depth]);

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -1,6 +1,8 @@
 #include "simdjson.h"
 #include "test_ondemand.h"
 
+#include <limits>
+
 using namespace simdjson;
 
 namespace error_tests {
@@ -179,6 +181,14 @@ namespace error_tests {
     auto json = R"({"k":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"})"_padded;
     ondemand::document doc;
     ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    TEST_SUCCEED();
+  }
+
+  bool parser_allocate_extreme_capacity() {
+    TEST_START();
+    ondemand::parser parser;
+    parser.set_max_capacity((std::numeric_limits<size_t>::max)());
+    ASSERT_ERROR(parser.allocate((std::numeric_limits<size_t>::max)()), CAPACITY);
     TEST_SUCCEED();
   }
 
@@ -476,6 +486,7 @@ namespace error_tests {
            empty_document_error() &&
            parser_max_capacity() &&
            parser_set_max_capacity() &&
+           parser_allocate_extreme_capacity() &&
            get_fail_then_succeed_bool() &&
            get_fail_then_succeed_null() &&
            simple_error_example() &&


### PR DESCRIPTION
This patch fixes an integer overflow risk in the On-Demand parser allocation path.

The previous computation used to derive the string buffer size:

       5 * capacity / 3 + SIMDJSON_PADDING

could overflow due to the intermediate multiplication `5 * capacity` leading to wraparound and potentially undersized allocations This creates a memory safety risk under extreme input values
