### PR TITLE
fix: ondeman raw_json boundaries for wildcard matches

### DIFF
--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -92,13 +92,20 @@ simdjson_warn_unused simdjson_warn_unused simdjson_inline error_code array::cons
 }
 
 simdjson_inline simdjson_result<std::string_view> array::raw_json() noexcept {
-  const uint8_t * starting_point{iter.peek_start()};
-  auto error = consume();
-  if(error) { return error; }
-  // After 'consume()', we could be left pointing just beyond the document, but that
-  // is ok because we are not going to dereference the final pointer position, we just
-  // use it to compute the length in bytes.
-  const uint8_t * final_point{iter._json_iter->unsafe_pointer()};
+  // Compute boundaries from a snapshot anchored to this value's start token so
+  // the span is stable even if the shared iterator has advanced elsewhere.
+  const token_position start_position{iter.start_position()};
+  const depth_t value_depth{iter.depth()};
+  const uint8_t * starting_point{iter._json_iter->peek(start_position)};
+
+  json_iterator boundary_iter(iter.json_iter());
+  boundary_iter.token.set_position(start_position);
+  boundary_iter._depth = value_depth;
+  auto boundary_error = boundary_iter.skip_child(value_depth - 1);
+  if (boundary_error) { return boundary_error; }
+  const uint8_t * final_point{boundary_iter.peek(-1) + boundary_iter.peek_length(-1)};
+
+  iter.json_iter() = std::move(boundary_iter);
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -98,10 +98,20 @@ simdjson_warn_unused simdjson_inline error_code object::consume() noexcept {
 }
 
 simdjson_inline simdjson_result<std::string_view> object::raw_json() noexcept {
-  const uint8_t * starting_point{iter.peek_start()};
-  auto error = consume();
-  if(error) { return error; }
-  const uint8_t * final_point{iter._json_iter->peek()};
+  // compute boundaries from a snapshot anchored to this value's start token so
+  // the span is stable even if the shared iterator has advanced elsewhere.
+  const token_position start_position{iter.start_position()};
+  const depth_t value_depth{iter.depth()};
+  const uint8_t * starting_point{iter._json_iter->peek(start_position)};
+
+  json_iterator boundary_iter(iter.json_iter());
+  boundary_iter.token.set_position(start_position);
+  boundary_iter._depth = value_depth;
+  auto boundary_error = boundary_iter.skip_child(value_depth - 1);
+  if (boundary_error) { return boundary_error; }
+    const uint8_t * final_point{boundary_iter.peek(-1) + boundary_iter.peek_length(-1)};
+
+  iter.json_iter() = std::move(boundary_iter);
   return std::string_view(reinterpret_cast<const char*>(starting_point), size_t(final_point - starting_point));
 }
 

--- a/tests/ondemand/ondemand_wildcard_tests.cpp
+++ b/tests/ondemand/ondemand_wildcard_tests.cpp
@@ -317,6 +317,25 @@ namespace wildcard_tests {
     TEST_SUCCEED();
   }
 
+  bool wildcard_raw_json_container_boundary() {
+    TEST_START();
+    auto json = R"([{"tag_meta":{"meta_code":2000211,"meta_value":""},"tag_value":""}])"_padded;
+
+    ondemand::parser parser;
+    auto doc = parser.iterate(json);
+
+    std::vector<ondemand::value> matches;
+    ASSERT_SUCCESS(doc.at_path_with_wildcard("$[*].tag_meta").get(matches));
+    ASSERT_EQUAL(matches.size(), 1);
+
+    std::string_view raw;
+    ASSERT_SUCCESS(matches[0].raw_json().get(raw));
+    ASSERT_EQUAL(raw, R"({"meta_code":2000211,"meta_value":""})");
+    ASSERT_TRUE(raw.find("tag_value") == std::string_view::npos);
+
+    TEST_SUCCEED();
+  }
+
   bool run() {
     return array_wildcard_basic() &&
            array_wildcard_numbers() &&
@@ -329,7 +348,8 @@ namespace wildcard_tests {
            wildcard_with_nested_objects() &&
            mixed_types_in_array() &&
            wildcard_nonexistent_field() &&
-           root_array_wildcard();
+           root_array_wildcard() &&
+           wildcard_raw_json_container_boundary();
   }
 }
 


### PR DESCRIPTION
Short title (summary):

Description
- Fixed a bug in On-Demand wildcard extraction where `ondemand::value::raw_json` could return a `string_view` that extended past the matched object/array and included sibling or outer JSON content.
- Related issue: https://github.com/simdjson/simdjson/issues/2684

Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to verify / test
- Added a regression test in `ondemand_wildcard_tests.cpp` covering `$[*].tag_meta`.
