### PR TITLE
Improve overflow-safe allocation sizing checks

### DIFF
--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -10,6 +10,7 @@
 #include "simdjson/internal/jsonformatutils.h"
 
 #include <cstring>
+#include <limits>
 
 namespace simdjson {
 namespace dom {
@@ -37,21 +38,65 @@ inline error_code document::allocate(size_t capacity) noexcept {
     return CAPACITY;
   }
 
+  auto add_checked = [](size_t lhs, size_t rhs, size_t &sum) noexcept -> bool {
+    if (lhs > (std::numeric_limits<size_t>::max)() - rhs) {
+      return false;
+    }
+    sum = lhs + rhs;
+    return true;
+  };
+
+  auto roundup64_checked = [](size_t value, size_t &rounded) noexcept -> bool {
+    constexpr size_t roundup_mask = 64 - 1;
+    if (value > (std::numeric_limits<size_t>::max)() - roundup_mask) {
+      return false;
+    }
+    rounded = SIMDJSON_ROUNDUP_N(value, 64);
+    return true;
+  };
+
+  auto string_bytes_for_capacity = [](size_t input_capacity, size_t &string_bytes) noexcept -> bool {
+    // Compute floor(5 * input_capacity / 3) without overflow.
+    const size_t capacity_div3 = input_capacity / 3;
+    const size_t capacity_mod3 = input_capacity % 3;
+    if (capacity_div3 > (std::numeric_limits<size_t>::max)() / 5) {
+      return false;
+    }
+    string_bytes = capacity_div3 * 5 + ((capacity_mod3 * 5) / 3);
+    return true;
+  };
+
   // a pathological input like "[[[[..." would generate capacity tape elements, so
   // need a capacity of at least capacity + 1, but it is also possible to do
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
   // generated, see issue https://github.com/simdjson/simdjson/issues/345
-  if(capacity + 3 < capacity) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  size_t tape_elements;
+  if (!add_checked(capacity, size_t(3), tape_elements)) {
+    return CAPACITY;
   }
-  size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
+  size_t tape_capacity;
+  if (!roundup64_checked(tape_elements, tape_capacity)) {
+    return CAPACITY;
+  }
+
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
-  if(5 * (capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  size_t string_bytes;
+  if (!string_bytes_for_capacity(capacity, string_bytes)) {
+    return CAPACITY;
   }
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (capacity / 3) + SIMDJSON_PADDING, 64);
+
+  size_t padded_string_bytes;
+  if (!add_checked(string_bytes, size_t(SIMDJSON_PADDING), padded_string_bytes)) {
+    return CAPACITY;
+  }
+
+  size_t string_capacity;
+  if (!roundup64_checked(padded_string_bytes, string_capacity)) {
+    return CAPACITY;
+  }
+
   string_buf.reset( new (std::nothrow) uint8_t[string_capacity]);
   tape.reset(new (std::nothrow) uint64_t[tape_capacity]);
   if(!(string_buf && tape)) {

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -71,28 +71,28 @@ inline error_code document::allocate(size_t capacity) noexcept {
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
   // generated, see issue https://github.com/simdjson/simdjson/issues/345
-  size_t tape_elements;
+  size_t tape_elements{0};
   if (!add_checked(capacity, size_t(3), tape_elements)) {
     return CAPACITY;
   }
-  size_t tape_capacity;
+  size_t tape_capacity{0};
   if (!roundup64_checked(tape_elements, tape_capacity)) {
     return CAPACITY;
   }
 
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
-  size_t string_bytes;
+  size_t string_bytes{0};
   if (!string_bytes_for_capacity(capacity, string_bytes)) {
     return CAPACITY;
   }
 
-  size_t padded_string_bytes;
+  size_t padded_string_bytes{0};
   if (!add_checked(string_bytes, size_t(SIMDJSON_PADDING), padded_string_bytes)) {
     return CAPACITY;
   }
 
-  size_t string_capacity;
+  size_t string_capacity{0};
   if (!roundup64_checked(padded_string_bytes, string_capacity)) {
     return CAPACITY;
   }

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -6,6 +6,8 @@
 #include "simdjson/internal/dom_parser_implementation.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#include <limits>
+
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 
@@ -63,11 +65,19 @@ inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parse
 inline simdjson_warn_unused error_code dom_parser_implementation::set_capacity(size_t capacity) noexcept {
   if(capacity > SIMDJSON_MAXSIZE_BYTES) { return CAPACITY; }
   // Stage 1 index output
-  size_t rounded_capacity = SIMDJSON_ROUNDUP_N(capacity, 64);
-  if(rounded_capacity + 9 < rounded_capacity) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  constexpr size_t roundup_mask = 64 - 1;
+  constexpr size_t structural_slack = 2 + 7;
+
+  if (capacity > (std::numeric_limits<size_t>::max)() - roundup_mask) {
+    return CAPACITY;
   }
-  size_t max_structures = rounded_capacity + 9;
+
+  const size_t rounded_capacity = SIMDJSON_ROUNDUP_N(capacity, 64);
+  if (rounded_capacity > (std::numeric_limits<size_t>::max)() - structural_slack) {
+    return CAPACITY;
+  }
+
+  const size_t max_structures = rounded_capacity + structural_slack;
   structural_indexes.reset( new (std::nothrow) uint32_t[max_structures] );
   if (!structural_indexes) { _capacity = 0; return MEMALLOC; }
   structural_indexes[0] = 0;

--- a/tests/dom/errortests.cpp
+++ b/tests/dom/errortests.cpp
@@ -37,6 +37,16 @@ namespace parser_load {
     TEST_FAIL("No documents returned");
   }
 
+  bool parser_allocate_capacity_overflow_32bit() {
+    TEST_START();
+    if (sizeof(size_t) != 4) {
+      TEST_SUCCEED();
+    }
+    dom::parser parser;
+    ASSERT_ERROR(parser.allocate(SIMDJSON_MAXSIZE_BYTES, DEFAULT_MAX_DEPTH), CAPACITY);
+    TEST_SUCCEED();
+  }
+
   bool parser_parse_many_documents_error_in_the_middle() {
     TEST_START();
     const padded_string DOC = "1 2 [} 3"_padded;
@@ -147,6 +157,7 @@ namespace parser_load {
     return true
         && parser_load_capacity()
         && parser_load_many_capacity()
+        && parser_allocate_capacity_overflow_32bit()
         && parser_load_nonexistent()
         && parser_load_many_nonexistent()
         && padded_string_load_nonexistent()


### PR DESCRIPTION
This PR keeps the overflow hardening from #2675 but rewrites it to be easier to read and review.

What changed:

Refactored allocation-size checks into small named steps in:
`document-inl.h`
`dom_parser_implementation.h`
Kept fail-closed behavior: return `CAPACITY` on any overflow-risk path.
Added/kept the 32-bit regression guard in:
`errortests.cpp`