### PR TITLE
builds with Fil-C

### DIFF
--- a/src/internal/isadetection.h
+++ b/src/internal/isadetection.h
@@ -52,11 +52,15 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #if defined(_MSC_VER)
 #include <intrin.h>
-#elif defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)
+#elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) || defined(__FILC__)
 #include <cpuid.h>
 #endif
 #if defined(__loongarch__) && defined(__linux__)
   #include <sys/auxv.h>
+#endif
+
+#ifdef __FILC__
+#include <stdfil.h>
 #endif
 
 namespace simdjson {
@@ -109,7 +113,7 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
   *ebx = cpu_info[1];
   *ecx = cpu_info[2];
   *edx = cpu_info[3];
-#elif defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)
+#elif (defined(HAVE_GCC_GET_CPUID) && defined(USE_GCC_GET_CPUID)) || defined(__FILC__)
   uint32_t level = *eax;
   __get_cpuid(level, eax, ebx, ecx, edx);
 #else
@@ -126,6 +130,8 @@ static inline void cpuid(uint32_t *eax, uint32_t *ebx, uint32_t *ecx,
 static inline uint64_t xgetbv() {
 #if defined(_MSC_VER)
   return _xgetbv(0);
+#elif defined(__FILC__)
+  return zxgetbv();
 #else
   uint32_t xcr0_lo, xcr0_hi;
   asm volatile("xgetbv\n\t" : "=a" (xcr0_lo), "=d" (xcr0_hi) : "c" (0));

--- a/tests/ondemand/ondemand_cacheline.cpp
+++ b/tests/ondemand/ondemand_cacheline.cpp
@@ -1,3 +1,12 @@
+#ifdef __FILC__
+#include <stdio.h>
+#include <stdlib.h>
+int main() {
+  printf("This test is not relevant for FILC.\n");
+  return EXIT_SUCCESS;
+}
+#else // This test is not relevant for FILC
+
 #ifdef _WIN32
 #include <windows.h>
 #include <sysinfoapi.h>
@@ -87,3 +96,5 @@ int main() {
   }
   return EXIT_SUCCESS;
 }
+
+#endif // This test is not relevant for FILC

--- a/tests/ondemand/ondemand_padded_input.cpp
+++ b/tests/ondemand/ondemand_padded_input.cpp
@@ -1,3 +1,12 @@
+#ifdef __FILC__
+#include <stdio.h>
+#include <stdlib.h>
+int main() {
+  printf("This test is not relevant for FILC.\n");
+  return EXIT_SUCCESS;
+}
+#else // This test is not relevant for FILC
+
 #include "simdjson.h"
 #include "simdjson/padded_string_view.h"
 #include <cstdio>
@@ -195,3 +204,5 @@ int main() {
 }
 
 #endif // SIMDJSON_CPLUSPLUS17
+
+#endif // This test is not relevant for FILC


### PR DESCRIPTION
This PR adds support for building simdjson with [Fil-C, the memory-safe C/C++ compiler](https://fil-c.org).

For the most part, we just have to adjust our cpu detection.

cc @pizlonator

