### PR TITLE
Add support for custom allocators

### DIFF
--- a/doc/performance.md
+++ b/doc/performance.md
@@ -9,6 +9,7 @@ testing and get the best performance.
 * [NDEBUG macro](#ndebug-macro)
 * [Reusing the parser for maximum efficiency](#reusing-the-parser-for-maximum-efficiency)
 * [Reusing string buffers](#reusing-string-buffers)
+* [Custom allocators](#custom-allocators)
 * [Server Loops: Long-Running Processes and Memory Capacity](#server-loops-long-running-processes-and-memory-capacity)
 * [Large files and huge page support](#large-files-and-huge-page-support)
 * [Number parsing](#number-parsing)
@@ -81,6 +82,106 @@ or simply
 ```cpp
  auto doc = parser.iterate(json_str, length, capacity);
 ```
+
+
+Custom allocators
+-----------------
+
+By default, simdjson uses `new[]` / `delete[]` for its internal buffers. If you
+want to use a custom allocator instead, you can do so by subclassing
+`simdjson::allocator`:
+
+```cpp
+class my_allocator : public simdjson::allocator {
+public:
+  simdjson::allocation_result allocate(size_t size) override {
+    // Return {nullptr, 0} on failure, OR throw (e.g. std::bad_alloc). Either is fine.
+    void* ptr = ::operator new(size, std::nothrow);
+    return {ptr, ptr ? size : 0};
+  }
+  void deallocate(void* ptr, size_t /*size*/) noexcept override {
+    ::operator delete(ptr);
+  }
+};
+```
+
+Then pass an instance to the parser or builder:
+
+```cpp
+my_allocator alloc;
+
+// DOM parser
+simdjson::dom::parser dom_parser(alloc);
+auto e1 = dom_parser.parse(json);
+
+// On-Demand parser
+simdjson::ondemand::parser od_parser(alloc);
+auto e2 = od_parser.iterate(json);
+
+// String builder
+simdjson::builder::string_builder sb(alloc);
+sb.append("hello");
+```
+
+`padded_string` and `padded_string_builder` do not support custom allocators.
+If you want to allocate a padded string with a custom allocator, you can do
+so in your own code, and then pass it into the simdjson library as a
+`padded_string_view`.
+
+Key points:
+
+- The allocator must outlive every parser, document, and builder that holds a
+  reference to it.
+- `allocate()` may either return `{nullptr, 0}` on failure (mapped to `MEMALLOC`
+  or `is_valid = false` on the builder) or throw. Exceptions are not caught by
+  simdjson: they propagate out of whichever call triggered the allocation.
+- `allocate()` may over-allocate: the returned `allocation_result::size` is the
+  true number of bytes handed out and may exceed the requested `size`
+  (modelled on C++23 `allocate_at_least`). simdjson may use the full returned
+  range.
+- `deallocate()` is called with the same byte count that the corresponding
+  `allocate()` returned in `allocation_result::size`, not necessarily the
+  originally requested size. Allocators that round up to buckets or slabs and
+  hand back a larger `size` receive that same larger value back on
+  `deallocate()`.
+- Returned memory must be aligned to at least `alignof(std::max_align_t)`. This
+  matches the guarantee of `malloc`, `::operator new`, and all mainstream pool
+  allocators.
+- The thread-local parser returned by `simdjson::ondemand::parser::get_parser()`
+  always uses the default allocator. Use your own parser instance if you need
+  a custom allocator.
+
+### Adapting a C++ standard allocator
+
+If you already have a type that models the C++ `Allocator` named requirement
+(e.g. `std::allocator<T>`, `std::pmr::polymorphic_allocator<T>`, or a
+third-party pool's allocator), you can use it directly via
+`simdjson::allocator_adapter<Alloc>` instead of subclassing
+`simdjson::allocator` yourself:
+
+```cpp
+#include <simdjson/allocator_adapter.h>
+
+// std::allocator
+simdjson::allocator_adapter<std::allocator<uint8_t>> a1;
+simdjson::dom::parser p1(a1);
+
+// std::pmr
+std::pmr::monotonic_buffer_resource mbr;
+simdjson::allocator_adapter<std::pmr::polymorphic_allocator<uint8_t>> a2(
+    std::pmr::polymorphic_allocator<uint8_t>{&mbr});
+simdjson::dom::parser p2(a2);
+```
+
+The adapter rebinds the wrapped allocator to `uint8_t`, forwards
+`allocate` / `deallocate`, and uses `allocate_at_least` when available
+(C++23).
+
+Alignment caveat: Your allocator must return memory that is aligned to at
+least `alignof(std::max_align_t)`. All standard-library-provided resources
+and every mainstream pool allocator already do so, but for custom allocators,
+you need to ensure that your allocator returns memory that is aligned to at
+least `alignof(std::max_align_t)`.
 
 
 Server Loops: Long-Running Processes and Memory Capacity

--- a/include/simdjson.h
+++ b/include/simdjson.h
@@ -42,6 +42,8 @@
 
 #include "simdjson/base.h"
 
+#include "simdjson/allocator.h"
+#include "simdjson/allocator_adapter.h"
 #include "simdjson/error.h"
 #include "simdjson/error-inl.h"
 #include "simdjson/implementation.h"

--- a/include/simdjson/allocator.h
+++ b/include/simdjson/allocator.h
@@ -1,0 +1,72 @@
+#ifndef SIMDJSON_ALLOCATOR_H
+#define SIMDJSON_ALLOCATOR_H
+
+#include <cstddef>
+
+namespace simdjson {
+
+/**
+ * Result of a successful allocation. Models `std::allocation_result<void*>`
+ * from C++23 (see `std::allocator::allocate_at_least`).
+ *
+ * `size` is the number of bytes actually handed out by the allocator and
+ * must be passed back unchanged to `allocator::deallocate`. It may exceed
+ * the size originally requested; callers may use the full returned range.
+ */
+struct allocation_result {
+  void* ptr;
+  size_t size;
+};
+
+/**
+ * Abstract base class for custom allocators.
+ *
+ * Subclass this and pass an instance to parser constructors to control where
+ * simdjson obtains memory. The allocator must outlive every parser that
+ * references it.
+ *
+ * For wrapping an existing C++ standard-`Allocator`-conforming type (such as
+ * `std::allocator<T>` or `std::pmr::polymorphic_allocator<T>`), include
+ * `simdjson/allocator_adapter.h` and use `simdjson::allocator_adapter<Alloc>`
+ * instead of subclassing this interface directly.
+ */
+class allocator {
+public:
+  virtual ~allocator() = default;
+
+  /**
+   * Allocate AT LEAST `size` bytes. Return `{nullptr, 0}` on failure, OR throw.
+   *
+   * The returned `allocation_result::size` is the true number of bytes
+   * handed out; it may be greater than `size` if the allocator operates on
+   * buckets or rounds up to a slab size. Callers may use the full returned
+   * range and must pass the returned `size` back to `deallocate` unchanged.
+   *
+   * Exceptions are propagated to the caller, simdjson will
+   * not catch them.
+   * The nullptr-returning failure mode is mapped to `MEMALLOC` errors or
+   * `is_valid = false` (on the builder).
+   *
+   * Alignment: returned memory must be suitably aligned for any fundamental
+   * type, i.e. at least `alignof(std::max_align_t)` (equivalently
+   * `__STDCPP_DEFAULT_NEW_ALIGNMENT__` in C++17+). This matches the guarantee
+   * of `malloc`, `::operator new`, and all mainstream pool allocators (jemalloc,
+   * tcmalloc, mimalloc, PMR).
+   */
+  virtual allocation_result allocate(size_t size) = 0;
+
+  /**
+   * Deallocate memory previously returned by `allocate()`.
+   * `size` must equal `allocation_result::size` from the corresponding
+   * `allocate()` call`.
+   */
+  virtual void deallocate(void* ptr, size_t size) noexcept = 0;
+};
+
+/**
+ * Returns a reference to a default allocator singleton which uses `new[]` / `delete[]`.
+ */
+allocator& get_default_allocator() noexcept;
+
+} // namespace simdjson
+#endif // SIMDJSON_ALLOCATOR_H

--- a/include/simdjson/allocator_adapter.h
+++ b/include/simdjson/allocator_adapter.h
@@ -1,0 +1,90 @@
+#ifndef SIMDJSON_ALLOCATOR_ADAPTER_H
+#define SIMDJSON_ALLOCATOR_ADAPTER_H
+
+#include "simdjson/allocator.h"
+#include "simdjson/compiler_check.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#if SIMDJSON_SUPPORTS_CONCEPTS
+#include <concepts>
+namespace simdjson::concepts {
+/**
+ * Models the C++ standard `Allocator` named requirement, as used by
+ * `simdjson::allocator_adapter`. We only check what the adapter actually
+ * uses on the byte-rebound allocator; any well-formed `Allocator` satisfies
+ * those checks.
+ */
+template <typename A>
+concept cpp_allocator =
+  requires { typename std::allocator_traits<A>::template rebind_alloc<uint8_t>; } &&
+  requires(typename std::allocator_traits<A>::template rebind_alloc<uint8_t> a,
+           std::size_t n, uint8_t* p) {
+    { std::allocator_traits<decltype(a)>::allocate(a, n) } -> std::convertible_to<uint8_t*>;
+    std::allocator_traits<decltype(a)>::deallocate(a, p, n);
+  };
+} // namespace simdjson::concepts
+#endif
+
+namespace simdjson {
+
+/**
+ * Adapter that exposes a C++ `Allocator (e.g. `std::allocator<T>`,
+ * `std::pmr::polymorphic_allocator<T>`, or a third-party pool's allocator)
+ * as a `simdjson::allocator`..
+ *
+ * When `__cpp_lib_allocate_at_least` is available (C++23), `allocate()`
+ * forwards to `std::allocator_traits::allocate_at_least` so over-allocation
+ * from the underlying allocator is surfaced to simdjson as usable capacity.
+ * Otherwise it falls back to `allocate(n)` and reports `{p, n}`.
+ *
+ * Alignment: `simdjson::allocator` requires `>= alignof(std::max_align_t)`
+ * alignment. `std::allocator<uint8_t>` returns `::operator new`-aligned
+ * memory (>= max_align_t), so it is always safe. For
+ * `std::pmr::polymorphic_allocator<uint8_t>` the rebound allocator only
+ * requests `alignof(uint8_t) == 1`; callers must use a memory resource
+ * that returns sufficiently aligned memory (all standard-library resources
+ * and mainstream pool allocators do).
+ */
+template <class Alloc>
+class allocator_adapter final : public allocator {
+  #if SIMDJSON_SUPPORTS_CONCEPTS
+  static_assert(concepts::cpp_allocator<Alloc>, "Alloc must satisfy the C++ standard Allocator named requirement");
+  #endif
+  using byte_alloc  = typename std::allocator_traits<Alloc>::template rebind_alloc<uint8_t>;
+  using byte_traits = std::allocator_traits<byte_alloc>;
+
+  byte_alloc inner{};
+
+public:
+  allocator_adapter() = default;
+  explicit allocator_adapter(const Alloc& a) : inner(a) {}
+  explicit allocator_adapter(Alloc&& a) : inner(std::move(a)) {}
+
+  allocation_result allocate(size_t size) override {
+#if defined(__cpp_lib_allocate_at_least)
+    auto r = byte_traits::allocate_at_least(inner, size);
+    return { r.ptr, r.count };
+#else
+    return { byte_traits::allocate(inner, size), size };
+#endif
+  }
+
+  void deallocate(void* ptr, size_t size) noexcept override {
+    byte_traits::deallocate(inner, static_cast<uint8_t*>(ptr), size);
+  }
+};
+
+#if SIMDJSON_CPLUSPLUS17
+// Deduction guide (CTAD is a C++17 feature)
+template <class A>
+allocator_adapter(A) -> allocator_adapter<A>;
+#endif
+
+} // namespace simdjson
+
+#endif // SIMDJSON_ALLOCATOR_ADAPTER_H

--- a/include/simdjson/arm64/implementation.h
+++ b/include/simdjson/arm64/implementation.h
@@ -19,8 +19,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/include/simdjson/base.h
+++ b/include/simdjson/base.h
@@ -11,6 +11,7 @@
 #include "simdjson/portability.h"
 #include "simdjson/concepts.h"
 #include "simdjson/constevalutil.h"
+#include "simdjson/allocator.h"
 
 /**
  * @brief The top level simdjson namespace, containing everything the library provides.

--- a/include/simdjson/common_defs.h
+++ b/include/simdjson/common_defs.h
@@ -45,6 +45,7 @@ double from_chars(const char *first, const char* end) noexcept;
 
 // Align to N-byte boundary
 #define SIMDJSON_ROUNDUP_N(a, n) (((a) + ((n)-1)) & ~((n)-1))
+#define SIMDJSON_ROUNDDOWN_N(a, n) ((a) & ~((n)-1))
 
 #if SIMDJSON_REGULAR_VISUAL_STUDIO
   // We could use [[deprecated]] but it requires C++14

--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -9,6 +9,7 @@
 #include "simdjson/internal/tape_ref-inl.h"
 #include "simdjson/internal/jsonformatutils.h"
 
+#include <algorithm>
 #include <cstring>
 
 namespace simdjson {
@@ -26,7 +27,7 @@ inline size_t document::capacity() const noexcept {
 }
 
 simdjson_warn_unused
-inline error_code document::allocate(size_t capacity) noexcept {
+inline error_code document::allocate(size_t capacity) {
   if (capacity == 0) {
     string_buf.reset();
     tape.reset();
@@ -52,17 +53,22 @@ inline error_code document::allocate(size_t capacity) noexcept {
     return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
   }
   size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (capacity / 3) + SIMDJSON_PADDING, 64);
-  string_buf.reset( new (std::nothrow) uint8_t[string_capacity]);
-  tape.reset(new (std::nothrow) uint64_t[tape_capacity]);
-  if(!(string_buf && tape)) {
-    allocated_capacity = 0;
-    string_buf.reset();
-    tape.reset();
-    return MEMALLOC;
-  }
-  // Technically the allocated_capacity might be larger than capacity
-  // so the next line is pessimistic.
-  allocated_capacity = capacity;
+
+  // Allocate into locals first (strong exception safety): if either
+  // allocation throws, the original string_buf/tape/allocated_capacity are
+  // untouched.
+  auto new_string_buf = internal::make_allocated_buffer<uint8_t>(string_capacity, *_allocator);
+  auto new_tape = internal::make_allocated_buffer<uint64_t>(tape_capacity, *_allocator);
+  if (!new_string_buf || !new_tape) { return MEMALLOC; }
+
+  string_buf = std::move(new_string_buf);
+  tape = std::move(new_tape);
+  // Inverse of the forward formulas above. The forward step uses
+  // 5*floor(c/3); the inverse maximises c such that 5*floor(c/3) <= cap-PAD,
+  // which is 3*floor((cap-PAD)/5) + 2.
+  size_t cap_s = 3 * ((string_buf.capacity() - SIMDJSON_PADDING) / 5) + 2;
+  size_t cap_t = tape.capacity() - 3;
+  allocated_capacity = std::min(cap_t, cap_s);
   return SUCCESS;
 }
 

--- a/include/simdjson/dom/document.h
+++ b/include/simdjson/dom/document.h
@@ -2,6 +2,7 @@
 #define SIMDJSON_DOM_DOCUMENT_H
 
 #include "simdjson/dom/base.h"
+#include "simdjson/internal/allocated_buffer.h"
 
 #include <memory>
 
@@ -19,8 +20,12 @@ public:
    * Create a document container with zero capacity.
    *
    * The parser will allocate capacity as needed.
+   *
+   * @param alloc The allocator used for the tape and string buffer. The allocator must
+   *    outlive this document.
    */
-  document() noexcept = default;
+  document(simdjson::allocator& alloc = get_default_allocator()) noexcept
+      : _allocator{&alloc}, allocated_capacity{0} {}
   ~document() noexcept = default;
 
   /**
@@ -54,13 +59,13 @@ public:
   bool dump_raw_tape(std::ostream &os) const noexcept;
 
   /** @private Structural values. */
-  std::unique_ptr<uint64_t[]> tape{};
+  internal::allocated_buffer<uint64_t> tape{};
 
   /** @private String values.
    *
    * Should be at least byte_capacity.
    */
-  std::unique_ptr<uint8_t[]> string_buf{};
+  internal::allocated_buffer<uint8_t> string_buf{};
   /** @private Allocate memory to support
    * input JSON documents of up to len bytes.
    *
@@ -71,8 +76,10 @@ public:
    * can you use this function to increase
    * or lower the amount of allocated memory.
    * Passing zero clears the memory.
+   *
+   * May propagate exceptions from the allocator (e.g. std::bad_alloc).
    */
-  error_code allocate(size_t len) noexcept;
+  error_code allocate(size_t len);
   /** @private Capacity in bytes, in terms
    * of how many bytes of input JSON we can
    * support.
@@ -81,7 +88,8 @@ public:
 
 
 private:
-  size_t allocated_capacity{0};
+  simdjson::allocator* _allocator;
+  size_t allocated_capacity;
   friend class parser;
 }; // class document
 

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -21,8 +21,13 @@ namespace dom {
 // parser inline implementation
 //
 simdjson_inline parser::parser(size_t max_capacity) noexcept
-  : _max_capacity{max_capacity},
-    loaded_bytes(nullptr) {
+  : parser{get_default_allocator(), max_capacity} {
+}
+simdjson_inline parser::parser(simdjson::allocator& alloc, size_t max_capacity) noexcept
+  : doc{alloc},
+    _allocator{&alloc},
+    _max_capacity{max_capacity},
+    loaded_bytes{} {
 }
 simdjson_inline parser::parser(parser &&other) noexcept = default;
 simdjson_inline parser &parser::operator=(parser &&other) noexcept = default;
@@ -72,17 +77,14 @@ inline simdjson_result<size_t> parser::read_file(std::string_view path) noexcept
   }
 #endif
 
-  // Make sure we have enough capacity to load the file
-  if (_loaded_bytes_capacity < size_t(len)) {
-    loaded_bytes.reset( internal::allocate_padded_buffer(len) );
-    if (!loaded_bytes) {
+  if (loaded_bytes.capacity() < size_t(len) + SIMDJSON_PADDING) {
+    error_code err = allocate_loaded_bytes(size_t(len));
+    if (err) {
       std::fclose(fp);
-      return MEMALLOC;
+      return err;
     }
-    _loaded_bytes_capacity = len;
   }
 
-  // Read the string
   std::rewind(fp);
   size_t bytes_read = std::fread(loaded_bytes.get(), 1, len, fp);
   if (std::fclose(fp) != 0 || bytes_read != size_t(len)) {
@@ -92,18 +94,31 @@ inline simdjson_result<size_t> parser::read_file(std::string_view path) noexcept
   return bytes_read;
 }
 
-inline simdjson_result<element> parser::load(std::string_view path) & noexcept {
+inline error_code parser::allocate_loaded_bytes(size_t len) {
+  const size_t padded_len = len + SIMDJSON_PADDING;
+  if (padded_len < len) { return MEMALLOC; }
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+  if (padded_len > (1UL << 20)) { return MEMALLOC; }
+#endif
+  auto new_bytes = internal::make_allocated_buffer<char>(padded_len, *_allocator);
+  if (!new_bytes) { return MEMALLOC; }
+  std::memset(new_bytes.get() + len, 0, SIMDJSON_PADDING);
+  loaded_bytes = std::move(new_bytes);
+  return SUCCESS;
+}
+
+inline simdjson_result<element> parser::load(std::string_view path) & {
   return load_into_document(doc, path);
 }
 
-inline simdjson_result<element> parser::load_into_document(document& provided_doc, std::string_view path) & noexcept {
+inline simdjson_result<element> parser::load_into_document(document& provided_doc, std::string_view path) & {
   size_t len;
   auto _error = read_file(path).get(len);
   if (_error) { return _error; }
   return parse_into_document(provided_doc, loaded_bytes.get(), len, false);
 }
 
-inline simdjson_result<document_stream> parser::load_many(std::string_view path, size_t batch_size) noexcept {
+inline simdjson_result<document_stream> parser::load_many(std::string_view path, size_t batch_size) {
   size_t len;
   auto _error = read_file(path).get(len);
   if (_error) { return _error; }
@@ -111,19 +126,14 @@ inline simdjson_result<document_stream> parser::load_many(std::string_view path,
   return document_stream(*this, reinterpret_cast<const uint8_t*>(loaded_bytes.get()), len, batch_size);
 }
 
-inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const uint8_t *buf, size_t len, bool realloc_if_needed) & noexcept {
+inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const uint8_t *buf, size_t len, bool realloc_if_needed) & {
   // Important: we need to ensure that document has enough capacity.
   // Important: It is possible that provided_doc is actually the internal 'doc' within the parser!!!
   error_code _error = ensure_capacity(provided_doc, len);
   if (_error) { return _error; }
   if (realloc_if_needed) {
-    // Make sure we have enough capacity to copy len bytes
-    if (!loaded_bytes || _loaded_bytes_capacity < len) {
-      loaded_bytes.reset( internal::allocate_padded_buffer(len) );
-      if (!loaded_bytes) {
-        return MEMALLOC;
-      }
-      _loaded_bytes_capacity = len;
+    if (loaded_bytes.capacity() < len + SIMDJSON_PADDING) {
+      SIMDJSON_TRY(allocate_loaded_bytes(len));
     }
     std::memcpy(static_cast<void *>(loaded_bytes.get()), buf, len);
     buf = reinterpret_cast<const uint8_t*>(loaded_bytes.get());
@@ -141,31 +151,31 @@ inline simdjson_result<element> parser::parse_into_document(document& provided_d
   return provided_doc.root();
 }
 
-simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const char *buf, size_t len, bool realloc_if_needed) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const char *buf, size_t len, bool realloc_if_needed) & {
   return parse_into_document(provided_doc, reinterpret_cast<const uint8_t *>(buf), len, realloc_if_needed);
 }
-simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const std::string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const std::string &s) & {
   return parse_into_document(provided_doc, s.data(), s.length(), s.capacity() - s.length() < SIMDJSON_PADDING);
 }
-simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const padded_string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const padded_string &s) & {
   return parse_into_document(provided_doc, s.data(), s.length(), false);
 }
 
 
-inline simdjson_result<element> parser::parse(const uint8_t *buf, size_t len, bool realloc_if_needed) & noexcept {
+inline simdjson_result<element> parser::parse(const uint8_t *buf, size_t len, bool realloc_if_needed) & {
   return parse_into_document(doc, buf, len, realloc_if_needed);
 }
 
-simdjson_inline simdjson_result<element> parser::parse(const char *buf, size_t len, bool realloc_if_needed) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse(const char *buf, size_t len, bool realloc_if_needed) & {
   return parse(reinterpret_cast<const uint8_t *>(buf), len, realloc_if_needed);
 }
-simdjson_inline simdjson_result<element> parser::parse(const std::string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse(const std::string &s) & {
   return parse(s.data(), s.length(), s.capacity() - s.length() < SIMDJSON_PADDING);
 }
-simdjson_inline simdjson_result<element> parser::parse(const padded_string &s) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse(const padded_string &s) & {
   return parse(s.data(), s.length(), false);
 }
-simdjson_inline simdjson_result<element> parser::parse(const padded_string_view &v) & noexcept {
+simdjson_inline simdjson_result<element> parser::parse(const padded_string_view &v) & {
   return parse(v.data(), v.length(), false);
 }
 
@@ -235,15 +245,12 @@ simdjson_pure simdjson_inline size_t parser::max_depth() const noexcept {
 }
 
 simdjson_warn_unused
-inline error_code parser::allocate(size_t capacity, size_t max_depth) noexcept {
-  //
-  // Reallocate implementation if needed
-  //
+inline error_code parser::allocate(size_t capacity, size_t max_depth) {
   error_code err;
   if (implementation) {
     err = implementation->allocate(capacity, max_depth);
   } else {
-    err = simdjson::get_active_implementation()->create_dom_parser_implementation(capacity, max_depth, implementation);
+    err = simdjson::get_active_implementation()->create_dom_parser_implementation(capacity, max_depth, implementation, *_allocator);
   }
   if (err) { return err; }
   return SUCCESS;
@@ -251,17 +258,17 @@ inline error_code parser::allocate(size_t capacity, size_t max_depth) noexcept {
 
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
 simdjson_warn_unused
-inline bool parser::allocate_capacity(size_t capacity, size_t max_depth) noexcept {
+inline bool parser::allocate_capacity(size_t capacity, size_t max_depth) {
   return !allocate(capacity, max_depth);
 }
 #endif // SIMDJSON_DISABLE_DEPRECATED_API
 
-inline error_code parser::ensure_capacity(size_t desired_capacity) noexcept {
+inline error_code parser::ensure_capacity(size_t desired_capacity) {
   return ensure_capacity(doc, desired_capacity);
 }
 
 
-inline error_code parser::ensure_capacity(document& target_document, size_t desired_capacity) noexcept {
+inline error_code parser::ensure_capacity(document& target_document, size_t desired_capacity) {
   // 1. It is wasteful to allocate a document and a parser for documents spanning less than MINIMAL_DOCUMENT_CAPACITY bytes.
   // 2. If we allow desired_capacity = 0 then it is possible to exit this function with implementation == nullptr.
   if(desired_capacity < MINIMAL_DOCUMENT_CAPACITY) { desired_capacity = MINIMAL_DOCUMENT_CAPACITY; }

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -3,6 +3,7 @@
 
 #include "simdjson/dom/base.h"
 #include "simdjson/dom/document.h"
+#include "simdjson/internal/allocated_buffer.h"
 
 namespace simdjson {
 
@@ -41,6 +42,19 @@ public:
    *    Defaults to SIMDJSON_MAXSIZE_BYTES (the largest single document simdjson can process).
    */
   simdjson_inline explicit parser(size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
+  /**
+   * Create a JSON parser with a custom allocator.
+   *
+   * The new parser will have zero capacity. All buffers (scratch buffers and
+   * the internal `doc`) will be allocated through `alloc`. The allocator must
+   * outlive the parser.
+   *
+   * @param alloc The allocator used for this parser's scratch buffers and its
+   *     internal document.
+   * @param max_capacity See the single-argument constructor.
+   */
+  simdjson_inline explicit parser(simdjson::allocator& alloc,
+                                  size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
   /**
    * Take another parser's buffers and state.
    *
@@ -102,7 +116,7 @@ public:
    *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
    *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
    */
-  inline simdjson_result<element> load(std::string_view path) & noexcept;
+  inline simdjson_result<element> load(std::string_view path) &;
   inline simdjson_result<element> load(std::string_view path) &&  = delete ;
 
   /**
@@ -148,7 +162,7 @@ public:
    *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
    *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
    */
-  inline simdjson_result<element> load_into_document(document& doc, std::string_view path) & noexcept;
+  inline simdjson_result<element> load_into_document(document& doc, std::string_view path) &;
   inline simdjson_result<element> load_into_document(document& doc, std::string_view path) && =delete;
 
   /**
@@ -231,19 +245,19 @@ public:
    *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
    *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
    */
-  inline simdjson_result<element> parse(const uint8_t *buf, size_t len, bool realloc_if_needed = true) & noexcept;
+  inline simdjson_result<element> parse(const uint8_t *buf, size_t len, bool realloc_if_needed = true) &;
   inline simdjson_result<element> parse(const uint8_t *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_inline simdjson_result<element> parse(const char *buf, size_t len, bool realloc_if_needed = true) & noexcept;
+  simdjson_inline simdjson_result<element> parse(const char *buf, size_t len, bool realloc_if_needed = true) &;
   simdjson_inline simdjson_result<element> parse(const char *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse(const std::string &) */
-  simdjson_inline simdjson_result<element> parse(const std::string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse(const std::string &s) &;
   simdjson_inline simdjson_result<element> parse(const std::string &s) && =delete;
   /** @overload parse(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_inline simdjson_result<element> parse(const padded_string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse(const padded_string &s) &;
   simdjson_inline simdjson_result<element> parse(const padded_string &s) && =delete;
   /** @overload parse(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_inline simdjson_result<element> parse(const padded_string_view &v) & noexcept;
+  simdjson_inline simdjson_result<element> parse(const padded_string_view &v) &;
   simdjson_inline simdjson_result<element> parse(const padded_string_view &v) && =delete;
 
   /** @private We do not want to allow implicit conversion from C string to std::string. */
@@ -293,16 +307,16 @@ public:
    *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
    *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
    */
-  inline simdjson_result<element> parse_into_document(document& doc, const uint8_t *buf, size_t len, bool realloc_if_needed = true) & noexcept;
+  inline simdjson_result<element> parse_into_document(document& doc, const uint8_t *buf, size_t len, bool realloc_if_needed = true) &;
   inline simdjson_result<element> parse_into_document(document& doc, const uint8_t *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse_into_document(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const char *buf, size_t len, bool realloc_if_needed = true) & noexcept;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const char *buf, size_t len, bool realloc_if_needed = true) &;
   simdjson_inline simdjson_result<element> parse_into_document(document& doc, const char *buf, size_t len, bool realloc_if_needed = true) && =delete;
   /** @overload parse_into_document(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const std::string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const std::string &s) &;
   simdjson_inline simdjson_result<element> parse_into_document(document& doc, const std::string &s) && =delete;
   /** @overload parse_into_document(const uint8_t *buf, size_t len, bool realloc_if_needed) */
-  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const padded_string &s) & noexcept;
+  simdjson_inline simdjson_result<element> parse_into_document(document& doc, const padded_string &s) &;
   simdjson_inline simdjson_result<element> parse_into_document(document& doc, const padded_string &s) && =delete;
 
   /** @private We do not want to allow implicit conversion from C string to std::string. */
@@ -383,7 +397,7 @@ public:
    *         - other json errors if parsing fails. You should not rely on these errors to always the same for the
    *           same document: they may vary under runtime dispatch (so they may vary depending on your system and hardware).
    */
-  inline simdjson_result<document_stream> load_many(std::string_view path, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
+  inline simdjson_result<document_stream> load_many(std::string_view path, size_t batch_size = dom::DEFAULT_BATCH_SIZE);
 
   /**
    * Parse a buffer containing many JSON documents.
@@ -531,7 +545,7 @@ public:
    * @param max_depth The new max_depth. Defaults to DEFAULT_MAX_DEPTH.
    * @return The error, if there is one.
    */
-  simdjson_warn_unused inline error_code allocate(size_t capacity, size_t max_depth = DEFAULT_MAX_DEPTH) noexcept;
+  simdjson_warn_unused inline error_code allocate(size_t capacity, size_t max_depth = DEFAULT_MAX_DEPTH);
 
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
   /**
@@ -546,7 +560,7 @@ public:
    * @return true if successful, false if allocation failed.
    */
   [[deprecated("Use allocate() instead.")]]
-  simdjson_warn_unused inline bool allocate_capacity(size_t capacity, size_t max_depth = DEFAULT_MAX_DEPTH) noexcept;
+  simdjson_warn_unused inline bool allocate_capacity(size_t capacity, size_t max_depth = DEFAULT_MAX_DEPTH);
 #endif // SIMDJSON_DISABLE_DEPRECATED_API
   /**
    * The largest document this parser can support without reallocating.
@@ -648,6 +662,11 @@ public:
 
 private:
   /**
+   * The allocator used for this parser.
+   */
+  simdjson::allocator* _allocator;
+
+  /**
    * The maximum document length this parser will automatically support.
    *
    * The parser will not be automatically allocated above this amount.
@@ -658,12 +677,11 @@ private:
   bool _number_as_string{false};
 
   /**
-   * The loaded buffer (reused each time load() is called)
+   * The loaded buffer (reused each time load() is called).
+   * Allocated through `_allocator`. The usable length (excluding the trailing
+   * SIMDJSON_PADDING bytes) is `loaded_bytes.capacity() - SIMDJSON_PADDING`.
    */
-  std::unique_ptr<char[]> loaded_bytes;
-
-  /** Capacity of loaded_bytes buffer. */
-  size_t _loaded_bytes_capacity{0};
+  internal::allocated_buffer<char> loaded_bytes{};
 
   // all nodes are stored on the doc.tape using a 64-bit word.
   //
@@ -684,13 +702,25 @@ private:
    * and auto-allocate if not. This also allocates memory if needed in the
    * internal document.
    */
-  inline error_code ensure_capacity(size_t desired_capacity) noexcept;
+  inline error_code ensure_capacity(size_t desired_capacity);
   /**
    * Ensure we have enough capacity to handle at least desired_capacity bytes,
    * and auto-allocate if not. This also allocates memory if needed in the
    * provided document.
    */
-  inline error_code ensure_capacity(document& doc, size_t desired_capacity) noexcept;
+  inline error_code ensure_capacity(document& doc, size_t desired_capacity);
+
+  /**
+   * Allocate a fresh `loaded_bytes` buffer through `_allocator` sized to hold
+   * `len` bytes plus `SIMDJSON_PADDING` trailing zero-filled padding. Any
+   * previous contents of `loaded_bytes` are dropped -- this is not a
+   * `realloc`-style grow.
+   *
+   * Mirrors `internal::allocate_padded_buffer` but routes through the parser's
+   * allocator instead of plain `new[]`. Returns `MEMALLOC` on overflow or
+   * allocation failure. May propagate allocator exceptions.
+   */
+  inline error_code allocate_loaded_bytes(size_t len);
 
   /** Read the file into loaded_bytes */
   inline simdjson_result<size_t> read_file(std::string_view path) noexcept;

--- a/include/simdjson/fallback/implementation.h
+++ b/include/simdjson/fallback/implementation.h
@@ -22,8 +22,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<simdjson::internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<simdjson::internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/include/simdjson/generic/builder/dependencies.h
+++ b/include/simdjson/generic/builder/dependencies.h
@@ -10,5 +10,6 @@
 // Otherwise, amalgamation will fail.
 #include "simdjson/concepts.h"
 #include "simdjson/dom/fractured_json.h"
+#include "simdjson/internal/allocated_buffer.h"
 
 #endif // SIMDJSON_GENERIC_BUILDER_DEPENDENCIES_H

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -484,15 +484,19 @@ inline size_t write_string_escaped(const std::string_view input, char *out) {
 }
 
 simdjson_inline string_builder::string_builder(size_t initial_capacity)
-    : buffer(new(std::nothrow) char[initial_capacity]), position(0),
-      capacity(buffer.get() != nullptr ? initial_capacity : 0),
-      is_valid(buffer.get() != nullptr) {}
+    : string_builder(simdjson::get_default_allocator(), initial_capacity) {}
+
+simdjson_inline string_builder::string_builder(simdjson::allocator& alloc, size_t initial_capacity)
+    : _allocator(&alloc),
+      buffer(simdjson::internal::make_allocated_buffer<char>(initial_capacity, *_allocator)),
+      position(0),
+      is_valid(static_cast<bool>(buffer)) {}
 
 simdjson_inline bool string_builder::capacity_check(size_t upcoming_bytes) {
   // We use the convention that when is_valid is false, then the capacity and
   // the position are 0.
   // Most of the time, this function will return true.
-  if (simdjson_likely(upcoming_bytes <= capacity - position)) {
+  if (simdjson_likely(upcoming_bytes <= buffer.capacity() - position)) {
     return true;
   }
   // check for overflow, most of the time there is no overflow
@@ -500,7 +504,7 @@ simdjson_inline bool string_builder::capacity_check(size_t upcoming_bytes) {
     return false;
   }
   // We will rarely get here.
-  grow_buffer((std::max)(capacity * 2, position + upcoming_bytes));
+  grow_buffer((std::max)(buffer.capacity() * 2, position + upcoming_bytes));
   // If the buffer allocation failed, we set is_valid to false.
   return is_valid;
 }
@@ -509,20 +513,18 @@ inline void string_builder::grow_buffer(size_t desired_capacity) {
   if (!is_valid) {
     return;
   }
-  std::unique_ptr<char[]> new_buffer(new (std::nothrow) char[desired_capacity]);
-  if (new_buffer.get() == nullptr) {
+  auto new_buffer = simdjson::internal::make_allocated_buffer<char>(desired_capacity, *_allocator);
+  if (!new_buffer) {
     set_valid(false);
     return;
   }
   std::memcpy(new_buffer.get(), buffer.get(), position);
-  buffer.swap(new_buffer);
-  capacity = desired_capacity;
+  buffer = std::move(new_buffer);
 }
 
 simdjson_inline void string_builder::set_valid(bool valid) noexcept {
   if (!valid) {
     is_valid = false;
-    capacity = 0;
     position = 0;
     buffer.reset();
   } else {
@@ -534,13 +536,13 @@ simdjson_inline size_t string_builder::size() const noexcept {
   return position;
 }
 
-simdjson_inline void string_builder::append(char c) noexcept {
+simdjson_inline void string_builder::append(char c) {
   if (capacity_check(1)) {
     buffer.get()[position++] = c;
   }
 }
 
-simdjson_inline void string_builder::append_null() noexcept {
+simdjson_inline void string_builder::append_null() {
   constexpr char null_literal[] = "null";
   constexpr size_t null_len = sizeof(null_literal) - 1;
   if (capacity_check(null_len)) {
@@ -553,7 +555,6 @@ simdjson_inline void string_builder::clear() noexcept {
   position = 0;
   // if it was invalid, we should try to repair it
   if (!is_valid) {
-    capacity = 0;
     buffer.reset();
     is_valid = true;
   }
@@ -639,7 +640,7 @@ static const char decimal_table[200] = {
 } // namespace internal
 
 template <typename number_type, typename>
-simdjson_inline void string_builder::append(number_type v) noexcept {
+simdjson_inline void string_builder::append(number_type v) {
   static_assert(std::is_same<number_type, bool>::value ||
                     std::is_integral<number_type>::value ||
                     std::is_floating_point<number_type>::value,
@@ -753,7 +754,7 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
 }
 
 simdjson_inline void
-string_builder::escape_and_append(std::string_view input) noexcept {
+string_builder::escape_and_append(std::string_view input) {
   // escaping might turn a control character into \x00xx so 6 characters.
   if (capacity_check(6 * input.size())) {
     position += write_string_escaped(input, buffer.get() + position);
@@ -761,7 +762,7 @@ string_builder::escape_and_append(std::string_view input) noexcept {
 }
 
 simdjson_inline void
-string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
+string_builder::escape_and_append_with_quotes(std::string_view input) {
   // escaping might turn a control character into \x00xx so 6 characters.
   if (capacity_check(2 + 6 * input.size())) {
     buffer.get()[position++] = '"';
@@ -771,7 +772,7 @@ string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
 }
 
 simdjson_inline void
-string_builder::escape_and_append_with_quotes(char input) noexcept {
+string_builder::escape_and_append_with_quotes(char input) {
   // escaping might turn a control character into \x00xx so 6 characters.
   if (capacity_check(2 + 6 * 1)) {
     buffer.get()[position++] = '"';
@@ -782,24 +783,24 @@ string_builder::escape_and_append_with_quotes(char input) noexcept {
 }
 
 simdjson_inline void
-string_builder::escape_and_append_with_quotes(const char *input) noexcept {
+string_builder::escape_and_append_with_quotes(const char *input) {
   std::string_view cinput(input);
   escape_and_append_with_quotes(cinput);
 }
 #if SIMDJSON_SUPPORTS_CONCEPTS
 template <constevalutil::fixed_string key>
-simdjson_inline void string_builder::escape_and_append_with_quotes() noexcept {
+simdjson_inline void string_builder::escape_and_append_with_quotes() {
   escape_and_append_with_quotes(constevalutil::string_constant<key>::value);
 }
 #endif
 
-simdjson_inline void string_builder::append_raw(const char *c) noexcept {
+simdjson_inline void string_builder::append_raw(const char *c) {
   size_t len = std::strlen(c);
   append_raw(c, len);
 }
 
 simdjson_inline void
-string_builder::append_raw(std::string_view input) noexcept {
+string_builder::append_raw(std::string_view input) {
   if (capacity_check(input.size())) {
     std::memcpy(buffer.get() + position, input.data(), input.size());
     position += input.size();
@@ -807,7 +808,7 @@ string_builder::append_raw(std::string_view input) noexcept {
 }
 
 simdjson_inline void string_builder::append_raw(const char *str,
-                                                size_t len) noexcept {
+                                                size_t len) {
   if (capacity_check(len)) {
     std::memcpy(buffer.get() + position, str, len);
     position += len;
@@ -843,7 +844,7 @@ simdjson_inline void string_builder::append(const T &value) {
 // Support for range-based appending (std::ranges::view, etc.)
 template <std::ranges::range R>
   requires(!std::is_convertible<R, std::string_view>::value && !concepts::optional_type<R> && !require_custom_serialization<R>)
-simdjson_inline void string_builder::append(const R &range) noexcept {
+simdjson_inline void string_builder::append(const R &range) {
   auto it = std::ranges::begin(range);
   auto end = std::ranges::end(range);
   if constexpr (concepts::is_pair<std::ranges::range_value_t<R>>) {
@@ -904,7 +905,7 @@ string_builder::view() const noexcept {
   return std::string_view(buffer.get(), position);
 }
 
-simdjson_inline simdjson_result<const char *> string_builder::c_str() noexcept {
+simdjson_inline simdjson_result<const char *> string_builder::c_str() {
   if (capacity_check(1)) {
     buffer.get()[position] = '\0';
     return buffer.get();
@@ -916,37 +917,37 @@ simdjson_inline bool string_builder::validate_unicode() const noexcept {
   return simdjson::validate_utf8(buffer.get(), position);
 }
 
-simdjson_inline void string_builder::start_object() noexcept {
+simdjson_inline void string_builder::start_object() {
   if (capacity_check(1)) {
     buffer.get()[position++] = '{';
   }
 }
 
-simdjson_inline void string_builder::end_object() noexcept {
+simdjson_inline void string_builder::end_object() {
   if (capacity_check(1)) {
     buffer.get()[position++] = '}';
   }
 }
 
-simdjson_inline void string_builder::start_array() noexcept {
+simdjson_inline void string_builder::start_array() {
   if (capacity_check(1)) {
     buffer.get()[position++] = '[';
   }
 }
 
-simdjson_inline void string_builder::end_array() noexcept {
+simdjson_inline void string_builder::end_array() {
   if (capacity_check(1)) {
     buffer.get()[position++] = ']';
   }
 }
 
-simdjson_inline void string_builder::append_comma() noexcept {
+simdjson_inline void string_builder::append_comma() {
   if (capacity_check(1)) {
     buffer.get()[position++] = ',';
   }
 }
 
-simdjson_inline void string_builder::append_colon() noexcept {
+simdjson_inline void string_builder::append_colon() {
   if (capacity_check(1)) {
     buffer.get()[position++] = ':';
   }
@@ -954,7 +955,7 @@ simdjson_inline void string_builder::append_colon() noexcept {
 
 template <typename key_type, typename value_type>
 simdjson_inline void
-string_builder::append_key_value(key_type key, value_type value) noexcept {
+string_builder::append_key_value(key_type key, value_type value) {
   static_assert(std::is_same<key_type, const char *>::value ||
                     std::is_convertible<key_type, std::string_view>::value,
                 "Unsupported key type");
@@ -981,7 +982,7 @@ string_builder::append_key_value(key_type key, value_type value) noexcept {
 #if SIMDJSON_SUPPORTS_CONCEPTS
 template <constevalutil::fixed_string key, typename value_type>
 simdjson_inline void
-string_builder::append_key_value(value_type value) noexcept {
+string_builder::append_key_value(value_type value) {
   escape_and_append_with_quotes<key>();
   append_colon();
   SIMDJSON_IF_CONSTEXPR(std::is_same<value_type, std::nullptr_t>::value) {

--- a/include/simdjson/generic/builder/json_string_builder.h
+++ b/include/simdjson/generic/builder/json_string_builder.h
@@ -3,6 +3,7 @@
 #ifndef SIMDJSON_CONDITIONAL_INCLUDE
 #define SIMDJSON_GENERIC_STRING_BUILDER_H
 #include "simdjson/generic/implementation_simdjson_result_base.h"
+#include "simdjson/internal/allocated_buffer.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 namespace simdjson {
@@ -50,9 +51,21 @@ namespace builder {
  */
 class string_builder {
 public:
-  simdjson_inline string_builder(size_t initial_capacity = DEFAULT_INITIAL_CAPACITY);
-
   static constexpr size_t DEFAULT_INITIAL_CAPACITY = 1024;
+
+  /**
+   * Construct a builder using the default allocator.
+   */
+  simdjson_inline explicit string_builder(size_t initial_capacity = DEFAULT_INITIAL_CAPACITY);
+
+  /**
+   * Construct a builder using a caller-supplied allocator.
+   *
+   * The allocator must outlive the builder. Allocator exceptions propagate
+   * out of the constructor and out of every allocating method below.
+   */
+  simdjson_inline explicit string_builder(simdjson::allocator& alloc,
+                                          size_t initial_capacity = DEFAULT_INITIAL_CAPACITY);
 
   /**
    * Append number (includes Booleans). Booleans are mapped to the strings
@@ -62,17 +75,17 @@ public:
    */
   template<typename number_type,
     typename = typename std::enable_if<std::is_arithmetic<number_type>::value>::type>
-  simdjson_inline void append(number_type v) noexcept;
+  simdjson_inline void append(number_type v);
 
   /**
    * Append character c.
    */
-  simdjson_inline void append(char c)  noexcept;
+  simdjson_inline void append(char c);
 
   /**
    * Append the string 'null'.
    */
-  simdjson_inline void append_null()  noexcept;
+  simdjson_inline void append_null();
 
   /**
    * Clear the content.
@@ -83,64 +96,64 @@ public:
    * Append the std::string_view, after escaping it.
    * There is no UTF-8 validation.
    */
-  simdjson_inline void escape_and_append(std::string_view input)  noexcept;
+  simdjson_inline void escape_and_append(std::string_view input);
 
   /**
    * Append the std::string_view surrounded by double quotes, after escaping it.
    * There is no UTF-8 validation.
    */
-  simdjson_inline void escape_and_append_with_quotes(std::string_view input)  noexcept;
+  simdjson_inline void escape_and_append_with_quotes(std::string_view input);
 #if SIMDJSON_SUPPORTS_CONCEPTS
   template<constevalutil::fixed_string key>
-  simdjson_inline void escape_and_append_with_quotes()  noexcept;
+  simdjson_inline void escape_and_append_with_quotes();
 #endif
   /**
    * Append the character surrounded by double quotes, after escaping it.
    * There is no UTF-8 validation.
    */
-  simdjson_inline void escape_and_append_with_quotes(char input)  noexcept;
+  simdjson_inline void escape_and_append_with_quotes(char input);
 
   /**
    * Append the character surrounded by double quotes, after escaping it.
    * There is no UTF-8 validation.
    */
-   simdjson_inline void escape_and_append_with_quotes(const char* input)  noexcept;
+   simdjson_inline void escape_and_append_with_quotes(const char* input);
 
   /**
    * Append the C string directly, without escaping.
    * There is no UTF-8 validation.
    */
-  simdjson_inline void append_raw(const char *c)  noexcept;
+  simdjson_inline void append_raw(const char *c);
 
   /**
    * Append "{" to the buffer.
    */
-  simdjson_inline void start_object()  noexcept;
+  simdjson_inline void start_object();
 
   /**
    * Append "}" to the buffer.
    */
-  simdjson_inline void end_object()  noexcept;
+  simdjson_inline void end_object();
 
   /**
    * Append "[" to the buffer.
    */
-  simdjson_inline void start_array()  noexcept;
+  simdjson_inline void start_array();
 
   /**
    * Append "]" to the buffer.
    */
-  simdjson_inline void end_array()  noexcept;
+  simdjson_inline void end_array();
 
   /**
    * Append "," to the buffer.
    */
-  simdjson_inline void append_comma()  noexcept;
+  simdjson_inline void append_comma();
 
   /**
    * Append ":" to the buffer.
    */
-  simdjson_inline void append_colon()  noexcept;
+  simdjson_inline void append_colon();
 
   /**
    * Append a key-value pair to the buffer.
@@ -148,10 +161,10 @@ public:
    * The value is escaped if it is a string.
    */
   template<typename key_type, typename value_type>
-  simdjson_inline void append_key_value(key_type key, value_type value) noexcept;
+  simdjson_inline void append_key_value(key_type key, value_type value);
 #if SIMDJSON_SUPPORTS_CONCEPTS
   template<constevalutil::fixed_string key, typename value_type>
-  simdjson_inline void append_key_value(value_type value) noexcept;
+  simdjson_inline void append_key_value(value_type value);
 
   // Support for optional types (std::optional, etc.)
   template <concepts::optional_type T>
@@ -172,19 +185,19 @@ public:
   // Support for range-based appending (std::ranges::view, etc.)
   template <std::ranges::range R>
 requires (!std::is_convertible<R, std::string_view>::value && !concepts::optional_type<R> && !require_custom_serialization<R>)
-  simdjson_inline void append(const R &range) noexcept;
+  simdjson_inline void append(const R &range);
 #endif
   /**
    * Append the std::string_view directly, without escaping.
    * There is no UTF-8 validation.
    */
-  simdjson_inline void append_raw(std::string_view input)  noexcept;
+  simdjson_inline void append_raw(std::string_view input);
 
   /**
    * Append len characters from str.
    * There is no UTF-8 validation.
    */
-  simdjson_inline void append_raw(const char *str, size_t len) noexcept;
+  simdjson_inline void append_raw(const char *str, size_t len);
 #if SIMDJSON_EXCEPTIONS
   /**
    * Creates an std::string from the written JSON buffer.
@@ -223,7 +236,7 @@ requires (!std::is_convertible<R, std::string_view>::value && !concepts::optiona
    * The result may not be valid UTF-8 if some of your content was not valid UTF-8.
    * Use validate_unicode() to check the content.
    */
-  simdjson_inline simdjson_result<const char *> c_str() noexcept;
+  simdjson_inline simdjson_result<const char *> c_str();
 
   /**
    * Return true if the content is valid UTF-8.
@@ -256,10 +269,10 @@ private:
    */
   simdjson_inline void set_valid(bool valid) noexcept;
 
-  std::unique_ptr<char[]> buffer{};
-  size_t position{0};
-  size_t capacity{0};
-  bool is_valid{true};
+  simdjson::allocator* _allocator;
+  simdjson::internal::allocated_buffer<char> buffer;
+  size_t position;
+  bool is_valid;
 };
 
 
@@ -271,8 +284,8 @@ private:
 #if !SIMDJSON_STATIC_REFLECTION
 // fallback implementation until we have static reflection
 template <class Z>
-simdjson_warn_unused simdjson_result<std::string> to_json(const Z &z, size_t initial_capacity = simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
-  simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder b(initial_capacity);
+simdjson_warn_unused simdjson_result<std::string> to_json(const Z &z, simdjson::allocator& alloc, size_t initial_capacity = simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
+  simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder b(alloc, initial_capacity);
   b.append(z);
   std::string_view s;
   auto e = b.view().get(s);
@@ -280,8 +293,12 @@ simdjson_warn_unused simdjson_result<std::string> to_json(const Z &z, size_t ini
   return std::string(s);
 }
 template <class Z>
-simdjson_warn_unused error_code to_json(const Z &z, std::string &s, size_t initial_capacity = simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
-  simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder b(initial_capacity);
+simdjson_warn_unused simdjson_result<std::string> to_json(const Z &z, size_t initial_capacity = simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
+  return to_json(z, simdjson::get_default_allocator(), initial_capacity);
+}
+template <class Z>
+simdjson_warn_unused error_code to_json(const Z &z, std::string &s, simdjson::allocator& alloc, size_t initial_capacity = simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
+  simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder b(alloc, initial_capacity);
   b.append(z);
   std::string_view sv;
   auto e = b.view().get(sv);
@@ -289,10 +306,11 @@ simdjson_warn_unused error_code to_json(const Z &z, std::string &s, size_t initi
   s.assign(sv.data(), sv.size());
   return simdjson::SUCCESS;
 }
+template <class Z>
+simdjson_warn_unused error_code to_json(const Z &z, std::string &s, size_t initial_capacity = simdjson::SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
+  return to_json(z, s, simdjson::get_default_allocator(), initial_capacity);
+}
 #endif
-
-#if SIMDJSON_SUPPORTS_CONCEPTS
-#endif // SIMDJSON_SUPPORTS_CONCEPTS
 
 } // namespace simdjson
 

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -4,6 +4,8 @@
 #define SIMDJSON_GENERIC_DOM_PARSER_IMPLEMENTATION_H
 #include "simdjson/generic/base.h"
 #include "simdjson/internal/dom_parser_implementation.h"
+
+#include <algorithm>
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 namespace simdjson {
@@ -20,9 +22,9 @@ static_assert(sizeof(open_container) == 64/8, "Open container must be 64 bits");
 class dom_parser_implementation final : public internal::dom_parser_implementation {
 public:
   /** Tape location of each open { or [ */
-  std::unique_ptr<open_container[]> open_containers{};
+  internal::allocated_buffer<open_container> open_containers{};
   /** Whether each open container is a [ or { */
-  std::unique_ptr<bool[]> is_array{};
+  internal::allocated_buffer<bool> is_array{};
   /** Buffer passed to stage 1 */
   const uint8_t *buf{};
   /** Length passed to stage 1 */
@@ -30,7 +32,7 @@ public:
   /** Document passed to stage 2 */
   dom::document *doc{};
 
-  inline dom_parser_implementation() noexcept;
+  inline explicit dom_parser_implementation(simdjson::allocator& alloc) noexcept;
   inline dom_parser_implementation(dom_parser_implementation &&other) noexcept;
   inline dom_parser_implementation &operator=(dom_parser_implementation &&other) noexcept;
   dom_parser_implementation(const dom_parser_implementation &) = delete;
@@ -42,8 +44,8 @@ public:
   simdjson_warn_unused error_code stage2_next(dom::document &doc) noexcept final;
   simdjson_warn_unused uint8_t *parse_string(const uint8_t *src, uint8_t *dst, bool allow_replacement) const noexcept final;
   simdjson_warn_unused uint8_t *parse_wobbly_string(const uint8_t *src, uint8_t *dst) const noexcept final;
-  inline simdjson_warn_unused error_code set_capacity(size_t capacity) noexcept final;
-  inline simdjson_warn_unused error_code set_max_depth(size_t max_depth) noexcept final;
+  inline simdjson_warn_unused error_code set_capacity(size_t capacity) final;
+  inline simdjson_warn_unused error_code set_max_depth(size_t max_depth) final;
 private:
   simdjson_inline simdjson_warn_unused error_code set_capacity_stage1(size_t capacity);
 
@@ -55,12 +57,13 @@ private:
 namespace simdjson {
 namespace SIMDJSON_IMPLEMENTATION {
 
-inline dom_parser_implementation::dom_parser_implementation() noexcept = default;
+inline dom_parser_implementation::dom_parser_implementation(simdjson::allocator& alloc) noexcept
+    : internal::dom_parser_implementation{alloc} {}
 inline dom_parser_implementation::dom_parser_implementation(dom_parser_implementation &&other) noexcept = default;
 inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parser_implementation &&other) noexcept = default;
 
 // Leaving these here so they can be inlined if so desired
-inline simdjson_warn_unused error_code dom_parser_implementation::set_capacity(size_t capacity) noexcept {
+inline simdjson_warn_unused error_code dom_parser_implementation::set_capacity(size_t capacity) {
   if(capacity > SIMDJSON_MAXSIZE_BYTES) { return CAPACITY; }
   // Stage 1 index output
   size_t rounded_capacity = SIMDJSON_ROUNDUP_N(capacity, 64);
@@ -68,23 +71,34 @@ inline simdjson_warn_unused error_code dom_parser_implementation::set_capacity(s
     return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
   }
   size_t max_structures = rounded_capacity + 9;
-  structural_indexes.reset( new (std::nothrow) uint32_t[max_structures] );
-  if (!structural_indexes) { _capacity = 0; return MEMALLOC; }
-  structural_indexes[0] = 0;
-  n_structural_indexes = 0;
 
-  _capacity = capacity;
+  // Allocate into a local first: if the allocator throws, existing state is
+  // preserved (strong exception safety).
+  auto new_structural_indexes = internal::make_allocated_buffer<uint32_t>(max_structures, *_allocator);
+  if (!new_structural_indexes) { return MEMALLOC; }
+  new_structural_indexes[0] = 0;
+
+  structural_indexes = std::move(new_structural_indexes);
+  n_structural_indexes = 0;
+  // Derive _capacity from the buffer's actual size so any allocator
+  // over-allocation is exposed via parser.capacity().
+  _capacity = SIMDJSON_ROUNDDOWN_N(structural_indexes.capacity() - 9, 64);
   return SUCCESS;
 }
 
-inline simdjson_warn_unused error_code dom_parser_implementation::set_max_depth(size_t max_depth) noexcept {
+inline simdjson_warn_unused error_code dom_parser_implementation::set_max_depth(size_t max_depth) {
   if(max_depth > SIMDJSON_MAX_DEPTH) { return CAPACITY; }
-  // Stage 2 stacks
-  open_containers.reset(new (std::nothrow) open_container[max_depth]);
-  is_array.reset(new (std::nothrow) bool[max_depth]);
-  if (!is_array || !open_containers) { _max_depth = 0; return MEMALLOC; }
+  // Stage 2 stacks. Allocate into locals first: if either allocation throws,
+  // existing state is preserved (strong exception safety).
+  auto new_open_containers = internal::make_allocated_buffer<open_container>(max_depth, *_allocator);
+  auto new_is_array = internal::make_allocated_buffer<bool>(max_depth, *_allocator);
+  if (!new_open_containers || !new_is_array) { return MEMALLOC; }
 
-  _max_depth = max_depth;
+  open_containers = std::move(new_open_containers);
+  is_array = std::move(new_is_array);
+  // Pin to the smaller of the two buffers. Both are guaranteed >= max_depth,
+  // so this is always >= the requested value.
+  _max_depth = std::min(open_containers.capacity(), is_array.capacity());
   return SUCCESS;
 }
 

--- a/include/simdjson/generic/ondemand/dependencies.h
+++ b/include/simdjson/generic/ondemand/dependencies.h
@@ -12,6 +12,7 @@
 #include "simdjson/implementation.h"
 #include "simdjson/padded_string.h"
 #include "simdjson/padded_string_view.h"
+#include "simdjson/internal/allocated_buffer.h"
 #include "simdjson/internal/dom_parser_implementation.h"
 #include "simdjson/jsonpathutil.h"
 

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -11,6 +11,8 @@
 #include "simdjson/generic/ondemand/document_stream.h"
 #include "simdjson/generic/ondemand/parser.h"
 #include "simdjson/generic/ondemand/raw_json_string.h"
+
+#include <algorithm>
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 namespace simdjson {
@@ -18,31 +20,69 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace ondemand {
 
 simdjson_inline parser::parser(size_t max_capacity) noexcept
-  : _max_capacity{max_capacity} {
+  : parser{simdjson::get_default_allocator(), max_capacity} {
 }
 
-simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capacity, size_t new_max_depth) noexcept {
-  if (new_capacity > max_capacity()) { return CAPACITY; }
-  if (string_buf && new_capacity == capacity() && new_max_depth == max_depth()) { return SUCCESS; }
+simdjson_inline parser::parser(simdjson::allocator& alloc, size_t max_capacity) noexcept
+  : _allocator{&alloc}, _max_capacity{max_capacity} {
+}
 
-  // string_capacity copied from document::allocate
-  _capacity = 0;
+simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capacity, size_t new_max_depth) {
+  if (new_capacity > max_capacity()) { return CAPACITY; }
+  // Only grow: with allocator over-allocation propagated into _capacity /
+  // _max_depth, a re-request for the same (or smaller) size is a no-op
+  // rather than a shrink-and-reallocate.
+  if (string_buf && new_capacity <= capacity() && new_max_depth <= max_depth()) { return SUCCESS; }
+
+  // Allocate into locals first (strong exception safety): if any allocation
+  // below fails, the parser's previous state is left untouched.
+  // string_capacity copied from document::allocate.
   if(5 * (new_capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
     return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
   }
   size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (new_capacity / 3) + SIMDJSON_PADDING, 64);
-  string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
+  auto new_string_buf = simdjson::internal::make_allocated_buffer<uint8_t>(string_capacity, *_allocator);
+  if (!new_string_buf) { return MEMALLOC; }
 #if SIMDJSON_DEVELOPMENT_CHECKS
-  start_positions.reset(new (std::nothrow) token_position[new_max_depth]);
+  auto new_start_positions = simdjson::internal::make_allocated_buffer<token_position>(new_max_depth, *_allocator);
+  if (!new_start_positions) { return MEMALLOC; }
 #endif
-  if (implementation) {
+  std::unique_ptr<simdjson::internal::dom_parser_implementation> new_implementation;
+  if (!implementation) {
+    SIMDJSON_TRY( simdjson::get_active_implementation()->create_dom_parser_implementation(new_capacity, new_max_depth, new_implementation, *_allocator) );
+  } else {
+    // set_capacity / set_max_depth each have their own strong exception
+    // safety internally; committing them here still precedes the member
+    // move-assigns below so parser-level state is only mutated on success.
     SIMDJSON_TRY( implementation->set_capacity(new_capacity) );
     SIMDJSON_TRY( implementation->set_max_depth(new_max_depth) );
-  } else {
-    SIMDJSON_TRY( simdjson::get_active_implementation()->create_dom_parser_implementation(new_capacity, new_max_depth, implementation) );
   }
-  _capacity = new_capacity;
+
+  // Commit: no more failure paths below.
+  if (new_implementation) { implementation = std::move(new_implementation); }
+  string_buf = std::move(new_string_buf);
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  start_positions = std::move(new_start_positions);
+  // start_positions is the only buffer sized by max_depth at this layer
+  // (the implementation's open_containers/is_array are only used by the DOM
+  // stage2, which on-demand never calls). Derive _max_depth from the buffer's
+  // actual capacity so any allocator over-allocation is exposed via
+  // parser.max_depth(); this also preserves the invariant that the bounds
+  // checks `depth < parser->max_depth()` in json_iterator imply
+  // `start_positions[depth]` is in range.
+  _max_depth = start_positions.capacity();
+#else
   _max_depth = new_max_depth;
+#endif
+  // Inverse of the forward formulas above. The forward step uses
+  // 5*floor(c/3); the inverse maximises c such that 5*floor(c/3) <= cap-PAD,
+  // which is 3*floor((cap-PAD)/5) + 2. The string_buf-derived capacity and
+  // the implementation's structural-indexes capacity may diverge under an
+  // over-allocating allocator; iterate() only checks `capacity() < len`, so
+  // the user-visible capacity must be the smaller of the two for stage1 to
+  // be safe.
+  size_t cap_from_string_buf = 3 * ((string_buf.capacity() - SIMDJSON_PADDING) / 5) + 2;
+  _capacity = std::min(cap_from_string_buf, implementation->capacity());
   return SUCCESS;
 }
 #if SIMDJSON_DEVELOPMENT_CHECKS
@@ -51,7 +91,7 @@ simdjson_inline simdjson_warn_unused bool parser::string_buffer_overflow(const u
 }
 #endif
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(padded_string_view json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(padded_string_view json) & {
   if (!json.has_sufficient_padding()) { return INSUFFICIENT_PADDING; }
 
   json.remove_utf8_bom();
@@ -67,7 +107,7 @@ simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(p
 }
 
 #ifdef SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate_allow_incomplete_json(padded_string_view json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate_allow_incomplete_json(padded_string_view json) & {
   if (!json.has_sufficient_padding()) { return INSUFFICIENT_PADDING; }
 
   json.remove_utf8_bom();
@@ -87,41 +127,41 @@ simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate_a
 }
 #endif // SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const char *json, size_t len, size_t allocated) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const char *json, size_t len, size_t allocated) & {
   return iterate(padded_string_view(json, len, allocated));
 }
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const uint8_t *json, size_t len, size_t allocated) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const uint8_t *json, size_t len, size_t allocated) & {
   return iterate(padded_string_view(json, len, allocated));
 }
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(std::string_view json, size_t allocated) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(std::string_view json, size_t allocated) & {
   return iterate(padded_string_view(json, allocated));
 }
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(std::string &json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(std::string &json) & {
   return iterate(pad_with_reserve(json));
 }
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const std::string &json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const std::string &json) & {
   return iterate(padded_string_view(json));
 }
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string_view> &result) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string_view> &result) & {
   // We don't presently have a way to temporarily get a const T& from a simdjson_result<T> without throwing an exception
   SIMDJSON_TRY( result.error() );
   padded_string_view json = result.value_unsafe();
   return iterate(json);
 }
 
-simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string> &result) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<document> parser::iterate(const simdjson_result<padded_string> &result) & {
   // We don't presently have a way to temporarily get a const T& from a simdjson_result<T> without throwing an exception
   SIMDJSON_TRY( result.error() );
   const padded_string &json = result.value_unsafe();
   return iterate(json);
 }
 
-simdjson_warn_unused simdjson_inline simdjson_result<json_iterator> parser::iterate_raw(padded_string_view json) & noexcept {
+simdjson_warn_unused simdjson_inline simdjson_result<json_iterator> parser::iterate_raw(padded_string_view json) & {
   if (!json.has_sufficient_padding()) { return INSUFFICIENT_PADDING; }
 
   json.remove_utf8_bom();

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -4,6 +4,7 @@
 #define SIMDJSON_GENERIC_ONDEMAND_PARSER_H
 #include "simdjson/generic/ondemand/base.h"
 #include "simdjson/generic/implementation_simdjson_result_base.h"
+#include "simdjson/internal/allocated_buffer.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 #include <memory>
@@ -42,6 +43,15 @@ public:
    * The new parser will have zero capacity.
    */
   inline explicit parser(size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
+
+  /**
+   * Create a JSON parser with a custom allocator.
+   *
+   * The new parser will have zero capacity. All buffers allocated by the
+   * parser will go through `alloc`, which must outlive the parser.
+   */
+  inline explicit parser(simdjson::allocator& alloc,
+                         size_t max_capacity = SIMDJSON_MAXSIZE_BYTES) noexcept;
 
   inline parser(parser &&other) noexcept = default;
   simdjson_inline parser(const parser &other) = delete;
@@ -114,28 +124,28 @@ public:
    *         - UNESCAPED_CHARS if a string contains control characters that must be escaped
    *         - UNCLOSED_STRING if there is an unclosed string in the document.
    */
-  simdjson_warn_unused simdjson_result<document> iterate(padded_string_view json) & noexcept;
+  simdjson_warn_unused simdjson_result<document> iterate(padded_string_view json) &;
 #ifdef SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON
-  simdjson_warn_unused simdjson_result<document> iterate_allow_incomplete_json(padded_string_view json) & noexcept;
+  simdjson_warn_unused simdjson_result<document> iterate_allow_incomplete_json(padded_string_view json) &;
 #endif // SIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
-  simdjson_warn_unused simdjson_result<document> iterate(const char *json, size_t len, size_t capacity) & noexcept;
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
-  simdjson_warn_unused simdjson_result<document> iterate(const uint8_t *json, size_t len, size_t capacity) & noexcept;
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
-  simdjson_warn_unused simdjson_result<document> iterate(std::string_view json, size_t capacity) & noexcept;
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
-  simdjson_warn_unused simdjson_result<document> iterate(const std::string &json) & noexcept;
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & */
+  simdjson_warn_unused simdjson_result<document> iterate(const char *json, size_t len, size_t capacity) &;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & */
+  simdjson_warn_unused simdjson_result<document> iterate(const uint8_t *json, size_t len, size_t capacity) &;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & */
+  simdjson_warn_unused simdjson_result<document> iterate(std::string_view json, size_t capacity) &;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & */
+  simdjson_warn_unused simdjson_result<document> iterate(const std::string &json) &;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) &
       The string instance might be have its capacity extended. Note that this can still
       result in AddressSanitizer: container-overflow in some cases. */
-  simdjson_warn_unused simdjson_result<document> iterate(std::string &json) & noexcept;
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
-  simdjson_warn_unused simdjson_result<document> iterate(const simdjson_result<padded_string> &json) & noexcept;
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
-  simdjson_warn_unused simdjson_result<document> iterate(const simdjson_result<padded_string_view> &json) & noexcept;
-  /** @overload simdjson_result<document> iterate(padded_string_view json) & noexcept */
-  simdjson_warn_unused simdjson_result<document> iterate(padded_string &&json) & noexcept = delete;
+  simdjson_warn_unused simdjson_result<document> iterate(std::string &json) &;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & */
+  simdjson_warn_unused simdjson_result<document> iterate(const simdjson_result<padded_string> &json) &;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & */
+  simdjson_warn_unused simdjson_result<document> iterate(const simdjson_result<padded_string_view> &json) &;
+  /** @overload simdjson_result<document> iterate(padded_string_view json) & */
+  simdjson_warn_unused simdjson_result<document> iterate(padded_string &&json) & = delete;
 
   /**
    * @private
@@ -177,7 +187,7 @@ public:
    *         - UNESCAPED_CHARS if a string contains control characters that must be escaped
    *         - UNCLOSED_STRING if there is an unclosed string in the document.
    */
-  simdjson_warn_unused simdjson_result<json_iterator> iterate_raw(padded_string_view json) & noexcept;
+  simdjson_warn_unused simdjson_result<json_iterator> iterate_raw(padded_string_view json) &;
 
 
   /**
@@ -266,7 +276,7 @@ public:
   /** @overload iterate_many(const uint8_t *buf, size_t len, size_t batch_size) */
   inline simdjson_result<document_stream> iterate_many(const padded_string &s, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept;
   /** @private We do not want to allow implicit conversion from C string to std::string. */
-  simdjson_result<document_stream> iterate_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) noexcept = delete;
+  simdjson_result<document_stream> iterate_many(const char *buf, size_t batch_size = DEFAULT_BATCH_SIZE) = delete;
 
 #ifndef SIMDJSON_DISABLE_DEPRECATED_API
   /**
@@ -329,7 +339,7 @@ public:
    * @param max_depth The new max_depth. Defaults to DEFAULT_MAX_DEPTH.
    * @return The error, if there is one.
    */
-  simdjson_warn_unused error_code allocate(size_t capacity, size_t max_depth=DEFAULT_MAX_DEPTH) noexcept;
+  simdjson_warn_unused error_code allocate(size_t capacity, size_t max_depth=DEFAULT_MAX_DEPTH);
 
   #ifdef SIMDJSON_THREADS_ENABLED
   /**
@@ -412,6 +422,10 @@ public:
    * Our simdjson::from functions use this parser instance.
    *
    * You can free the related parser by calling release_parser().
+   *
+   * Note: the thread-local parser always uses the default allocator.
+   * There is no API for customizing the thread-local parser's allocator.
+   * Users who need a custom allocator must own and pass their own parser instance.
    */
   static simdjson_inline simdjson_warn_unused ondemand::parser& get_parser();
   /**
@@ -426,15 +440,16 @@ private:
   static simdjson_inline simdjson_warn_unused std::unique_ptr<ondemand::parser>& get_parser_instance();
   /** Get the thread-local parser instance, it might be null */
   static simdjson_inline simdjson_warn_unused std::unique_ptr<ondemand::parser>& get_threadlocal_parser_if_exists();
+  simdjson::allocator* _allocator{&get_default_allocator()};
   /** @private [for benchmarking access] The implementation to use */
   std::unique_ptr<simdjson::internal::dom_parser_implementation> implementation{};
   size_t _capacity{0};
   size_t _max_capacity;
   size_t _max_depth{DEFAULT_MAX_DEPTH};
-  std::unique_ptr<uint8_t[]> string_buf{};
+  simdjson::internal::allocated_buffer<uint8_t> string_buf{};
 
 #if SIMDJSON_DEVELOPMENT_CHECKS
-  std::unique_ptr<token_position[]> start_positions{};
+  simdjson::internal::allocated_buffer<token_position> start_positions{};
 #endif
 
   friend class json_iterator;

--- a/include/simdjson/haswell/implementation.h
+++ b/include/simdjson/haswell/implementation.h
@@ -24,8 +24,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/include/simdjson/icelake/implementation.h
+++ b/include/simdjson/icelake/implementation.h
@@ -24,8 +24,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/include/simdjson/implementation.h
+++ b/include/simdjson/implementation.h
@@ -89,16 +89,21 @@ public:
    *     const implementation *impl = simdjson::get_active_implementation();
    *     cout << "simdjson is optimized for " << impl->name() << "(" << impl->description() << ")" << endl;
    *
+   * May propagate exceptions from the allocator (e.g. std::bad_alloc).
+   *
    * @param capacity The largest document that will be passed to the parser.
    * @param max_depth The maximum JSON object/array nesting this parser is expected to handle.
    * @param dst The place to put the resulting parser implementation.
+   * @param alloc The allocator that internal buffers will be routed through.
+   *              Must outlive the resulting parser implementation.
    * @return the error code, or SUCCESS if there was no error.
    */
   virtual error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_depth,
-    std::unique_ptr<internal::dom_parser_implementation> &dst
-  ) const noexcept = 0;
+    std::unique_ptr<internal::dom_parser_implementation> &dst,
+    simdjson::allocator& alloc
+  ) const = 0;
 
   /**
    * @private For internal implementation use

--- a/include/simdjson/internal/allocated_buffer.h
+++ b/include/simdjson/internal/allocated_buffer.h
@@ -1,0 +1,106 @@
+#ifndef SIMDJSON_INTERNAL_ALLOCATED_BUFFER_H
+#define SIMDJSON_INTERNAL_ALLOCATED_BUFFER_H
+
+#include "simdjson/allocator.h"
+
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+
+namespace simdjson {
+namespace internal {
+
+/**
+ * Move-only RAII wrapper for a buffer allocated through `simdjson::allocator`.
+ * Replaces `std::unique_ptr<T[]>` for internal buffers.
+ */
+template<typename T>
+class allocated_buffer {
+  T* ptr_ = nullptr;
+  size_t allocated_bytes_ = 0;
+  /**
+   * Stores the allocator as a pointer (not a reference) so that move-assign
+   * can rebind it. A default-constructed (empty) buffer has `alloc_ == nullptr`;
+   * that is fine because `reset()` guards on `ptr_` being non-null.
+   */
+  simdjson::allocator* alloc_ = nullptr;
+
+public:
+  allocated_buffer() noexcept = default;
+
+  /**
+   * Takes ownership of `ptr` (previously obtained from `alloc.allocate(allocated_bytes)`).
+   */
+  allocated_buffer(T* ptr, size_t allocated_bytes, simdjson::allocator& alloc) noexcept
+      : ptr_(ptr), allocated_bytes_(allocated_bytes), alloc_(&alloc) {}
+
+  ~allocated_buffer() noexcept { reset(); }
+
+  allocated_buffer(allocated_buffer&& o) noexcept
+      : ptr_(o.ptr_), allocated_bytes_(o.allocated_bytes_), alloc_(o.alloc_) {
+    o.ptr_ = nullptr;
+    o.allocated_bytes_ = 0;
+    o.alloc_ = nullptr;
+  }
+
+  allocated_buffer& operator=(allocated_buffer&& o) noexcept {
+    if (this != &o) {
+      reset();
+      ptr_ = o.ptr_;
+      allocated_bytes_ = o.allocated_bytes_;
+      alloc_ = o.alloc_;
+      o.ptr_ = nullptr;
+      o.allocated_bytes_ = 0;
+      o.alloc_ = nullptr;
+    }
+    return *this;
+  }
+
+  allocated_buffer(const allocated_buffer&) = delete;
+  allocated_buffer& operator=(const allocated_buffer&) = delete;
+
+  void reset() noexcept {
+    if (ptr_) {
+      alloc_->deallocate(ptr_, allocated_bytes_);
+    }
+    ptr_ = nullptr;
+    allocated_bytes_ = 0;
+  }
+
+  T* get() const noexcept { return ptr_; }
+  T& operator[](size_t i) const noexcept { return ptr_[i]; }
+  explicit operator bool() const noexcept { return ptr_ != nullptr; }
+
+  /**
+   * Number of T elements the buffer can hold. May exceed what the caller
+   * originally asked for if the allocator over-allocated (bucket / slab
+   * allocators, `allocate_at_least`-style behaviour).
+   */
+  size_t capacity() const noexcept { return allocated_bytes_ / sizeof(T); }
+};
+
+/**
+ * Helper: allocate at least `count` elements of type T via the given allocator.
+ * Returns an empty buffer if the allocator returned a null pointer.
+ * If the allocator throws, the exception propagates to the caller unchanged --
+ * simdjson never catches it.
+ *
+ * The returned buffer may have a larger `capacity()` than `count` if the
+ * allocator over-allocated; callers interested in that extra space can query
+ * `allocated_buffer<T>::capacity()`.
+ */
+template<typename T>
+allocated_buffer<T> make_allocated_buffer(size_t count, simdjson::allocator& alloc) {
+  static_assert(alignof(T) <= alignof(std::max_align_t),
+      "simdjson::allocator only guarantees max_align_t alignment");
+  // Guard against overflow.
+  if (count > (std::numeric_limits<size_t>::max)() / sizeof(T)) { return {}; }
+  allocation_result r = alloc.allocate(count * sizeof(T));
+  if (!r.ptr) { return {}; }
+  return allocated_buffer<T>(static_cast<T*>(r.ptr), r.size, alloc);
+}
+
+} // namespace internal
+} // namespace simdjson
+
+#endif // SIMDJSON_INTERNAL_ALLOCATED_BUFFER_H

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -3,6 +3,7 @@
 
 #include "simdjson/base.h"
 #include "simdjson/error.h"
+#include "simdjson/internal/allocated_buffer.h"
 #include <memory>
 
 namespace simdjson {
@@ -147,22 +148,26 @@ public:
    *
    * Generally used for reallocation.
    *
+   * May propagate exceptions from the allocator (e.g. std::bad_alloc).
+   *
    * @param capacity The new capacity.
    * @param max_depth The new max_depth.
    * @return The error code, or SUCCESS if there was no error.
    */
-  virtual error_code set_capacity(size_t capacity) noexcept = 0;
+  virtual error_code set_capacity(size_t capacity) = 0;
 
   /**
    * Change the max depth of this parser.
    *
    * Generally used for reallocation.
    *
+   * May propagate exceptions from the allocator (e.g. std::bad_alloc).
+   *
    * @param capacity The new capacity.
    * @param max_depth The new max_depth.
    * @return The error code, or SUCCESS if there was no error.
    */
-  virtual error_code set_max_depth(size_t max_depth) noexcept = 0;
+  virtual error_code set_max_depth(size_t max_depth) = 0;
 
   /**
    * Deallocate this parser.
@@ -172,7 +177,7 @@ public:
   /** Number of structural indices passed from stage 1 to stage 2 */
   uint32_t n_structural_indexes{0};
   /** Structural indices passed from stage 1 to stage 2 */
-  std::unique_ptr<uint32_t[]> structural_indexes{};
+  internal::allocated_buffer<uint32_t> structural_indexes{};
   /** Next structural index to parse */
   uint32_t next_structural_index{0};
 
@@ -194,11 +199,13 @@ public:
    * Ensure this parser has enough memory to process JSON documents up to `capacity` bytes in length
    * and `max_depth` depth.
    *
+   * May propagate exceptions from the allocator (e.g. std::bad_alloc).
+   *
    * @param capacity The new capacity.
    * @param max_depth The new max_depth. Defaults to DEFAULT_MAX_DEPTH.
    * @return The error, if there is one.
    */
-  simdjson_warn_unused inline error_code allocate(size_t capacity, size_t max_depth) noexcept;
+  simdjson_warn_unused inline error_code allocate(size_t capacity, size_t max_depth);
 
 
 protected:
@@ -216,6 +223,15 @@ protected:
    */
   size_t _max_depth{0};
 
+  /**
+   * The allocator used for this parser.
+   *
+   * Set once at construction; only rebound via move-assign (which also
+   * transfers the RAII buffers). No public setter. Stored as a pointer
+   * (not a reference) so the compiler-generated move-assign can rebind it.
+   */
+  simdjson::allocator* _allocator;
+
 public:
   /** Whether to store big integers as strings instead of returning BIGINT_ERROR */
   bool _number_as_string{false};
@@ -223,7 +239,9 @@ public:
 protected:
 
   // Declaring these so that subclasses can use them to implement their constructors.
-  simdjson_inline dom_parser_implementation() noexcept;
+  // No default argument: internal classes must have the allocator threaded
+  // through explicitly by the owning parser.
+  simdjson_inline explicit dom_parser_implementation(simdjson::allocator& alloc) noexcept;
   simdjson_inline dom_parser_implementation(dom_parser_implementation &&other) noexcept;
   simdjson_inline dom_parser_implementation &operator=(dom_parser_implementation &&other) noexcept;
 
@@ -231,7 +249,8 @@ protected:
   simdjson_inline dom_parser_implementation &operator=(const dom_parser_implementation &other) noexcept = delete;
 }; // class dom_parser_implementation
 
-simdjson_inline dom_parser_implementation::dom_parser_implementation() noexcept = default;
+simdjson_inline dom_parser_implementation::dom_parser_implementation(simdjson::allocator& alloc) noexcept
+    : _allocator{&alloc} {}
 simdjson_inline dom_parser_implementation::dom_parser_implementation(dom_parser_implementation &&other) noexcept = default;
 simdjson_inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parser_implementation &&other) noexcept = default;
 
@@ -244,12 +263,15 @@ simdjson_pure simdjson_inline size_t dom_parser_implementation::max_depth() cons
 }
 
 simdjson_warn_unused
-inline error_code dom_parser_implementation::allocate(size_t capacity, size_t max_depth) noexcept {
-  if (this->max_depth() != max_depth) {
+inline error_code dom_parser_implementation::allocate(size_t capacity, size_t max_depth) {
+  // Only grow: with allocator over-allocation, _capacity / _max_depth may legitimately
+  // exceed the most-recently-requested values, and a re-request for the same (or smaller)
+  // size is a no-op rather than a shrink.
+  if (this->max_depth() < max_depth) {
     error_code err = set_max_depth(max_depth);
     if (err) { return err; }
   }
-  if (_capacity != capacity) {
+  if (this->capacity() < capacity) {
     error_code err = set_capacity(capacity);
     if (err) { return err; }
   }

--- a/include/simdjson/lasx/implementation.h
+++ b/include/simdjson/lasx/implementation.h
@@ -19,8 +19,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/include/simdjson/lsx/implementation.h
+++ b/include/simdjson/lsx/implementation.h
@@ -19,8 +19,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/include/simdjson/ppc64/implementation.h
+++ b/include/simdjson/ppc64/implementation.h
@@ -25,8 +25,9 @@ public:
 
   simdjson_warn_unused error_code create_dom_parser_implementation(
       size_t capacity, size_t max_length,
-      std::unique_ptr<internal::dom_parser_implementation> &dst)
-      const noexcept final;
+      std::unique_ptr<internal::dom_parser_implementation> &dst,
+      simdjson::allocator& alloc)
+      const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len,
                                          uint8_t *dst,
                                          size_t &dst_len) const noexcept final;

--- a/include/simdjson/rvv-vls/implementation.h
+++ b/include/simdjson/rvv-vls/implementation.h
@@ -22,8 +22,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<simdjson::internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<simdjson::internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/include/simdjson/westmere/implementation.h
+++ b/include/simdjson/westmere/implementation.h
@@ -20,8 +20,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<internal::dom_parser_implementation>& dst
-  ) const noexcept final;
+    std::unique_ptr<internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final;
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final;
   simdjson_warn_unused bool validate_utf8(const char *buf, size_t len) const noexcept final;
 };

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -1,0 +1,31 @@
+#ifndef SIMDJSON_SRC_ALLOCATOR_CPP
+#define SIMDJSON_SRC_ALLOCATOR_CPP
+
+#include <base.h>
+#include <simdjson/allocator.h>
+
+#include <new>
+
+namespace simdjson {
+
+/**
+ * The built-in default allocator. Uses `new[]` / `delete[]`.
+ */
+class default_allocator final : public allocator {
+public:
+  allocation_result allocate(size_t size) override {
+    return { new (std::nothrow) uint8_t[size], size };
+  }
+  void deallocate(void* ptr, size_t /*size*/) noexcept override {
+    delete[] static_cast<uint8_t*>(ptr);
+  }
+};
+
+allocator& get_default_allocator() noexcept {
+  static default_allocator instance;
+  return instance;
+}
+
+} // namespace simdjson
+
+#endif // SIMDJSON_SRC_ALLOCATOR_CPP

--- a/src/arm64.cpp
+++ b/src/arm64.cpp
@@ -22,9 +22,10 @@ namespace arm64 {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/fallback.cpp
+++ b/src/fallback.cpp
@@ -26,9 +26,10 @@ namespace fallback {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) SIMDJSON_IMPLEMENTATION::dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) SIMDJSON_IMPLEMENTATION::dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/haswell.cpp
+++ b/src/haswell.cpp
@@ -23,9 +23,10 @@ namespace SIMDJSON_IMPLEMENTATION {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/icelake.cpp
+++ b/src/icelake.cpp
@@ -28,9 +28,10 @@ namespace icelake {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/implementation.cpp
+++ b/src/implementation.cpp
@@ -191,9 +191,10 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t capacity,
     size_t max_length,
-    std::unique_ptr<internal::dom_parser_implementation>& dst
-  ) const noexcept final {
-    return set_best()->create_dom_parser_implementation(capacity, max_length, dst);
+    std::unique_ptr<internal::dom_parser_implementation>& dst,
+    simdjson::allocator& alloc
+  ) const final {
+    return set_best()->create_dom_parser_implementation(capacity, max_length, dst, alloc);
   }
   simdjson_warn_unused error_code minify(const uint8_t *buf, size_t len, uint8_t *dst, size_t &dst_len) const noexcept final {
     return set_best()->minify(buf, len, dst, dst_len);
@@ -247,8 +248,9 @@ public:
   simdjson_warn_unused error_code create_dom_parser_implementation(
     size_t,
     size_t,
-    std::unique_ptr<internal::dom_parser_implementation>&
-  ) const noexcept final {
+    std::unique_ptr<internal::dom_parser_implementation>&,
+    simdjson::allocator&
+  ) const final {
     return UNSUPPORTED_ARCHITECTURE;
   }
   simdjson_warn_unused error_code minify(const uint8_t *, size_t, uint8_t *, size_t &) const noexcept final override {

--- a/src/lasx.cpp
+++ b/src/lasx.cpp
@@ -22,9 +22,10 @@ namespace lasx {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/lsx.cpp
+++ b/src/lsx.cpp
@@ -22,9 +22,10 @@ namespace lsx {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/ppc64.cpp
+++ b/src/ppc64.cpp
@@ -22,9 +22,10 @@ namespace ppc64 {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/rvv-vls.cpp
+++ b/src/rvv-vls.cpp
@@ -23,9 +23,10 @@ namespace rvv_vls {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/src/simdjson.cpp
+++ b/src/simdjson.cpp
@@ -4,6 +4,7 @@
 
 SIMDJSON_PUSH_DISABLE_UNUSED_WARNINGS
 
+#include <allocator.cpp>
 #include <to_chars.cpp>
 #include <from_chars.cpp>
 #include <internal/error_tables.cpp>

--- a/src/westmere.cpp
+++ b/src/westmere.cpp
@@ -23,9 +23,10 @@ namespace westmere {
 simdjson_warn_unused error_code implementation::create_dom_parser_implementation(
   size_t capacity,
   size_t max_depth,
-  std::unique_ptr<internal::dom_parser_implementation>& dst
-) const noexcept {
-  dst.reset( new (std::nothrow) dom_parser_implementation() );
+  std::unique_ptr<internal::dom_parser_implementation>& dst,
+  simdjson::allocator& alloc
+) const {
+  dst.reset( new (std::nothrow) dom_parser_implementation(alloc) );
   if (!dst) { return MEMALLOC; }
   if (auto err = dst->set_capacity(capacity))
     return err;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_cpp_test(padded_string_tests LABELS other acceptance                   )
 add_cpp_test(memory_map_tests    LABELS other acceptance                   )
 add_cpp_test(prettify_tests      LABELS other acceptance per_implementation)
 add_cpp_test(fractured_json_tests LABELS other acceptance per_implementation)
+add_cpp_test(allocator_tests     LABELS other acceptance per_implementation)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
   # Copy the simdjson dll into the tests directory

--- a/tests/allocator_tests.cpp
+++ b/tests/allocator_tests.cpp
@@ -1,0 +1,475 @@
+#include "simdjson.h"
+#include "test_macros.h"
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+using simdjson::allocator;
+using simdjson::padded_string;
+
+namespace {
+
+// Counts bytes outstanding and total allocations. Uses malloc/free internally
+// so we can interleave with the default allocator in the same test binary.
+struct tracking_allocator : allocator {
+  std::atomic<size_t> bytes_outstanding{0};
+  std::atomic<size_t> total_allocs{0};
+  std::atomic<size_t> total_frees{0};
+
+  simdjson::allocation_result allocate(size_t size) override {
+    if (size == 0) {
+      ++total_allocs;
+      return { std::malloc(1), 0 };
+    }
+    void* p = std::malloc(size);
+    if (p == nullptr) { return { nullptr, 0 }; }
+    bytes_outstanding += size;
+    ++total_allocs;
+    return { p, size };
+  }
+
+  void deallocate(void* ptr, size_t size) noexcept override {
+    if (ptr == nullptr) { return; }
+    bytes_outstanding -= size;
+    ++total_frees;
+    std::free(ptr);
+  }
+};
+
+// An allocator that always returns nullptr so we can exercise MEMALLOC paths.
+struct null_allocator : allocator {
+  std::atomic<size_t> attempted{0};
+  simdjson::allocation_result allocate(size_t) override {
+    ++attempted;
+    return { nullptr, 0 };
+  }
+  void deallocate(void*, size_t) noexcept override {}
+};
+
+// An allocator that returns successfully for the first `n_successes` calls and
+// throws `std::bad_alloc` afterwards. Tracks deallocation counts so we can
+// verify there is no leak on the exception path.
+struct throwing_allocator : allocator {
+  size_t n_successes;
+  std::atomic<size_t> allocs{0};
+  std::atomic<size_t> frees{0};
+  std::atomic<size_t> bytes_outstanding{0};
+  explicit throwing_allocator(size_t n) : n_successes(n) {}
+  simdjson::allocation_result allocate(size_t size) override {
+    if (allocs.fetch_add(1) >= n_successes) {
+      throw std::bad_alloc{};
+    }
+    void* p = std::malloc(size == 0 ? 1 : size);
+    if (p == nullptr) { return { nullptr, 0 }; }
+    bytes_outstanding += size;
+    return { p, size };
+  }
+  void deallocate(void* ptr, size_t size) noexcept override {
+    if (!ptr) { return; }
+    bytes_outstanding -= size;
+    ++frees;
+    std::free(ptr);
+  }
+};
+
+// Always rounds the requested size up to the nearest 4 KiB so callers see
+// real over-allocation through allocate_at_least semantics.
+struct rounding_allocator : allocator {
+  static constexpr size_t CHUNK = 4096;
+  std::atomic<size_t> total_allocs{0};
+  std::atomic<size_t> bytes_outstanding{0};
+
+  simdjson::allocation_result allocate(size_t size) override {
+    size_t rounded = (size + CHUNK - 1) & ~(CHUNK - 1);
+    if (rounded == 0) { rounded = CHUNK; }
+    void* p = std::malloc(rounded);
+    if (p == nullptr) { return { nullptr, 0 }; }
+    ++total_allocs;
+    bytes_outstanding += rounded;
+    return { p, rounded };
+  }
+  void deallocate(void* ptr, size_t size) noexcept override {
+    if (!ptr) { return; }
+    bytes_outstanding -= size;
+    std::free(ptr);
+  }
+};
+
+static const char *const SAMPLE_JSON = R"({
+  "name": "simdjson",
+  "stars": 42,
+  "tags": ["json", "parser", "simd"],
+  "nested": { "inner": true, "depth": 3 }
+})";
+
+// ---- dom tests ----
+
+bool test_dom_default_allocator_matches() {
+  TEST_START();
+  simdjson::dom::parser parser;
+  simdjson::dom::element elem;
+  ASSERT_SUCCESS(parser.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(elem));
+  int64_t stars;
+  ASSERT_SUCCESS(elem["stars"].get(stars));
+  ASSERT_EQUAL(stars, 42);
+  TEST_SUCCEED();
+}
+
+bool test_dom_custom_allocator_basic() {
+  TEST_START();
+  tracking_allocator alloc;
+  {
+    simdjson::dom::parser parser(alloc);
+    simdjson::dom::element elem;
+    ASSERT_SUCCESS(parser.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(elem));
+    int64_t stars;
+    ASSERT_SUCCESS(elem["stars"].get(stars));
+    ASSERT_EQUAL(stars, 42);
+    ASSERT_TRUE(alloc.bytes_outstanding.load() > 0);
+    ASSERT_TRUE(alloc.total_allocs.load() > 0);
+  }
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  ASSERT_EQUAL(alloc.total_allocs.load(), alloc.total_frees.load());
+  TEST_SUCCEED();
+}
+
+bool test_dom_two_parsers_two_allocators() {
+  TEST_START();
+  tracking_allocator a1;
+  tracking_allocator a2;
+  {
+    simdjson::dom::parser p1(a1);
+    simdjson::dom::parser p2(a2);
+    simdjson::dom::element e1, e2;
+    ASSERT_SUCCESS(p1.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(e1));
+    ASSERT_SUCCESS(p2.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(e2));
+    // Both allocators must have non-zero traffic.
+    ASSERT_TRUE(a1.total_allocs.load() > 0);
+    ASSERT_TRUE(a2.total_allocs.load() > 0);
+    // And neither should touch the other: if they swapped we'd see a delta
+    // in one while the other stays zero, which can't happen when both run.
+  }
+  ASSERT_EQUAL(a1.bytes_outstanding.load(), size_t(0));
+  ASSERT_EQUAL(a2.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+bool test_dom_allocator_memalloc_on_null() {
+  TEST_START();
+  null_allocator alloc;
+  simdjson::dom::parser parser(alloc);
+  simdjson::dom::element elem;
+  auto err = parser.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(elem);
+  ASSERT_EQUAL(err, simdjson::MEMALLOC);
+  ASSERT_TRUE(alloc.attempted.load() > 0);
+  TEST_SUCCEED();
+}
+
+bool test_dom_allocator_exception_propagates() {
+  TEST_START();
+  // Allow exactly one successful allocation, then throw. This will trigger the
+  // exception inside parse; we verify that nothing leaks and the exception
+  // escapes.
+  throwing_allocator alloc(1);
+  bool caught = false;
+  try {
+    simdjson::dom::parser parser(alloc);
+    simdjson::dom::element elem;
+    (void)parser.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(elem);
+  } catch (const std::bad_alloc &) {
+    caught = true;
+  }
+  ASSERT_TRUE(caught);
+  // After the parser's destructor runs, no bytes should be outstanding.
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+bool test_dom_move_assign_preserves_allocator() {
+  TEST_START();
+  tracking_allocator a1;
+  tracking_allocator a2;
+  {
+    simdjson::dom::parser p1(a1);
+    simdjson::dom::element e1;
+    ASSERT_SUCCESS(p1.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(e1));
+    size_t a1_bytes_before = a1.bytes_outstanding.load();
+    ASSERT_TRUE(a1_bytes_before > 0);
+
+    simdjson::dom::parser p2(a2);
+    simdjson::dom::element e2;
+    ASSERT_SUCCESS(p2.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(e2));
+    size_t a2_bytes_before = a2.bytes_outstanding.load();
+    ASSERT_TRUE(a2_bytes_before > 0);
+
+    p1 = std::move(p2);
+    // After move, p1 now owns the buffers that were allocated by a2. a1 must
+    // have been fully drained of the bytes it lent to p1 previously.
+    ASSERT_EQUAL(a1.bytes_outstanding.load(), size_t(0));
+    // a2 still has its bytes outstanding, now owned by p1.
+    ASSERT_EQUAL(a2.bytes_outstanding.load(), a2_bytes_before);
+  }
+  ASSERT_EQUAL(a1.bytes_outstanding.load(), size_t(0));
+  ASSERT_EQUAL(a2.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+bool test_allocator_adapter_std_allocator() {
+  TEST_START();
+  simdjson::allocator_adapter<std::allocator<std::byte>> a;
+  simdjson::dom::parser parser(a);
+  simdjson::dom::element elem;
+  ASSERT_SUCCESS(parser.parse(SAMPLE_JSON, std::strlen(SAMPLE_JSON)).get(elem));
+  int64_t stars;
+  ASSERT_SUCCESS(elem["stars"].get(stars));
+  ASSERT_EQUAL(stars, 42);
+  TEST_SUCCEED();
+}
+
+// ---- ondemand tests ----
+
+static padded_string make_padded(const char* s) {
+  return padded_string(s, std::strlen(s));
+}
+
+bool test_ondemand_custom_allocator_basic() {
+  TEST_START();
+  tracking_allocator alloc;
+  {
+    simdjson::ondemand::parser parser(alloc);
+    auto padded = make_padded(SAMPLE_JSON);
+    simdjson::ondemand::document doc;
+    ASSERT_SUCCESS(parser.iterate(padded).get(doc));
+    int64_t stars;
+    ASSERT_SUCCESS(doc["stars"].get(stars));
+    ASSERT_EQUAL(stars, 42);
+    ASSERT_TRUE(alloc.total_allocs.load() > 0);
+  }
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+bool test_ondemand_allocator_memalloc_on_null() {
+  TEST_START();
+  null_allocator alloc;
+  simdjson::ondemand::parser parser(alloc);
+  auto padded = make_padded(SAMPLE_JSON);
+  simdjson::ondemand::document doc;
+  auto err = parser.iterate(padded).get(doc);
+  ASSERT_EQUAL(err, simdjson::MEMALLOC);
+  ASSERT_TRUE(alloc.attempted.load() > 0);
+  TEST_SUCCEED();
+}
+
+bool test_ondemand_allocator_exception_propagates() {
+  TEST_START();
+  throwing_allocator alloc(1);
+  bool caught = false;
+  try {
+    simdjson::ondemand::parser parser(alloc);
+    auto padded = make_padded(SAMPLE_JSON);
+    simdjson::ondemand::document doc;
+    (void)parser.iterate(padded).get(doc);
+  } catch (const std::bad_alloc &) {
+    caught = true;
+  }
+  ASSERT_TRUE(caught);
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+// ---- document_stream tests ----
+//
+// parse_many / iterate_many own a `document_stream` that allocates its own
+// scratch buffers on top of the parser's; make sure those allocations also
+// flow through the user-supplied allocator.
+
+static const char *const STREAMED_JSON =
+    R"({"i":0}{"i":1}{"i":2}{"i":3}{"i":4})";
+
+bool test_dom_parse_many_custom_allocator() {
+  TEST_START();
+  tracking_allocator alloc;
+  {
+    simdjson::dom::parser parser(alloc);
+    simdjson::dom::document_stream stream;
+    auto padded = make_padded(STREAMED_JSON);
+    ASSERT_SUCCESS(parser.parse_many(padded).get(stream));
+    int64_t expected = 0;
+    for (auto doc : stream) {
+      simdjson::dom::element e;
+      ASSERT_SUCCESS(doc.get(e));
+      int64_t i;
+      ASSERT_SUCCESS(e["i"].get(i));
+      ASSERT_EQUAL(i, expected);
+      ++expected;
+    }
+    ASSERT_EQUAL(expected, int64_t(5));
+    ASSERT_TRUE(alloc.total_allocs.load() > 0);
+  }
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  ASSERT_EQUAL(alloc.total_allocs.load(), alloc.total_frees.load());
+  TEST_SUCCEED();
+}
+
+bool test_ondemand_iterate_many_custom_allocator() {
+  TEST_START();
+  tracking_allocator alloc;
+  {
+    simdjson::ondemand::parser parser(alloc);
+    auto padded = make_padded(STREAMED_JSON);
+    simdjson::ondemand::document_stream stream;
+    ASSERT_SUCCESS(parser.iterate_many(padded).get(stream));
+    int64_t expected = 0;
+    for (auto doc : stream) {
+      int64_t i;
+      ASSERT_SUCCESS(doc["i"].get(i));
+      ASSERT_EQUAL(i, expected);
+      ++expected;
+    }
+    ASSERT_EQUAL(expected, int64_t(5));
+    ASSERT_TRUE(alloc.total_allocs.load() > 0);
+  }
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  ASSERT_EQUAL(alloc.total_allocs.load(), alloc.total_frees.load());
+  TEST_SUCCEED();
+}
+
+// ---- builder::string_builder tests ----
+
+bool test_builder_default_allocator() {
+  TEST_START();
+  simdjson::builder::string_builder b;
+  b.start_object();
+  b.append_key_value("k", int64_t(7));
+  b.end_object();
+  std::string_view sv;
+  ASSERT_SUCCESS(b.view().get(sv));
+  ASSERT_EQUAL(std::string(sv), std::string("{\"k\":7}"));
+  TEST_SUCCEED();
+}
+
+bool test_builder_custom_allocator() {
+  TEST_START();
+  tracking_allocator alloc;
+  {
+    simdjson::builder::string_builder b(alloc, 16);
+    // Force a re-grow at least once.
+    std::string big(1000, 'x');
+    b.escape_and_append_with_quotes(big);
+    std::string_view sv;
+    ASSERT_SUCCESS(b.view().get(sv));
+    ASSERT_EQUAL(sv.size(), big.size() + 2);
+    ASSERT_TRUE(alloc.total_allocs.load() >= 2);
+  }
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+bool test_builder_allocator_exception_propagates() {
+  TEST_START();
+  // Builder succeeds on the first (ctor) allocation but throws when growing.
+  throwing_allocator alloc(1);
+  bool caught = false;
+  try {
+    simdjson::builder::string_builder b(alloc, 16);
+    std::string big(1024, 'x');
+    b.escape_and_append_with_quotes(big);
+  } catch (const std::bad_alloc &) {
+    caught = true;
+  }
+  ASSERT_TRUE(caught);
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+bool test_dom_loaded_bytes_uses_actual_allocated_size() {
+  TEST_START();
+  // With allocate_at_least semantics the dom::parser's loaded_bytes buffer
+  // must treat the allocator's over-allocation as usable capacity rather than
+  // re-allocating as soon as the requested size grows slightly.
+  rounding_allocator alloc;
+  {
+    simdjson::dom::parser parser(alloc);
+    // Pre-allocate parser-state and document buffers so growth of `capacity()`
+    // doesn't muddle the accounting; we're only interested in loaded_bytes.
+    ASSERT_SUCCESS(parser.allocate(8 * rounding_allocator::CHUNK));
+    ASSERT_SUCCESS(parser.doc.allocate(8 * rounding_allocator::CHUNK));
+
+    simdjson::dom::element elem;
+    // First parse: small doc. Triggers the initial loaded_bytes allocation
+    // (requested small + padding, rounded up to CHUNK by the allocator).
+    std::string small_doc = R"({"a":1})";
+    ASSERT_SUCCESS(parser.parse(small_doc.c_str(), small_doc.size()).get(elem));
+    size_t allocs_after_first = alloc.total_allocs.load();
+
+    // Second parse: a doc noticeably larger than the first but still small
+    // enough that, together with SIMDJSON_PADDING, it fits inside the
+    // over-allocated CHUNK-sized loaded_bytes buffer. No re-allocation should
+    // happen anywhere.
+    std::string larger_doc = "[0";
+    for (int i = 0; i < 100; ++i) { larger_doc += ",0"; }
+    larger_doc += "]";
+    ASSERT_TRUE(larger_doc.size() + simdjson::SIMDJSON_PADDING <=
+                rounding_allocator::CHUNK);
+    ASSERT_SUCCESS(parser.parse(larger_doc.c_str(), larger_doc.size()).get(elem));
+    ASSERT_EQUAL(alloc.total_allocs.load(), allocs_after_first);
+  }
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+bool test_builder_uses_actual_allocated_size() {
+  TEST_START();
+  // With allocate_at_least semantics the string_builder must treat the
+  // allocator's over-allocation as usable capacity rather than asking for a
+  // second buffer as soon as the requested size is exceeded.
+  rounding_allocator alloc;
+  {
+    simdjson::builder::string_builder b(alloc, 64);
+    // We asked for 64 bytes, the allocator rounded up to CHUNK. Writing
+    // CHUNK/2 bytes must NOT trigger a re-grow.
+    std::string chunk(rounding_allocator::CHUNK / 2, 'x');
+    b.append_raw(chunk);
+    ASSERT_EQUAL(alloc.total_allocs.load(), size_t(1));
+    std::string_view sv;
+    ASSERT_SUCCESS(b.view().get(sv));
+    ASSERT_EQUAL(sv.size(), chunk.size());
+  }
+  ASSERT_EQUAL(alloc.bytes_outstanding.load(), size_t(0));
+  TEST_SUCCEED();
+}
+
+// ---- runner ----
+
+int test_main() {
+  std::cout << "Running allocator tests." << std::endl;
+  if (!test_dom_default_allocator_matches()) { return EXIT_FAILURE; }
+  if (!test_dom_custom_allocator_basic()) { return EXIT_FAILURE; }
+  if (!test_dom_two_parsers_two_allocators()) { return EXIT_FAILURE; }
+  if (!test_dom_allocator_memalloc_on_null()) { return EXIT_FAILURE; }
+  if (!test_dom_allocator_exception_propagates()) { return EXIT_FAILURE; }
+  if (!test_dom_move_assign_preserves_allocator()) { return EXIT_FAILURE; }
+  if (!test_allocator_adapter_std_allocator()) { return EXIT_FAILURE; }
+  if (!test_dom_loaded_bytes_uses_actual_allocated_size()) { return EXIT_FAILURE; }
+  if (!test_ondemand_custom_allocator_basic()) { return EXIT_FAILURE; }
+  if (!test_ondemand_allocator_memalloc_on_null()) { return EXIT_FAILURE; }
+  if (!test_ondemand_allocator_exception_propagates()) { return EXIT_FAILURE; }
+  if (!test_dom_parse_many_custom_allocator()) { return EXIT_FAILURE; }
+  if (!test_ondemand_iterate_many_custom_allocator()) { return EXIT_FAILURE; }
+  if (!test_builder_default_allocator()) { return EXIT_FAILURE; }
+  if (!test_builder_custom_allocator()) { return EXIT_FAILURE; }
+  if (!test_builder_allocator_exception_propagates()) { return EXIT_FAILURE; }
+  if (!test_builder_uses_actual_allocated_size()) { return EXIT_FAILURE; }
+  std::cout << "All allocator tests passed." << std::endl;
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+int main() {
+  return test_main();
+}


### PR DESCRIPTION
**Description**: Support for custom allocators (addresses #1017).

I also added support for [allocate_at_least](https://en.cppreference.com/cpp/memory/allocator/allocate_at_least)-style overallocations.
(The use case I would like to integrate simdjson into could benefit from it)

**Type of change**: New Feature
**How to verify / test**: New test cases added as part of the PR

**AI Disclaimer**:

**Please don't review the code line-by-line yet** -- I would first like
high-level alignment on the API shape and the rationale. I am happy
to redo the implementation once we agree on the direction.

This PR is intended as the discussion vehicle for adding custom-allocator
support; per CONTRIBUTING.md I would normally open an issue first, but
the design is concrete enough that a PR seemed clearer and drafting the
code change was not too much effort thanks to Claude & Cursor.

**Open design questions**

- Is the general approach (custom abstract base class + RAII buffer
  wrapper) acceptable, or would you prefer a different shape entirely
  (templated, `std::pmr`-only, hooks, ...)?
- Are we OK with threading the allocator through so many API layers
  (parser → document → `dom_parser_implementation` → per-kernel
  subclasses)? It is mechanical but still a bit of churn.
- I had to drop `noexcept` from a number of public methods because a
  user allocator may throw. Three options:
  1. Drop `noexcept` unconditionally (current PR).
  2. Drop `noexcept` only when `SIMDJSON_EXCEPTIONS` is set.
  3. Gate behind a new `SIMDJSON_SUPPORT_THROWING_ALLOCATOR` macro,
     defaulting to off.
- Do we actually care about *strong* exception safety? If not, several
  reallocation sites can be simplified by skipping the
  allocate-into-local-then-move-assign dance.

----

**High-level Design**

We use a virtual base class `simdjson::allocator`. This class provides virtual
`allocate` and `deallocate` functions.

A `simdjson::allocator&` is threaded through the various classes / interfaces,
so we have it available at all allocation sites.

Users who already have a `std::pmr::memory_resource` or a
`std::allocator<T>`-conforming type can plug it in via
`simdjson::allocator_adapter<Alloc>`.

**Why not `std::pmr` or `std::allocator` directly?**

PR #1467 attempted to use `std::allocator` and was closed because of
three issues:

1. `std::allocator::allocate` throws `std::bad_alloc` -- incompatible
   with simdjson's error-code model.
2. Mixing `operator new[]` / `delete[]` with allocator-allocated memory
   produced alloc-dealloc-mismatch under sanitizers.
3. `std::unique_ptr<T[]>` does not natively support stateful allocators;
   per-allocation custom deleters get unwieldy.

I tried to address all 3 issues in this design.

**The allocator interface**

```cpp
struct allocation_result {
  void* ptr;
  size_t size;  // actual bytes allocated, >= requested
};

class allocator {
public:
  virtual ~allocator() = default;

  /**
   * Allocate AT LEAST `size` bytes. Return `{nullptr, 0}` on failure, OR throw.
   * The returned `size` may exceed the request; pass it back to `deallocate`
   * unchanged. Modelled on std::allocator::allocate_at_least (C++23).
   */
  virtual allocation_result allocate(size_t size) = 0;

  /**
   * Deallocate memory previously returned by `allocate()`.
   * `size` must equal `allocation_result::size` from the corresponding
   * `allocate()` call (sized-deallocation style, like C++14
   * `operator delete(void*, size_t)`).
   */
  virtual void deallocate(void* ptr, size_t size) noexcept = 0;
};
```

Notes:

- `allocate` *may* throw, but the default never does, so existing
  behaviour is preserved.
- The default allocator is a process-wide singleton, wrapping
  `new[] (std::nothrow)`. Parsers store a single `allocator*`; users
  who don't opt in pay no extra indirection on the hot path beyond
  one virtual call per (rare) allocation.
- `allocation_result::size` returns the *actual* bytes allocated. This
  is propagated into the parser's `_capacity` / `_max_depth` /
  `loaded_bytes.capacity()` etc., so when the allocator over-provisions
  (jemalloc size classes, huge-page rounding, slab allocators) the next
  slightly-larger document can often be parsed without reallocating at
  all. There are tests covering this for both `dom::parser` and the
  builder.

**RAII wrapper**

`internal::allocated_buffer<T>` replaces the `std::unique_ptr<T[]>` buffers.
It stores the byte size and the allocator pointer that produced the memory,
so sized-deallocation works correctly even after move-assigning between parsers
that use different allocators.

**Exception safety**

Reallocation sites allocate into a local `allocated_buffer` first and
only move-assign into the member on success. A failed allocation
(returned `nullptr` or thrown) leaves the parser in its previous usable
state -- strong exception safety. simdjson itself never catches
allocator exceptions; they propagate to the caller unchanged.

**Adapter for standard `Allocator` types**

For users that already have a type modelling the C++ `Allocator` named
requirement (`std::allocator<T>`, `std::pmr::polymorphic_allocator<T>`,
or a third-party pool's allocator), `simdjson::allocator_adapter<Alloc>`
wraps it as a `simdjson::allocator`. When `__cpp_lib_allocate_at_least`
is available it forwards to `std::allocator_traits::allocate_at_least`
so over-allocation surfaces through to simdjson's capacity tracking.

```cpp
simdjson::allocator_adapter<std::pmr::polymorphic_allocator<uint8_t>> a{
    std::pmr::polymorphic_allocator<uint8_t>{&my_resource}};
simdjson::ondemand::parser parser{a};
```

**Scope**

Applies to `dom::parser`, `dom::document`, `ondemand::parser`,
`dom_parser_implementation` (+ kernel subclasses), and
`builder::string_builder`.

Deliberately *not* applied to:

- `padded_string` / `padded_string_builder` -- input role symmetrical
  with `padded_string_view` (caller brings the buffer).
- `ondemand::parser::get_parser()` -- swappable allocator on a static
  thread-local would make lifetime reasoning brittle.

**Performance**

The default-allocator path is unchanged: same `new[] (std::nothrow)`,
no extra heap traffic, one extra `allocator*` member on each parser.
No measurable regression is expected; happy to run a before/after
parsing benchmark if you want hard numbers before merging.
