### PR TITLE
Prevent overflow in parser allocation size calculations

### DIFF
--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -48,10 +48,11 @@ inline error_code document::allocate(size_t capacity) noexcept {
   size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
-  if(5 * (capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  uint64_t string_capacity_64 = SIMDJSON_ROUNDUP_N(5ULL * (uint64_t(capacity) / 3) + SIMDJSON_PADDING, 64);
+  if (string_capacity_64 > SIZE_MAX) {
+    return CAPACITY;
   }
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (capacity / 3) + SIMDJSON_PADDING, 64);
+  size_t string_capacity = size_t(string_capacity_64);
   string_buf.reset( new (std::nothrow) uint8_t[string_capacity]);
   tape.reset(new (std::nothrow) uint64_t[tape_capacity]);
   if(!(string_buf && tape)) {

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -27,10 +27,11 @@ simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capa
 
   // string_capacity copied from document::allocate
   _capacity = 0;
-  if(5 * (new_capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  uint64_t string_capacity_64 = SIMDJSON_ROUNDUP_N(5ULL * (uint64_t(new_capacity) / 3) + SIMDJSON_PADDING, 64);
+  if (string_capacity_64 > SIZE_MAX) {
+    return CAPACITY;
   }
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (new_capacity / 3) + SIMDJSON_PADDING, 64);
+  size_t string_capacity = size_t(string_capacity_64);
   string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
 #if SIMDJSON_DEVELOPMENT_CHECKS
   start_positions.reset(new (std::nothrow) token_position[new_max_depth]);


### PR DESCRIPTION
This updates the allocation size calculations in document::allocate and
ondemand::parser::allocate to use overflow-safe arithmetic.

The previous code performed multiplication before division when computing
string buffer capacity, which could overflow size_t on some edge-case inputs
before the final bounds check.

This change moves the calculation to a wider intermediate type and adds an
explicit bounds check before casting back.

Normal allocation behavior is unchanged for valid inputs.