### PR TITLE
add bounds check when skipping leading zeros

### DIFF
--- a/src/from_chars.cpp
+++ b/src/from_chars.cpp
@@ -172,7 +172,7 @@ decimal parse_decimal(const char *&p, const char * end) noexcept {
     // if we have not yet encountered a zero, we have to skip it as well
     if (answer.num_digits == 0) {
       // skip zeros
-      while (*p == '0') {
+      while ((p != end) && (*p == '0')) {
         ++p;
       }
     }


### PR DESCRIPTION
## Description
- Add a boundary check (`p != end`) when skipping leading zeros in `parse_decimal` to avoid reading past the input buffer.
- This is a small defensive fix; behavior for valid inputs remains unchanged.
- Issue reproduced / related issue: N/A

---

## Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

---

## How to verify / test
- Build and run the existing test suite:
  ```bash
  cmake -B build -D SIMDJSON_SANITIZE=ON -D SIMDJSON_DEVELOPER_MODE=ON
  cmake --build build
  ctest --test-dir build
  
  *   No new tests added; change does not affect behavior for valid inputs.
    

Checklist before submitting
---------------------------

- [x] Code builds locally and passes my check
    
- [x] Commits are atomic and messages are clear
    
- [x] I linked the related issue (if applicable)
    

Final notes
-----------

*   Minimal, localized change to improve boundary safety.

