### PR TITLE
Prevent overflow in large-capacity parser allocations

### DIFF
--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -42,16 +42,19 @@ inline error_code document::allocate(size_t capacity) noexcept {
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
   // generated, see issue https://github.com/simdjson/simdjson/issues/345
-  if(capacity + 3 < capacity) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  uint64_t tape_capacity_64 = (uint64_t(capacity) + 3 + 63) & ~63ULL;
+  if(tape_capacity_64 > SIMDJSON_MAXSIZE_BYTES) {
+    return CAPACITY;
   }
-  size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
+  size_t tape_capacity = size_t(tape_capacity_64);
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
-  if(5 * (capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  uint64_t string_capacity_64 = 5 * (uint64_t(capacity) / 3) + SIMDJSON_PADDING;
+  string_capacity_64 = (string_capacity_64 + 63) & ~63ULL;
+  if(string_capacity_64 > SIMDJSON_MAXSIZE_BYTES) {
+    return CAPACITY;
   }
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (capacity / 3) + SIMDJSON_PADDING, 64);
+  size_t string_capacity = size_t(string_capacity_64);
   string_buf.reset( new (std::nothrow) uint8_t[string_capacity]);
   tape.reset(new (std::nothrow) uint64_t[tape_capacity]);
   if(!(string_buf && tape)) {

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -63,10 +63,8 @@ inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parse
 inline simdjson_warn_unused error_code dom_parser_implementation::set_capacity(size_t capacity) noexcept {
   if(capacity > SIMDJSON_MAXSIZE_BYTES) { return CAPACITY; }
   // Stage 1 index output
+  if (capacity > SIMDJSON_MAXSIZE_BYTES - 63) { return CAPACITY; }
   size_t rounded_capacity = SIMDJSON_ROUNDUP_N(capacity, 64);
-  if(rounded_capacity + 9 < rounded_capacity) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
-  }
   size_t max_structures = rounded_capacity + 9;
   structural_indexes.reset( new (std::nothrow) uint32_t[max_structures] );
   if (!structural_indexes) { _capacity = 0; return MEMALLOC; }

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -27,10 +27,12 @@ simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capa
 
   // string_capacity copied from document::allocate
   _capacity = 0;
-  if(5 * (new_capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
-    return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
+  uint64_t string_capacity_64 = 5 * (uint64_t(new_capacity) / 3) + SIMDJSON_PADDING;
+  string_capacity_64 = (string_capacity_64 + 63) & ~63ULL;
+  if(string_capacity_64 > SIMDJSON_MAXSIZE_BYTES) {
+    return CAPACITY;
   }
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (new_capacity / 3) + SIMDJSON_PADDING, 64);
+  size_t string_capacity = size_t(string_capacity_64);
   string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
 #if SIMDJSON_DEVELOPMENT_CHECKS
   start_positions.reset(new (std::nothrow) token_position[new_max_depth]);


### PR DESCRIPTION
This fixes overflow issues in parser capacity calculations when handling
very large capacity values near the supported maximum size.

A few allocation paths were doing rounding/multiplication on size_t values
before the final bounds checks, which could overflow on 32-bit builds and
lead to incorrect buffer sizing.

The fix adds precise overflow-safe guards and performs intermediate
capacity calculations in 64-bit arithmetic where needed.
