### PR TITLE
Fix from(std::string) input lifetime (#2703)

### DIFF
--- a/include/simdjson/convert-inl.h
+++ b/include/simdjson/convert-inl.h
@@ -19,6 +19,12 @@ inline auto_parser<parser_type>::auto_parser(parser_type &&parser, padded_string
 }
 
 template <typename parser_type>
+inline auto_parser<parser_type>::auto_parser(parser_type &&parser, padded_string &&str) noexcept requires(!std::is_pointer_v<parser_type>)
+  : m_parser{std::move(parser)}, m_owned_input{std::move(str)}, m_doc{}, m_error{SUCCESS} {
+  m_error = m_parser.iterate(m_owned_input).get(m_doc);
+}
+
+template <typename parser_type>
 inline auto_parser<parser_type>::auto_parser(std::remove_pointer_t<parser_type> &parser, ondemand::document &&doc) noexcept requires(std::is_pointer_v<parser_type>)
   : m_parser{&parser}, m_doc{std::move(doc)} {}
 
@@ -29,8 +35,18 @@ inline auto_parser<parser_type>::auto_parser(std::remove_pointer_t<parser_type> 
 }
 
 template <typename parser_type>
+inline auto_parser<parser_type>::auto_parser(std::remove_pointer_t<parser_type> &parser, padded_string &&str) noexcept requires(std::is_pointer_v<parser_type>)
+  : m_parser{&parser}, m_owned_input{std::move(str)}, m_doc{}, m_error{SUCCESS} {
+  m_error = m_parser->iterate(m_owned_input).get(m_doc);
+}
+
+template <typename parser_type>
 inline auto_parser<parser_type>::auto_parser(padded_string_view const str) noexcept requires(std::is_pointer_v<parser_type>)
   : auto_parser{ondemand::parser::get_parser(), str} {}
+
+template <typename parser_type>
+inline auto_parser<parser_type>::auto_parser(padded_string &&str) noexcept requires(std::is_pointer_v<parser_type>)
+  : auto_parser{ondemand::parser::get_parser(), std::move(str)} {}
 
 template <typename parser_type>
 inline auto_parser<parser_type>::auto_parser(parser_type parser, ondemand::document &&doc) noexcept requires(std::is_pointer_v<parser_type>)
@@ -115,18 +131,28 @@ inline auto to_adaptor<T>::operator()(padded_string_view const str) const noexce
 }
 
 template <typename T>
+inline auto to_adaptor<T>::operator()(padded_string &&str) const noexcept {
+  return auto_parser<ondemand::parser *>{std::move(str)};
+}
+
+template <typename T>
 inline auto to_adaptor<T>::operator()(ondemand::parser &parser, padded_string_view const str) const noexcept {
   return auto_parser<ondemand::parser *>{parser, str};
 }
 
 template <typename T>
+inline auto to_adaptor<T>::operator()(ondemand::parser &parser, padded_string &&str) const noexcept {
+  return auto_parser<ondemand::parser *>{parser, std::move(str)};
+}
+
+template <typename T>
 inline auto to_adaptor<T>::operator()(std::string str) const noexcept {
-  return auto_parser<ondemand::parser *>{pad_with_reserve(str)};
+  return auto_parser<ondemand::parser *>{padded_string(std::string_view(str))};
 }
 
 template <typename T>
 inline auto to_adaptor<T>::operator()(ondemand::parser &parser, std::string str) const noexcept {
-  return auto_parser<ondemand::parser *>{parser, pad_with_reserve(str)};
+  return auto_parser<ondemand::parser *>{parser, padded_string(std::string_view(str))};
 }
 } // namespace internal
 } // namespace convert

--- a/include/simdjson/convert.h
+++ b/include/simdjson/convert.h
@@ -3,6 +3,7 @@
 #define SIMDJSON_CONVERT_H
 
 #include "simdjson/ondemand.h"
+#include "simdjson/padded_string.h"
 #include <optional>
 
 #if SIMDJSON_SUPPORTS_CONCEPTS
@@ -22,6 +23,7 @@ template <typename parser_type = ondemand::parser*>
 struct auto_parser {
 private:
 	parser_type m_parser;
+	padded_string m_owned_input{};
 	ondemand::document m_doc;
 	error_code m_error{SUCCESS};
 
@@ -32,9 +34,12 @@ private:
 public:
 	explicit auto_parser(parser_type &&parser, ondemand::document &&doc) noexcept requires(!std::is_pointer_v<parser_type>);
 	explicit auto_parser(parser_type &&parser, padded_string_view const str) noexcept requires(!std::is_pointer_v<parser_type>);
+	explicit auto_parser(parser_type &&parser, padded_string &&str) noexcept requires(!std::is_pointer_v<parser_type>);
 	explicit auto_parser(std::remove_pointer_t<parser_type> &parser, ondemand::document &&doc) noexcept requires(std::is_pointer_v<parser_type>);
 	explicit auto_parser(std::remove_pointer_t<parser_type> &parser, padded_string_view const str) noexcept requires(std::is_pointer_v<parser_type>);
+	explicit auto_parser(std::remove_pointer_t<parser_type> &parser, padded_string &&str) noexcept requires(std::is_pointer_v<parser_type>);
 	explicit auto_parser(padded_string_view const str) noexcept requires(std::is_pointer_v<parser_type>);
+	explicit auto_parser(padded_string &&str) noexcept requires(std::is_pointer_v<parser_type>);
 	explicit auto_parser(parser_type parser, ondemand::document &&doc) noexcept requires(std::is_pointer_v<parser_type>);
 		auto_parser(auto_parser const &) = delete;
 		auto_parser &operator=(auto_parser const &) = delete;
@@ -74,7 +79,9 @@ template <typename T = void>
 struct to_adaptor {
 	T operator()(simdjson_result<ondemand::value> &val) const noexcept;
 	auto operator()(padded_string_view const str) const noexcept;
+	auto operator()(padded_string &&str) const noexcept;
 	auto operator()(ondemand::parser &parser, padded_string_view const str) const noexcept;
+	auto operator()(ondemand::parser &parser, padded_string &&str) const noexcept;
 	// The std::string is padded with reserve to ensure there is enough space for padding.
 	// Some sanitizers may not like this, so you can use simdjson::pad instead.
 	// simdjson::from(simdjson::pad(str))

--- a/tests/ondemand/ondemand_convert_tests.cpp
+++ b/tests/ondemand/ondemand_convert_tests.cpp
@@ -140,6 +140,82 @@ simdjson::padded_string json_cars =
     }
     TEST_SUCCEED();
   }
+
+  std::string make_large_car_json() {
+    std::string make(4096, 'T');
+    return R"({"make":")" + make + R"(","model":"Camry","year":2018,"tire_pressure":[40.1,39.9]})";
+  }
+
+  bool from_std_string_keeps_input_alive() {
+    TEST_START();
+    std::string json = make_large_car_json();
+    const size_t json_size = json.size();
+    auto parser = simdjson::from(std::move(json));
+
+    // Reuse recently freed heap blocks before consuming the auto_parser.
+    std::vector<std::string> heap_churn;
+    heap_churn.reserve(256);
+    for (size_t i = 0; i < 256; i++) {
+      heap_churn.emplace_back(json_size + (i % simdjson::SIMDJSON_PADDING), 'x');
+    }
+
+    Car car;
+    ASSERT_SUCCESS(std::move(parser).get(car));
+    ASSERT_EQUAL(car.make, std::string(4096, 'T'));
+    ASSERT_EQUAL(car.model, "Camry");
+    ASSERT_EQUAL(car.year, 2018);
+    TEST_SUCCEED();
+  }
+
+  bool from_std_string_with_parser_keeps_input_alive() {
+    TEST_START();
+    simdjson::ondemand::parser parser;
+    std::string json = make_large_car_json();
+    const size_t json_size = json.size();
+    auto auto_parser = simdjson::from(parser, std::move(json));
+
+    std::vector<std::string> heap_churn;
+    heap_churn.reserve(256);
+    for (size_t i = 0; i < 256; i++) {
+      heap_churn.emplace_back(json_size + (i % simdjson::SIMDJSON_PADDING), 'x');
+    }
+
+    Car car;
+    ASSERT_SUCCESS(std::move(auto_parser).get(car));
+    ASSERT_EQUAL(car.make, std::string(4096, 'T'));
+    ASSERT_EQUAL(car.model, "Camry");
+    ASSERT_EQUAL(car.year, 2018);
+    TEST_SUCCEED();
+  }
+
+  bool from_padded_string_moves_input() {
+    TEST_START();
+    simdjson::padded_string json(make_large_car_json());
+    auto auto_parser = simdjson::from(std::move(json));
+    ASSERT_EQUAL(json.size(), 0);
+
+    Car car;
+    ASSERT_SUCCESS(std::move(auto_parser).get(car));
+    ASSERT_EQUAL(car.make, std::string(4096, 'T'));
+    ASSERT_EQUAL(car.model, "Camry");
+    ASSERT_EQUAL(car.year, 2018);
+    TEST_SUCCEED();
+  }
+
+  bool from_padded_string_with_parser_moves_input() {
+    TEST_START();
+    simdjson::ondemand::parser parser;
+    simdjson::padded_string json(make_large_car_json());
+    auto auto_parser = simdjson::from(parser, std::move(json));
+    ASSERT_EQUAL(json.size(), 0);
+
+    Car car;
+    ASSERT_SUCCESS(std::move(auto_parser).get(car));
+    ASSERT_EQUAL(car.make, std::string(4096, 'T'));
+    ASSERT_EQUAL(car.model, "Camry");
+    ASSERT_EQUAL(car.year, 2018);
+    TEST_SUCCEED();
+  }
 #endif // SIMDJSON_SUPPORTS_CONCEPTS
 #if SIMDJSON_EXCEPTIONS && SIMDJSON_SUPPORTS_CONCEPTS
 
@@ -501,7 +577,10 @@ bool run() {
       missing_key_optional_player() && missing_key_player() && meeting_time_test() && meeting_test() && bad_player() && good_player() && complicated_weather_test() &&
 #endif
 #if SIMDJSON_SUPPORTS_CONCEPTS
-      simple_no_except() &&
+      simple_no_except() && from_std_string_keeps_input_alive() &&
+      from_std_string_with_parser_keeps_input_alive() &&
+      from_padded_string_moves_input() &&
+      from_padded_string_with_parser_moves_input() &&
 #endif
 #if SIMDJSON_EXCEPTIONS && SIMDJSON_SUPPORTS_CONCEPTS
       broken() && simple() && simple_optional() && with_parser() && to_array() &&


### PR DESCRIPTION
Short title (summary):
Fix input lifetime in from(std::string)

Description
  `simdjson::from(std::string)` could leave the returned `auto_parser` referring to storage owned by the input string. Since on-demand conversion may happen after `from(...)` returns, temporary string input could be destroyed before the
  document is materialized.

  This change makes `auto_parser` own padded input for `std::string` inputs, so the backing storage remains valid for the parser/document lifetime. It also adds `padded_string&&` overloads so callers with already padded input can transfer
  ownership without copying the JSON payload.
  Issue reproduced / related issue: fixes #2703

Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to verify / test

Added regression tests covering:

  - `from(std::string)`
  - `from(parser, std::string)`
  - `from(std::move(padded_string))`
  - `from(parser, std::move(padded_string))`
 
  Verified locally with:

  ```bash
  cmake --build /tmp/simdjson-review-build-cxx20-asan --target ondemand_convert_tests -j 6
  ctest --test-dir /tmp/simdjson-review-build-cxx20-asan --output-on-failure -R ondemand_convert_tests
  cmake --build /tmp/simdjson-review-build-dev --target ondemand_convert_tests -j 6
  ctest --test-dir /tmp/simdjson-review-build-dev --output-on-failure -R ondemand_convert_tests


Checklist before submitting
- [x] I added/updated tests covering my change (if applicable)
- [x] Code builds locally and passes my check
- [x] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear
- [x] I linked the related issue (if applicable)

Final notes
- For large PRs, prefer smaller incremental PRs or request staged review.

Thanks for the contribution!

