### PR TITLE
fixing issue 2703

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -1602,6 +1602,10 @@ type without a document instance like so:
 Car car = simdjson::from(json);
 ```
 
+The string must be a `simdjson::padded_string_view`, which can be created from an std::string
+instance with `simdjson::pad()` function, from a `simdjson::padded_string` instance, or string literal using the `_padded`  user-defined literal.
+
+
 You can also use the `simdjson::from` syntax without exceptions, like so:
 ```cpp
 Car car;

--- a/include/simdjson/convert-inl.h
+++ b/include/simdjson/convert-inl.h
@@ -37,9 +37,6 @@ inline auto_parser<parser_type>::auto_parser(parser_type parser, ondemand::docum
   : auto_parser{*parser, std::move(doc)} {}
 
 
-
-
-
 template <typename parser_type>
 inline std::remove_pointer_t<parser_type> &auto_parser<parser_type>::parser() noexcept {
   if constexpr (std::is_pointer_v<parser_type>) {
@@ -117,16 +114,6 @@ inline auto to_adaptor<T>::operator()(padded_string_view const str) const noexce
 template <typename T>
 inline auto to_adaptor<T>::operator()(ondemand::parser &parser, padded_string_view const str) const noexcept {
   return auto_parser<ondemand::parser *>{parser, str};
-}
-
-template <typename T>
-inline auto to_adaptor<T>::operator()(std::string str) const noexcept {
-  return auto_parser<ondemand::parser *>{pad_with_reserve(str)};
-}
-
-template <typename T>
-inline auto to_adaptor<T>::operator()(ondemand::parser &parser, std::string str) const noexcept {
-  return auto_parser<ondemand::parser *>{parser, pad_with_reserve(str)};
 }
 } // namespace internal
 } // namespace convert

--- a/include/simdjson/convert.h
+++ b/include/simdjson/convert.h
@@ -36,12 +36,12 @@ public:
 	explicit auto_parser(std::remove_pointer_t<parser_type> &parser, padded_string_view const str) noexcept requires(std::is_pointer_v<parser_type>);
 	explicit auto_parser(padded_string_view const str) noexcept requires(std::is_pointer_v<parser_type>);
 	explicit auto_parser(parser_type parser, ondemand::document &&doc) noexcept requires(std::is_pointer_v<parser_type>);
-		auto_parser(auto_parser const &) = delete;
-		auto_parser &operator=(auto_parser const &) = delete;
-		auto_parser(auto_parser &&) noexcept = default;
-		auto_parser &operator=(auto_parser &&) noexcept = default;
-		~auto_parser() = default;
-
+	auto_parser(auto_parser const &) = delete;
+	auto_parser &operator=(auto_parser const &) = delete;
+	~auto_parser() = default;
+    // Prevent moving
+    auto_parser(auto_parser&&) = delete;
+	auto_parser &operator=(auto_parser &&) noexcept = delete;
 	simdjson_warn_unused std::remove_pointer_t<parser_type> &parser() noexcept;
 
 	template <typename T>
@@ -75,11 +75,6 @@ struct to_adaptor {
 	T operator()(simdjson_result<ondemand::value> &val) const noexcept;
 	auto operator()(padded_string_view const str) const noexcept;
 	auto operator()(ondemand::parser &parser, padded_string_view const str) const noexcept;
-	// The std::string is padded with reserve to ensure there is enough space for padding.
-	// Some sanitizers may not like this, so you can use simdjson::pad instead.
-	// simdjson::from(simdjson::pad(str))
-	auto operator()(std::string str) const noexcept;
-	auto operator()(ondemand::parser &parser, std::string str) const noexcept;
 };
 // deduction guide
 auto_parser(padded_string_view const str) -> auto_parser<ondemand::parser*>;
@@ -90,7 +85,12 @@ auto_parser(padded_string_view const str) -> auto_parser<ondemand::parser*>;
  * The simdjson::from instance is EXPERIMENTAL AND SUBJECT TO CHANGES.
  *
  * The `from` instance is a utility adaptor for parsing JSON strings into objects.
- * It provides a convenient way to convert JSON data into C++ objects using the `auto_parser`.
+ *
+ * The string must be a simdjson::padded_string_view, which can be created from a std::string
+ * with simdjson::pad(), from a simdjson::padded_string, or string literal using the `_padded`
+ * user-defined literal.
+ *
+ * The `from` instance provides a convenient way to convert JSON data into C++ objects using the `auto_parser`.
  *
  * Example usage:
  *


### PR DESCRIPTION
@yangzhg found an issue whereas the `std::string` overloads of `simdjson::from` are unsafe/broken manner. (The `simdjson::from` is still marked as experimental.)

This PR removed them. We also prevent the result of `simdjson::from`  from being moved. It is not meant to be copied or stored. It is meant for convenience and immediate consumption.


@yangzhg also created a fix in https://github.com/simdjson/simdjson/pull/2704 Their fix is correct as far as I can tell, but it basically copies the string content inside the `simdjson::from` instance. We don't want to go there as it increases the complexity and harms the performance.

Fixes https://github.com/simdjson/simdjson/issues/2703
