### PR TITLE
builder: hoist write position into a local register in the struct atom

### DIFF
--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -89,14 +89,18 @@ template <class T>
            !std::is_same_v<T, const char*> &&
            !std::is_same_v<T, char> && !require_custom_serialization<T>)
 constexpr void atom(string_builder &b, const T &t) {
+  // Coalesce the per-field separator+key+colon writes into a single
+  // append_raw, so each field does one capacity_check + one memcpy instead of
+  // three. The leading-comma variant is selected at runtime by the compile-time
+  // peeled `i` counter, which clang folds away after the template-for unroll.
   int i = 0;
   b.append('{');
   template for (constexpr auto dm : std::define_static_array(std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked()))) {
-    if (i != 0)
-      b.append(',');
-    constexpr auto key = std::define_static_string(constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)));
-    b.append_raw(key);
-    b.append(':');
+    constexpr auto first_key = std::define_static_string(
+        constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)) + ":");
+    constexpr auto rest_key = std::define_static_string(
+        std::string(",") + constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)) + ":");
+    b.append_raw(i == 0 ? first_key : rest_key);
     atom(b, t.[:dm:]);
     i++;
   };
@@ -224,14 +228,15 @@ template <class Z>
            !std::is_same_v<Z, const char*> &&
            !std::is_same_v<Z, char> && !require_custom_serialization<Z>)
 void append(string_builder &b, const Z &z) {
+  // Same coalescing as the atom() overload above.
   int i = 0;
   b.append('{');
   template for (constexpr auto dm : std::define_static_array(std::meta::nonstatic_data_members_of(^^Z, std::meta::access_context::unchecked()))) {
-    if (i != 0)
-      b.append(',');
-    constexpr auto key = std::define_static_string(constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)));
-    b.append_raw(key);
-    b.append(':');
+    constexpr auto first_key = std::define_static_string(
+        constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)) + ":");
+    constexpr auto rest_key = std::define_static_string(
+        std::string(",") + constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)) + ":");
+    b.append_raw(i == 0 ? first_key : rest_key);
     atom(b, z.[:dm:]);
     i++;
   };
@@ -304,15 +309,13 @@ void extract_from(string_builder &b, const T &obj) {
 
       // Only serialize this field if it's in our list of requested fields
       if constexpr (((FieldNames.view() == key) || ...)) {
-        if (!first) {
-          b.append(',');
-        }
+        // Same coalescing as the atom() / append() struct overloads.
+        static constexpr auto first_key = std::define_static_string(
+            constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(mem)) + ":");
+        static constexpr auto rest_key = std::define_static_string(
+            std::string(",") + constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(mem)) + ":");
+        b.append_raw(first ? first_key : rest_key);
         first = false;
-
-        // Serialize the key
-        static constexpr auto quoted_key = std::define_static_string(constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(mem)));
-        b.append_raw(quoted_key);
-        b.append(':');
 
         // Serialize the value
         atom(b, obj.[:mem:]);

--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -89,22 +89,71 @@ template <class T>
            !std::is_same_v<T, const char*> &&
            !std::is_same_v<T, char> && !require_custom_serialization<T>)
 constexpr void atom(string_builder &b, const T &t) {
-  // Coalesce the per-field separator+key+colon writes into a single
-  // append_raw, so each field does one capacity_check + one memcpy instead of
-  // three. The leading-comma variant is selected at runtime by the compile-time
-  // peeled `i` counter, which clang folds away after the template-for unroll.
+  // Hoist the write position into a local register for each run of fixed
+  // bytes (separator, key, colon, brace, and arithmetic field values). The
+  // position is synced back to the builder before any call that may grow the
+  // buffer, and reloaded after, so unsafe writes between syncs avoid the
+  // per-call capacity_check + memory traffic that string_builder member
+  // access would otherwise impose.
+  if (!b.reserve(1)) { return; }
+  char *buf = b.unsafe_data();
+  size_t pos = b.unsafe_position();
+  buf[pos++] = '{';
   int i = 0;
-  b.append('{');
   template for (constexpr auto dm : std::define_static_array(std::meta::nonstatic_data_members_of(^^T, std::meta::access_context::unchecked()))) {
+    // The two key forms (with and without leading comma) are precomputed at
+    // consteval, then their lengths are kept as separate constants so that
+    // the runtime memcpy uses an explicit known size rather than strlen.
     constexpr auto first_key = std::define_static_string(
         constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)) + ":");
     constexpr auto rest_key = std::define_static_string(
         std::string(",") + constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)) + ":");
-    b.append_raw(i == 0 ? first_key : rest_key);
-    atom(b, t.[:dm:]);
+    constexpr size_t quoted_size =
+        constevalutil::consteval_to_quoted_escaped(std::meta::identifier_of(dm)).size();
+    constexpr size_t first_key_len = quoted_size + 1;            // "key":
+    constexpr size_t rest_key_len = quoted_size + 2;             // ,"key":
+    using FieldT = [: std::meta::type_of(dm) :];
+    constexpr bool is_unsigned_int_field =
+        std::is_unsigned_v<FieldT> && !std::is_same_v<FieldT, bool> &&
+        !std::is_same_v<FieldT, char>;
+    constexpr size_t max_value_size =
+        is_unsigned_int_field ? string_builder::MAX_UINT64_DIGITS : 0;
+    // Reserve enough for the key plus (for arithmetic fields) the value. If
+    // reserve grew the buffer the local `buf` pointer is stale and must be
+    // refetched.
+    b.unsafe_position() = pos;
+    if (!b.reserve(rest_key_len + max_value_size)) { return; }
+    buf = b.unsafe_data();
+    pos = b.unsafe_position();
+    if (i == 0) {
+      std::memcpy(buf + pos, first_key, first_key_len);
+      pos += first_key_len;
+    } else {
+      std::memcpy(buf + pos, rest_key, rest_key_len);
+      pos += rest_key_len;
+    }
+    if constexpr (is_unsigned_int_field) {
+      // Capacity for the value was reserved above; just sync, write, reload.
+      b.unsafe_position() = pos;
+      b.unsafe_append_uint(t.[:dm:]);
+      pos = b.unsafe_position();
+    } else {
+      // The inner atom() may grow the buffer, invalidating both `buf` and
+      // any remaining unwritten reservation. Sync, recurse, reload.
+      b.unsafe_position() = pos;
+      atom(b, t.[:dm:]);
+      buf = b.unsafe_data();
+      pos = b.unsafe_position();
+    }
     i++;
   };
-  b.append('}');
+  // Closing brace.
+  b.unsafe_position() = pos;
+  if (!b.reserve(1)) { return; }
+  buf = b.unsafe_data();
+  pos = b.unsafe_position();
+  buf[pos++] = '}';
+  b.unsafe_position() = pos;
 }
 
 // Support for optional types (std::optional, etc.)

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -644,7 +644,7 @@ static const char decimal_table[200] = {
 
 template <typename UInt>
 simdjson_inline void string_builder::unsafe_append_uint(UInt v) noexcept {
-  static_assert(std::is_unsigned_v<UInt>, "unsafe_append_uint requires unsigned");
+  static_assert(std::is_unsigned<UInt>::value, "unsafe_append_uint requires unsigned");
   // Same 4-digit-batched algorithm as the checked path in append, but skips
   // capacity_check. Caller must have reserved at least 20 bytes.
   size_t dc = internal::digit_count(v);

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -534,6 +534,10 @@ simdjson_inline size_t string_builder::size() const noexcept {
   return position;
 }
 
+simdjson_inline bool string_builder::reserve(size_t upcoming_bytes) noexcept {
+  return capacity_check(upcoming_bytes);
+}
+
 simdjson_inline void string_builder::append(char c) noexcept {
   if (capacity_check(1)) {
     buffer.get()[position++] = c;
@@ -637,6 +641,36 @@ static const char decimal_table[200] = {
     0x39, 0x36, 0x39, 0x37, 0x39, 0x38, 0x39, 0x39,
 };
 } // namespace internal
+
+template <typename UInt>
+simdjson_inline void string_builder::unsafe_append_uint(UInt v) noexcept {
+  static_assert(std::is_unsigned_v<UInt>, "unsafe_append_uint requires unsigned");
+  // Same 4-digit-batched algorithm as the checked path in append, but skips
+  // capacity_check. Caller must have reserved at least 20 bytes.
+  size_t dc = internal::digit_count(v);
+  char *write_pointer = buffer.get() + position + dc - 1;
+  while (v >= 10000) {
+    UInt q = v / 10000;
+    UInt r = v % 10000;
+    UInt r_hi = r / 100;
+    UInt r_lo = r % 100;
+    std::memcpy(write_pointer - 1, &internal::decimal_table[r_lo * 2], 2);
+    std::memcpy(write_pointer - 3, &internal::decimal_table[r_hi * 2], 2);
+    write_pointer -= 4;
+    v = q;
+  }
+  while (v >= 100) {
+    std::memcpy(write_pointer - 1, &internal::decimal_table[(v % 100) * 2], 2);
+    write_pointer -= 2;
+    v /= 100;
+  }
+  if (v >= 10) {
+    *write_pointer-- = char('0' + (v % 10));
+    v /= 10;
+  }
+  *write_pointer = char('0' + v);
+  position += dc;
+}
 
 template <typename number_type, typename>
 simdjson_inline void string_builder::append(number_type v) noexcept {

--- a/include/simdjson/generic/builder/json_string_builder.h
+++ b/include/simdjson/generic/builder/json_string_builder.h
@@ -236,6 +236,43 @@ requires (!std::is_convertible<R, std::string_view>::value && !concepts::optiona
    */
   simdjson_inline size_t size() const noexcept;
 
+  /**
+   * Reserve at least `upcoming_bytes` of capacity, growing the buffer if
+   * needed. Returns true on success. After this returns true, callers may use
+   * the `unsafe_*` helpers below to write up to `upcoming_bytes` bytes without
+   * further bounds checking. Calling any other method that may grow the
+   * buffer (anything not prefixed `unsafe_`) invalidates the reservation, so
+   * the caller must re-reserve before continuing with unsafe writes.
+   */
+  simdjson_inline bool reserve(size_t upcoming_bytes) noexcept;
+
+  /**
+   * Pointer to the underlying buffer. Valid until the next call that may
+   * grow the buffer (capacity_check, append, append_raw, ...). The reflection
+   * serializer holds this in a local register across runs of fixed-byte
+   * writes to amortize the OOP method-call overhead.
+   */
+  simdjson_inline char *unsafe_data() noexcept { return buffer.get(); }
+
+  /**
+   * Reference to the current write offset. Allows the caller to update the
+   * position after a sequence of unsafe writes done through `unsafe_data()`.
+   */
+  simdjson_inline size_t &unsafe_position() noexcept { return position; }
+
+  /**
+   * Write `v` as decimal ASCII at the current position. The caller must have
+   * reserved at least `MAX_UINT64_DIGITS` bytes of capacity.
+   */
+  template <typename UInt>
+  simdjson_inline void unsafe_append_uint(UInt v) noexcept;
+
+  /**
+   * The maximum number of decimal digits a uint64_t can occupy. Used as the
+   * worst-case reservation size before a call to `unsafe_append_uint`.
+   */
+  static constexpr size_t MAX_UINT64_DIGITS = 20;
+
 private:
   /**
    * Returns true if we can write at least upcoming_bytes bytes.


### PR DESCRIPTION
## Summary

Reduce per-byte memory traffic in the reflection-driven struct serializer
by holding the write position in a local register across runs of fixed
bytes, instead of going through the `string_builder.position` member on
every write.

Layered on top of #2698 (already merged into master).

Type of change
- [x] Optimization

## The problem

After the per-field key coalescing in #2698, every byte the struct atom
wrote still went through `string_builder::position`. Because the buffer
itself is a `char*`, C++'s strict aliasing rules force the compiler to
assume that any write to `buffer.get()[...]` could overwrite `position`
or `capacity` — those are other members of the same object reachable
through the `string_builder &`. Result: after each byte/memcpy, the
compiler had to reload both fields from memory before the next write.

A representative inner-loop snippet from `atom<CITMSeatCategory>` writing
a `,` between vector elements (baseline post-#2698):

```
ldr   x0, [x24]              ; reload buffer.get()
add   x1, x22, #0x1          ; new position
str   x1, [x24, #8]          ; store position back
mov   w1, #0x2c              ; ','
strb  w1, [x0, x22]          ; write the comma
ldp   x22, x27, [x24, #8]    ; reload position AND capacity
cmp   x27, x22               ; check capacity for next byte
b.eq  <fallback>
ldr   x0, [x24]              ; reload buffer.get() AGAIN
...
```

Six instructions per single-byte write, of which only the `strb` is the
real work.

## What changed

Three small "unsafe" helpers added to `string_builder`:

- `bool reserve(size_t n)`: ensures at least `n` bytes are available,
  growing the buffer if needed.
- `char *unsafe_data()` and `size_t &unsafe_position()`: expose the
  buffer pointer and position so the caller can write directly.
- `void unsafe_append_uint(UInt v)`: writes the digits of an unsigned
  integer at the current position with no bounds check (caller has
  already reserved `MAX_UINT64_DIGITS`).

The reflection struct atom is rewritten to:

1. `reserve(N)` enough capacity for the next run of fixed bytes.
2. Pull the buffer pointer (`buf`) and write position (`pos`) into
   local variables.
3. Issue every write in that run directly through `buf[pos++]` or
   `memcpy(buf + pos, ..., N); pos += N`. No bounds checks, no member
   access — the compiler can prove the locals don't alias each other and
   keeps `pos` in a register.
4. Sync `pos` back to `b.unsafe_position()` and reload after any
   call that may grow the buffer or move position (`reserve` calls
   that may realloc, `unsafe_append_uint`, recursive `atom()` for
   variable-size fields).

Why the sync/reload dance is needed: `reserve` may `grow_buffer`
(realloc), which moves `buf`. Recursive `atom()` for strings,
vectors, and nested structs writes through `b.position` itself, so
our local `pos` and `b.position` must agree at the boundary.

The win is concentrated in the struct atom because that's where you have
runs of small fixed-byte writes (separator + key + colon + arithmetic
value) between calls. Container atoms have no such runs — just a comma
between recursive calls — and would not benefit, so they are unchanged.

## Performance

Build: gcc-trunk g++ 16.0.1, `-O3 -DNDEBUG -freflection -std=c++26`,
on aarch64 Linux. Median of 5 contemporaneous runs, both states built
clean on top of current master, output byte-identical to baseline.

CITM serialization (496 682 bytes):

| variant | baseline | patched | delta |
|---|---|---|---|
| simdjson_static_reflection | 3243 MB/s | 3831 MB/s | **+18.1%** |
| simdjson_reuse_buffer | 3422 MB/s | 3970 MB/s | **+16.0%** |
| simdjson_to | 3048 MB/s | 3593 MB/s | **+17.9%** |
| simdjson_to_reuse | 2992 MB/s | 3631 MB/s | **+21.4%** |

Twitter serialization (81 927 bytes):

| variant | baseline | patched | delta |
|---|---|---|---|
| simdjson_static_reflection | 5485 MB/s | 5660 MB/s | +3.2% |
| simdjson_reuse_buffer | 6774 MB/s | 6977 MB/s | +3.0% |
| simdjson_to | 5037 MB/s | 5066 MB/s | +0.6% |
| simdjson_to_reuse | 4986 MB/s | 5067 MB/s | +1.6% |

CITM benefits more than Twitter because its structs are smaller-fielded
(CITMArea has 2, CITMPrice has 3, CITMSeatCategory has 2) and those
fields are mostly arithmetic, so the per-field overhead dominates.
Twitter's structs have larger string fields, where the variable-size
write paths still dominate the cost.

## How to verify / test

```bash
cmake -B buildreflect -D SIMDJSON_STATIC_REFLECTION=ON -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build buildreflect --target benchmark_serialization_citm_catalog \
    benchmark_serialization_twitter static_reflection_comprehensive_tests
./buildreflect/tests/builder/static_reflection_comprehensive_tests
./buildreflect/benchmark/static_reflect/citm_catalog_benchmark/benchmark_serialization_citm_catalog -f simdjson
./buildreflect/benchmark/static_reflect/twitter_benchmark/benchmark_serialization_twitter -f simdjson
```

The reflection round-trip tests in `static_reflection_comprehensive_tests`
exercise both the new struct atom and the unchanged `extract_from` and
pass with this change.

## AI usage disclosure

This PR was AI-assisted by Opus 4.7 (1M context).
