### PR TITLE
JSON Pointer array index overflow handling

### DIFF
--- a/include/simdjson/dom/array-inl.h
+++ b/include/simdjson/dom/array-inl.h
@@ -103,21 +103,9 @@ inline simdjson_result<element> array::at_pointer(std::string_view json_pointer)
   // We don't support this, because we're returning a real element, not a position.
   if (json_pointer == "-") { return INDEX_OUT_OF_BOUNDS; }
 
-  // Read the array index
   size_t array_index = 0;
   size_t i;
-  for (i = 0; i < json_pointer.length() && json_pointer[i] != '/'; i++) {
-    uint8_t digit = uint8_t(json_pointer[i] - '0');
-    // Check for non-digit in array index. If it's there, we're trying to get a field in an object
-    if (digit > 9) { return INCORRECT_TYPE; }
-    array_index = array_index*10 + digit;
-  }
-
-  // 0 followed by other digits is invalid
-  if (i > 1 && json_pointer[0] == '0') { return INVALID_JSON_POINTER; } // "JSON pointer array index has other characters after 0"
-
-  // Empty string is invalid; so is a "/" with no digits before it
-  if (i == 0) { return INVALID_JSON_POINTER; } // "Empty string in JSON pointer array index"
+  SIMDJSON_TRY(internal::parse_json_pointer_array_index(json_pointer, array_index, i));
 
   // Get the child
   auto child = array(tape).at(array_index);

--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -135,21 +135,9 @@ inline simdjson_result<value> array::at_pointer(std::string_view json_pointer) n
   // We don't support this, because we're returning a real element, not a position.
   if (json_pointer == "-") { return INDEX_OUT_OF_BOUNDS; }
 
-  // Read the array index
   size_t array_index = 0;
   size_t i;
-  for (i = 0; i < json_pointer.length() && json_pointer[i] != '/'; i++) {
-    uint8_t digit = uint8_t(json_pointer[i] - '0');
-    // Check for non-digit in array index. If it's there, we're trying to get a field in an object
-    if (digit > 9) { return INCORRECT_TYPE; }
-    array_index = array_index*10 + digit;
-  }
-
-  // 0 followed by other digits is invalid
-  if (i > 1 && json_pointer[0] == '0') { return INVALID_JSON_POINTER; } // "JSON pointer array index has other characters after 0"
-
-  // Empty string is invalid; so is a "/" with no digits before it
-  if (i == 0) { return INVALID_JSON_POINTER; } // "Empty string in JSON pointer array index"
+  SIMDJSON_TRY(internal::parse_json_pointer_array_index(json_pointer, array_index, i));
   // Get the child
   auto child = at(array_index);
   // If there is an error, it ends here

--- a/include/simdjson/jsonpathutil.h
+++ b/include/simdjson/jsonpathutil.h
@@ -1,12 +1,55 @@
 #ifndef SIMDJSON_JSONPATHUTIL_H
 #define SIMDJSON_JSONPATHUTIL_H
 
+#include "simdjson/error.h"
 #include <string>
 #include "simdjson/common_defs.h"
 
+#include <limits>
 #include <utility>
 
 namespace simdjson {
+namespace internal {
+/**
+ * Parses the next JSON Pointer array index token.
+ *
+ * The caller passes a pointer fragment with no leading '/', such as "123/foo".
+ * On success, array_index receives the parsed index and token_length receives
+ * the number of bytes consumed before the next '/' or the end of the fragment.
+ */
+simdjson_inline error_code parse_json_pointer_array_index(std::string_view json_pointer,
+                                                          size_t &array_index,
+                                                          size_t &token_length) noexcept {
+  array_index = 0;
+  token_length = 0;
+
+  for (; token_length < json_pointer.length() && json_pointer[token_length] != '/';
+       token_length++) {
+    uint8_t digit = uint8_t(json_pointer[token_length] - '0');
+    // Check for non-digit in array index. If it's there, we're trying to get a field in an object.
+    if (digit > 9) {
+      return INCORRECT_TYPE;
+    }
+    // 0 followed by other digits is invalid.
+    if (token_length > 0 && json_pointer[0] == '0') {
+      return INVALID_JSON_POINTER;
+    }
+    if (array_index >
+        (((std::numeric_limits<size_t>::max)() - digit) / 10)) {
+      return INDEX_OUT_OF_BOUNDS;
+    }
+    array_index = array_index * 10 + digit;
+  }
+
+  // Empty string is invalid; so is a "/" with no digits before it.
+  if (token_length == 0) {
+    return INVALID_JSON_POINTER;
+  }
+
+  return SUCCESS;
+}
+} // namespace internal
+
 /**
  * Converts JSONPath to JSON Pointer.
  * @param json_path The JSONPath string to be converted.

--- a/tests/dom/pointercheck.cpp
+++ b/tests/dom/pointercheck.cpp
@@ -257,6 +257,7 @@ int main() {
     && json_pointer_failure_test(TEST_JSON, "/~01abc", NO_SUCH_FIELD) // Test that we don't try to compare the literal key
     && json_pointer_failure_test(TEST_JSON, "/~1~001abc/01", INVALID_JSON_POINTER) // Leading 0 in integer index
     && json_pointer_failure_test(TEST_JSON, "/~1~001abc/", INVALID_JSON_POINTER) // Empty index to array
+    && json_pointer_failure_test(TEST_JSON, "/~1~001abc/18446744073709551616", INDEX_OUT_OF_BOUNDS) // Overflowed index
     && json_pointer_failure_test(TEST_JSON, "/~1~001abc/-", INDEX_OUT_OF_BOUNDS) // End index is always out of bounds
   ) {
     std::cout << "Success!" << std::endl;

--- a/tests/ondemand/ondemand_json_pointer_tests.cpp
+++ b/tests/ondemand/ondemand_json_pointer_tests.cpp
@@ -509,6 +509,7 @@ namespace json_pointer_tests {
                 run_failure_test(TEST_JSON, "/~01abc", NO_SUCH_FIELD) &&
                 run_failure_test(TEST_JSON, "/~1~001abc/01", INVALID_JSON_POINTER) &&
                 run_failure_test(TEST_JSON, "/~1~001abc/", INVALID_JSON_POINTER) &&
+                run_failure_test(TEST_JSON, "/~1~001abc/18446744073709551616", INDEX_OUT_OF_BOUNDS) &&
                 run_failure_test(TEST_JSON, "/~1~001abc/-", INDEX_OUT_OF_BOUNDS) &&
                 many_json_pointers() &&
                 document_as_scalar() &&


### PR DESCRIPTION
## Short title (summary)

Fix JSON Pointer array index overflow handling

---

## Description

This patch fixes unchecked overflow during JSON Pointer array index parsing in DOM and On Demand `at_pointer()` handling.

Previously, oversized index tokens were accumulated using unchecked decimal arithmetic, which could wrap on 64-bit builds and incorrectly resolve oversized indexes such as `/18446744073709551616` as `/0` instead of failing. The fix centralizes overflow-checked parsing and reuses it in both implementations.

Issue reproduced with a standalone runtime repro before the patch.

---

## Type of change

* [x] Bug fix
* [ ] Optimization
* [ ] New feature
* [ ] Refactor / cleanup
* [x] Documentation / tests
* [ ] Other (please describe):

---

## How to verify / test

Regression tests added for both DOM and On Demand JSON Pointer handling.

Verified with:

```bash
ctest --test-dir build -R "^(pointercheck|ondemand_json_pointer_tests)$" --output-on-failure -C Debug

ctest --test-dir build_debug -R "^(pointercheck|ondemand_json_pointer_tests)$" --output-on-failure -C Debug
```

Also verified with a standalone runtime reproducer:

* pre-patch: oversized index aliases `/0`
* post-patch: oversized index returns `INDEX_OUT_OF_BOUNDS`

---

## Checklist before submitting

* [x] I added/updated tests covering my change (if applicable)
* [x] Code builds locally and passes my check
* [ ] Documentation / README updated if needed
* [x] Commits are atomic and messages are clear
* [ ] I linked the related issue (if applicable)
