### PR TITLE
fix -Wunneeded-internal-declaration warning

### DIFF
--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -497,7 +497,7 @@ simdjson_inline size_t significant_digits(const uint8_t * start_digits, size_t d
 } // unnamed namespace
 
 /** @private */
-static error_code slow_float_parsing(simdjson_unused const uint8_t * src, double* answer) {
+inline error_code slow_float_parsing(simdjson_unused const uint8_t * src, double* answer) {
   if (parse_float_fallback(src, answer)) {
     return SUCCESS;
   }


### PR DESCRIPTION
Short title (summary): A `static` function that is not declared inline appears in a header file. Compilers warn about this, and the warning can be pretty noisy.

### Description
- Changed linkage of function from 'static' to 'inline'

### Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

### How to verify / test

Reproducing:

```cpp
// example.cpp
#include <simdjson/builder.h>
#include <simdjson/dom.h>

int main() {}
```

Compile with:

```
clang++ example.cpp -I include -std=c++17 build/libsimdjson.a -Wall
```
Error message:

```
In file included from example.cpp:2:
In file included from include/simdjson/builder.h:4:
In file included from include/simdjson/builtin/builder.h:4:
In file included from include/simdjson/builtin.h:12:
In file included from include/simdjson/arm64.h:5:
In file included from include/simdjson/generic/amalgamated.h:10:
include/simdjson/generic/numberparsing.h:500:19: warning: 'static' function 'slow_float_parsing' declared in header file should be declared 'static inline' [-Wunneeded-internal-declaration]
  500 | static error_code slow_float_parsing(simdjson_unused const uint8_t * src, double* answer) {
      |                   ^~~~~~~~~~~~~~~~~~
1 warning generated.
```

### Checklist before submitting
- [x] I added/updated tests covering my change (if applicable) (N/A)
- [x] Code builds locally and passes my check
- [x] Documentation / README updated if needed (N/A)
- [x] Commits are atomic and messages are clear
- [x] I linked the related issue (if applicable) (N/A)