### PR TITLE
avoid unnecessary pointer member

### DIFF
--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -46,7 +46,7 @@ struct writer {
   char *ptr;        // buffer pointer (refreshed after a grow)
   size_t pos;       // write position (local)
   size_t cap;       // capacity (refreshed after a grow)
-  string_builder *sb;  // back-ref for grow / sync
+  string_builder &sb;  // back-ref for grow / sync
 
   // Snapshot string_builder state into a writer for the duration of
   // a write chain.
@@ -54,13 +54,13 @@ struct writer {
       : ptr(builder.unsafe_data())
       , pos(builder.unsafe_position())
       , cap(builder.unsafe_capacity())
-      , sb(&builder) {}
+      , sb(builder) {}
 
   // Write the local position back to the underlying string_builder.
   // Caller is responsible for invoking before the writer is dropped
   // (otherwise data is lost). Idempotent.
   simdjson_really_inline void sync() noexcept {
-    sb->unsafe_set_position(pos);
+    sb.unsafe_set_position(pos);
   }
 
   // Ensure at least `n` more bytes of free capacity. Grows the
@@ -80,14 +80,14 @@ struct writer {
     // Detect overflow.
     // This is pedantic except maybe on 32-bit targets.
     if (simdjson_unlikely(pos + n < pos)) return false;
-    sb->unsafe_set_position(pos);
+    sb.unsafe_set_position(pos);
     // even if 2*capacity overflows, the (std::max) below will pick the needed value,
     // so we do not need a separate overflow check here.
-    if (!sb->unsafe_grow((std::max)(cap * 2, pos + n))) {
+    if (!sb.unsafe_grow((std::max)(cap * 2, pos + n))) {
       return false;
     }
-    ptr = sb->unsafe_data();
-    cap = sb->unsafe_capacity();
+    ptr = sb.unsafe_data();
+    cap = sb.unsafe_capacity();
     return true;
   }
 };
@@ -100,10 +100,10 @@ struct writer {
 template <class F>
 simdjson_really_inline void call_through_string_builder(writer &w, F &&f) noexcept {
   w.sync();
-  f(*w.sb);
-  w.ptr = w.sb->unsafe_data();
-  w.pos = w.sb->unsafe_position();
-  w.cap = w.sb->unsafe_capacity();
+  f(w.sb);
+  w.ptr = w.sb.unsafe_data();
+  w.pos = w.sb.unsafe_position();
+  w.cap = w.sb.unsafe_capacity();
 }
 
 template <class T>


### PR DESCRIPTION
This is a minor change over @FranciscoThiesen's recent PR, replacing the pointer member with a reference.

In this context, the reference seems a better fit.

(Performance won't be affected, or should not be affected.)
