### PR TITLE
Require physical padding for padded string views

### DIFF
--- a/include/simdjson/padded_string_view-inl.h
+++ b/include/simdjson/padded_string_view-inl.h
@@ -45,19 +45,7 @@ inline padded_string_view::padded_string_view(std::string_view s, size_t capacit
 }
 
 inline bool padded_string_view::has_sufficient_padding() const noexcept {
-  if (padding() >= SIMDJSON_PADDING) {
-    return true;
-  }
-  size_t missing_padding = SIMDJSON_PADDING - padding();
-  if(length() < missing_padding) { return false; }
-
-  for (size_t i = length() - missing_padding; i < length(); i++) {
-    char c = data()[i];
-    if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
-      return false;
-    }
-  }
-  return true;
+  return padding() >= SIMDJSON_PADDING;
 }
 
 inline size_t padded_string_view::capacity() const noexcept { return _capacity; }
@@ -94,7 +82,7 @@ inline padded_string_view pad(std::string& s) noexcept {
     s.append(needed_padding, ' ');
   }
 
-  return padded_string_view(s.data(), s.size() - needed_padding, s.size());
+  return padded_string_view(s.data(), s.size() - SIMDJSON_PADDING, s.size());
 }
 
 inline padded_string_view pad_with_reserve(std::string& s) noexcept {

--- a/tests/ondemand/ondemand_parse_api_tests.cpp
+++ b/tests/ondemand/ondemand_parse_api_tests.cpp
@@ -1,6 +1,13 @@
 #include "simdjson.h"
 #include "test_ondemand.h"
 
+#include <cstring>
+
+#if SIMDJSON_HAS_UNISTD_H
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
 using namespace simdjson;
 
 namespace parse_api_tests {
@@ -161,6 +168,58 @@ namespace parse_api_tests {
     TEST_SUCCEED();
   }
 
+  bool parser_iterate_trailing_whitespace_is_not_padding() {
+    TEST_START();
+
+    {
+      std::string json = "{}";
+      json.append(SIMDJSON_PADDING, ' ');
+      padded_string_view padded = pad(json);
+      ASSERT_EQUAL(padded.length(), 2);
+      ASSERT_EQUAL(padded.padding(), SIMDJSON_PADDING);
+      ondemand::parser parser;
+      ASSERT_SUCCESS(parser.iterate(padded));
+    }
+
+#if SIMDJSON_HAS_UNISTD_H
+    long page = sysconf(_SC_PAGESIZE);
+    if (page <= 0) {
+      std::cout << "Warning: could not get page size; skipping guard-page test." << std::endl;
+      TEST_SUCCEED();
+    }
+
+    char *region = static_cast<char *>(
+        mmap(nullptr, static_cast<size_t>(page) * 2, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (region == MAP_FAILED) {
+      std::cout << "Warning: mmap failed; skipping guard-page test." << std::endl;
+      TEST_SUCCEED();
+    }
+    if (mprotect(region + page, static_cast<size_t>(page), PROT_NONE) != 0) {
+      munmap(region, static_cast<size_t>(page) * 2);
+      std::cout << "Warning: mprotect failed; skipping guard-page test." << std::endl;
+      TEST_SUCCEED();
+    }
+
+    const size_t len = 2 + SIMDJSON_PADDING;
+    char *buf = region + page - static_cast<long>(len);
+    std::memcpy(buf, "{}", 2);
+    std::memset(buf + 2, ' ', SIMDJSON_PADDING);
+
+    padded_string_view unpadded(buf, len, len);
+    ASSERT_EQUAL(unpadded.padding(), 0);
+    ASSERT_EQUAL(unpadded.has_sufficient_padding(), false);
+
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_ERROR(parser.iterate(buf, len, len).get(doc), INSUFFICIENT_PADDING);
+
+    munmap(region, static_cast<size_t>(page) * 2);
+#endif
+
+    TEST_SUCCEED();
+  }
+
 #if SIMDJSON_EXCEPTIONS
   bool parser_iterate_exception() {
     TEST_START();
@@ -270,6 +329,7 @@ namespace parse_api_tests {
            parser_iterate_padded() &&
            parser_iterate_padded_string_view() &&
            parser_iterate_insufficient_padding() &&
+           parser_iterate_trailing_whitespace_is_not_padding() &&
 #if SIMDJSON_EXCEPTIONS
            parser_document_reuse() &&
            parser_iterate_exception() &&


### PR DESCRIPTION
`padded_string_view::has_sufficient_padding()` currently treats trailing JSON whitespace inside the view as if it were physical padding after the view. That can make checked overloads such as `ondemand::parser::iterate(buf, len, len)` accept an input with `capacity == length` when the last 64 logical bytes are whitespace.

That is not safe for the On Demand iterator. If the buffer ends at a page boundary, the parser can return `SUCCESS`, then a later access can read into the next unmapped page.

This change makes `has_sufficient_padding()` require actual capacity beyond `length()`. It also updates `pad(std::string&)` so the returned view always excludes the full `SIMDJSON_PADDING` bytes from the logical length, including whitespace that was already present in the input string.

Added a regression test that maps two pages, protects the second page, places `{}` plus 64 trailing spaces at the end of the first page, and verifies that `iterate(buf, len, len)` returns `INSUFFICIENT_PADDING` instead of accepting the view.

Local checks:

```text
ninja -C build_asan ondemand_parse_api_tests
build_asan/tests/ondemand/ondemand_parse_api_tests

ninja -C build_asan ondemand_document_stream_tests ondemand_iterate_many_csv
build_asan/tests/ondemand/ondemand_document_stream_tests
build_asan/tests/ondemand/ondemand_iterate_many_csv

ninja -C build_asan padded_string_tests
build_asan/tests/padded_string_tests
```

All were run on an ASan/UBSan build.
