### PR TITLE
Harden parser allocation sizing overflow checks

### DIFF
--- a/include/simdjson/dom/document-inl.h
+++ b/include/simdjson/dom/document-inl.h
@@ -6,6 +6,7 @@
 #include "simdjson/dom/base.h"
 #include "simdjson/dom/document.h"
 #include "simdjson/dom/element-inl.h"
+#include "simdjson/internal/dom_parser_implementation.h"
 #include "simdjson/internal/tape_ref-inl.h"
 #include "simdjson/internal/jsonformatutils.h"
 
@@ -42,16 +43,20 @@ inline error_code document::allocate(size_t capacity) noexcept {
   // worse with "[7,7,7,7,6,7,7,7,6,7,7,6,[7,7,7,7,6,7,7,7,6,7,7,6,7,7,7,7,7,7,6"
   //where capacity + 1 tape elements are
   // generated, see issue https://github.com/simdjson/simdjson/issues/345
-  if(capacity + 3 < capacity) {
+  size_t tape_capacity_unrounded;
+  if(internal::add_overflow(capacity, size_t(3), tape_capacity_unrounded)) {
     return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
   }
-  size_t tape_capacity = SIMDJSON_ROUNDUP_N(capacity + 3, 64);
+  size_t tape_capacity;
+  if(internal::roundup_64_overflow(tape_capacity_unrounded, tape_capacity)) {
+    return CAPACITY;
+  }
   // a document with only zero-length strings... could have capacity/3 string
   // and we would need capacity/3 * 5 bytes on the string buffer
-  if(5 * (capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
+  size_t string_capacity;
+  if(internal::dom_string_capacity(capacity, string_capacity)) {
     return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
   }
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (capacity / 3) + SIMDJSON_PADDING, 64);
   string_buf.reset( new (std::nothrow) uint8_t[string_capacity]);
   tape.reset(new (std::nothrow) uint64_t[tape_capacity]);
   if(!(string_buf && tape)) {

--- a/include/simdjson/generic/dom_parser_implementation.h
+++ b/include/simdjson/generic/dom_parser_implementation.h
@@ -63,11 +63,14 @@ inline dom_parser_implementation &dom_parser_implementation::operator=(dom_parse
 inline simdjson_warn_unused error_code dom_parser_implementation::set_capacity(size_t capacity) noexcept {
   if(capacity > SIMDJSON_MAXSIZE_BYTES) { return CAPACITY; }
   // Stage 1 index output
-  size_t rounded_capacity = SIMDJSON_ROUNDUP_N(capacity, 64);
-  if(rounded_capacity + 9 < rounded_capacity) {
+  size_t rounded_capacity;
+  if(internal::roundup_64_overflow(capacity, rounded_capacity)) {
     return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
   }
-  size_t max_structures = rounded_capacity + 9;
+  size_t max_structures;
+  if(internal::add_overflow(rounded_capacity, size_t(9), max_structures)) {
+    return CAPACITY;
+  }
   structural_indexes.reset( new (std::nothrow) uint32_t[max_structures] );
   if (!structural_indexes) { _capacity = 0; return MEMALLOC; }
   structural_indexes[0] = 0;

--- a/include/simdjson/generic/ondemand/parser-inl.h
+++ b/include/simdjson/generic/ondemand/parser-inl.h
@@ -23,14 +23,15 @@ simdjson_inline parser::parser(size_t max_capacity) noexcept
 
 simdjson_warn_unused simdjson_inline error_code parser::allocate(size_t new_capacity, size_t new_max_depth) noexcept {
   if (new_capacity > max_capacity()) { return CAPACITY; }
+  if (new_capacity > SIMDJSON_MAXSIZE_BYTES) { return CAPACITY; }
   if (string_buf && new_capacity == capacity() && new_max_depth == max_depth()) { return SUCCESS; }
 
   // string_capacity copied from document::allocate
   _capacity = 0;
-  if(5 * (new_capacity / 3) + SIMDJSON_PADDING < SIMDJSON_PADDING) {
+  size_t string_capacity;
+  if(internal::dom_string_capacity(new_capacity, string_capacity)) {
     return CAPACITY; // overflow, only happen on legacy 32-bit systems with very large capacity
   }
-  size_t string_capacity = SIMDJSON_ROUNDUP_N(5 * (new_capacity / 3) + SIMDJSON_PADDING, 64);
   string_buf.reset(new (std::nothrow) uint8_t[string_capacity]);
 #if SIMDJSON_DEVELOPMENT_CHECKS
   start_positions.reset(new (std::nothrow) token_position[new_max_depth]);

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -3,6 +3,7 @@
 
 #include "simdjson/base.h"
 #include "simdjson/error.h"
+#include <limits>
 #include <memory>
 
 namespace simdjson {
@@ -37,6 +38,43 @@ inline bool is_streaming(stage1_mode mode) {
 }
 
 namespace internal {
+
+simdjson_inline bool add_overflow(size_t a, size_t b, size_t &out) noexcept {
+  if (a > (std::numeric_limits<size_t>::max)() - b) {
+    return true;
+  }
+  out = a + b;
+  return false;
+}
+
+simdjson_inline bool multiply_overflow(size_t a, size_t b, size_t &out) noexcept {
+  if (a != 0 && b > (std::numeric_limits<size_t>::max)() / a) {
+    return true;
+  }
+  out = a * b;
+  return false;
+}
+
+simdjson_inline bool roundup_64_overflow(size_t value, size_t &out) noexcept {
+  size_t rounded;
+  if (add_overflow(value, size_t(63), rounded)) {
+    return true;
+  }
+  out = rounded & ~size_t(63);
+  return false;
+}
+
+simdjson_inline bool dom_string_capacity(size_t capacity, size_t &string_capacity) noexcept {
+  size_t max_strings;
+  if (multiply_overflow(capacity / 3, size_t(5), max_strings)) {
+    return true;
+  }
+  size_t padded_capacity;
+  if (add_overflow(max_strings, SIMDJSON_PADDING, padded_capacity)) {
+    return true;
+  }
+  return roundup_64_overflow(padded_capacity, string_capacity);
+}
 
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_cpp_test(padded_string_tests LABELS other acceptance                   )
 add_cpp_test(memory_map_tests    LABELS other acceptance                   )
 add_cpp_test(prettify_tests      LABELS other acceptance per_implementation)
 add_cpp_test(fractured_json_tests LABELS other acceptance per_implementation)
+add_cpp_test(arithmetic_overflow_tests LABELS other acceptance)
 
 if(WIN32 AND BUILD_SHARED_LIBS)
   # Copy the simdjson dll into the tests directory

--- a/tests/arithmetic_overflow_tests.cpp
+++ b/tests/arithmetic_overflow_tests.cpp
@@ -1,0 +1,95 @@
+#include "simdjson.h"
+#include "test_macros.h"
+#include "test_main.h"
+
+#include <limits>
+
+namespace arithmetic_overflow_tests {
+
+using simdjson::internal::add_overflow;
+using simdjson::internal::dom_string_capacity;
+using simdjson::internal::multiply_overflow;
+using simdjson::internal::roundup_64_overflow;
+
+bool helper_add_overflow_boundaries() {
+  TEST_START();
+  size_t out = 0;
+  ASSERT_FALSE(add_overflow(size_t(10), size_t(20), out));
+  ASSERT_EQUAL(out, size_t(30));
+
+  const size_t max = (std::numeric_limits<size_t>::max)();
+  ASSERT_FALSE(add_overflow(max - size_t(3), size_t(3), out));
+  ASSERT_EQUAL(out, max);
+  ASSERT_TRUE(add_overflow(max - size_t(2), size_t(3), out));
+  TEST_SUCCEED();
+}
+
+bool helper_multiply_overflow_boundaries() {
+  TEST_START();
+  size_t out = 0;
+  ASSERT_FALSE(multiply_overflow(size_t(123), size_t(456), out));
+  ASSERT_EQUAL(out, size_t(56088));
+
+  const size_t max = (std::numeric_limits<size_t>::max)();
+  ASSERT_FALSE(multiply_overflow(max / size_t(5), size_t(5), out));
+  ASSERT_EQUAL(out, (max / size_t(5)) * size_t(5));
+  ASSERT_TRUE(multiply_overflow((max / size_t(5)) + size_t(1), size_t(5), out));
+  TEST_SUCCEED();
+}
+
+bool helper_roundup_overflow_and_compatibility() {
+  TEST_START();
+  size_t out = 0;
+
+  // Safe boundary and exact compatibility with the historical formula.
+  const size_t safe_boundary = (std::numeric_limits<size_t>::max)() - size_t(63);
+  ASSERT_FALSE(roundup_64_overflow(safe_boundary, out));
+  ASSERT_EQUAL(out, safe_boundary);
+
+  // Overflow boundary: this was previously wrapped by unsigned arithmetic.
+  ASSERT_TRUE(roundup_64_overflow(safe_boundary + size_t(1), out));
+
+  // Prove old expression would wrap for this input.
+  const size_t old_wrapped = (safe_boundary + size_t(1) + size_t(63)) & ~size_t(63);
+  ASSERT_EQUAL(old_wrapped, size_t(0));
+  TEST_SUCCEED();
+}
+
+bool helper_dom_string_capacity_boundaries() {
+  TEST_START();
+  size_t out = 0;
+
+  // Preserves historical formula when safe.
+  const size_t safe_cap = size_t(1024);
+  ASSERT_FALSE(dom_string_capacity(safe_cap, out));
+  const size_t expected = ((size_t(5) * (safe_cap / size_t(3)) + simdjson::SIMDJSON_PADDING + size_t(63)) & ~size_t(63));
+  ASSERT_EQUAL(out, expected);
+
+  // Exact overflow boundary:
+  // dom_string_capacity computes roundup_64(5 * (capacity / 3) + SIMDJSON_PADDING).
+  // Let q = capacity / 3. For the rounded value to stay in range:
+  //   5*q + SIMDJSON_PADDING + 63 <= SIZE_MAX
+  // so:
+  //   q <= floor((SIZE_MAX - SIMDJSON_PADDING - 63) / 5)
+  const size_t max = (std::numeric_limits<size_t>::max)();
+  const size_t qmax = (max - simdjson::SIMDJSON_PADDING - size_t(63)) / size_t(5);
+  const size_t largest_safe_capacity = qmax * size_t(3) + size_t(2);
+  const size_t first_overflow_capacity = largest_safe_capacity + size_t(1);
+
+  ASSERT_FALSE(dom_string_capacity(largest_safe_capacity, out));
+  ASSERT_TRUE(dom_string_capacity(first_overflow_capacity, out));
+  TEST_SUCCEED();
+}
+
+bool run() {
+  return helper_add_overflow_boundaries() &&
+         helper_multiply_overflow_boundaries() &&
+         helper_roundup_overflow_and_compatibility() &&
+         helper_dom_string_capacity_boundaries();
+}
+
+} // namespace arithmetic_overflow_tests
+
+int main(int argc, char *argv[]) {
+  return test_main(argc, argv, arithmetic_overflow_tests::run);
+}

--- a/tests/ondemand/ondemand_parse_api_tests.cpp
+++ b/tests/ondemand/ondemand_parse_api_tests.cpp
@@ -1,6 +1,8 @@
 #include "simdjson.h"
 #include "test_ondemand.h"
 
+#include <limits>
+
 using namespace simdjson;
 
 namespace parse_api_tests {
@@ -161,6 +163,25 @@ namespace parse_api_tests {
     TEST_SUCCEED();
   }
 
+  bool parser_allocate_rejects_internal_capacity_overflow() {
+    TEST_START();
+    ondemand::parser parser((std::numeric_limits<size_t>::max)());
+    ASSERT_ERROR(parser.allocate((std::numeric_limits<size_t>::max)()), CAPACITY);
+    ASSERT_EQUAL(parser.capacity(), 0);
+    TEST_SUCCEED();
+  }
+
+  bool parser_allocate_rejects_above_maxsize_before_growth() {
+    TEST_START();
+    // This targets the fail-order bug: capacities above SIMDJSON_MAXSIZE_BYTES
+    // must be rejected up front, independent of caller-supplied max_capacity.
+    ondemand::parser parser((std::numeric_limits<size_t>::max)());
+    const size_t invalid_capacity = simdjson::SIMDJSON_MAXSIZE_BYTES + size_t(1);
+    ASSERT_ERROR(parser.allocate(invalid_capacity), CAPACITY);
+    ASSERT_EQUAL(parser.capacity(), 0);
+    TEST_SUCCEED();
+  }
+
 #if SIMDJSON_EXCEPTIONS
   bool parser_iterate_exception() {
     TEST_START();
@@ -270,6 +291,8 @@ namespace parse_api_tests {
            parser_iterate_padded() &&
            parser_iterate_padded_string_view() &&
            parser_iterate_insufficient_padding() &&
+           parser_allocate_rejects_internal_capacity_overflow() &&
+           parser_allocate_rejects_above_maxsize_before_growth() &&
 #if SIMDJSON_EXCEPTIONS
            parser_document_reuse() &&
            parser_iterate_exception() &&


### PR DESCRIPTION
Description

* Centralized checked `size_t` arithmetic used by DOM and ondemand allocation sizing paths to prevent wrapped intermediate values during roundup/add/multiply calculations.
* Added early rejection for ondemand capacities above `SIMDJSON_MAXSIZE_BYTES` before internal buffer growth, and added regression tests covering overflow boundaries and fail-order behavior.
* No related issue linked.

Type of change

* [x] Bug fix
* [ ] Optimization
* [ ] New feature
* [ ] Refactor / cleanup
* [ ] Documentation / tests
* [ ] Other (please describe):

How to verify / test

```bash
cmake --build build --config Release

ctest --test-dir build -R arithmetic_overflow_tests --output-on-failure

ctest --test-dir build -R ondemand_parse_api_tests --output-on-failure

ctest --test-dir build -R document_tests --output-on-failure

ctest --test-dir build -R padded_string_tests --output-on-failure

git diff --check
```

Checklist 

* [x] I added/updated tests covering my change (if applicable)
* [x] Code builds locally and passes my check
* [ ] Documentation / README updated if needed
* [x] Commits are atomic and messages are clear
* [ ] I linked the related issue (if applicable)