### PR TITLE
docs: exception-free API guide and HACKING.md in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Usage documentation is available:
   how you can work with it.
 * [API](https://simdjson.github.io/simdjson/) contains the automatically generated API documentation.
 * [Compile-Time Parsing](doc/compile_time.md) presents our compile-time parsing function (C++26 only).
+* [HACKING.md](HACKING.md) is a guide for contributors (building, testing, and project layout).
 
 
 Godbolt

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -2253,6 +2253,49 @@ The simdjson can be build with exceptions entirely disabled. It checks the `__cp
 target_compile_definitions(simdjson PUBLIC SIMDJSON_EXCEPTIONS=OFF)
 ```
 
+#### API when exceptions are disabled
+
+When `SIMDJSON_EXCEPTIONS` is off, simdjson APIs return a `simdjson_result<T>`
+instead of throwing. You must check errors explicitly; implicit conversions to
+`T` that would throw in exception mode are not available.
+
+**On-Demand API (recommended):**
+
+```cpp
+simdjson::ondemand::parser parser;
+simdjson::padded_string json = simdjson::padded_string::load("twitter.json");
+simdjson::ondemand::document doc;
+auto error = parser.iterate(json).get(doc);
+if (error) { std::cerr << error << std::endl; return EXIT_FAILURE; }
+
+uint64_t identifier{};
+error = doc["statuses"].at(0)["id"].get(identifier);
+if (error) {
+  std::cerr << error << " near " << doc.current_location() << std::endl;
+  return EXIT_FAILURE;
+}
+```
+
+You can also chain operations and check once at the end, or use
+`if (auto x = doc["key"]; x.error()) { ... }` as described in
+[Error handling examples without exceptions](#error-handling-examples-without-exceptions).
+
+**DOM API:**
+
+```cpp
+simdjson::dom::parser parser;
+simdjson::dom::element doc;
+auto error = parser.load("twitter.json").get(doc);
+if (error) { return EXIT_FAILURE; }
+
+uint64_t identifier{};
+error = doc["statuses"].at(0)["id"].get(identifier);
+if (error) { return EXIT_FAILURE; }
+```
+
+See also the [DOM documentation](dom.md#error-handling) and the
+[Godbolt examples without exceptions](https://godbolt.org/z/e9dWb9E4v).
+
 ### Exceptions
 
 Users more comfortable with an exception flow may choose to directly cast the `simdjson_result<T>` to the desired type:


### PR DESCRIPTION
## Summary

- **#709**: Expands `doc/basics.md` under *Disabling exceptions* with On-Demand and DOM examples using `simdjson_result<T>` and explicit `.get()` / error checks when `SIMDJSON_EXCEPTIONS` is off.
- **#801**: Adds [HACKING.md](HACKING.md) to the README documentation list for contributors.

## Test plan

- [x] Documentation-only; examples match existing error-handling sections and Godbolt links.