### PR TITLE
docs: use HTTPS for Boost license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ This code is made available under the [Apache License 2.0](https://www.apache.or
 
 Under Windows, we build some tools using the windows/dirent_portable.h file (which is outside our library code): it is under the liberal (business-friendly) MIT license.
 
-For compilers that do not support [C++17](https://en.wikipedia.org/wiki/C%2B%2B17), we bundle the string-view library which is published under the [Boost license](http://www.boost.org/LICENSE_1_0.txt). Like the Apache license, the Boost license is a permissive license allowing commercial redistribution.
+For compilers that do not support [C++17](https://en.wikipedia.org/wiki/C%2B%2B17), we bundle the string-view library which is published under the [Boost license](https://www.boost.org/LICENSE_1_0.txt). Like the Apache license, the Boost license is a permissive license allowing commercial redistribution.
 
 For efficient number serialization, we bundle Florian Loitsch's implementation of the Grisu2 algorithm for binary to decimal floating-point numbers. The implementation was slightly modified by JSON for Modern C++ library. Both Florian Loitsch's implementation and JSON for Modern C++ are provided under the MIT license.
 


### PR DESCRIPTION
## Summary
- Update the bundled string-view Boost license URL to `https://www.boost.org/LICENSE_1_0.txt`.

## Test plan
- [ ] README renders correctly on GitHub