### PR TITLE
bound zero-skip loop to end in parse_decimal

### DIFF
--- a/src/from_chars.cpp
+++ b/src/from_chars.cpp
@@ -172,7 +172,7 @@ decimal parse_decimal(const char *&p, const char * end) noexcept {
     // if we have not yet encountered a zero, we have to skip it as well
     if (answer.num_digits == 0) {
       // skip zeros
-      while (*p == '0') {
+      while ((p != end) && (*p == '0')) {
         ++p;
       }
     }


### PR DESCRIPTION
The bounded parse_decimal skips fraction-leading zeros without a `p != end` guard, so a value like `0.000` whose zeros reach end reads one byte past it.