### PR TITLE
docs: thread safety in HACKING.md and ondemand::parser

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -9,6 +9,7 @@ If you plan to contribute to simdjson, please read our [CONTRIBUTING](https://gi
 - [Hacking simdjson](#hacking-simdjson)
   - [Build Quickstart](#build-quickstart)
   - [Design notes](#design-notes)
+  - [Thread safety](#thread-safety)
   - [Developer mode](#developer-mode)
   - [Directory Structure and Source](#directory-structure-and-source)
   - [Runtime Dispatching](#runtime-dispatching)
@@ -16,6 +17,24 @@ If you plan to contribute to simdjson, please read our [CONTRIBUTING](https://gi
   - [Usage (CMake on 64-bit platforms like Linux, FreeBSD or macOS)](#usage-cmake-on-64-bit-platforms-like-linux-freebsd-or-macos)
   - [Usage (CMake on 64-bit Windows using Visual Studio 2019 or better)](#usage-cmake-on-64-bit-windows-using-visual-studio-2019-or-better)
   - [Various References](#various-references)
+
+Thread safety
+-------------
+
+Simdjson is intended for multi-threaded programs when a few rules are followed.
+The full user-facing guide is in [Thread safety](doc/basics.md#thread-safety)
+in `doc/basics.md`. In short:
+
+- Use one `ondemand::parser` (or `dom::parser`) per thread; documents and field
+  iterators are not thread-safe because they advance internal state.
+- `iterate_many` / `parse_many` may use an internal worker thread when the
+  library is built with thread support (`SIMDJSON_THREADS_ENABLED`).
+- Runtime CPU dispatch runs once and is thread-safe; avoid using the library
+  from other threads while the main thread is shutting down (see `quick_exit`
+  note in the basics doc).
+
+When adding mutable state to on-demand values (for example array/object
+iterators), document whether callers must serialize access.
 
 Build Quickstart
 ------------------------------

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -33,6 +33,9 @@ static constexpr size_t MINIMAL_BATCH_SIZE = 32;
  * A JSON fragment iterator.
  *
  * This holds the actual iterator as well as the buffer for writing strings.
+ *
+ * @note Not thread-safe: use one parser (and its documents) per thread. CPU
+ *       dispatch is thread-safe. See doc/basics.md#thread-safety.
  */
 class parser {
 public:


### PR DESCRIPTION
## Summary

- **#681**: Adds a *Thread safety* section to `HACKING.md` with a link to the existing user guide in `doc/basics.md#thread-safety`.
- Documents `ondemand::parser` as not thread-safe in the class Doxygen comment (aligned with the existing `dom::parser` note).

## Test plan

- [x] Documentation and comment-only change

Made with [Cursor](https://cursor.com)