### PR TITLE
docs: clarify raw_json() consumption and rewind option

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -3012,8 +3012,10 @@ simdjson::ondemand::array arr = doc.get_array();
 string_view token = arr.raw_json(); // gives you `[1,2,3]`
 ```
 
-Because `raw_json()` consumes to object or the array, if you want to both have
-access to the raw string, and also use the array or object, you should call `reset()`.
+Because `raw_json()` consumes the object or the array, if you want both the raw
+substring and later field access on the same instance, call `reset()` on that
+object or array (as below). To re-parse the whole document from the start,
+use `document::rewind()` instead (see [Rewinding](#rewinding)).
 
 ```cpp
 simdjson::ondemand::parser parser;
@@ -3021,7 +3023,7 @@ simdjson::padded_string docdata =  R"({"value":123})"_padded;
 simdjson::ondemand::document doc = parser.iterate(docdata);
 simdjson::ondemand::object obj = doc.get_object();
 string_view token = obj.raw_json(); // gives you `{"value":123}`
-obj.reset(); // revise the object
+obj.reset(); // re-open the same object for further iteration
 uint64_t x = obj["value"]; // gives me 123
 ```
 


### PR DESCRIPTION
## Summary

The On-Demand guide already documents `raw_json()`; this clarifies that the call **consumes** the current object/array and points readers to `reset()` or `document::rewind()` when they need to iterate again.

Related to #1943 (does not change API behavior).

## Test plan

- [x] Documentation-only

Made with [Cursor](https://cursor.com)