### PR TITLE
docs: use HTTPS for arXiv and JSON Lines links

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -2494,7 +2494,7 @@ write out multiple records as independent JSON documents, to be read one-by-one.
 
 The simdjson library also supports multithreaded JSON streaming through a large file
 containing many smaller JSON documents in either [ndjson](https://github.com/ndjson/ndjson-spec)
-or [JSON lines](http://jsonlines.org) format. If your JSON documents all contain arrays
+or [JSON lines](https://jsonlines.org) format. If your JSON documents all contain arrays
 or objects, we even support direct file concatenation without whitespace. However, if there
 is content between your JSON documents, it should be exclusively ASCII white-space characters.
 
@@ -3570,4 +3570,4 @@ Further reading
 --------
 
 
-- John Keiser, Daniel Lemire, [On-Demand JSON: A Better Way to Parse Documents?](http://arxiv.org/abs/2312.17149), Software: Practice and Experience 54 (6), 2024
+- John Keiser, Daniel Lemire, [On-Demand JSON: A Better Way to Parse Documents?](https://arxiv.org/abs/2312.17149), Software: Practice and Experience 54 (6), 2024

--- a/doc/iterate_many.md
+++ b/doc/iterate_many.md
@@ -133,7 +133,7 @@ E.g., `[1,2]{"32":1}` is recognized as two documents.
 
 Some official formats **(non-exhaustive list)**:
 - [Newline-Delimited JSON (NDJSON)](https://github.com/ndjson/ndjson-spec/)
-- [JSON lines (JSONL)](http://jsonlines.org/)
+- [JSON lines (JSONL)](https://jsonlines.org/)
 - [Record separator-delimited JSON (RFC 7464)](https://tools.ietf.org/html/rfc7464)
 - [More on Wikipedia...](https://en.wikipedia.org/wiki/JSON_streaming)
 
@@ -238,7 +238,7 @@ ondemand::document doc = parser.iterate(view); // parse the JSON
 
 ## Use cases
 
-From [jsonlines.org](http://jsonlines.org/examples/):
+From [jsonlines.org](https://jsonlines.org/examples/):
 
 - **Better than CSV**
     ```json

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -132,7 +132,7 @@ Whitespace Characters:
 
 Some official formats **(non-exhaustive list)**:
 - [Newline-Delimited JSON (NDJSON)](https://github.com/ndjson/ndjson-spec)
-- [JSON lines (JSONL)](http://jsonlines.org/)
+- [JSON lines (JSONL)](https://jsonlines.org/)
 - [Record separator-delimited JSON (RFC 7464)](https://tools.ietf.org/html/rfc7464)
 - [More on Wikipedia...](https://en.wikipedia.org/wiki/JSON_streaming)
 
@@ -143,7 +143,7 @@ See [basics.md](basics.md#newline-delimited-json-ndjson-and-json-lines) for an o
 
 ## Use cases
 
-From [jsonlines.org](http://jsonlines.org/examples/):
+From [jsonlines.org](https://jsonlines.org/examples/):
 
 - **Better than CSV**
     ```json


### PR DESCRIPTION
## Summary

Updates external documentation links from `http://` to `https://` in:

- `doc/basics.md` (arXiv reference + JSON Lines)
- `doc/parse_many.md`
- `doc/iterate_many.md`

## Test plan

- [x] Documentation only

Made with [Cursor](https://cursor.com)