### PR TITLE
docs: expand DOM ranges example and README doc links (#1826, #1943)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ to parse JSON 4x  faster than RapidJSON and 25x faster than JSON for Modern C++.
 * **Easy:** First-class, easy to use and carefully documented APIs.
 * **Strict:** Full JSON and UTF-8 validation, lossless parsing. Performance with no compromises.
 * **Automatic:** Selects a CPU-tailored parser at runtime. No configuration needed.
+* **Thread-aware:** Documented concurrency model; see [thread safety](doc/basics.md#thread-safety) (use one parser per thread).
 * **Reliable:** From memory allocation to error handling, simdjson's design avoids surprises.
 * **Peer Reviewed:** Our research appears in venues like VLDB Journal, Software: Practice and Experience.
 
@@ -120,6 +121,10 @@ Usage documentation is available:
   how you can work with it.
 * [API](https://simdjson.github.io/simdjson/) contains the automatically generated API documentation.
 * [Compile-Time Parsing](doc/compile_time.md) presents our compile-time parsing function (C++26 only).
+* [Thread safety](doc/basics.md#thread-safety) summarizes which APIs are safe to use from multiple threads.
+* [HACKING.md](HACKING.md) is a guide for contributors (building, testing, and project layout).
+* [C++20 ranges (DOM)](doc/dom.md#c20-support) and [On-Demand ranges](doc/basics.md#c20-ranges-support) show range adaptor usage.
+* [Raw JSON access](doc/basics.md#raw-json-string-for-objects-and-arrays) explains `raw_json()` / `raw_json_token()`.
 
 
 Godbolt

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -322,18 +322,28 @@ for (dom::key_value_pair field : object) {
 C++20 Support
 ------------
 
-simdjson library also supports some C++20 feature including `std::ranges`:
+simdjson supports `std::ranges` with the DOM API. You can pipe a `dom::array` into
+range adaptors such as `std::views::transform`. For the On-Demand API, see
+[C++20 Ranges Support](basics.md#c20-ranges-support) in the basics guide.
 
 ```cpp
-auto cars_json = R"( [
+#include "simdjson.h"
+#include <iostream>
+#include <ranges>
+
+using namespace simdjson;
+
+int main() {
+  auto cars_json = R"( [
   { "make": "Toyota", "model": "Camry",  "year": 2018, "tire_pressure": [ 40.1, 39.9, 37.7, 40.4 ] },
   { "make": "Kia",    "model": "Soul",   "year": 2012, "tire_pressure": [ 30.1, 31.0, 28.6, 28.7 ] },
   { "make": "Toyota", "model": "Tercel", "year": 1999, "tire_pressure": [ 29.8, 30.0, 30.2, 30.5 ] }
 ] )"_padded;
-dom::parser parser;
-auto justmodel = [](auto car) { return car["model"]; };
-for (auto car : parser.parse(cars_json).get_array() | std::views::transform(justmodel)) {
-  std::cout << car << std::endl;
+  dom::parser parser;
+  auto justmodel = [](auto car) { return car["model"]; };
+  for (auto car : parser.parse(cars_json).get_array() | std::views::transform(justmodel)) {
+    std::cout << car << std::endl;
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
- Expands the DOM `std::ranges` example in `doc/dom.md` into a complete, copy-pastable program (Fixes #1826)
- Cross-links the existing On-Demand ranges section in `doc/basics.md`
- Adds README documentation index links for C++20 ranges and raw JSON access (Related to #1943)

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)