### PR TITLE
docs: document On-Demand depth model (#1533)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Usage documentation is available:
   how you can work with it.
 * [API](https://simdjson.github.io/simdjson/) contains the automatically generated API documentation.
 * [Compile-Time Parsing](doc/compile_time.md) presents our compile-time parsing function (C++26 only).
+* [On-Demand design](doc/ondemand_design.md) walks through parsing logic including the depth model ([#1533](https://github.com/simdjson/simdjson/issues/1533)).
 
 
 Godbolt

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -354,6 +354,30 @@ We refer to "On-Demand" as a front-end component since it is an interface betwee
 low-level parsing functions and the user. It hides much of the complexity of parsing JSON
 documents.
 
+### Depth model
+
+On-Demand parsing tracks a **depth** counter as it walks the JSON text. Depth starts at
+**1** at the document root and increases when you enter an object or array (`{` or `[`),
+then decreases when that value is fully consumed (matching `}` or `]`). Field lookup,
+array iteration, and skipping all rely on this counter to know where the current value
+ends and whether nested content remains.
+
+Practical rules:
+
+* Entering an `ondemand::object` or `ondemand::array` (or casting to one) validates the
+  opening bracket and increases depth.
+* Finishing iteration, consuming a value, or skipping nested content decreases depth back
+  to the enclosing context.
+* When you skip a field or array element without using it, simdjson advances until depth
+  returns to the previous level—without fully validating unused inner values (see
+  [On-Demand design notes](ondemand_design.md)).
+* By default, documents with nesting depth above **1024** are rejected (see
+  [Standard compliance](#standard-compliance)).
+
+For a step-by-step walkthrough with depth annotations at each API call, see
+[On-Demand design notes](ondemand_design.md). Related: [#1533](https://github.com/simdjson/simdjson/issues/1533).
+
+
 ### Parser, document and JSON scope
 
 For code safety, you should keep (1) the `parser` instance, (2) the input string and (3) the document instance alive throughout your parsing. Additionally, you should follow the following rules:


### PR DESCRIPTION
## Summary
- Adds **Depth model** subsection to `doc/basics.md` explaining how On-Demand tracks nesting depth
- Links `doc/ondemand_design.md` from the README documentation index

Fixes #1533.

## Test plan
- [x] Markdown-only change

Made with [Cursor](https://cursor.com)