### PR TITLE
docs: link tape structure doc from README (Fixes #951)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Usage documentation is available:
   how you can work with it.
 * [API](https://simdjson.github.io/simdjson/) contains the automatically generated API documentation.
 * [Compile-Time Parsing](doc/compile_time.md) presents our compile-time parsing function (C++26 only).
+* [Tape structure](doc/tape.md) documents the internal DOM tape layout (developer reference; [#951](https://github.com/simdjson/simdjson/issues/951)).
 
 
 Godbolt


### PR DESCRIPTION
## Summary
Add a README entry pointing to `doc/tape.md`, which documents the internal DOM tape layout for contributors and advanced users.

Fixes #951

## Test plan
- [x] Docs-only change; link target `doc/tape.md` exists on `master`.

Made with [Cursor](https://cursor.com)