### PR TITLE
docs: cross-link tape structure doc from DOM and HACKING (#951)

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -204,7 +204,7 @@ Other important files and directories:
 * **test:** The tests are here. basictests.cpp and errortests.cpp are the primary ones.
 * **tools:** Source for executables that can be distributed with simdjson. Some examples:
   * `json2json mydoc.json` parses the document, constructs a model and then dumps back the result to standard output.
-  * `json2json -d mydoc.json` parses the document, constructs a model and then dumps model (as a tape) to standard output. The tape format is described in the accompanying file `tape.md`.
+  * `json2json -d mydoc.json` parses the document, constructs a model and then dumps model (as a tape) to standard output. The tape format is described in [doc/tape.md](doc/tape.md).
   * `minify mydoc.json` minifies the JSON document, outputting the result to standard output. Minifying means to remove the unneeded white space characters.
   * `jsonpointer mydoc.json <jsonpath> <jsonpath> ... <jsonpath>` parses the document, constructs a model and then processes a series of [JSON Pointer paths](https://tools.ietf.org/html/rfc6901). The result is itself a JSON document.
 

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -188,7 +188,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   `SIMDJSON_MINUS_ZERO_AS_FLOAT` to `1` when building simdjson, you can get that `-0` is mapped to `-0.0`
   as in JavaScript. You can get the desired effect by building simdjson with cmake setting the
   `SIMDJSON_MINUS_ZERO_AS_FLOAT` to on: `cmake -B build -D SIMDJSON_MINUS_ZERO_AS_FLOAT=ON`.
-* **Big Integer Support (opt-in):** By default, integers that exceed the 64-bit range cause parsing to fail with `BIGINT_ERROR`. You can opt in to big integer support so that these numbers are stored as raw digit strings on the tape instead:
+* **Big Integer Support (opt-in):** By default, integers that exceed the 64-bit range cause parsing to fail with `BIGINT_ERROR`. You can opt in to big integer support so that these numbers are stored as raw digit strings on the [internal DOM tape](tape.md) instead:
   ```cpp
   simdjson::dom::parser parser;
   parser.number_as_string(true); // opt-in, default false


### PR DESCRIPTION
## Summary
- Link `doc/tape.md` from the DOM big-integer section where values are stored on the tape.
- Fix the broken `tape.md` reference in `HACKING.md` to point at `doc/tape.md`.

Related to #951 (tape layout documentation discoverability).

## Test plan
- [x] Docs-only change; link targets exist on `master`.

Made with [Cursor](https://cursor.com)