### PR TITLE
docs: add documentation index under doc/ (#801)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,21 @@
+# simdjson documentation
+
+User-facing guides live in this directory. For building from source, testing, and internal layout, see [HACKING.md](../HACKING.md) ([#801](https://github.com/simdjson/simdjson/issues/801)).
+
+## Guides
+
+| Document | Description |
+|----------|-------------|
+| [basics.md](basics.md) | Getting started, parsing, On-Demand API, error handling |
+| [dom.md](dom.md) | DOM API (materialized JSON trees) |
+| [builder.md](builder.md) | JSON serialization / `string_builder` ([#1327](https://github.com/simdjson/simdjson/issues/1327)) |
+| [parse_many.md](parse_many.md) | NDJSON / JSON Lines (`parse_many`) |
+| [iterate_many.md](iterate_many.md) | Streaming iteration over many documents |
+| [performance.md](performance.md) | Tuning, `NDEBUG`, buffers, huge pages |
+| [implementation-selection.md](implementation-selection.md) | Runtime CPU dispatch |
+| [tape.md](tape.md) | DOM tape layout (developer-oriented) ([#951](https://github.com/simdjson/simdjson/issues/951)) |
+| [ondemand_design.md](ondemand_design.md) | On-Demand parsing model and depth ([#1533](https://github.com/simdjson/simdjson/issues/1533)) |
+| [compile_time.md](compile_time.md) | Compile-time parsing (C++26) |
+| [compile_time_accessors.md](compile_time_accessors.md) | Compile-time accessors |
+
+API reference: [simdjson.github.io/simdjson](https://simdjson.github.io/simdjson/).

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -3,6 +3,7 @@ The Basics
 
 
 An overview of what you need to know to use simdjson to parse JSON documents, with examples.
+See the [documentation index](README.md) for all guides, including [HACKING.md](../HACKING.md) for contributors ([#801](https://github.com/simdjson/simdjson/issues/801)).
 [Our documentation regarding the generation (serialization) of JSON documents is in a
 separate document](https://github.com/simdjson/simdjson/blob/master/doc/builder.md).
 


### PR DESCRIPTION
## Summary
- Add `doc/README.md` as a table of contents for user guides and contributor docs.
- Link from `doc/basics.md` to the index and [HACKING.md](../HACKING.md).

Addresses discoverability in #801 (HACKING.md as part of main documentation).

## Test plan
- [x] Docs-only change; all link targets exist on `master`.

Made with [Cursor](https://cursor.com)