### PR TITLE
docs: link README to doc/ documentation index (#801)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Documentation
 
 Usage documentation is available:
 
+* [Documentation index](doc/README.md) lists all guides in `doc/` ([#801](https://github.com/simdjson/simdjson/issues/801)).
 * [Basics](doc/basics.md) is an overview of how to use simdjson and its APIs.
 * [Builder](doc/builder.md) is an overview of how to efficiently write JSON strings using simdjson.
 * [Performance](doc/performance.md) shows some more advanced scenarios and how to tune for them.


### PR DESCRIPTION
## Summary
- Add `doc/README.md` to the README documentation list.

Complements #2756 (adds the index file under `doc/`). Merge either PR first; the other rebases cleanly.

## Test plan
- [x] Docs-only change.

Made with [Cursor](https://cursor.com)