### PR TITLE
docs: link implementation selection to performance guide

### DIFF
--- a/doc/implementation-selection.md
+++ b/doc/implementation-selection.md
@@ -18,6 +18,8 @@ much of its speed. Because these instruction sets work differently, simdjson has
 different version of the JSON parser for different CPU architectures, often with different
 algorithms to take better advantage of a given CPU!
 
+For tuning parser reuse, buffers, and release builds, see [performance.md](performance.md).
+
 The current implementations are:
 * icelake: AVX-512F, AVX-512_VBMI, AVX-512_VBMI2, AVX-512_DQ, AVX-512512_CD, AVX-512_BW, AVX-512_VL (2019 Intel Ice Lake, Intel Rocket Lake, Intel Sapphire Rapids, AMD Zen 4)
 * haswell: AVX2 (2013 Intel Haswell or later, all AMD Zen processors)


### PR DESCRIPTION
## Summary
Point readers at performance tuning from the CPU dispatch overview.

## Test plan
- [x] Docs-only change.

Made with [Cursor](https://cursor.com)