### PR TITLE
docs: add doc index and link from CONTRIBUTING (#801)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,7 @@ Getting Started Hacking
 
 An overview of simdjson's directory structure, with pointers to architecture and design
 considerations and other helpful notes, can be found at [HACKING.md](HACKING.md).
+User guides under `doc/` are listed in [doc/README.md](doc/README.md) ([#801](https://github.com/simdjson/simdjson/issues/801)).
 
 
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,21 @@
+# simdjson documentation
+
+User-facing guides live in this directory. For building from source, testing, and internal layout, see [HACKING.md](../HACKING.md) ([#801](https://github.com/simdjson/simdjson/issues/801)).
+
+## Guides
+
+| Document | Description |
+|----------|-------------|
+| [basics.md](basics.md) | Getting started, parsing, On-Demand API, error handling |
+| [dom.md](dom.md) | DOM API (materialized JSON trees) |
+| [builder.md](builder.md) | JSON serialization ([#1327](https://github.com/simdjson/simdjson/issues/1327)) |
+| [parse_many.md](parse_many.md) | NDJSON / JSON Lines |
+| [iterate_many.md](iterate_many.md) | Streaming iteration over many documents |
+| [performance.md](performance.md) | Tuning and `NDEBUG` |
+| [implementation-selection.md](implementation-selection.md) | Runtime CPU dispatch |
+| [tape.md](tape.md) | DOM tape layout ([#951](https://github.com/simdjson/simdjson/issues/951)) |
+| [ondemand_design.md](ondemand_design.md) | On-Demand model ([#1533](https://github.com/simdjson/simdjson/issues/1533)) |
+| [compile_time.md](compile_time.md) | Compile-time parsing (C++26) |
+| [compile_time_accessors.md](compile_time_accessors.md) | Compile-time accessors |
+
+API reference: [simdjson.github.io/simdjson](https://simdjson.github.io/simdjson/).


### PR DESCRIPTION
## Summary
- Add `doc/README.md` as documentation table of contents.
- Link from CONTRIBUTING.md.

Complements #2756.

## Test plan
- [x] Docs-only change.

Made with [Cursor](https://cursor.com)