### PR TITLE
docs: link basics On-Demand section to design notes (#1533)

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -352,7 +352,7 @@ immediately (e.g., see [General direct access to the raw JSON string](#general-d
 
 We refer to "On-Demand" as a front-end component since it is an interface between the
 low-level parsing functions and the user. It hides much of the complexity of parsing JSON
-documents.
+documents. For a walkthrough of On-Demand parsing including the depth model, see [On-Demand design notes](ondemand_design.md) ([#1533](https://github.com/simdjson/simdjson/issues/1533)).
 
 ### Parser, document and JSON scope
 


### PR DESCRIPTION
## Summary
Link the On-Demand overview in basics.md to ondemand_design.md.

## Test plan
- [x] Docs-only change.

Made with [Cursor](https://cursor.com)