### PR TITLE
docs: link README contributing section to doc index (#801)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Contributing to simdjson
 
 Head over to [CONTRIBUTING.md](CONTRIBUTING.md) for information on contributing to simdjson, and
 [HACKING.md](HACKING.md) for information on source, building, and architecture/design.
+User guides are listed in [doc/README.md](doc/README.md) ([#801](https://github.com/simdjson/simdjson/issues/801)).
 
 
 Stars


### PR DESCRIPTION
## Summary
Point contributors at doc/README.md per #801.

## Test plan
- [x] Docs-only.

Made with [Cursor](https://cursor.com)