### PR TITLE
DOM without padding (experimental)

### DIFF
--- a/benchmark/benchmarker.h
+++ b/benchmark/benchmarker.h
@@ -259,6 +259,11 @@ struct benchmarker {
   const char *filename;
   // Event collector that can be turned on to measure cycles, missed branches, etc.
   event_collector& collector;
+  // When true, parse the input as if it had no trailing padding: use
+  // dom::parser::parse_unpadded (no padded copy) and the bounds-safe stage-2
+  // string parser. Stage 1 is identical either way. This benchmarks the cost of
+  // the unpadded path relative to the standard padded parse.
+  bool unpadded;
 
   // Statistics about the JSON file independent of its speed (amount of utf-8, structurals, etc.).
   // Loaded on first parse.
@@ -274,8 +279,8 @@ struct benchmarker {
   // Speed and event summary for the repeatly-parsing mode
   event_aggregate loop{};
 
-  benchmarker(const char *_filename, event_collector& _collector)
-    : filename(_filename), collector(_collector), stats(NULL) {
+  benchmarker(const char *_filename, event_collector& _collector, bool _unpadded = false)
+    : filename(_filename), collector(_collector), unpadded(_unpadded), stats(NULL) {
     verbose() << "[verbose] loading " << filename << endl;
     auto error = padded_string::load(filename).get(json);
     if (error) {
@@ -320,13 +325,19 @@ struct benchmarker {
     allocate_stage << allocate_count;
     // Run it once to get hot buffers
     if(hotbuffers) {
-      auto result = parser.parse(reinterpret_cast<const uint8_t *>(json.data()), json.size());
+      auto result = unpadded
+        ? parser.parse_unpadded(reinterpret_cast<const uint8_t *>(json.data()), json.size())
+        : parser.parse(reinterpret_cast<const uint8_t *>(json.data()), json.size());
       if (result.error()) {
         exit_error(string("Failed to parse ") + filename + string(":") + error_message(result.error()));
       }
     }
 
     verbose() << "[verbose] allocated memory for parsed JSON " << endl;
+
+    // Tell the implementation whether the timed stage 2 below should use the
+    // bounds-safe (unpadded) string parser. Stage 1 is unaffected.
+    parser.implementation->_unpadded = unpadded;
 
     // Stage 1 (find structurals)
     collector.start();
@@ -366,7 +377,9 @@ struct benchmarker {
 
   void run_loop(size_t iterations) {
     dom::parser parser;
-    auto firstresult = parser.parse(reinterpret_cast<const uint8_t *>(json.data()), json.size());
+    auto firstresult = unpadded
+      ? parser.parse_unpadded(reinterpret_cast<const uint8_t *>(json.data()), json.size())
+      : parser.parse(reinterpret_cast<const uint8_t *>(json.data()), json.size());
     if (firstresult.error()) {
       exit_error(string("Failed to parse ") + filename + string(":") + error_message(firstresult.error()));
     }
@@ -374,7 +387,9 @@ struct benchmarker {
     collector.start();
     // some users want something closer to "number of documents per second"
     for(size_t i = 0; i < iterations; i++) {
-      auto result = parser.parse(reinterpret_cast<const uint8_t *>(json.data()), json.size());
+      auto result = unpadded
+        ? parser.parse_unpadded(reinterpret_cast<const uint8_t *>(json.data()), json.size())
+        : parser.parse(reinterpret_cast<const uint8_t *>(json.data()), json.size());
       if (result.error()) {
         exit_error(string("Failed to parse ") + filename + string(":") + error_message(result.error()));
       }

--- a/benchmark/dom/parse.cpp
+++ b/benchmark/dom/parse.cpp
@@ -64,6 +64,7 @@ void print_usage(ostream& out) {
   out << "-s all       - Run all stages." << endl;
   out << "-C           - Leave the buffers cold (includes page allocation and related OS tasks during parsing, speed tied to OS performance)" << endl;
   out << "-H           - Make the buffers hot (reduce page allocation and related OS tasks during parsing) [default]" << endl;
+  out << "-u           - Parse without padding, using dom::parser::parse_unpadded (no padded copy, bounds-safe stage 2)." << endl;
   out << "-a IMPL      - Use the given parser implementation. By default, detects the most advanced" << endl;
   out << "               implementation supported on the host machine." << endl;
   for (auto impl : simdjson::get_available_implementations()) {
@@ -89,6 +90,8 @@ struct option_struct {
 
   bool verbose = false;
   bool tabbed_output = false;
+  // When true, parse with parse_unpadded (no padded copy; bounds-safe stage 2).
+  bool unpadded = false;
   /**
    * Benchmarking on a cold parser instance means that the parsing may include
    * memory allocation at the OS level. This may lead to apparently odd results
@@ -101,8 +104,11 @@ struct option_struct {
   option_struct(int argc, char **argv) {
     int c;
 
-    while ((c = getopt(argc, argv, "vtn:i:a:s:HC")) != -1) {
+    while ((c = getopt(argc, argv, "vtn:i:a:s:HCu")) != -1) {
       switch (c) {
+      case 'u':
+        unpadded = true;
+        break;
       case 'n':
         iterations = atoi(optarg);
         break;
@@ -190,7 +196,7 @@ int main(int argc, char *argv[]) {
   // Set up benchmarkers by reading all files
   vector<benchmarker*> benchmarkers;
   for (size_t i=0; i<options.files.size(); i++) {
-    benchmarkers.push_back(new benchmarker(options.files[i], collector));
+    benchmarkers.push_back(new benchmarker(options.files[i], collector, options.unpadded));
   }
 
   // Run the benchmarks

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -21,6 +21,7 @@ separate document](https://github.com/simdjson/simdjson/blob/master/doc/builder.
 * [Server Loops: Long-Running Processes and Memory Capacity](#server-loops-long-running-processes-and-memory-capacity)
 * [Best Use of the DOM API](#best-use-of-the-dom-api)
 * [Padding and Temporary Copies](#padding-and-temporary-copies)
+* [Parsing Without Padding](#parsing-without-padding)
 * [Performance Tips](#performance-tips)
 
 DOM vs On-Demand
@@ -916,6 +917,26 @@ simdjson::dom::element element = parser.parse(input);
 
 The actual padding only occurs if the JSON string ends near the boundary of a memory page, which is uncommon. Using a `simdjson::padded_input` is safe although sanitizers and tools like valgrind might report illegal reads (which are safe in our case because they remain in the mapped page). You should avoid `simdjson::padded_input` on systems without a page size of at least 4096: virtually all systems qualify except for some niche embedded systems running custom operating systems. Standard Linux, Windows, macOS, Android, iOS, etc., are all fine.  Note that, most times, an `simdjson::padded_input` instance will not copy the data and will only act
 as a view (it does not own the memory).
+
+If you have a buffer with no trailing padding at all and you want neither to add padding nor to let the library make a padded copy, see [Parsing Without Padding](#parsing-without-padding) below.
+
+
+Parsing Without Padding
+---------------------
+
+(*This feature is currently experimental.*)
+
+If you have a buffer with **no** trailing padding and you do not want the library to copy it into a padded buffer, the DOM API offers `dom::parser::parse_unpadded`:
+
+```cpp
+dom::parser parser;
+std::string_view json = get_json();          // exactly json.size() bytes, no padding
+dom::element doc = parser.parse_unpadded(json);
+```
+
+`parse_unpadded` parses directly from your buffer of exactly `len` bytes and is guaranteed never to read past `buf + len`. It is the zero-copy alternative to `parser.parse(buf, len, /* realloc_if_needed */ true)`, which instead allocates a padded copy of the whole input. As with `parse(buf, len, false)`, the input is read (never written) and must stay alive, together with the parser, while you use the returned document. Overloads accept `std::string_view`, `const char*`/length, and `const uint8_t*`/length, and `parse_into_document_unpadded` lets you supply your own `dom::document`.
+
+**There is a performance penalty.** `parse_unpadded` is slower than parsing an already-padded buffer with `parse()`. simdjson's value parsers normally read a few bytes (up to `SIMDJSON_PADDING`) past the end of each value, relying on the padding; near the end of an unpadded buffer that would read out of bounds, so `parse_unpadded` parses values in the final stretch of the buffer with extra care (it finishes the last string, and copies near-the-end numbers/atoms into a small padded scratch). This is **stage 2 only** — stage 1 (structure finding) is unaffected. On a string-heavy document such as `twitter.json` the penalty is on the order of **a few percent of total parsing time** (about +7% of stage-2 instructions); it varies with how much string/number content sits near the very end of the buffer. The standard padded `parse()` path is *not* affected: it is compiled separately and runs exactly as before. **Prefer padding your input when you can; reach for `parse_unpadded` only when you genuinely cannot pad and want to avoid the `O(n)` copy that `parse(buf, len, true)` performs.**
 
 
 Performance Tips

--- a/doc/unpadded_ondemand.md
+++ b/doc/unpadded_ondemand.md
@@ -1,0 +1,134 @@
+# Plan: `iterate_unpadded` for the On-Demand API
+
+This is a design/execution plan for adding an *unpadded* entry point to the
+On-Demand API, analogous to `dom::parser::parse_unpadded`. It is a planning
+document for discussion, not a description of shipped behaviour.
+
+## Goal
+
+Let users run the On-Demand API on a buffer that has **no** trailing
+`SIMDJSON_PADDING` bytes, without the library copying the whole input into a
+padded buffer first. The library must never read past `buf + len`.
+
+The On-Demand `iterate(...)` entry points currently *require* padding: they call
+`json.has_sufficient_padding()` and return `INSUFFICIENT_PADDING` otherwise.
+
+## Background: how the DOM case was solved
+
+`dom::parser::parse_unpadded` (see the "Parsing without padding (DOM)" note in
+[basics.md](basics.md)) parses in place with **zero penalty on the padded path**. That was possible
+because DOM parsing has a single chokepoint — `tape_builder` — which we templated
+on a compile-time `bool UNPADDED`. `parse_document` selects the instantiation once
+per document, so the padded build compiles with no extra branch (verified: same
+instruction count as before). The only places that over-read for unpadded input
+turned out to be:
+
+- string unescaping (`parse_string`) — handled with a bounds-safe finisher;
+- floats — `is_made_of_eight_digits_fast` reads 8 bytes, so a number whose digits
+  reach the final bytes over-reads; handled by parsing near-the-end numbers from a
+  space-padded copy of the tail (like `visit_root_number`);
+- malformed/truncated non-root atoms at the buffer end — handled with the
+  length-aware atom validators.
+
+Thorough testing (exact-size heap buffers under AddressSanitizer + a randomized
+fuzz) was essential: the float and atom over-reads were **not** caught by
+string-only coverage.
+
+## Why On-Demand is harder than DOM
+
+The DOM "free lunch" (compile-time gating at one chokepoint) does **not** transfer:
+
+- On-Demand parsing is **lazy** and **interleaved with user code**. Values are
+  parsed when the user calls `get_double()`, `get_string()`, iterates, or calls
+  `find_field`/`operator[]`. There is no single chokepoint.
+- The over-read-prone code is spread across the non-templated class API
+  (`value`, `array`, `object`, `document`, `value_iterator`, `json_iterator`).
+  Templating all of it on `UNPADDED` is impractical.
+- The "unpadded" state must persist for the **document's whole lifetime**, not for
+  one call.
+
+## Survey of On-Demand read sites
+
+Already safe (no work needed):
+
+- **Stage 1** — identical to DOM; tail-copies the last block.
+- **Root scalars** — already parsed bounded: `peek_root_length()` +
+  `json_iterator::copy_to_buffer(json, max_len, tmpbuf)` and length-aware checks
+  (`numberparsing::check_if_integer(json, max_len)`,
+  `raw_json_string_is_quote_terminated(json, max_len)`). The bounded-primitive
+  pattern we need already exists in the code.
+
+Over-read sites for unpadded input (the work), with file references:
+
+1. **Non-root numbers** — `value_iterator-inl.h` (~567–621):
+   `numberparsing::parse_double/parse_unsigned/parse_integer/parse_number(
+   peek_non_root_scalar(...))` have no length bound (the float 8-byte over-read).
+2. **String unescaping** — `get_string` / `raw_json_string::unescape` →
+   `json_iterator::unescape` → shared `parse_string`. The quote-*termination*
+   check is already bounded (`raw_json_string_is_quote_terminated(json, max_len)`);
+   the unescape pass is not.
+3. **Key matching** — `raw_json_string::unsafe_is_equal(std::string_view)`
+   (`raw_json_string-inl.h:74`) reads `raw()[target.size()]` and
+   `memcmp(raw(), target.data(), target.size())`. **A new class of over-read not
+   present in DOM**: `find_field`/`operator[]` with a search key longer than a
+   near-the-end document key reads past the buffer.
+4. **Atoms** — `is_null`/true/false; mirror the DOM fix (length-aware validators).
+5. **To audit** — `peek`/`advance`/document-end & trailing-content scans;
+   `get<T>` reflection paths; `document_stream`/`parse_many`.
+
+## Design options (the decision to make)
+
+- **(A) Copy into a padded buffer at `iterate_unpadded`.** Copy the input once
+  into the parser's internal buffer, then iterate normally. Zero parsing-code
+  changes, zero padded-path penalty, lowest risk. Cost: an `O(n)` copy that
+  touches the whole input — which partly defeats On-Demand's "don't read what you
+  don't use" benefit.
+- **(B) True in-place + a runtime `unpadded` flag.** Store a flag on
+  `json_iterator`; when set, route the non-root scalar/string/key paths through
+  the bounded primitives that root scalars already use. No copy. Cost: a small
+  per-access predicted branch on the padded path — i.e. a non-zero
+  instruction-count penalty (the same kind we eliminated for DOM, but here it
+  cannot be removed without (C)).
+- **(C) In-place + compile-time gating.** Zero penalty, but requires templating
+  the entire On-Demand class API on `UNPADDED`. Impractical.
+
+**Open question for discussion:** for On-Demand, do we accept a one-time `O(n)`
+copy (A) to keep the padded path byte-for-byte unchanged, or a small per-access
+runtime cost (B) to stay copy-free? DOM's zero-penalty approach (C) is not
+realistically available here.
+
+## Proposed execution plan (assuming option B, in place)
+
+1. **Entry point & flag.** Add `parser::iterate_unpadded(...)` overloads that skip
+   `has_sufficient_padding()` and set a `bool unpadded` on the `json_iterator`
+   (persisted for the document's lifetime).
+2. **Non-root numbers.** When `unpadded`, route the non-root number getters
+   through the bounded path root scalars already use (`copy_to_buffer` into a
+   stack `tmpbuf`, parse from there). Reuses proven code.
+3. **String unescape.** When `unpadded`, give the unescape path the buffer end and
+   finish with a bounds-safe routine — reuse `parse_string_safe` (factor it into a
+   shared location, or mirror it).
+4. **Key matching.** Add a length-bounded `unsafe_is_equal` variant (the max
+   readable length is known from `remaining_input_length`/`peek_length`); use it
+   when `unpadded`. This is the genuinely new piece.
+5. **Atoms.** Mirror the DOM fix: length-aware validators when `unpadded`.
+6. **Audit the rest** — peek/advance/document-end/trailing scans; defer
+   `document_stream`/`parse_many` and `get<T>` reflection if possible.
+7. **Tests.** New ASAN test on the DOM lesson: parse from **exact-size heap
+   buffers** and exercise every *access* pattern near the end —
+   `get_double/uint64/int64/string/bool/is_null`, array/object iteration, and
+   especially `find_field`/`operator[]` with keys shorter, equal, and **longer**
+   than the document's near-the-end keys; plus a randomized fuzz comparing
+   `iterate_unpadded` against padded `iterate`. The DOM experience shows the test
+   must explicitly hit numbers, atoms, strings **and keys**.
+8. **Performance.** Extend an On-Demand benchmark with an unpadded flag (like the
+   DOM `parse -u`) to quantify the option-(B) penalty and inform the A-vs-B call.
+
+## Risks
+
+- On-Demand has more read sites and more `SIMDJSON_PADDING` assumptions than DOM
+  (the survey already found key-matching as a brand-new one); expect the
+  exact-buffer ASAN fuzz to surface more, as it did for DOM.
+- The option-(B) runtime-flag penalty is unavoidable without the impractical (C).
+- `document_stream`/`parse_many` and the C++26 reflection `get<T>` paths add
+  scope; propose deferring them.

--- a/include/simdjson/dom/parser-inl.h
+++ b/include/simdjson/dom/parser-inl.h
@@ -141,6 +141,29 @@ inline simdjson_result<element> parser::parse_into_document(document& provided_d
   return provided_doc.root();
 }
 
+inline simdjson_result<element> parser::parse_into_document_unpadded(document& provided_doc, const uint8_t *buf, size_t len) & noexcept {
+  // Like parse_into_document with realloc_if_needed=false (no copy, parse in
+  // place), but we tell the implementation the buffer is not padded so stage 2
+  // avoids reading past buf+len: string unescaping is bounded, near-the-end
+  // numbers are parsed from a padded copy, and atoms use length-aware
+  // validators (see tape_builder). Stage 1 is already safe for unpadded input.
+  error_code _error = ensure_capacity(provided_doc, len);
+  if (_error) { return _error; }
+
+  if((len >= 3) && (std::memcmp(buf, "\xEF\xBB\xBF", 3) == 0)) {
+    buf += 3;
+    len -= 3;
+  }
+  implementation->_number_as_string = _number_as_string;
+  implementation->_unpadded = true;
+  _error = implementation->parse(buf, len, provided_doc);
+  implementation->_unpadded = false; // restore so later padded parses use the fast path
+
+  if (_error) { return _error; }
+
+  return provided_doc.root();
+}
+
 simdjson_inline simdjson_result<element> parser::parse_into_document(document& provided_doc, const char *buf, size_t len, bool realloc_if_needed) & noexcept {
   return parse_into_document(provided_doc, reinterpret_cast<const uint8_t *>(buf), len, realloc_if_needed);
 }
@@ -167,6 +190,16 @@ simdjson_inline simdjson_result<element> parser::parse(const padded_string &s) &
 }
 simdjson_inline simdjson_result<element> parser::parse(const padded_string_view &v) & noexcept {
   return parse(v.data(), v.length(), false);
+}
+
+inline simdjson_result<element> parser::parse_unpadded(const uint8_t *buf, size_t len) & noexcept {
+  return parse_into_document_unpadded(doc, buf, len);
+}
+simdjson_inline simdjson_result<element> parser::parse_unpadded(const char *buf, size_t len) & noexcept {
+  return parse_unpadded(reinterpret_cast<const uint8_t *>(buf), len);
+}
+simdjson_inline simdjson_result<element> parser::parse_unpadded(std::string_view s) & noexcept {
+  return parse_unpadded(reinterpret_cast<const uint8_t *>(s.data()), s.size());
 }
 
 inline simdjson_result<document_stream> parser::parse_many(const uint8_t *buf, size_t len, size_t batch_size) noexcept {

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -250,6 +250,64 @@ public:
   simdjson_inline simdjson_result<element> parse(const char *buf) noexcept = delete;
 
   /**
+   * Parse a JSON document whose buffer is **not** padded, in place and without
+   * copying it.
+   *
+   * *This feature is currently experimental.*
+   *
+   * The standard parse() methods require the input buffer to have at least
+   * SIMDJSON_PADDING extra readable bytes after the document (or they copy it
+   * into a padded buffer when realloc_if_needed is true). parse_unpadded() lifts
+   * that requirement: it parses directly from your buffer of exactly `len` bytes,
+   * never reading past `buf + len`, and never allocating a full padded copy.
+   *
+   *   dom::parser parser;
+   *   std::string_view json = get_json(); // no trailing padding needed
+   *   dom::element doc = parser.parse_unpadded(json);
+   *
+   * This is the convenient way to use simdjson when you cannot (or do not want
+   * to) pad your input, e.g. a std::string_view into a larger buffer or a memory
+   * mapped file whose tail you do not control. It is generally a little slower
+   * than parsing a padded buffer with parse() (the very end of the document is
+   * handled with extra care), but it avoids the O(n) copy that
+   * parse(buf, len, true) performs when realloc_if_needed is true.
+   *
+   * The input is read but not modified, and it must remain valid (and the parser
+   * alive) for as long as you navigate the returned document, exactly like
+   * parse(buf, len, false).
+   *
+   * @param buf The JSON to parse. Only `len` bytes are read; no padding required.
+   * @param len The length of the JSON.
+   * @return An element pointing at the root of the document, or an error:
+   *         - MEMALLOC if the parser does not have enough capacity and allocation fails.
+   *         - CAPACITY if the parser does not have enough capacity and len > max_capacity.
+   *         - other json errors if parsing fails.
+   */
+  inline simdjson_result<element> parse_unpadded(const uint8_t *buf, size_t len) & noexcept;
+  inline simdjson_result<element> parse_unpadded(const uint8_t *buf, size_t len) && =delete;
+  /** @overload parse_unpadded(const uint8_t *buf, size_t len) */
+  simdjson_inline simdjson_result<element> parse_unpadded(const char *buf, size_t len) & noexcept;
+  simdjson_inline simdjson_result<element> parse_unpadded(const char *buf, size_t len) && =delete;
+  /** @overload parse_unpadded(const uint8_t *buf, size_t len) */
+  simdjson_inline simdjson_result<element> parse_unpadded(std::string_view s) & noexcept;
+  simdjson_inline simdjson_result<element> parse_unpadded(std::string_view s) && =delete;
+
+  /**
+   * Parse a non-padded JSON document into a caller-provided document instance, in
+   * place and without copying. This is to parse_unpadded() what
+   * parse_into_document() is to parse(). See parse_unpadded() for the padding and
+   * lifetime semantics.
+   *
+   * *This feature is currently experimental.*
+   *
+   * @param doc The document instance where the parsed data will be stored (on success).
+   * @param buf The JSON to parse. Only `len` bytes are read; no padding required.
+   * @param len The length of the JSON.
+   */
+  inline simdjson_result<element> parse_into_document_unpadded(document& doc, const uint8_t *buf, size_t len) & noexcept;
+  inline simdjson_result<element> parse_into_document_unpadded(document& doc, const uint8_t *buf, size_t len) && =delete;
+
+  /**
    * Parse a JSON document into a provide document instance and return a temporary reference to it.
    * It is similar to the function `parse` except that instead of parsing into the internal
    * `document` instance associated with the parser, it allows the user to provide a document

--- a/include/simdjson/internal/dom_parser_implementation.h
+++ b/include/simdjson/internal/dom_parser_implementation.h
@@ -220,6 +220,16 @@ public:
   /** Whether to store big integers as strings instead of returning BIGINT_ERROR */
   bool _number_as_string{false};
 
+  /**
+   * Whether the input buffer passed to parse() is *not* padded to len +
+   * SIMDJSON_PADDING bytes. When true, stage 2 string parsing avoids reading
+   * past buf+len (it finishes the final, near-the-end bytes from a small padded
+   * scratch buffer). This is set only by the no-padding DOM parse entry points
+   * (dom::parser::parse_unpadded); the default padded fast path leaves it false
+   * and is unaffected.
+   */
+  bool _unpadded{false};
+
 protected:
 
   // Declaring these so that subclasses can use them to implement their constructors.

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -212,7 +212,15 @@ simdjson_warn_unused simdjson_inline uint8_t *parse_string_safe(const uint8_t *s
   // SIMDJSON_PADDING (>= BYTES_PROCESSED) so copy_and_find never reads past
   // buf_end; escape/Unicode look-aheads read within the string (before the
   // closing quote, which is < buf_end), so they are in bounds here too.
-  while (src + SIMDJSON_PADDING <= buf_end) {
+  // We add margin (+12) for handle_unicode_codepoint's worst-case lookahead:
+  // after seeing a high surrogate, it does hex_to_u32_nocheck on the immediate
+  // following bytes (+6 from the '\'), then (if it sees \u) another
+  // hex_to_u32_nocheck at +8..+11 relative to the backslash that started the
+  // escape. With bs_dist up to BYTES_PROCESSED-1 this reaches +11 from the
+  // chunk start. The +12 margin ensures that even on kernels where
+  // BYTES_PROCESSED == SIMDJSON_PADDING (e.g. icelake) the 4-byte read stays
+  // in-bounds. The scratch fallback (3*PAD) is already safe.
+  while (src + SIMDJSON_PADDING + 12 <= buf_end) {
     auto b = backslash_and_quote{};
     auto bs_quote = b.copy_and_find(src, dst);
     if (bs_quote.has_quote_first()) {

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -193,6 +193,69 @@ simdjson_warn_unused simdjson_inline uint8_t *parse_string(const uint8_t *src, u
   }
 }
 
+/**
+ * Bounds-safe variant of parse_string for input buffers that are NOT padded to
+ * len + SIMDJSON_PADDING bytes. `buf_end` is one past the last readable input
+ * byte (buf + len). It behaves exactly like parse_string while we are at least
+ * SIMDJSON_PADDING bytes away from buf_end (so every speculative SIMD read stays
+ * in bounds); once within the final SIMDJSON_PADDING bytes it copies the few
+ * remaining bytes into a space-padded scratch buffer and finishes with the
+ * regular parse_string. This keeps the delicate escape/Unicode handling in one
+ * place (the proven parse_string) rather than duplicating it.
+ *
+ * Correctness relies on stage 1 having validated the string, i.e. there is an
+ * unescaped closing quote within [src, buf_end); that quote is therefore inside
+ * the copied scratch, so parse_string finds it without running off the scratch.
+ */
+simdjson_warn_unused simdjson_inline uint8_t *parse_string_safe(const uint8_t *src, uint8_t *dst, bool allow_replacement, const uint8_t *buf_end) {
+  // Far from the end: identical to parse_string's loop. The guard uses
+  // SIMDJSON_PADDING (>= BYTES_PROCESSED) so copy_and_find never reads past
+  // buf_end; escape/Unicode look-aheads read within the string (before the
+  // closing quote, which is < buf_end), so they are in bounds here too.
+  while (src + SIMDJSON_PADDING <= buf_end) {
+    auto b = backslash_and_quote{};
+    auto bs_quote = b.copy_and_find(src, dst);
+    if (bs_quote.has_quote_first()) {
+      return dst + bs_quote.quote_index();
+    }
+    if (bs_quote.has_backslash()) {
+      auto bs_dist = bs_quote.backslash_index();
+      uint8_t escape_char = src[bs_dist + 1];
+      if (escape_char == 'u') {
+        src += bs_dist;
+        dst += bs_dist;
+        if (!handle_unicode_codepoint(&src, &dst, allow_replacement)) {
+          return nullptr;
+        }
+      } else {
+        uint8_t escape_result = escape_map[escape_char];
+        if (escape_result == 0u) {
+          return nullptr;
+        }
+        dst[bs_dist] = escape_result;
+        src += bs_dist + 2;
+        dst += bs_dist + 1;
+      }
+    } else {
+      src += backslash_and_quote::BYTES_PROCESSED;
+      dst += backslash_and_quote::BYTES_PROCESSED;
+    }
+  }
+  // Within the final SIMDJSON_PADDING bytes: copy what remains into a
+  // space-padded scratch (spaces are neither quote nor backslash, so they do not
+  // disturb matching) and let the regular parser finish from there. The closing
+  // quote is within `remaining` (< SIMDJSON_PADDING), so parse_string finds it in
+  // the chunk starting at some offset <= remaining and reads at most
+  // BYTES_PROCESSED (<= SIMDJSON_PADDING) further -- i.e. under 2*SIMDJSON_PADDING.
+  // We size at 3x for a comfortable margin (the unicode look-ahead reads a few
+  // extra bytes past an escape).
+  uint8_t scratch[SIMDJSON_PADDING * 3];
+  const size_t remaining = size_t(buf_end - src); // < SIMDJSON_PADDING
+  std::memset(scratch, ' ', sizeof(scratch));
+  std::memcpy(scratch, src, remaining);
+  return parse_string(scratch, dst, allow_replacement);
+}
+
 simdjson_warn_unused simdjson_inline uint8_t *parse_wobbly_string(const uint8_t *src, uint8_t *dst) {
   // It is not ideal that this function is nearly identical to parse_string.
   while (1) {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -18,12 +18,8 @@ namespace SIMDJSON_IMPLEMENTATION {
 namespace {
 namespace stage2 {
 
-struct tape_builder {
-  template<bool STREAMING>
-  simdjson_warn_unused static simdjson_inline error_code parse_document(
-    dom_parser_implementation &dom_parser,
-    dom::document &doc) noexcept;
-
+template <bool UNPADDED>
+struct tape_builder_impl {
   /** Called when a non-empty document starts. */
   simdjson_warn_unused simdjson_inline error_code visit_document_start(json_iterator &iter) noexcept;
   /** Called when a non-empty document ends without error. */
@@ -90,11 +86,11 @@ struct tape_builder {
 
   /** Next location to write to tape */
   tape_writer tape;
+public:
+  simdjson_inline tape_builder_impl(dom::document &doc) noexcept;
 private:
   /** Next write location in the string buf for stage 2 parsing */
   uint8_t *current_string_buf_loc;
-
-  simdjson_inline tape_builder(dom::document &doc) noexcept;
 
   simdjson_inline uint32_t next_tape_index(json_iterator &iter) const noexcept;
   simdjson_inline void start_container(json_iterator &iter) noexcept;
@@ -102,71 +98,104 @@ private:
   simdjson_warn_unused simdjson_inline error_code empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept;
   simdjson_inline uint8_t *on_start_string(json_iterator &iter) noexcept;
   simdjson_inline void on_end_string(uint8_t *dst) noexcept;
-}; // struct tape_builder
+}; // struct tape_builder_impl
 
-template<bool STREAMING>
-simdjson_warn_unused simdjson_inline error_code tape_builder::parse_document(
-    dom_parser_implementation &dom_parser,
-    dom::document &doc) noexcept {
-  dom_parser.doc = &doc;
-  json_iterator iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
-  tape_builder builder(doc);
-  return iter.walk_document<STREAMING>(builder);
-}
+// Thin, non-templated entry so each architecture's stage2() keeps calling
+// tape_builder::parse_document<STREAMING> unchanged. It chooses the bounds-safe
+// (unpadded) or the regular (padded) tape_builder_impl ONCE per document, so the
+// choice is a compile-time constant inside the walk: the padded path carries no
+// extra branch or load (see tape_builder_impl::visit_string).
+struct tape_builder {
+  template<bool STREAMING>
+  simdjson_warn_unused static simdjson_inline error_code parse_document(
+      dom_parser_implementation &dom_parser, dom::document &doc) noexcept {
+    dom_parser.doc = &doc;
+    json_iterator iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
+    if (dom_parser._unpadded) {
+      tape_builder_impl<true> builder(doc);
+      return iter.walk_document<STREAMING>(builder);
+    } else {
+      tape_builder_impl<false> builder(doc);
+      return iter.walk_document<STREAMING>(builder);
+    }
+  }
+};
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_primitive(json_iterator &iter, const uint8_t *value) noexcept {
   return iter.visit_root_primitive(*this, value);
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_primitive(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_primitive(json_iterator &iter, const uint8_t *value) noexcept {
   return iter.visit_primitive(*this, value);
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_empty_object(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_empty_object(json_iterator &iter) noexcept {
   return empty_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_empty_array(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_empty_array(json_iterator &iter) noexcept {
   return empty_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_document_start(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_document_start(json_iterator &iter) noexcept {
   start_container(iter);
   return SUCCESS;
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_object_start(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_object_start(json_iterator &iter) noexcept {
   start_container(iter);
   return SUCCESS;
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_array_start(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_array_start(json_iterator &iter) noexcept {
   start_container(iter);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_object_end(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_object_end(json_iterator &iter) noexcept {
   return end_container(iter, internal::tape_type::START_OBJECT, internal::tape_type::END_OBJECT);
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_array_end(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_array_end(json_iterator &iter) noexcept {
   return end_container(iter, internal::tape_type::START_ARRAY, internal::tape_type::END_ARRAY);
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_document_end(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_document_end(json_iterator &iter) noexcept {
   constexpr uint32_t start_tape_index = 0;
   tape.append(start_tape_index, internal::tape_type::ROOT);
   tape_writer::write(iter.dom_parser.doc->tape[start_tape_index], next_tape_index(iter), internal::tape_type::ROOT);
   return SUCCESS;
 }
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_key(json_iterator &iter, const uint8_t *key) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_key(json_iterator &iter, const uint8_t *key) noexcept {
   return visit_string(iter, key, true);
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::increment_count(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::increment_count(json_iterator &iter) noexcept {
   iter.dom_parser.open_containers[iter.depth].count++; // we have a key value pair in the object at parser.dom_parser.depth - 1
   return SUCCESS;
 }
 
-simdjson_inline tape_builder::tape_builder(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
+template <bool UNPADDED>
+simdjson_inline tape_builder_impl<UNPADDED>::tape_builder_impl(dom::document &doc) noexcept : tape{doc.tape.get()}, current_string_buf_loc{doc.string_buf.get()} {}
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_string(json_iterator &iter, const uint8_t *value, bool key) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_string(json_iterator &iter, const uint8_t *value, bool key) noexcept {
   iter.log_value(key ? "key" : "string");
   uint8_t *dst = on_start_string(iter);
-  dst = stringparsing::parse_string(value+1, dst, false); // We do not allow replacement when the escape characters are invalid.
+  // We do not allow replacement when the escape characters are invalid.
+  // UNPADDED is a compile-time constant chosen once per document by
+  // tape_builder::parse_document, so the padded build instantiates only the
+  // plain parse_string call below -- no runtime branch and no flag load.
+  SIMDJSON_IF_CONSTEXPR (UNPADDED) {
+    dst = stringparsing::parse_string_safe(value+1, dst, false, iter.buf + iter.dom_parser.len);
+  } else {
+    dst = stringparsing::parse_string(value+1, dst, false);
+  }
   if (dst == nullptr) {
     iter.log_error("Invalid escape in string");
     return STRING_ERROR;
@@ -175,24 +204,45 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::visit_string(json_
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_string(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_string(json_iterator &iter, const uint8_t *value) noexcept {
   return visit_string(iter, value);
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_number(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("number");
-  error_code err = numberparsing::parse_number(value, tape);
+  const uint8_t *num = value;
+  std::unique_ptr<uint8_t[]> copy{}; // keeps a padded copy of the tail alive when used
+  SIMDJSON_IF_CONSTEXPR (UNPADDED) {
+    // numberparsing reads ahead in 8-byte blocks for floats
+    // (is_made_of_eight_digits_fast reads up to 7 bytes past the digits), so a
+    // number whose digits reach the final bytes of an unpadded buffer would read
+    // past it. *(next_structural) is the offset of the token following this
+    // number, hence an upper bound on where the digits end; when that is within
+    // SIMDJSON_PADDING of the end we parse from a space-padded copy of the tail
+    // (mirroring visit_root_number). This fires only for numbers near the end.
+    if (simdjson_unlikely(*(iter.next_structural) + SIMDJSON_PADDING > iter.dom_parser.len)) {
+      const size_t rl = iter.remaining_len(); // bytes from `value` to the end of the document
+      copy.reset(new (std::nothrow) uint8_t[rl + SIMDJSON_PADDING]);
+      if (copy.get() == nullptr) { return MEMALLOC; }
+      std::memcpy(copy.get(), value, rl);
+      std::memset(copy.get() + rl, ' ', SIMDJSON_PADDING);
+      num = copy.get();
+    }
+  }
+  error_code err = numberparsing::parse_number(num, tape);
   if (simdjson_unlikely(err == BIGINT_ERROR &&
       iter.dom_parser._number_as_string)) {
     // Write big integer to string buffer using the same format as strings.
     // Scan digits the same way parse_number does (skip optional '-', then digits).
-    const uint8_t *p = value;
+    const uint8_t *p = num;
     if (*p == '-') p++;
     while (numberparsing::is_digit(*p)) p++;
-    size_t len = size_t(p - value);
+    size_t len = size_t(p - num);
     tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::BIGINT);
     uint8_t *dst = current_string_buf_loc + sizeof(uint32_t);
-    memcpy(dst, value, len);
+    memcpy(dst, num, len);
     dst += len;
     on_end_string(dst);
     return SUCCESS;
@@ -200,7 +250,8 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::visit_number(json_
   return err;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_number(json_iterator &iter, const uint8_t *value) noexcept {
   //
   // We need to make a copy to make sure that the string is space terminated.
   // This is not about padding the input, which should already padded up
@@ -222,42 +273,57 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_number(
   return error;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("true");
-  if (!atomparsing::is_valid_true_atom(value)) { return T_ATOM_ERROR; }
+  // The non-length-aware validator reads a fixed 5 bytes; a malformed/truncated
+  // token at the very end of an unpadded buffer would over-read. Use the
+  // length-aware form there (the root variant already does this).
+  const bool ok = UNPADDED ? atomparsing::is_valid_true_atom(value, iter.remaining_len())
+                           : atomparsing::is_valid_true_atom(value);
+  if (!ok) { return T_ATOM_ERROR; }
   tape.append(0, internal::tape_type::TRUE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_true_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("true");
   if (!atomparsing::is_valid_true_atom(value, iter.remaining_len())) { return T_ATOM_ERROR; }
   tape.append(0, internal::tape_type::TRUE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("false");
-  if (!atomparsing::is_valid_false_atom(value)) { return F_ATOM_ERROR; }
+  const bool ok = UNPADDED ? atomparsing::is_valid_false_atom(value, iter.remaining_len())
+                           : atomparsing::is_valid_false_atom(value);
+  if (!ok) { return F_ATOM_ERROR; }
   tape.append(0, internal::tape_type::FALSE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_false_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("false");
   if (!atomparsing::is_valid_false_atom(value, iter.remaining_len())) { return F_ATOM_ERROR; }
   tape.append(0, internal::tape_type::FALSE_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("null");
-  if (!atomparsing::is_valid_null_atom(value)) { return N_ATOM_ERROR; }
+  const bool ok = UNPADDED ? atomparsing::is_valid_null_atom(value, iter.remaining_len())
+                           : atomparsing::is_valid_null_atom(value);
+  if (!ok) { return N_ATOM_ERROR; }
   tape.append(0, internal::tape_type::NULL_VALUE);
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_null_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("null");
   if (!atomparsing::is_valid_null_atom(value, iter.remaining_len())) { return N_ATOM_ERROR; }
   tape.append(0, internal::tape_type::NULL_VALUE);
@@ -265,29 +331,41 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_null_at
 }
 
 #if SIMDJSON_ENABLE_NAN_INF
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_nan_atom(json_iterator &iter, const uint8_t *value, error_code errc) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_nan_atom(json_iterator &iter, const uint8_t *value, error_code errc) noexcept {
   iter.log_value("nan");
-  if (!atomparsing::is_valid_nan_atom(value)) { return errc; }
+  // For unpadded input use the length-aware validator so the 'infinity'-style
+  // 8-byte compare cannot read past the buffer on a malformed token at the end.
+  const bool ok = UNPADDED ? atomparsing::is_valid_nan_atom(value, iter.remaining_len())
+                           : atomparsing::is_valid_nan_atom(value);
+  if (!ok) { return errc; }
   tape.append_double(std::numeric_limits<double>::quiet_NaN());
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_nan_atom(json_iterator &iter, const uint8_t *value, error_code errc) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_nan_atom(json_iterator &iter, const uint8_t *value, error_code errc) noexcept {
   iter.log_value("nan");
   if (!atomparsing::is_valid_nan_atom(value, iter.remaining_len())) { return errc; }
   tape.append_double(std::numeric_limits<double>::quiet_NaN());
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_inf_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_inf_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("inf");
-  // Because 'inf' is an extension, non a canonical atom, a tape error should be returned on failure
-  if (!atomparsing::is_valid_inf_atom(value)) { return TAPE_ERROR; }
+  // Because 'inf' is an extension, non a canonical atom, a tape error should be returned on failure.
+  // For unpadded input use the length-aware validator so the 'infinity' 8-byte
+  // compare cannot read past the buffer on a malformed token at the end.
+  const bool ok = UNPADDED ? atomparsing::is_valid_inf_atom(value, iter.remaining_len())
+                           : atomparsing::is_valid_inf_atom(value);
+  if (!ok) { return TAPE_ERROR; }
   tape.append_double(std::numeric_limits<double>::infinity());
   return SUCCESS;
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_inf_atom(json_iterator &iter, const uint8_t *value) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::visit_root_inf_atom(json_iterator &iter, const uint8_t *value) noexcept {
   iter.log_value("inf");
   // Because 'inf' is an extension, non a canonical atom, a tape error should be returned on failure
   if (!atomparsing::is_valid_inf_atom(value, iter.remaining_len())) { return TAPE_ERROR; }
@@ -298,24 +376,28 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::visit_root_inf_ato
 
 // private:
 
-simdjson_inline uint32_t tape_builder::next_tape_index(json_iterator &iter) const noexcept {
+template <bool UNPADDED>
+simdjson_inline uint32_t tape_builder_impl<UNPADDED>::next_tape_index(json_iterator &iter) const noexcept {
   return uint32_t(tape.next_tape_loc - iter.dom_parser.doc->tape.get());
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::empty_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
   auto start_index = next_tape_index(iter);
   tape.append(start_index+2, start);
   tape.append(start_index, end);
   return SUCCESS;
 }
 
-simdjson_inline void tape_builder::start_container(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_inline void tape_builder_impl<UNPADDED>::start_container(json_iterator &iter) noexcept {
   iter.dom_parser.open_containers[iter.depth].tape_index = next_tape_index(iter);
   iter.dom_parser.open_containers[iter.depth].count = 0;
   tape.skip(); // We don't actually *write* the start element until the end.
 }
 
-simdjson_warn_unused simdjson_inline error_code tape_builder::end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
+template <bool UNPADDED>
+simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::end_container(json_iterator &iter, internal::tape_type start, internal::tape_type end) noexcept {
   // Write the ending tape element, pointing at the start location
   const uint32_t start_tape_index = iter.dom_parser.open_containers[iter.depth].tape_index;
   tape.append(start_tape_index, end);
@@ -328,13 +410,15 @@ simdjson_warn_unused simdjson_inline error_code tape_builder::end_container(json
   return SUCCESS;
 }
 
-simdjson_inline uint8_t *tape_builder::on_start_string(json_iterator &iter) noexcept {
+template <bool UNPADDED>
+simdjson_inline uint8_t *tape_builder_impl<UNPADDED>::on_start_string(json_iterator &iter) noexcept {
   // we advance the point, accounting for the fact that we have a NULL termination
   tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::STRING);
   return current_string_buf_loc + sizeof(uint32_t);
 }
 
-simdjson_inline void tape_builder::on_end_string(uint8_t *dst) noexcept {
+template <bool UNPADDED>
+simdjson_inline void tape_builder_impl<UNPADDED>::on_end_string(uint8_t *dst) noexcept {
   uint32_t str_length = uint32_t(dst - (current_string_buf_loc + sizeof(uint32_t)));
   // TODO check for overflow in case someone has a crazy string (>=4GB?)
   // But only add the overflow check when the document itself exceeds 4GB

--- a/tests/dom/CMakeLists.txt
+++ b/tests/dom/CMakeLists.txt
@@ -9,6 +9,7 @@ add_cpp_test(basictests                 LABELS dom acceptance per_implementation
 add_cpp_test(document_stream_tests      LABELS dom acceptance per_implementation)
 add_cpp_test(document_stream_fuzz_tests LABELS dom acceptance per_implementation)
 add_cpp_test(document_tests             LABELS dom acceptance per_implementation)
+add_cpp_test(unpadded_tests             LABELS dom acceptance per_implementation)
 add_cpp_test(errortests                 LABELS dom acceptance per_implementation)
 add_cpp_test(extracting_values_example  LABELS dom acceptance per_implementation)
 add_cpp_test(integer_tests              LABELS dom acceptance per_implementation)

--- a/tests/dom/unpadded_tests.cpp
+++ b/tests/dom/unpadded_tests.cpp
@@ -1,0 +1,390 @@
+// Tests for dom::parser::parse_unpadded: parsing JSON in place from a buffer
+// that has NO trailing SIMDJSON_PADDING.
+//
+// The key safety property is that parse_unpadded must never read past buf+len.
+// To enforce that, every document here is parsed from a std::vector<char> sized
+// to *exactly* len bytes: under AddressSanitizer (the ubuntu-build-address-
+// sanitizer CI job) any read past the end lands in the redzone and fails the
+// test. We also check that the result is identical to parsing the same bytes
+// with the regular padded parser.
+
+#include <cstring>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "simdjson.h"
+#include "test_macros.h"
+
+namespace unpadded_tests {
+using namespace simdjson;
+
+// Serialize a DOM element to a string so two parses can be compared for equality.
+simdjson_inline std::string to_text(dom::element e) {
+  std::ostringstream out;
+  out << e;
+  return out.str();
+}
+
+// Parse `json` two ways and require success + identical output:
+//  - padded:   the normal parser over a padded_string
+//  - unpadded: parse_unpadded over a heap buffer of exactly json.size() bytes
+// The exact-size buffer is what makes an over-read observable under ASAN.
+bool check_matches(const std::string &json) {
+  dom::parser padded_parser;
+  dom::element padded_elt;
+  auto padded_err = padded_parser.parse(simdjson::padded_string(json)).get(padded_elt);
+
+  // Exact-size buffer: no readable byte after data()+size().
+  std::vector<char> exact(json.begin(), json.end());
+  dom::parser unpadded_parser;
+  dom::element unpadded_elt;
+  auto unpadded_err = unpadded_parser.parse_unpadded(exact.data(), exact.size()).get(unpadded_elt);
+
+  // The two parsers must agree on whether the document is valid.
+  if (padded_err != unpadded_err) {
+    std::cerr << "mismatched error codes for <" << json << ">: padded="
+              << padded_err << " unpadded=" << unpadded_err << std::endl;
+    return false;
+  }
+  if (padded_err) { return true; } // both failed the same way: fine
+  std::string a = to_text(padded_elt);
+  std::string b = to_text(unpadded_elt);
+  if (a != b) {
+    std::cerr << "mismatched output: padded=<" << a << "> unpadded=<" << b << ">" << std::endl;
+    return false;
+  }
+  return true;
+}
+
+// Root and non-root numbers in every shape. Root numbers exercise the
+// space-padded-copy path (visit_root_number); non-root numbers are followed by
+// an in-buffer structural character.
+bool numbers() {
+  TEST_START();
+  const std::vector<std::string> nums = {
+    "0", "-0", "1", "-1", "123", "-123", "3.14", "-3.14", "1e10", "1E10",
+    "1e-10", "1.5e+3", "0.0", "0.1", "3.141592653589793",
+    "123456789012345678", "9223372036854775807", "-9223372036854775808",
+    "18446744073709551615", "1.7976931348623157e308", "100000000000000000000",
+  };
+  for (const auto &n : nums) {
+    if (!check_matches(n)) { return false; }                    // root (copy path)
+    if (!check_matches("[" + n + "]")) { return false; }        // last array element
+    if (!check_matches("{\"k\":" + n + "}")) { return false; }  // last object value
+    if (!check_matches("[" + n + ",1]")) { return false; }      // followed by a comma
+    if (!check_matches("[1," + n + "]")) { return false; }
+  }
+  TEST_SUCCEED();
+}
+
+// Sweep a float so its (8-byte-read) fractional digits land at every offset
+// relative to the end of the buffer, including long fractional parts preceded by
+// filler (which a start-position threshold would miss).
+bool number_at_end_sweep() {
+  TEST_START();
+  for (size_t frac = 1; frac <= 3 * SIMDJSON_PADDING + 5; frac++) {
+    std::string num = "0." + std::string(frac, '9');
+    if (!check_matches(num)) { return false; }                       // root float
+    if (!check_matches("[" + num + "]")) { return false; }           // float ends the array
+    if (!check_matches("{\"k\":" + num + "}")) { return false; }     // float ends the object
+    // Long float preceded by filler so it starts far from the end but its digits
+    // still reach the final bytes (exercises the next-structural-based trigger).
+    if (!check_matches("[123456789," + num + "]")) { return false; }
+    // Long integer at the end too.
+    std::string bignum = std::string(frac, '7');
+    if (!check_matches("[1," + bignum + "]")) { return false; }
+  }
+  TEST_SUCCEED();
+}
+
+// Malformed / truncated atom-like tokens at the buffer end. The 'n'/'t'/'f'
+// dispatch validates a value against the full null/true/false atom, reading a
+// fixed number of bytes; a shorter or wrong token at the end of an unpadded
+// buffer must not read past it (caught here under ASAN). All of these are
+// invalid JSON, so padded and unpadded must agree on the error.
+bool malformed_atoms_at_end() {
+  TEST_START();
+  const std::vector<std::string> toks = {
+    "n", "nu", "nul", "nulx", "nall", "t", "tr", "tru", "trux", "ture",
+    "f", "fa", "fal", "fals", "falx", "fale", "true", "false", "null",
+  };
+  for (const auto &t : toks) {
+    if (!check_matches(t)) { return false; }                        // root
+    if (!check_matches("[" + t + "]")) { return false; }            // ends the array
+    if (!check_matches("{\"k\":" + t + "}")) { return false; }      // ends the object
+    if (!check_matches("[" + t + ",1]")) { return false; }
+    if (!check_matches("[" + std::string(SIMDJSON_PADDING, ' ') + t + "]")) { return false; }
+  }
+  TEST_SUCCEED();
+}
+
+// --- Deterministic random JSON generator (for fuzz-style comparison) ----------
+// xorshift64 so any failure is reproducible from its seed.
+struct rng {
+  uint64_t s;
+  explicit rng(uint64_t seed) : s(seed ? seed : 0x9e3779b97f4a7c15ull) {}
+  uint64_t next() { s ^= s << 13; s ^= s >> 7; s ^= s << 17; return s; }
+  uint32_t below(uint32_t n) { return static_cast<uint32_t>(next() % n); }
+};
+
+void gen_string(rng &r, std::string &out) {
+  out += '"';
+  uint32_t n = r.below(24);
+  for (uint32_t i = 0; i < n; i++) {
+    switch (r.below(9)) {
+      case 0: out += "\\n"; break;
+      case 1: out += "\\t"; break;
+      case 2: out += "\\\""; break;
+      case 3: out += "\\\\"; break;
+      case 4: out += "\\/"; break;
+      case 5: out += "\\u00e9"; break;          // U+00E9 via JSON \u escape
+      case 6: out += "\xC3\xA9"; break;         // U+00E9 as raw UTF-8
+      case 7: out += "\xF0\x9F\x98\x80"; break; // U+1F600 emoji (4-byte UTF-8)
+      default: out += static_cast<char>('a' + r.below(26)); break;
+    }
+  }
+  out += '"';
+}
+
+void gen_number(rng &r, std::string &out) {
+  switch (r.below(6)) {
+    case 0: out += std::to_string(r.below(1000000)); break;
+    case 1: out += "-" + std::to_string(r.below(1000000)); break;
+    case 2: out += std::to_string(r.below(1000)) + "." + std::to_string(r.below(1000)); break;
+    case 3: out += std::to_string(r.below(100)) + "e" + std::to_string(int(r.below(20)) - 10); break;
+    case 4: out += "0"; break;
+    default: out += std::to_string(r.next()); break; // big uint64
+  }
+}
+
+void gen_value(rng &r, std::string &out, int depth) {
+  // At depth 0 only emit scalars so generation terminates (and produces many
+  // short documents near the padding boundary).
+  uint32_t choice = (depth <= 0) ? (3 + r.below(4)) : r.below(7);
+  switch (choice) {
+    case 0: { // object
+      out += '{';
+      uint32_t n = r.below(5);
+      for (uint32_t i = 0; i < n; i++) { if (i) { out += ','; } gen_string(r, out); out += ':'; gen_value(r, out, depth - 1); }
+      out += '}';
+      break;
+    }
+    case 1: { // array
+      out += '[';
+      uint32_t n = r.below(6);
+      for (uint32_t i = 0; i < n; i++) { if (i) { out += ','; } gen_value(r, out, depth - 1); }
+      out += ']';
+      break;
+    }
+    case 2: gen_string(r, out); break;
+    case 3: gen_number(r, out); break;
+    case 4: out += "true"; break;
+    case 5: out += "false"; break;
+    default: out += "null"; break;
+  }
+}
+
+// Generate thousands of diverse valid documents and require parse_unpadded to
+// agree with the padded parser on every one. Under ASAN this is the broadest
+// over-read check: many documents end in strings/numbers/escapes at every
+// possible offset relative to the buffer end.
+bool random_documents() {
+  TEST_START();
+  for (uint64_t seed = 1; seed <= 5000; seed++) {
+    rng r(seed * 0x100000001b3ull);
+    std::string json;
+    gen_value(r, json, 4);
+    if (!check_matches(json)) {
+      std::cerr << "random_documents failed at seed " << seed << " json=<" << json << ">" << std::endl;
+      return false;
+    }
+  }
+  TEST_SUCCEED();
+}
+
+// Sweep a string value of every length so its closing quote lands at every
+// offset relative to the SIMDJSON_PADDING boundary and the scratch-copy path.
+bool string_at_end_sweep() {
+  TEST_START();
+  for (size_t n = 0; n <= 3 * SIMDJSON_PADDING + 5; n++) {
+    std::string json = "{\"k\":\"" + std::string(n, 'a') + "\"}";
+    if (!check_matches(json)) { return false; }
+    // Also a bare root string of length n.
+    std::string root = "\"" + std::string(n, 'b') + "\"";
+    if (!check_matches(root)) { return false; }
+  }
+  TEST_SUCCEED();
+}
+
+// Strings with escapes / unicode landing right against the end of the buffer.
+bool escapes_at_end() {
+  TEST_START();
+  const std::vector<std::string> tails = {
+    R"(\n)", R"(\t)", R"(\")", R"(\\)", R"(\/)", R"(\b)", R"(\f)", R"(\r)",
+    "\xC3\xA9" /* U+00E9 'e-acute', raw UTF-8 */, "\xF0\x9F\x98\x80" /* U+1F600 emoji */,
+    R"(\uD800)" /* lone high surrogate (valid JSON string) */,
+  };
+  // Vary a leading filler so the escape sits at many offsets near the end.
+  for (const auto &tail : tails) {
+    for (size_t pad = 0; pad <= 2 * SIMDJSON_PADDING; pad++) {
+      std::string json = "{\"k\":\"" + std::string(pad, 'x') + tail + "\"}";
+      if (!check_matches(json)) { return false; }
+      std::string root = "\"" + std::string(pad, 'y') + tail + "\"";
+      if (!check_matches(root)) { return false; }
+    }
+  }
+  TEST_SUCCEED();
+}
+
+// A grab-bag of small documents, including root primitives and the degenerate
+// small-length cases (len < 3 exercises the BOM guard).
+bool assorted_documents() {
+  TEST_START();
+  const std::vector<std::string> docs = {
+    "{}", "[]", "true", "false", "null", "0", "-1", "123", "3.14", "1e10",
+    "\"\"", "\"a\"", "\"hello world\"", "1", "[1]", "[1,2,3]",
+    R"({"a":1,"b":2,"c":[true,false,null],"d":{"x":"y"}})",
+    R"([{"k":"v"},{"k2":"v2"},123,4.5,"end"])",
+    // {"unicode":"<U+00E9 U+00E8 U+00EA>","emoji":"<U+1F600>"} as raw UTF-8
+    "{\"unicode\":\"\xC3\xA9\xC3\xA8\xC3\xAA\",\"emoji\":\"\xF0\x9F\x98\x80\"}",
+    R"(  {  "spaced" :  "value"  }  )",
+    R"({"nested":{"deep":{"deeper":{"value":42}}}})",
+    "\"\xEF\xBB\xBF\"", // a string whose content is a BOM (not a leading BOM)
+  };
+  for (const auto &d : docs) {
+    if (!check_matches(d)) { return false; }
+  }
+  // Leading BOM + document.
+  if (!check_matches(std::string("\xEF\xBB\xBF") + "[1,2,3]")) { return false; }
+  TEST_SUCCEED();
+}
+
+// Larger, real-world files parsed unpadded from an exact-size buffer. Files that
+// are not present in this build are skipped (some are fetched at build time).
+bool real_files() {
+  TEST_START();
+  const char *paths[] = {
+    TWITTER_JSON, TWITTER_TIMELINE_JSON, CANADA_JSON, MESH_JSON, APACHE_JSON,
+    GSOC_JSON, REPEAT_JSON, DEMO_JSON, SMALLDEMO_JSON, ADVERSARIAL_JSON,
+    FLATADVERSARIAL_JSON, TRUENULL_JSON,
+  };
+  size_t tested = 0;
+  for (const char *path : paths) {
+    simdjson::padded_string contents;
+    if (simdjson::padded_string::load(path).get(contents)) { continue; } // skip missing
+    std::string json(contents.data(), contents.size());
+    if (!check_matches(json)) {
+      std::cerr << "mismatch on file " << path << std::endl;
+      return false;
+    }
+    tested++;
+  }
+  std::cout << "  (compared " << tested << " real files)" << std::endl;
+  TEST_SUCCEED();
+}
+
+// The std::string_view / const char* overloads of the public API.
+bool api_overloads() {
+  TEST_START();
+  std::string json = R"({"hello":"world","n":42})";
+  std::vector<char> exact(json.begin(), json.end());
+
+  int64_t n = 0;
+  std::string_view sv;
+
+  dom::parser p1;
+  dom::element e1;
+  ASSERT_SUCCESS( p1.parse_unpadded(std::string_view(exact.data(), exact.size())).get(e1) );
+  ASSERT_SUCCESS( e1["n"].get(n) );
+  ASSERT_EQUAL( n, 42 );
+  ASSERT_SUCCESS( e1["hello"].get(sv) );
+  ASSERT_EQUAL( sv, "world" );
+
+  dom::parser p2;
+  dom::element e2;
+  ASSERT_SUCCESS( p2.parse_unpadded(exact.data(), exact.size()).get(e2) ); // const char*, len
+  ASSERT_SUCCESS( e2["n"].get(n) );
+  ASSERT_EQUAL( n, 42 );
+
+  // parse_into_document_unpadded with a caller-provided document.
+  dom::parser p3;
+  dom::document doc;
+  dom::element e3;
+  ASSERT_SUCCESS( p3.parse_into_document_unpadded(doc, reinterpret_cast<const uint8_t*>(exact.data()), exact.size()).get(e3) );
+  ASSERT_SUCCESS( e3["hello"].get(sv) );
+  ASSERT_EQUAL( sv, "world" );
+
+  // Reusing a parser for an unpadded then a padded parse must work (flag reset).
+  dom::parser p4;
+  dom::element tmp;
+  ASSERT_SUCCESS( p4.parse_unpadded(exact.data(), exact.size()).get(tmp) );
+  ASSERT_SUCCESS( p4.parse(simdjson::padded_string(json)).get(tmp) );
+  ASSERT_SUCCESS( tmp["n"].get(n) );
+  ASSERT_EQUAL( n, 42 );
+  TEST_SUCCEED();
+}
+
+// Degenerate / invalid inputs: empty, whitespace-only, and truncated documents.
+// parse_unpadded must agree with parse (same error) and, crucially, must not
+// read past the (tiny) buffer -- caught here under ASAN.
+bool degenerate_inputs() {
+  TEST_START();
+  const std::vector<std::string> docs = {
+    "", " ", "   ", "\t\n", "{", "[", "\"", "\"abc", "[1,", "{\"a\":", "tru",
+    "nul", "fals", "12.", "-", "[\"unterminated", std::string(1, '\0'),
+  };
+  for (const auto &d : docs) {
+    if (!check_matches(d)) { return false; }
+  }
+  TEST_SUCCEED();
+}
+
+#if SIMDJSON_ENABLE_NAN_INF
+// Only built with -DSIMDJSON_ENABLE_NAN_INF=ON. The non-root inf validator does
+// an 8-byte 'infinity' compare; a malformed inf-spelling at the very end of an
+// unpadded buffer would over-read it without the length-aware guard. Includes
+// valid and malformed tokens, at the document end and behind padding-sized filler.
+bool nan_inf_at_end() {
+  TEST_START();
+  const std::vector<std::string> toks = {
+    "inf", "Inf", "INF", "infinity", "Infinity", "nan", "NaN", "NAN",
+    "in", "inf2", "infi", "infin", "infinit", "na", "nat", "nana",
+  };
+  for (const auto &t : toks) {
+    if (!check_matches(t)) { return false; }                         // root
+    if (!check_matches("[" + t + "]")) { return false; }             // ends the array
+    if (!check_matches("{\"k\":" + t + "}")) { return false; }       // ends the object
+    if (!check_matches("[" + std::string(SIMDJSON_PADDING, ' ') + t + "]")) { return false; }
+  }
+  TEST_SUCCEED();
+}
+#endif
+
+bool run() {
+  return
+#if SIMDJSON_ENABLE_NAN_INF
+         nan_inf_at_end() &&
+#endif
+         numbers() &&
+         number_at_end_sweep() &&
+         malformed_atoms_at_end() &&
+         string_at_end_sweep() &&
+         escapes_at_end() &&
+         assorted_documents() &&
+         degenerate_inputs() &&
+         random_documents() &&
+         real_files() &&
+         api_overloads();
+}
+} // namespace unpadded_tests
+
+int main() {
+  std::cout << "Running parse_unpadded tests." << std::endl;
+  if (unpadded_tests::run()) {
+    std::cout << "parse_unpadded tests are ok." << std::endl;
+    return EXIT_SUCCESS;
+  }
+  return EXIT_FAILURE;
+}

--- a/tests/dom/unpadded_tests.cpp
+++ b/tests/dom/unpadded_tests.cpp
@@ -85,16 +85,19 @@ bool numbers() {
 bool number_at_end_sweep() {
   TEST_START();
   for (size_t frac = 1; frac <= 3 * SIMDJSON_PADDING + 5; frac++) {
-    std::string num = "0." + std::string(frac, '9');
+    std::string num = "0.";
+    num.append(frac, '9');
     if (!check_matches(num)) { return false; }                       // root float
-    if (!check_matches("[" + num + "]")) { return false; }           // float ends the array
-    if (!check_matches("{\"k\":" + num + "}")) { return false; }     // float ends the object
+    { std::string s = "["; s += num; s += "]"; if (!check_matches(s)) { return false; } }           // float ends the array
+    { std::string s = "{\"k\":"; s += num; s += "}"; if (!check_matches(s)) { return false; } }     // float ends the object
     // Long float preceded by filler so it starts far from the end but its digits
     // still reach the final bytes (exercises the next-structural-based trigger).
-    if (!check_matches("[123456789," + num + "]")) { return false; }
+    std::string longfloat = "[123456789,"; longfloat += num; longfloat += "]";
+    if (!check_matches(longfloat)) { return false; }
     // Long integer at the end too.
     std::string bignum = std::string(frac, '7');
-    if (!check_matches("[1," + bignum + "]")) { return false; }
+    std::string longint = "[1,"; longint += bignum; longint += "]";
+    if (!check_matches(longint)) { return false; }
   }
   TEST_SUCCEED();
 }
@@ -115,7 +118,7 @@ bool malformed_atoms_at_end() {
     if (!check_matches("[" + t + "]")) { return false; }            // ends the array
     if (!check_matches("{\"k\":" + t + "}")) { return false; }      // ends the object
     if (!check_matches("[" + t + ",1]")) { return false; }
-    if (!check_matches("[" + std::string(SIMDJSON_PADDING, ' ') + t + "]")) { return false; }
+    { std::string s = "["; s.append(SIMDJSON_PADDING, ' '); s += t; s += "]"; if (!check_matches(s)) { return false; } }
   }
   TEST_SUCCEED();
 }
@@ -151,9 +154,9 @@ void gen_string(rng &r, std::string &out) {
 void gen_number(rng &r, std::string &out) {
   switch (r.below(6)) {
     case 0: out += std::to_string(r.below(1000000)); break;
-    case 1: out += "-" + std::to_string(r.below(1000000)); break;
-    case 2: out += std::to_string(r.below(1000)) + "." + std::to_string(r.below(1000)); break;
-    case 3: out += std::to_string(r.below(100)) + "e" + std::to_string(int(r.below(20)) - 10); break;
+    case 1: out += "-"; out += std::to_string(r.below(1000000)); break;
+    case 2: out += std::to_string(r.below(1000)); out += '.'; out += std::to_string(r.below(1000)); break;
+    case 3: out += std::to_string(r.below(100)); out += 'e'; out += std::to_string(int(r.below(20)) - 10); break;
     case 4: out += "0"; break;
     default: out += std::to_string(r.next()); break; // big uint64
   }
@@ -209,10 +212,14 @@ bool random_documents() {
 bool string_at_end_sweep() {
   TEST_START();
   for (size_t n = 0; n <= 3 * SIMDJSON_PADDING + 5; n++) {
-    std::string json = "{\"k\":\"" + std::string(n, 'a') + "\"}";
+    std::string json = "{\"k\":\"";
+    json.append(n, 'a');
+    json += "\"}";
     if (!check_matches(json)) { return false; }
     // Also a bare root string of length n.
-    std::string root = "\"" + std::string(n, 'b') + "\"";
+    std::string root = "\"";
+    root.append(n, 'b');
+    root += "\"";
     if (!check_matches(root)) { return false; }
   }
   TEST_SUCCEED();
@@ -229,12 +236,43 @@ bool escapes_at_end() {
   // Vary a leading filler so the escape sits at many offsets near the end.
   for (const auto &tail : tails) {
     for (size_t pad = 0; pad <= 2 * SIMDJSON_PADDING; pad++) {
-      std::string json = "{\"k\":\"" + std::string(pad, 'x') + tail + "\"}";
+      std::string json = "{\"k\":\"";
+      json.append(pad, 'x');
+      json += tail;
+      json += "\"}";
       if (!check_matches(json)) { return false; }
-      std::string root = "\"" + std::string(pad, 'y') + tail + "\"";
+      std::string root = "\"";
+      root.append(pad, 'y');
+      root += tail;
+      root += "\"";
       if (!check_matches(root)) { return false; }
     }
   }
+  TEST_SUCCEED();
+}
+
+// Targeted regression test for a surrogate-pair lookahead read that reaches
+// +11 bytes past a backslash in the fast (BYTES_PROCESSED-sized) loop of
+// parse_string_safe. On kernels where BYTES_PROCESSED == SIMDJSON_PADDING
+// (e.g. icelake) this requires a guard margin of at least +12. Stage 1 accepts
+// the document (the final " closes the string) but the escape is a high
+// surrogate followed by a truncated \u; the second hex_to_u32_nocheck reads
+// 4 bytes at the critical offset. We place the backslash at content offset 63
+// so it is bs_dist=63 of the first chunk on 64-byte kernels.
+bool surrogate_pair_deep_lookahead_at_chunk_boundary() {
+  TEST_START();
+  // Root string case.
+  std::string json = "\"";
+  json.append(63, 'a');
+  json += "\\uD800\\u\"";   // high surrogate + \u (truncated) + string closer
+  if (!check_matches(json)) { return false; }
+
+  // Non-root (object value) case.
+  std::string obj = "{\"k\":\"";
+  obj.append(63, 'b');
+  obj += "\\uD800\\u\"}";  // final " closes the string value
+  if (!check_matches(obj)) { return false; }
+
   TEST_SUCCEED();
 }
 
@@ -356,7 +394,7 @@ bool nan_inf_at_end() {
     if (!check_matches(t)) { return false; }                         // root
     if (!check_matches("[" + t + "]")) { return false; }             // ends the array
     if (!check_matches("{\"k\":" + t + "}")) { return false; }       // ends the object
-    if (!check_matches("[" + std::string(SIMDJSON_PADDING, ' ') + t + "]")) { return false; }
+    { std::string s = "["; s.append(SIMDJSON_PADDING, ' '); s += t; s += "]"; if (!check_matches(s)) { return false; } }
   }
   TEST_SUCCEED();
 }
@@ -372,6 +410,7 @@ bool run() {
          malformed_atoms_at_end() &&
          string_at_end_sweep() &&
          escapes_at_end() &&
+         surrogate_pair_deep_lookahead_at_chunk_boundary() &&
          assorted_documents() &&
          degenerate_inputs() &&
          random_documents() &&


### PR DESCRIPTION
Years ago @jkeiser had tried introducing a padding-free DOM parser. This is an implementation. It is meant to be optional and we check that it does not harm the performance of the padded approach.

Fixes https://github.com/simdjson/simdjson/issues/174