### PR TITLE
to_chars.cpp, fast path to avoid i128 emulation when possible

### DIFF
--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -53,7 +53,7 @@ inline std::uint64_t umul64(std::uint32_t x, std::uint32_t y) noexcept {
 // 64x64 -> 128 bit multiplication.
 inline uint128 umul128(std::uint64_t x, std::uint64_t y) noexcept {
 #if defined(__SIZEOF_INT128__)
-  const __uint128_t p = (__uint128_t)x*y;
+  const __uint128_t p = static_cast<__uint128_t>(x)*y;
   return {std::uint64_t(p>>64), std::uint64_t(p)};
 #else // using fallback on 32-bit targets and MSVC
   const std::uint32_t a = std::uint32_t(x >> 32);
@@ -77,7 +77,7 @@ inline uint128 umul128(std::uint64_t x, std::uint64_t y) noexcept {
 // High 64 bits of a 64x64 -> 128 bit multiplication.
 inline std::uint64_t umul128_upper64(std::uint64_t x, std::uint64_t y) noexcept {
 #if defined(__SIZEOF_INT128__)
-  return std::uint64_t(((__uint128_t)x*y)>>64);
+  return std::uint64_t((static_cast<__uint128_t>(x)*y)>>64);
 #else // using fallback on 32-bit targets and MSVC
   const std::uint32_t a = std::uint32_t(x >> 32);
   const std::uint32_t b = std::uint32_t(x);

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -52,6 +52,10 @@ inline std::uint64_t umul64(std::uint32_t x, std::uint32_t y) noexcept {
 
 // 64x64 -> 128 bit multiplication.
 inline uint128 umul128(std::uint64_t x, std::uint64_t y) noexcept {
+#if defined(__SIZEOF_INT128__)
+  const __uint128_t p = (__uint128_t)x*y;
+  return {std::uint64_t(p>>64), std::uint64_t(p)};
+#else // using fallback on 32-bit targets and MSVC
   const std::uint32_t a = std::uint32_t(x >> 32);
   const std::uint32_t b = std::uint32_t(x);
   const std::uint32_t c = std::uint32_t(y >> 32);
@@ -67,10 +71,14 @@ inline uint128 umul128(std::uint64_t x, std::uint64_t y) noexcept {
 
   return {ac + (intermediate >> 32) + (ad >> 32) + (bc >> 32),
           (intermediate << 32) + std::uint32_t(bd)};
+#endif
 }
 
 // High 64 bits of a 64x64 -> 128 bit multiplication.
 inline std::uint64_t umul128_upper64(std::uint64_t x, std::uint64_t y) noexcept {
+#if defined(__SIZEOF_INT128__)
+  return std::uint64_t(((__uint128_t)x*y)>>64);
+#else // using fallback on 32-bit targets and MSVC
   const std::uint32_t a = std::uint32_t(x >> 32);
   const std::uint32_t b = std::uint32_t(x);
   const std::uint32_t c = std::uint32_t(y >> 32);
@@ -85,6 +93,7 @@ inline std::uint64_t umul128_upper64(std::uint64_t x, std::uint64_t y) noexcept 
       (bd >> 32) + std::uint32_t(ad) + std::uint32_t(bc);
 
   return ac + (intermediate >> 32) + (ad >> 32) + (bc >> 32);
+#endif
 }
 
 // Upper 128 bits of a 64 x 128 -> 192 bit multiplication.


### PR DESCRIPTION
### Summary
This PR propose a fast-path inside `src/to_chars::umul128()` and `src/to_chars::umul128_upper64()` via:  
```cpp
#if defined(__SIZEOF_INT128__)
// proposed fast path  (__uint128_t)
#else
// fallback to original emulation (4*(uint32_t * uint32_t))
#endif
```
fast-path will be computed if target is not:
- 32-bit base
- MSVC

### Context
This PR continue:
- #2777 

Issues related to this PR:
- #1692 
- #1450 


100% on tests with:
```bash
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build
```

benchmarked with `benchmark/car_builder/benchmark_car_builder.cpp`:
```bash
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON -D CMAKE_BUILD_TYPE=Release
cmake --build build --target benchmark_car_builder -j
./build/benchmark/car_builder/benchmark_car_builder
```

#### Bench
master:
```
Trial 1: string_builder:     1.21 ns  0.82 GB/s  5.24 GHz  6.35 cycles/char  23.39 ins./char  3.68 i/c
Trial 2: string_builder:     1.21 ns  0.82 GB/s  5.23 GHz  6.36 cycles/char  23.39 ins./char  3.68 i/c
Trial 3: string_builder:     1.21 ns  0.82 GB/s  5.25 GHz  6.37 cycles/char  23.38 ins./char  3.67 i/c
```
this PR:
```
Trial 1: string_builder:     1.09 ns  0.91 GB/s  5.30 GHz  5.80 cycles/char  21.57 ins./char  3.72 i/c
Trial 2: string_builder:     1.09 ns  0.92 GB/s  5.32 GHz  5.80 cycles/char  21.57 ins./char  3.72 i/c
Trial 3: string_builder:     1.09 ns  0.92 GB/s  5.32 GHz  5.82 cycles/char  21.57 ins./char  3.71 i/c
```

> computed with:
> - AMD Ryzen 5 7600X (6cores)
> - CPU governor pinned to `Performance`