### PR TITLE
to_chars.cpp,  2 digits at a time and avoiding reversal loop

### DIFF
--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -988,17 +988,39 @@ inline void dragonbox(char *buf, int &len, int &decimal_exponent,
 
   const decimal_fp dec = to_decimal(binary_significand, binary_exponent);
 
-  // Write the significand digits most-significant first.
+  // Convert the decimal significand to digits:
+  // 1) Proceed 2 digits at a time (s % 100) via a 00..99 lookup table
+  //     (see Alexandrescu, "Three Optimization Tips for C++", 2012),
+  // 2) Digits come out least-significant first, writing them back-to-front
+  //     with p = tmp + sizeof(tmp); to avoid reversal pass
+  // 3) Proceed remaining digits after loop to avoid branchs inside it
+  // 4) memcpy digits to char* buf (inside function input)
+  static const char digits2[201] =
+      "0001020304050607080910111213141516171819"
+      "2021222324252627282930313233343536373839"
+      "4041424344454647484950515253545556575859"
+      "6061626364656667686970717273747576777879"
+      "8081828384858687888990919293949596979899";
   char tmp[24];
-  int n = 0;
+  char *p = tmp + sizeof(tmp); // write backward
   std::uint64_t s = dec.significand;
-  do {
-    tmp[n++] = static_cast<char>('0' + (s % 10));
-    s /= 10;
-  } while (s != 0);
-  for (int i = 0; i < n; ++i) {
-    buf[i] = tmp[n - 1 - i];
+  while (s >= 100) {
+    const std::uint32_t idx = static_cast<std::uint32_t>(s % 100) * 2;
+    s /= 100;
+    p -= 2;
+    p[0] = digits2[idx];
+    p[1] = digits2[idx + 1];
   }
+  if (s >= 10) {
+    const std::uint32_t idx = static_cast<std::uint32_t>(s) * 2;
+    p -= 2;
+    p[0] = digits2[idx];
+    p[1] = digits2[idx + 1];
+  } else {
+    *--p = static_cast<char>('0' + s);
+  }
+  const int n = static_cast<int>(tmp + sizeof(tmp) - p);
+  std::memcpy(buf, p, static_cast<size_t>(n));
   len = n;
   decimal_exponent = dec.exponent;
 }


### PR DESCRIPTION
### Summary
This PR propose an improvement of `src/to_chars::dragonbox()` by using 2-at-a-time method (Alexandrescu, "Three Optimization Tips for C++", 2012) and back-to-front+memcpy write in buffer to avoid reversal loop. Reducing by 3x the number of loop iterations in this function.


### Context
This PR continue:
- #2777 

Issues related to this PR:
- #1692 
- #1450 


100% on tests with:
```bash
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build
```

benchmarked with `benchmark/car_builder/benchmark_car_builder.cpp`:
```bash
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON -D CMAKE_BUILD_TYPE=Release
cmake --build build --target benchmark_car_builder -j
./build/benchmark/car_builder/benchmark_car_builder
```

#### Bench
master:
```
Trial 1: string_builder:     1.21 ns  0.82 GB/s  5.24 GHz  6.35 cycles/char  23.39 ins./char  3.68 i/c
Trial 2: string_builder:     1.21 ns  0.82 GB/s  5.23 GHz  6.36 cycles/char  23.39 ins./char  3.68 i/c
Trial 3: string_builder:     1.21 ns  0.82 GB/s  5.25 GHz  6.37 cycles/char  23.38 ins./char  3.67 i/c
```
this PR:
```
Trial 1: string_builder:     0.95 ns  1.05 GB/s  5.23 GHz  4.98 cycles/char  17.03 ins./char  3.42 i/c
Trial 2: string_builder:     0.95 ns  1.05 GB/s  5.25 GHz  4.98 cycles/char  17.03 ins./char  3.42 i/c
Trial 3: string_builder:     0.95 ns  1.05 GB/s  5.23 GHz  4.97 cycles/char  17.03 ins./char  3.42 i/c
```

> computed with:
> - AMD Ryzen 5 7600X (6cores)
> - CPU governor pinned to `Performance`


### Notes
- Latency of `to_chars.cpp` of this PR, over `benchmark/car_builder/benchmark_car_builder.cpp`, drop from 0.95 ns/char to 0.85 ns/char if merged with #2780 
- No license needed for 2-at-a-time method; credit given inside `to_chars.cpp::dragonbox()` doc as comments.
- tried `jeaiii` algorithm inside `dragonbox()` to avoid completly modulo and division but it become 0.02ns/char slower than this PR.