### PR TITLE
Fix incorrect doc comments (find_field example, batch_size default, get_uint64 return type)

### DIFF
--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -532,7 +532,7 @@ public:
    * @param batch_size The batch size to use. MUST be larger than the largest document. The sweet
    *                   spot is cache-related: small enough to fit in cache, yet big enough to
    *                   parse as many documents as possible in one tight loop.
-   *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
+   *                   Defaults to 1MB, which has been a reasonable sweet spot in our tests.
    * @return The stream, or an error. An empty input will yield 0 documents rather than an EMPTY error. Errors:
    *         - MEMALLOC if the parser does not have enough capacity and memory allocation fails
    *         - CAPACITY if the parser does not have enough capacity and batch_size > max_capacity.

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -51,14 +51,14 @@ public:
   /**
    * Cast this JSON value to an unsigned integer.
    *
-   * @returns A signed 64-bit integer.
+   * @returns A unsigned 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
   simdjson_inline simdjson_result<uint64_t> get_uint64() noexcept;
   /**
    * Cast this JSON value (inside string) to an unsigned integer.
    *
-   * @returns A signed 64-bit integer.
+   * @returns A unsigned 64-bit integer.
    * @returns INCORRECT_TYPE If the JSON value is not a 64-bit unsigned integer.
    */
   simdjson_inline simdjson_result<uint64_t> get_uint64_in_string() noexcept;
@@ -316,7 +316,7 @@ public:
   /**
    * Cast this JSON value to an unsigned integer.
    *
-   * @returns A signed 64-bit integer.
+   * @returns A unsigned 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
   explicit simdjson_inline operator uint64_t() noexcept(false);

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -117,10 +117,11 @@ public:
    *
    * ```cpp
    * simdjson::ondemand::parser parser;
-   * auto obj = parser.parse(R"( { "x": 1, "y": 2, "z": 3 } )"_padded);
-   * double z = obj.find_field("z");
-   * double y = obj.find_field("y");
-   * double x = obj.find_field("x");
+   * auto json = R"( { "x": 1, "y": 2, "z": 3 } )"_padded;
+   * auto doc = parser.iterate(json);
+   * double z = doc.find_field("z");
+   * double y = doc.find_field("y");
+   * double x = doc.find_field("x");
    * ```
    * If you have multiple fields with a matching key ({"x": 1,  "x": 1}) be mindful
    * that only one field is returned.

--- a/include/simdjson/generic/ondemand/parser.h
+++ b/include/simdjson/generic/ondemand/parser.h
@@ -243,7 +243,7 @@ public:
    * @param batch_size The batch size to use. MUST be larger than the largest document. The sweet
    *                   spot is cache-related: small enough to fit in cache, yet big enough to
    *                   parse as many documents as possible in one tight loop.
-   *                   Defaults to 10MB, which has been a reasonable sweet spot in our tests.
+   *                   Defaults to 1MB, which has been a reasonable sweet spot in our tests.
    * @param allow_comma_separated @deprecated Use stream_format::comma_delimited instead.
    *                   When true, maps internally to stream_format::comma_delimited.
    *                   Defaults to false.

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -313,7 +313,7 @@ public:
   /**
    * Cast this JSON value to an unsigned integer.
    *
-   * @returns A signed 64-bit integer.
+   * @returns A unsigned 64-bit integer.
    * @exception simdjson_error(INCORRECT_TYPE) If the JSON value is not a 64-bit unsigned integer.
    */
   simdjson_inline operator uint64_t() noexcept(false);


### PR DESCRIPTION
A few small, verified doc-comment corrections in public headers.

### 1. `find_field` example doesn't compile (`ondemand/object.h`)

The example called `parser.parse(...)`, which doesn't exist on `ondemand::parser`. Updated it to the canonical `parser.iterate(json)` form used elsewhere in these headers (a named `_padded` variable is required, since `iterate` on a temporary is a deleted overload):

```cpp
simdjson::ondemand::parser parser;
auto json = R"( { "x": 1, "y": 2, "z": 3 } )"_padded;
auto doc = parser.iterate(json);
double z = doc.find_field("z");
...
```

### 2. `iterate_many` `batch_size` default is documented as 10MB but is 1MB (`ondemand/parser.h`, `dom/parser.h`)

`DEFAULT_BATCH_SIZE` is `1000000` (1MB) in both `ondemand/parser.h` and `dom/base.h`, and other copies of this comment already say 1MB. PR #1054 (which tried to bump the constant to 10MB to match this text) was closed, so the docs are the wrong side. Fixed the two remaining "10MB" occurrences to "1MB".

### 3. `get_uint64` / `operator uint64_t` say they return a *signed* integer (`ondemand/document.h`, `ondemand/value.h`)

`get_uint64`, `get_uint64_in_string` and `operator uint64_t` return `uint64_t`, and their own summary lines say "Cast this JSON value to an unsigned integer", but `@returns` said "A signed 64-bit integer". Changed those three (in `document.h`) plus `operator uint64_t` (in `value.h`) to "A unsigned 64-bit integer", matching the already-correct `value.h` `get_uint64` comment. The `int64_t` overloads are left as "signed" (correct).

Documentation only — no code changes. Left the `singleheader/` amalgamation untouched (per HACKING.md it's regenerated at release time); happy to regenerate it if you'd prefer.
