### PR TITLE
Add std::chrono::system_clock::time_point serialization support

### DIFF
--- a/include/simdjson/generic/builder/json_string_builder.h
+++ b/include/simdjson/generic/builder/json_string_builder.h
@@ -5,6 +5,10 @@
 #include "simdjson/generic/implementation_simdjson_result_base.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+
 namespace simdjson {
 
 
@@ -33,6 +37,39 @@ struct has_custom_serialization<T, std::void_t<
 
 template <typename T>
 constexpr bool require_custom_serialization = has_custom_serialization<T>::value;
+
+/**
+ * Serializes std::chrono::system_clock::time_point as an ISO 8601 UTC string
+ * with millisecond precision, e.g. "2024-01-15T10:30:00.123Z" (issue #2447).
+ */
+template <typename builder_type>
+void tag_invoke(serialize_tag, builder_type &b, const std::chrono::system_clock::time_point &tp) {
+  using namespace std::chrono;
+
+  auto ms_since_epoch = duration_cast<milliseconds>(tp.time_since_epoch()).count();
+  auto secs = static_cast<std::time_t>(ms_since_epoch / 1000);
+  auto ms = static_cast<int>(ms_since_epoch % 1000);
+  if (ms < 0) {
+    // time points before 1970 can produce a negative remainder; normalize
+    // so that ms is always in [0, 999].
+    ms += 1000;
+    secs -= 1;
+  }
+
+  std::tm tm_utc{};
+#if defined(_WIN32)
+  gmtime_s(&tm_utc, &secs);
+#else
+  gmtime_r(&secs, &tm_utc);
+#endif
+
+  char buf[32];
+  int n = std::snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d.%03dZ",
+      tm_utc.tm_year + 1900, tm_utc.tm_mon + 1, tm_utc.tm_mday,
+      tm_utc.tm_hour, tm_utc.tm_min, tm_utc.tm_sec, ms);
+
+  b.escape_and_append_with_quotes(std::string_view(buf, static_cast<size_t>(n)));
+}
 #else
 struct has_custom_serialization : std::false_type {};
 #endif // SIMDJSON_SUPPORTS_CONCEPTS

--- a/include/simdjson/generic/ondemand/std_deserialize.h
+++ b/include/simdjson/generic/ondemand/std_deserialize.h
@@ -9,7 +9,11 @@
 #include "simdjson/annotations.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#include <chrono>
 #include <concepts>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
 #include <limits>
 #if SIMDJSON_STATIC_REFLECTION
 #include <meta>
@@ -54,6 +58,68 @@ error_code tag_invoke(deserialize_tag, auto &val, T &out) noexcept {
     return NUMBER_OUT_OF_RANGE;
   }
   out = static_cast<T>(x);
+  return SUCCESS;
+}
+
+//////////////////////////////
+// Chrono deserialization
+//////////////////////////////
+
+/**
+ * Deserializes an ISO 8601 UTC string of the form "YYYY-MM-DDTHH:MM:SS[.fff]Z"
+ * (as produced by the matching serialize tag_invoke in json_string_builder.h)
+ * back into a std::chrono::system_clock::time_point (issue #2447).
+ */
+error_code tag_invoke(deserialize_tag, auto &val, std::chrono::system_clock::time_point &out) noexcept {
+  std::string_view str;
+  SIMDJSON_TRY(val.get_string().get(str));
+
+  // Shortest valid form is "YYYY-MM-DDTHH:MM:SSZ" (20 chars); allow up to
+  // a few extra digits of fractional seconds.
+  if (str.size() < 20 || str.size() > 30 || str.back() != 'Z') {
+    return INCORRECT_TYPE;
+  }
+
+  char buf[32];
+  std::memcpy(buf, str.data(), str.size());
+  buf[str.size()] = '\0';
+
+  int year, month, day, hour, minute, second;
+  int matched = std::sscanf(buf, "%4d-%2d-%2dT%2d:%2d:%2d",
+      &year, &month, &day, &hour, &minute, &second);
+  if (matched != 6) {
+    return INCORRECT_TYPE;
+  }
+
+  int ms = 0;
+  const char *dot = static_cast<const char *>(std::memchr(buf, '.', str.size()));
+  if (dot != nullptr) {
+    char frac[4] = {'0', '0', '0', '\0'};
+    size_t i = 0;
+    for (const char *p = dot + 1; *p >= '0' && *p <= '9' && i < 3; ++p, ++i) {
+      frac[i] = *p;
+    }
+    ms = (frac[0] - '0') * 100 + (frac[1] - '0') * 10 + (frac[2] - '0');
+  }
+
+  std::tm tm_utc{};
+  tm_utc.tm_year = year - 1900;
+  tm_utc.tm_mon = month - 1;
+  tm_utc.tm_mday = day;
+  tm_utc.tm_hour = hour;
+  tm_utc.tm_min = minute;
+  tm_utc.tm_sec = second;
+
+#if defined(_WIN32)
+  std::time_t secs = _mkgmtime(&tm_utc);
+#else
+  std::time_t secs = timegm(&tm_utc);
+#endif
+  if (secs == static_cast<std::time_t>(-1)) {
+    return INCORRECT_TYPE;
+  }
+
+  out = std::chrono::system_clock::from_time_t(secs) + std::chrono::milliseconds(ms);
   return SUCCESS;
 }
 

--- a/tests/builder/builder_string_builder_tests.cpp
+++ b/tests/builder/builder_string_builder_tests.cpp
@@ -768,6 +768,53 @@ bool car_test_simple_complete_exceptions() {
 #endif // SIMDJSON_EXCEPTIONS
 #endif // SIMDJSONS_SUPPORT_RANGES
 
+#if SIMDJSON_SUPPORTS_CONCEPTS
+bool chrono_time_point_test() {
+  TEST_START();
+  using namespace std::chrono;
+  // 2024-01-15T10:30:00.123Z, chosen to exercise both a non-zero
+  // millisecond component and a UTC calendar date.
+  system_clock::time_point tp =
+      system_clock::from_time_t(1705314600) + milliseconds(123);
+
+  std::string s;
+  ASSERT_SUCCESS(simdjson::to_json(tp).get(s));
+  ASSERT_EQUAL(s, "\"2024-01-15T10:30:00.123Z\"");
+
+  simdjson::padded_string json(s);
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc;
+  ASSERT_SUCCESS(parser.iterate(json).get(doc));
+
+  system_clock::time_point round_tripped;
+  ASSERT_SUCCESS(doc.get(round_tripped));
+  ASSERT_EQUAL(round_tripped.time_since_epoch().count(),
+               tp.time_since_epoch().count());
+  TEST_SUCCEED();
+}
+
+bool chrono_time_point_epoch_test() {
+  TEST_START();
+  using namespace std::chrono;
+  system_clock::time_point tp = system_clock::from_time_t(0);
+
+  std::string s;
+  ASSERT_SUCCESS(simdjson::to_json(tp).get(s));
+  ASSERT_EQUAL(s, "\"1970-01-01T00:00:00.000Z\"");
+
+  simdjson::padded_string json(s);
+  simdjson::ondemand::parser parser;
+  simdjson::ondemand::document doc;
+  ASSERT_SUCCESS(parser.iterate(json).get(doc));
+
+  system_clock::time_point round_tripped;
+  ASSERT_SUCCESS(doc.get(round_tripped));
+  ASSERT_EQUAL(round_tripped.time_since_epoch().count(),
+               tp.time_since_epoch().count());
+  TEST_SUCCEED();
+}
+#endif // SIMDJSON_SUPPORTS_CONCEPTS
+
 #if SIMDJSON_EXCEPTIONS
 bool car_test_exception() {
   TEST_START();
@@ -796,6 +843,7 @@ bool run() {
 #endif
 #if SIMDJSON_SUPPORTS_CONCEPTS
          issue2549() && car_test_template() && serialize_optional() &&
+         chrono_time_point_test() && chrono_time_point_epoch_test() &&
 #endif
          append_char() && append_integer() && append_float() && append_null() &&
 #if SIMDJSON_ENABLE_NAN_INF


### PR DESCRIPTION
## Summary
Closes #2447: adds automatic serialization/deserialization support for
std::chrono::system_clock::time_point to both builder::string_builder
(to_json) and the On-Demand deserialize/.get<T>() path.

Represented as ISO 8601 UTC strings with millisecond precision, e.g.
"2024-01-15T10:30:00.123Z".

## Why this format
ISO 8601/RFC 3339 is the standard for timestamps in JSON APIs, and matches
JavaScript's Date.toISOString(). I used gmtime_r/_mkgmtime/timegm instead of
C++20 chrono's stream formatting since <chrono> calendar support is still
inconsistent across libstdc++/libc++ versions.

## Testing
Built and ran this for real:
cmake .. -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_CXX_STANDARD=20 -GNinja
ninja builder_string_builder_tests && ./tests/builder/builder_string_builder_tests

Both new tests (chrono_time_point_test, chrono_time_point_epoch_test) pass
alongside the full existing suite. Also verified the amalgamated singleheader
compiles standalone under -std=c++20 -fconcepts.

Not tested: the _WIN32 path (_mkgmtime/gmtime_s) — no Windows machine
available. Happy to adjust format/precision if you'd prefer something else.