### PR TITLE
Add C++20 u8 variants of string access methods (#2731)

### DIFF
--- a/include/simdjson/dom/element-inl.h
+++ b/include/simdjson/dom/element-inl.h
@@ -65,6 +65,12 @@ simdjson_inline simdjson_result<std::string_view> simdjson_result<dom::element>:
   if (error()) { return error(); }
   return first.get_string();
 }
+#if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+simdjson_inline simdjson_result<std::u8string_view> simdjson_result<dom::element>::get_u8string() const noexcept {
+  if (error()) { return error(); }
+  return first.get_u8string();
+}
+#endif
 simdjson_inline simdjson_result<int64_t> simdjson_result<dom::element>::get_int64() const noexcept {
   if (error()) { return error(); }
   return first.get_int64();
@@ -263,6 +269,13 @@ inline simdjson_result<std::string_view> element::get_string() const noexcept {
       return INCORRECT_TYPE;
   }
 }
+#if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+inline simdjson_result<std::u8string_view> element::get_u8string() const noexcept {
+  std::string_view v;
+  SIMDJSON_TRY(get_string().get(v));
+  return std::u8string_view(reinterpret_cast<const char8_t*>(v.data()), v.size());
+}
+#endif
 inline simdjson_result<uint64_t> element::get_uint64() const noexcept {
   SIMDJSON_DEVELOPMENT_ASSERT(tape.usable()); // https://github.com/simdjson/simdjson/issues/1914
   if(simdjson_unlikely(!tape.is_uint64())) { // branch rarely taken

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -92,6 +92,20 @@ public:
    *          Returns INCORRECT_TYPE if the JSON element is not a string.
    */
   inline simdjson_result<std::string_view> get_string() const noexcept;
+
+  #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+  /**
+   * Cast this element to a C++20 UTF-8 string.
+   *
+   * The string is guaranteed to be valid UTF-8.
+   *
+   * @returns A std::u8string_view. The string is stored in the parser and will be invalidated the next time it
+   *          parses a document or when it is destroyed.
+   *          Returns INCORRECT_TYPE if the JSON element is not a string.
+   */
+  inline simdjson_result<std::u8string_view> get_u8string() const noexcept;
+  #endif
+
   /**
    * Cast this element to a signed integer.
    *
@@ -545,6 +559,9 @@ public:
   simdjson_inline simdjson_result<const char *> get_c_str() const noexcept;
   simdjson_inline simdjson_result<size_t> get_string_length() const noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string() const noexcept;
+  #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+  simdjson_inline simdjson_result<std::u8string_view> get_u8string() const noexcept;
+  #endif
   simdjson_inline simdjson_result<int64_t> get_int64() const noexcept;
   simdjson_inline simdjson_result<uint64_t> get_uint64() const noexcept;
   simdjson_inline simdjson_result<double> get_double() const noexcept;

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -918,6 +918,22 @@ namespace dom_api_tests {
 #endif // SIMDJSON_ENABLE_DEPRECATED_API
 
   SIMDJSON_POP_DISABLE_WARNINGS
+  #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+  bool u8string_value() {
+    std::cout << "Running " << __func__ << std::endl;
+    string json(R"({ "str": "hello u8" })");
+    dom::parser parser;
+    dom::object object;
+    ASSERT_SUCCESS( parser.parse(json).get(object) );
+
+    std::u8string_view u8_val;
+    ASSERT_SUCCESS( object["str"].get_u8string().get(u8_val) );
+
+    ASSERT_EQUAL( u8_val.size(), 8 );
+    ASSERT_TRUE( u8_val == u8"hello u8" );
+    return true;
+  }
+  #endif
 
   bool object_iterator() {
     std::cout << "Running " << __func__ << std::endl;
@@ -1426,6 +1442,9 @@ namespace dom_api_tests {
 
   bool run() {
     return
+    #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+           u8string_value() &&
+    #endif
     #if SIMDJSON_ENABLE_DEPRECATED_API
         ParsedJson_Iterator_test() &&
     #endif


### PR DESCRIPTION
Short title (summary):

Description
- What did you change and why? (1-3 sentences)
This PR adds C++20 `char8_t` support by introducing the `get_u8string()` method to `dom::element` and `simdjson_result<dom::element>`. This allows C++20 users to directly retrieve valid UTF-8 strings as `std::u8string_view` using a safe `reinterpret_cast` without needing to cast it manually. The implementations are strictly guarded by `#if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L` to ensure zero impact on C++11/C++17 builds.


Type of change
- [ ] Bug fix
- [ ] Optimization
- [ x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to verify / test
- Added the `u8string_value()` test case to `tests/dom/basictests.cpp` to verify correct parsing and casting behavior. 
- Verified locally that building with `SIMDJSON_CXX_STANDARD=17` correctly ignores the macro guards.
- Verified locally that building with `SIMDJSON_CXX_STANDARD=20` compiles the new code, executes the test, and passes all assertions.


Checklist before submitting
- [x ] I added/updated tests covering my change (if applicable)
- [ x] Code builds locally and passes my check
- [ ] Documentation / README updated if needed
- [x ] Commits are atomic and messages are clear
- [x ] I linked the related issue (if applicable)


