### PR TITLE
Add experimental multi-threaded ondemand stream parsing [research]

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -12,6 +12,12 @@ endif(SIMDJSON_STATIC_REFLECTION)
 add_executable(benchfeatures benchfeatures.cpp)
 add_executable(get_corpus_benchmark get_corpus_benchmark.cpp)
 
+# Multi-threaded ondemand stream parsing (experimental). Requires exceptions and
+# threads; both are on by default.
+if(SIMDJSON_EXCEPTIONS AND SIMDJSON_ENABLE_THREADS)
+  add_executable(bench_parallel_stream bench_parallel_stream.cpp)
+endif()
+
 if (TARGET benchmark::benchmark)
   link_libraries(benchmark::benchmark)
   add_executable(bench_parse_call bench_parse_call.cpp)

--- a/benchmark/bench_parallel_stream.cpp
+++ b/benchmark/bench_parallel_stream.cpp
@@ -1,0 +1,337 @@
+// Benchmark for simdjson::experimental::parse_many_parallel.
+//
+// It contrasts three ways of extracting a value out of every document in a
+// large newline-delimited JSON stream:
+//
+//   * serial            : one parser, single-threaded iterate_many
+//   * builtin-2thread   : iterate_many with parser.threaded = true (simdjson's
+//                         own stage1/stage2 pipeline; needs several batches)
+//   * parallel(N)       : parse_many_parallel with N worker threads
+//
+// Two datasets exercise the two regimes:
+//   * amazon_cellphones.ndjson (repeated) : light per-document work, so it
+//                         becomes memory-bandwidth bound as threads grow.
+//   * synthetic points {"x":..,"y":..,"z":..} : number-heavy, so stage 2
+//                         dominates and it scales with core count.
+//
+// This is a plain timing harness (no google-benchmark dependency) so it can be
+// run anywhere:  ./bench_parallel_stream [target_megabytes]
+//
+// It relies on threads; build simdjson with SIMDJSON_ENABLE_THREADS (the
+// default), which links -pthread and defines SIMDJSON_THREADS_ENABLED.
+
+#include "simdjson.h"
+#include "json_benchmark/constants.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace simdjson;
+
+namespace {
+
+// ---- datasets --------------------------------------------------------------
+
+// Load a file, drop its first line (the amazon file's header row of field
+// names), then repeat the remaining rows until the buffer reaches target bytes.
+std::string load_repeat(const char *path, size_t target_bytes) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    std::fprintf(stderr, "error: cannot open %s\n", path);
+    std::exit(EXIT_FAILURE);
+  }
+  std::stringstream buffer;
+  buffer << in.rdbuf();
+  std::string all = buffer.str();
+  size_t first_newline = all.find('\n');
+  std::string body =
+      (first_newline == std::string::npos) ? all : all.substr(first_newline + 1);
+  if (!body.empty() && body.back() != '\n') { body.push_back('\n'); }
+  std::string out;
+  out.reserve(target_bytes + body.size());
+  while (out.size() < target_bytes) { out += body; }
+  return out;
+}
+
+// Load a file and return its data rows (header line dropped, blank lines
+// skipped) so we can re-serialize them in any stream format.
+std::vector<std::string> load_rows(const char *path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    std::fprintf(stderr, "error: cannot open %s\n", path);
+    std::exit(EXIT_FAILURE);
+  }
+  std::stringstream buffer;
+  buffer << in.rdbuf();
+  std::string all = buffer.str();
+  std::vector<std::string> rows;
+  size_t start = all.find('\n'); // skip the header row
+  start = (start == std::string::npos) ? all.size() : start + 1;
+  while (start < all.size()) {
+    size_t end = all.find('\n', start);
+    if (end == std::string::npos) { end = all.size(); }
+    if (end > start) { rows.emplace_back(all, start, end - start); }
+    start = end + 1;
+  }
+  return rows;
+}
+
+// Serialize the rows, repeated up to target_bytes, in the requested format
+// (whitespace_delimited or json_sequence).
+std::string build_stream(const std::vector<std::string> &rows,
+                         size_t target_bytes, stream_format format) {
+  std::string out;
+  out.reserve(target_bytes + 4096);
+  size_t i = 0;
+  while (out.size() < target_bytes) {
+    const std::string &row = rows[i++ % rows.size()];
+    if (format == stream_format::json_sequence) { out.push_back('\x1e'); } // RS
+    out += row;
+    out.push_back('\n');
+  }
+  return out;
+}
+
+// Newline-delimited {"x":..,"y":..,"z":..} documents.
+std::string make_points(size_t target_bytes) {
+  std::string out;
+  out.reserve(target_bytes + 64);
+  std::mt19937_64 rng(12345);
+  std::uniform_real_distribution<double> dist(-1000.0, 1000.0);
+  char line[128];
+  while (out.size() < target_bytes) {
+    int n = std::snprintf(line, sizeof(line),
+                          "{\"x\":%.6f,\"y\":%.6f,\"z\":%.6f}\n", dist(rng),
+                          dist(rng), dist(rng));
+    out.append(line, size_t(n));
+  }
+  return out;
+}
+
+// ---- extracted value types + extractors ------------------------------------
+
+struct point {
+  double x, y, z;
+};
+
+// amazon rows are arrays: [asin, brand, title, url, image, rating, reviewUrl,
+// totalReviews, prices]. We pull a few representative fields.
+struct amazon_record {
+  double rating;
+  int64_t total_reviews;
+  uint32_t brand_length;
+};
+
+template <typename Doc>
+error_code extract_point(Doc doc, point &out) noexcept {
+  if (auto e = doc["x"].get_double().get(out.x)) { return e; }
+  if (auto e = doc["y"].get_double().get(out.y)) { return e; }
+  return doc["z"].get_double().get(out.z);
+}
+
+// A cheap value sink so the compiler cannot optimize the extraction away, and
+// so results can be sanity-checked across configurations.
+double sink_value(const point &p) noexcept { return p.x + p.y + p.z; }
+double sink_value(const amazon_record &r) noexcept {
+  return r.rating + double(r.total_reviews) + double(r.brand_length);
+}
+
+template <typename Doc>
+error_code extract_amazon(Doc doc, amazon_record &out) noexcept {
+  ondemand::array array;
+  if (auto e = doc.get_array().get(array)) { return e; }
+  out = {0.0, 0, 0};
+  size_t index = 0;
+  for (auto value : array) {
+    if (index == 1) {
+      std::string_view brand;
+      if (auto e = value.get_string().get(brand)) { return e; }
+      out.brand_length = uint32_t(brand.size());
+    } else if (index == 5) {
+      if (auto e = value.get_double().get(out.rating)) { return e; }
+    } else if (index == 7) {
+      if (auto e = value.get_int64().get(out.total_reviews)) { return e; }
+    }
+    index++;
+  }
+  return SUCCESS;
+}
+
+// ---- timing helpers --------------------------------------------------------
+
+struct measurement {
+  double seconds;
+  size_t docs;
+  double checksum;
+};
+
+template <typename Fn>
+measurement best_of(int repetitions, Fn &&fn) {
+  measurement best{1e30, 0, 0.0};
+  for (int r = 0; r < repetitions; r++) {
+    measurement m = fn();
+    if (m.seconds < best.seconds) { best = m; }
+  }
+  return best;
+}
+
+// serial / builtin-2thread reference via a single iterate_many.
+template <typename T, typename Extract>
+measurement run_serial(padded_string_view json, bool threaded, size_t batch,
+                       Extract &&extract,
+                       stream_format format = stream_format::whitespace_delimited) {
+  ondemand::parser parser;
+  parser.threaded = threaded;
+  double checksum = 0.0;
+  size_t docs = 0;
+  auto start = std::chrono::steady_clock::now();
+  ondemand::document_stream stream;
+  if (!parser.iterate_many(json.data(), json.size(), batch, format).get(stream)) {
+    for (auto it = stream.begin(); it != stream.end(); ++it) {
+      auto doc = *it;
+      T value;
+      if (!extract(doc, value)) {
+        checksum += sink_value(value);
+        docs++;
+      }
+    }
+  }
+  auto end = std::chrono::steady_clock::now();
+  return {std::chrono::duration<double>(end - start).count(), docs, checksum};
+}
+
+template <typename T, typename Extract>
+measurement run_parallel(padded_string_view json, size_t threads,
+                         Extract &&extract,
+                         stream_format format = stream_format::whitespace_delimited) {
+  experimental::parallel_stream_options options;
+  options.threads = threads;
+  options.format = format;
+  double checksum = 0.0;
+  auto start = std::chrono::steady_clock::now();
+  auto result =
+      experimental::parse_many_parallel<T>(json, extract, options);
+  auto end = std::chrono::steady_clock::now();
+  result.for_each(
+      [&](const T &value) { checksum += sink_value(value); });
+  return {std::chrono::duration<double>(end - start).count(), result.size(),
+          checksum};
+}
+
+void print_row(const char *tag, double megabytes, const measurement &m,
+               double baseline_seconds) {
+  double gbps = megabytes / 1024.0 / m.seconds;
+  double mdocs = double(m.docs) / 1e6 / m.seconds;
+  std::printf("  %-22s %8.3f GB/s  %8.2f Mdoc/s  %6.2fx  (docs=%zu)\n", tag,
+              gbps, mdocs, baseline_seconds / m.seconds, m.docs);
+}
+
+template <typename T, typename Extract>
+void run_dataset(const char *name, const std::string &raw, Extract &&extract) {
+  padded_string padded(raw.data(), raw.size());
+  padded_string_view json(padded);
+  double megabytes = double(raw.size()) / (1024.0 * 1024.0);
+  std::printf("\n== %s : %.1f MB ==\n", name, megabytes);
+
+  auto serial =
+      best_of(3, [&] { return run_serial<T>(json, false, 1u << 20, extract); });
+  double base = serial.seconds;
+  print_row("serial", megabytes, serial, base);
+
+  // built-in two-thread: overlap needs multiple batches; 16 MiB is a good size.
+  auto builtin = best_of(
+      3, [&] { return run_serial<T>(json, true, 16u << 20, extract); });
+  print_row("builtin-2thread", megabytes, builtin, base);
+
+  unsigned hardware = std::thread::hardware_concurrency();
+  std::vector<size_t> counts;
+  for (size_t t = 1; t <= hardware; t *= 2) { counts.push_back(t); }
+  if (counts.empty() || counts.back() != hardware) { counts.push_back(hardware); }
+  for (size_t t : counts) {
+    auto parallel =
+        best_of(3, [&] { return run_parallel<T>(json, t, extract); });
+    char tag[32];
+    std::snprintf(tag, sizeof(tag), "parallel(%zu)", t);
+    print_row(tag, megabytes, parallel, base);
+  }
+}
+
+// Verify every stream format: parse the same documents serially and in
+// parallel and confirm the document count and checksum agree, then report the
+// parallel throughput. This proves the format-aware slicing never splits or
+// drops a document.
+template <typename T, typename Extract>
+void verify_formats(const std::vector<std::string> &rows, size_t target_bytes,
+                    Extract &&extract) {
+  struct named_format {
+    const char *name;
+    stream_format format;
+  };
+  const named_format formats[] = {
+      {"whitespace_delimited", stream_format::whitespace_delimited},
+      {"json_sequence (RFC7464)", stream_format::json_sequence},
+  };
+  unsigned hardware = std::thread::hardware_concurrency();
+  std::printf("\n== format coverage (parallel vs serial, %u threads) ==\n",
+              hardware);
+  for (const named_format &nf : formats) {
+    std::string raw = build_stream(rows, target_bytes, nf.format);
+    padded_string padded(raw.data(), raw.size());
+    padded_string_view json(padded);
+    double megabytes = double(raw.size()) / (1024.0 * 1024.0);
+
+    auto serial = run_serial<T>(json, false, 1u << 20, extract, nf.format);
+    auto parallel =
+        best_of(3, [&] { return run_parallel<T>(json, hardware, extract, nf.format); });
+
+    bool ok = serial.docs == parallel.docs &&
+              std::abs(serial.checksum - parallel.checksum) < 1e-3;
+    double gbps = megabytes / 1024.0 / parallel.seconds;
+    std::printf("  %-24s %s  serial=%zu parallel=%zu docs  %7.2f GB/s\n",
+                nf.name, ok ? "[OK]  " : "[FAIL]", serial.docs, parallel.docs,
+                gbps);
+  }
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  size_t target_mb = 256;
+  if (argc > 1) { target_mb = strtoull(argv[1], nullptr, 10); }
+  size_t target_bytes = target_mb * 1024 * 1024;
+
+  std::printf("simdjson implementation: %s\n",
+              get_active_implementation()->name().c_str());
+#ifndef SIMDJSON_THREADS_ENABLED
+  std::printf("WARNING: SIMDJSON_THREADS_ENABLED is off; parallel == serial.\n");
+#endif
+  std::printf("hardware_concurrency: %u\n", std::thread::hardware_concurrency());
+
+  run_dataset<amazon_record>(
+      "amazon_cellphones.ndjson (repeated)",
+      load_repeat(json_benchmark::AMAZON_CELLPHONES_NDJSON, target_bytes),
+      [](auto doc, amazon_record &out) { return extract_amazon(doc, out); });
+
+  run_dataset<point>(
+      "synthetic points", make_points(target_bytes),
+      [](auto doc, point &out) { return extract_point(doc, out); });
+
+  // Exercise all four stream formats on the amazon rows (use a smaller size so
+  // building four copies stays cheap).
+  verify_formats<amazon_record>(
+      load_rows(json_benchmark::AMAZON_CELLPHONES_NDJSON),
+      std::min<size_t>(target_bytes, size_t(256) * 1024 * 1024),
+      [](auto doc, amazon_record &out) { return extract_amazon(doc, out); });
+
+  return 0;
+}

--- a/include/simdjson.h
+++ b/include/simdjson.h
@@ -54,6 +54,7 @@
 #include "simdjson/dom.h"
 #include "simdjson/builder.h"
 #include "simdjson/ondemand.h"
+#include "simdjson/ondemand_parallel.h"
 #include "simdjson/convert.h"
 #include "simdjson/convert-inl.h"
 

--- a/include/simdjson/ondemand_parallel.h
+++ b/include/simdjson/ondemand_parallel.h
@@ -9,10 +9,8 @@
 #include <vector>
 
 #ifdef SIMDJSON_THREADS_ENABLED
-#include <condition_variable>
+#include <atomic>
 #include <cstring>
-#include <mutex>
-#include <queue>
 #include <thread>
 #endif
 
@@ -30,11 +28,11 @@ namespace simdjson {
  *
  * ## Design
  *
- * A single dispatcher thread scans the input for document boundaries and carves
- * it into slices (each a whole number of documents), which it feeds to a pool
- * of worker threads through a bounded queue. Each worker owns its own
- * `ondemand::parser` and its own output vector, so no locking happens on the
- * hot path. A user-supplied `extract` function turns each document into a value
+ * Each worker claims a byte range from a shared atomic counter and snaps both
+ * ends forward to the next delimiter, so the slices are contiguous, never split
+ * a document, and are computed without any coordination beyond that counter.
+ * Each worker owns its own `ondemand::parser` and its own output vector, so no
+ * locking happens on the hot path. A user-supplied `extract` function turns each document into a value
  * of type `T`; the values are collected into one vector per worker ("shards").
  *
  * Because documents are distributed across workers, the resulting values are
@@ -55,7 +53,7 @@ namespace simdjson {
  *
  * The comma-delimited formats are intentionally not supported here: a comma can
  * appear nested or inside a string, so top-level commas can only be located by
- * a serial structural scan, which would make the dispatcher the bottleneck.
+ * a serial structural scan, which cannot be done from an arbitrary offset.
  * Whitespace-only-separated input with no newlines still parses correctly; it
  * just is not split (one slice).
  */
@@ -64,9 +62,11 @@ namespace experimental {
 /** Options controlling parse_many_parallel. */
 struct parallel_stream_options {
   /**
-   * Number of worker (parser) threads. When 0, we use
-   * `std::thread::hardware_concurrency() - 1` (reserving one core for the
-   * dispatcher), with a floor of 1.
+   * Number of worker (parser) threads, and the exact number of threads
+   * spawned. When 0, we use `std::thread::hardware_concurrency()`, with a
+   * floor of 1. Note that throughput normally peaks at or below the number of
+   * *physical* cores, so on a machine with simultaneous multithreading the
+   * default overshoots.
    */
   size_t threads = 0;
   /**
@@ -137,65 +137,21 @@ private:
 #ifdef SIMDJSON_THREADS_ENABLED
 namespace internal {
 
-/** A [offset, length) view into the shared input buffer. */
-struct stream_slice {
-  size_t offset;
-  size_t length;
-};
-
-/** A minimal bounded blocking queue used to feed slices to the workers. */
-class slice_queue {
-public:
-  explicit slice_queue(size_t capacity) noexcept : _capacity{capacity} {}
-
-  void push(stream_slice slice) {
-    std::unique_lock<std::mutex> lock(_mutex);
-    _not_full.wait(lock, [this] { return _queue.size() < _capacity; });
-    _queue.push(slice);
-    lock.unlock();
-    _not_empty.notify_one();
-  }
-
-  /** Returns false once the queue is both empty and closed. */
-  bool pop(stream_slice &out) {
-    std::unique_lock<std::mutex> lock(_mutex);
-    _not_empty.wait(lock, [this] { return !_queue.empty() || _closed; });
-    if (_queue.empty()) { return false; }
-    out = _queue.front();
-    _queue.pop();
-    lock.unlock();
-    _not_full.notify_one();
-    return true;
-  }
-
-  void close() {
-    std::unique_lock<std::mutex> lock(_mutex);
-    _closed = true;
-    lock.unlock();
-    _not_empty.notify_all();
-  }
-
-private:
-  std::mutex _mutex{};
-  std::condition_variable _not_full{};
-  std::condition_variable _not_empty{};
-  std::queue<stream_slice> _queue{};
-  size_t _capacity;
-  bool _closed = false;
-};
-
 /**
- * Compute the end (exclusive) of the slice beginning at `pos`, within
- * [pos, hi). The boundary is a delimiter byte that cannot occur inside a JSON
- * value, so a document is never split:
+ * Snap `want` forward to the next slice boundary within [0, hi). The boundary
+ * is a delimiter byte that cannot occur inside a JSON value, so a document is
+ * never split:
  *  - whitespace_delimited: just after a newline ('\n');
  *  - json_sequence: just before a record separator (0x1E).
- * Any other format returns `hi` (no split). The slice is at least `target`
- * bytes unless the input ends first.
+ * Any other format returns `hi` (no split).
+ *
+ * This depends only on `want`, which is what lets every worker compute its own
+ * slice: worker i's end is snap(raw + slice_bytes) and worker i+1's start is
+ * snap(raw + slice_bytes) for the same value, so the slices are contiguous and
+ * never overlap.
  */
-inline size_t next_slice_end(const char *data, size_t hi, size_t pos,
-                             size_t target, stream_format format) {
-  size_t want = pos + target;
+inline size_t snap_to_boundary(const char *data, size_t hi, size_t want,
+                               stream_format format) {
   if (want >= hi) { return hi; }
   switch (format) {
   case stream_format::whitespace_delimited: {
@@ -254,7 +210,7 @@ parse_many_parallel(padded_string_view json, F &&extract,
   size_t worker_count = options.threads;
   if (worker_count == 0) {
     unsigned hardware = std::thread::hardware_concurrency();
-    worker_count = hardware > 2 ? size_t(hardware) - 1 : 1;
+    worker_count = hardware > 1 ? size_t(hardware) : 1;
   }
   const size_t slice_bytes =
       options.slice_bytes ? options.slice_bytes : (1u << 20);
@@ -265,21 +221,11 @@ parse_many_parallel(padded_string_view json, F &&extract,
   std::vector<size_t> local_errors(worker_count, 0);
   std::vector<error_code> local_first(worker_count, SUCCESS);
 
-  // A little slack in the queue keeps every worker fed without letting the
-  // dispatcher run arbitrarily far ahead of the parsers.
-  internal::slice_queue queue(worker_count * 4 + 8);
-
-  std::thread dispatcher([&] {
-    size_t pos = 0;
-    while (pos < length) {
-      size_t end =
-          internal::next_slice_end(data, length, pos, slice_bytes, format);
-      if (end <= pos) { end = length; }
-      queue.push(internal::stream_slice{pos, end - pos});
-      pos = end;
-    }
-    queue.close();
-  });
+  // Each worker claims its own byte range from this counter and snaps both ends
+  // to a delimiter itself. Slicing needs no state from the preceding slice, so
+  // there is nothing for a dedicated dispatcher thread to know that a worker
+  // does not, and the pool spawns exactly `worker_count` threads.
+  std::atomic<size_t> cursor{0};
 
   std::vector<std::thread> workers;
   workers.reserve(worker_count);
@@ -291,13 +237,22 @@ parse_many_parallel(padded_string_view json, F &&extract,
       size_t errors = 0;
       error_code first = SUCCESS;
 
-      internal::stream_slice slice;
-      while (queue.pop(slice)) {
+      for (;;) {
+        const size_t raw =
+            cursor.fetch_add(slice_bytes, std::memory_order_relaxed);
+        if (raw >= length) { break; }
+        const size_t begin =
+            (raw == 0) ? 0
+                       : internal::snap_to_boundary(data, length, raw, format);
+        const size_t end = internal::snap_to_boundary(data, length,
+                                                      raw + slice_bytes, format);
+        // Two claims can land inside one long document; the earlier one covers
+        // it and this slice is empty.
+        if (begin >= end) { continue; }
+        const size_t slice_length = end - begin;
         ondemand::document_stream stream;
         error_code slice_error =
-            parser
-                .iterate_many(data + slice.offset, slice.length, slice.length,
-                              format)
+            parser.iterate_many(data + begin, slice_length, slice_length, format)
                 .get(stream);
         if (slice_error) {
           errors++;
@@ -321,7 +276,6 @@ parse_many_parallel(padded_string_view json, F &&extract,
     });
   }
 
-  dispatcher.join();
   for (std::thread &worker : workers) { worker.join(); }
 
   for (size_t w = 0; w < worker_count; w++) {

--- a/include/simdjson/ondemand_parallel.h
+++ b/include/simdjson/ondemand_parallel.h
@@ -1,0 +1,363 @@
+#ifndef SIMDJSON_ONDEMAND_PARALLEL_H
+#define SIMDJSON_ONDEMAND_PARALLEL_H
+
+#include "simdjson/base.h"
+#include "simdjson/padded_string_view.h"
+#include "simdjson/ondemand.h"
+
+#include <utility>
+#include <vector>
+
+#ifdef SIMDJSON_THREADS_ENABLED
+#include <condition_variable>
+#include <cstring>
+#include <mutex>
+#include <queue>
+#include <thread>
+#endif
+
+namespace simdjson {
+/**
+ * @private Experimental API (subject to change).
+ *
+ * Scale the *parsing* step of a large JSON document stream across several
+ * threads. simdjson's built-in `parser.iterate_many(...)` can already overlap
+ * stage 1 (structural indexing) of one batch with stage 2 (value materializa-
+ * tion) of the previous batch, but that tops out at a ~2x speedup and only
+ * when the input is split into several batches. When the bottleneck is stage 2
+ * (extracting values out of each document), it pays to run many parser threads
+ * at once. That is what this header provides.
+ *
+ * ## Design
+ *
+ * A single dispatcher thread scans the input for document boundaries and carves
+ * it into slices (each a whole number of documents), which it feeds to a pool
+ * of worker threads through a bounded queue. Each worker owns its own
+ * `ondemand::parser` and its own output vector, so no locking happens on the
+ * hot path. A user-supplied `extract` function turns each document into a value
+ * of type `T`; the values are collected into one vector per worker ("shards").
+ *
+ * Because documents are distributed across workers, the resulting values are
+ * interleaved: values keep their relative order *within* a shard, but the
+ * shards themselves are interleaved with respect to the original input. Callers
+ * that do not care about global order (the common case for bulk extraction)
+ * simply iterate every shard.
+ *
+ * ## Input format
+ *
+ * Two stream formats are supported, each with a slicing rule that relies on a
+ * delimiter byte that can never occur inside a JSON value (JSON forbids
+ * unescaped control characters in strings), so a slice never splits a document
+ * and boundaries are found with a single `memchr`:
+ *
+ *   - `whitespace_delimited` (ndjson/JSONL, default): cut just after a newline.
+ *   - `json_sequence` (RFC 7464): cut just before a record separator (`0x1E`).
+ *
+ * The comma-delimited formats are intentionally not supported here: a comma can
+ * appear nested or inside a string, so top-level commas can only be located by
+ * a serial structural scan, which would make the dispatcher the bottleneck.
+ * Whitespace-only-separated input with no newlines still parses correctly; it
+ * just is not split (one slice).
+ */
+namespace experimental {
+
+/** Options controlling parse_many_parallel. */
+struct parallel_stream_options {
+  /**
+   * Number of worker (parser) threads. When 0, we use
+   * `std::thread::hardware_concurrency() - 1` (reserving one core for the
+   * dispatcher), with a floor of 1.
+   */
+  size_t threads = 0;
+  /**
+   * Target size, in bytes, of each slice handed to a worker. Each slice is
+   * extended to the next document boundary so that documents are never split.
+   * Larger slices amortize per-slice overhead; smaller slices improve load
+   * balancing.
+   */
+  size_t slice_bytes = 1u << 20; // 1 MiB
+  /**
+   * The format of the input stream. Determines both how the input is sliced and
+   * how each worker parses its slice. Only stream_format::whitespace_delimited
+   * (the default, ndjson) and stream_format::json_sequence (RFC 7464) are
+   * supported; any other value disables slicing (the input is parsed as a
+   * single slice, i.e. serially).
+   */
+  stream_format format = stream_format::whitespace_delimited;
+};
+
+/**
+ * The result of parse_many_parallel: one std::vector<T> per worker thread.
+ *
+ * Values keep their relative order within a shard; shards are interleaved with
+ * respect to the original input.
+ */
+template <typename T>
+class parallel_stream_result {
+public:
+  parallel_stream_result() noexcept = default;
+
+  /** The per-worker vectors of extracted values. */
+  const std::vector<std::vector<T>> &shards() const noexcept { return _shards; }
+
+  /** Total number of values extracted across all shards. */
+  size_t size() const noexcept {
+    size_t total = 0;
+    for (const auto &shard : _shards) { total += shard.size(); }
+    return total;
+  }
+
+  /** Whether any value was extracted. */
+  bool empty() const noexcept { return size() == 0; }
+
+  /** Number of documents that failed to parse or that `extract` rejected. */
+  size_t error_count() const noexcept { return _errors; }
+
+  /** The first error reported by a slice or by `extract` (or SUCCESS). */
+  error_code first_error() const noexcept { return _first_error; }
+
+  /** Invoke `fn(const T&)` for every value, shard by shard. */
+  template <typename Fn>
+  void for_each(Fn &&fn) const {
+    for (const auto &shard : _shards) {
+      for (const auto &value : shard) { fn(value); }
+    }
+  }
+
+private:
+  std::vector<std::vector<T>> _shards{};
+  size_t _errors = 0;
+  error_code _first_error = SUCCESS;
+
+  template <typename U, typename F>
+  friend parallel_stream_result<U>
+  parse_many_parallel(padded_string_view, F &&, parallel_stream_options);
+};
+
+#ifdef SIMDJSON_THREADS_ENABLED
+namespace internal {
+
+/** A [offset, length) view into the shared input buffer. */
+struct stream_slice {
+  size_t offset;
+  size_t length;
+};
+
+/** A minimal bounded blocking queue used to feed slices to the workers. */
+class slice_queue {
+public:
+  explicit slice_queue(size_t capacity) noexcept : _capacity{capacity} {}
+
+  void push(stream_slice slice) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _not_full.wait(lock, [this] { return _queue.size() < _capacity; });
+    _queue.push(slice);
+    lock.unlock();
+    _not_empty.notify_one();
+  }
+
+  /** Returns false once the queue is both empty and closed. */
+  bool pop(stream_slice &out) {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _not_empty.wait(lock, [this] { return !_queue.empty() || _closed; });
+    if (_queue.empty()) { return false; }
+    out = _queue.front();
+    _queue.pop();
+    lock.unlock();
+    _not_full.notify_one();
+    return true;
+  }
+
+  void close() {
+    std::unique_lock<std::mutex> lock(_mutex);
+    _closed = true;
+    lock.unlock();
+    _not_empty.notify_all();
+  }
+
+private:
+  std::mutex _mutex{};
+  std::condition_variable _not_full{};
+  std::condition_variable _not_empty{};
+  std::queue<stream_slice> _queue{};
+  size_t _capacity;
+  bool _closed = false;
+};
+
+/**
+ * Compute the end (exclusive) of the slice beginning at `pos`, within
+ * [pos, hi). The boundary is a delimiter byte that cannot occur inside a JSON
+ * value, so a document is never split:
+ *  - whitespace_delimited: just after a newline ('\n');
+ *  - json_sequence: just before a record separator (0x1E).
+ * Any other format returns `hi` (no split). The slice is at least `target`
+ * bytes unless the input ends first.
+ */
+inline size_t next_slice_end(const char *data, size_t hi, size_t pos,
+                             size_t target, stream_format format) {
+  size_t want = pos + target;
+  if (want >= hi) { return hi; }
+  switch (format) {
+  case stream_format::whitespace_delimited: {
+    const void *newline = std::memchr(data + want, '\n', hi - want);
+    return newline ? size_t(static_cast<const char *>(newline) - data) + 1 : hi;
+  }
+  case stream_format::json_sequence: {
+    const void *rs = std::memchr(data + want, 0x1e, hi - want);
+    return rs ? size_t(static_cast<const char *>(rs) - data) : hi;
+  }
+  default:
+    return hi; // unsupported format: a single slice (parsed serially)
+  }
+}
+
+} // namespace internal
+#endif // SIMDJSON_THREADS_ENABLED
+
+/**
+ * @private Experimental API (subject to change).
+ *
+ * Parse a stream of JSON documents across multiple threads, extracting a value
+ * of type `T` from each document.
+ *
+ * `extract` is invoked as `extract(doc, out)` where `doc` is the current
+ * document (usable exactly as in an `iterate_many` loop) and `out` is a `T&` to
+ * fill. It must return `SUCCESS` to keep the value or an error to skip it:
+ *
+ *     struct point { double x, y, z; };
+ *     auto extract = [](auto doc, point &out) -> error_code {
+ *       if (auto e = doc["x"].get_double().get(out.x)) { return e; }
+ *       if (auto e = doc["y"].get_double().get(out.y)) { return e; }
+ *       return doc["z"].get_double().get(out.z);
+ *     };
+ *     auto result = simdjson::experimental::parse_many_parallel<point>(json, extract);
+ *
+ * @tparam T       The extracted value type.
+ * @tparam F       The extractor callable, `error_code(auto doc, T&)`.
+ * @param json     The padded input buffer (see iterate_many for padding rules).
+ * @param extract  The per-document extractor.
+ * @param options  Threading / slicing options.
+ * @return A parallel_stream_result<T> holding one vector per worker.
+ *
+ * When SIMDJSON_THREADS_ENABLED is not defined, this falls back to a
+ * single-threaded implementation producing a single shard.
+ */
+template <typename T, typename F>
+parallel_stream_result<T>
+parse_many_parallel(padded_string_view json, F &&extract,
+                    parallel_stream_options options = {}) {
+  parallel_stream_result<T> result;
+  const char *const data = json.data();
+  const size_t length = json.size();
+
+#ifdef SIMDJSON_THREADS_ENABLED
+  size_t worker_count = options.threads;
+  if (worker_count == 0) {
+    unsigned hardware = std::thread::hardware_concurrency();
+    worker_count = hardware > 2 ? size_t(hardware) - 1 : 1;
+  }
+  const size_t slice_bytes =
+      options.slice_bytes ? options.slice_bytes : (1u << 20);
+
+  const stream_format format = options.format;
+
+  result._shards.resize(worker_count);
+  std::vector<size_t> local_errors(worker_count, 0);
+  std::vector<error_code> local_first(worker_count, SUCCESS);
+
+  // A little slack in the queue keeps every worker fed without letting the
+  // dispatcher run arbitrarily far ahead of the parsers.
+  internal::slice_queue queue(worker_count * 4 + 8);
+
+  std::thread dispatcher([&] {
+    size_t pos = 0;
+    while (pos < length) {
+      size_t end =
+          internal::next_slice_end(data, length, pos, slice_bytes, format);
+      if (end <= pos) { end = length; }
+      queue.push(internal::stream_slice{pos, end - pos});
+      pos = end;
+    }
+    queue.close();
+  });
+
+  std::vector<std::thread> workers;
+  workers.reserve(worker_count);
+  for (size_t w = 0; w < worker_count; w++) {
+    workers.emplace_back([&, w] {
+      ondemand::parser parser;
+      parser.threaded = false; // this worker's parser must stay single-threaded
+      std::vector<T> &shard = result._shards[w];
+      size_t errors = 0;
+      error_code first = SUCCESS;
+
+      internal::stream_slice slice;
+      while (queue.pop(slice)) {
+        ondemand::document_stream stream;
+        error_code slice_error =
+            parser
+                .iterate_many(data + slice.offset, slice.length, slice.length,
+                              format)
+                .get(stream);
+        if (slice_error) {
+          errors++;
+          if (!first) { first = slice_error; }
+          continue;
+        }
+        for (auto it = stream.begin(); it != stream.end(); ++it) {
+          auto doc = *it;
+          T out;
+          error_code extract_error = extract(doc, out);
+          if (extract_error) {
+            errors++;
+            if (!first) { first = extract_error; }
+            continue;
+          }
+          shard.push_back(std::move(out));
+        }
+      }
+      local_errors[w] = errors;
+      local_first[w] = first;
+    });
+  }
+
+  dispatcher.join();
+  for (std::thread &worker : workers) { worker.join(); }
+
+  for (size_t w = 0; w < worker_count; w++) {
+    result._errors += local_errors[w];
+    if (!result._first_error) { result._first_error = local_first[w]; }
+  }
+#else  // SIMDJSON_THREADS_ENABLED
+  const size_t slice_bytes =
+      options.slice_bytes ? options.slice_bytes : (1u << 20);
+  result._shards.resize(1);
+  ondemand::parser parser;
+  ondemand::document_stream stream;
+  error_code stream_error =
+      parser.iterate_many(data, length, slice_bytes, options.format).get(stream);
+  if (stream_error) {
+    result._errors = 1;
+    result._first_error = stream_error;
+    return result;
+  }
+  for (auto it = stream.begin(); it != stream.end(); ++it) {
+    auto doc = *it;
+    T out;
+    error_code extract_error = extract(doc, out);
+    if (extract_error) {
+      result._errors++;
+      if (!result._first_error) { result._first_error = extract_error; }
+      continue;
+    }
+    result._shards[0].push_back(std::move(out));
+  }
+#endif // SIMDJSON_THREADS_ENABLED
+
+  return result;
+}
+
+} // namespace experimental
+} // namespace simdjson
+
+#endif // SIMDJSON_ONDEMAND_PARALLEL_H


### PR DESCRIPTION
Introduce simdjson::experimental::parse_many_parallel, which scales the stage-2 (value materialization) step of iterate_many across many threads. A single dispatcher thread carves the input into document-aligned slices and feeds a pool of worker threads through a bounded queue. Each worker owns its own ondemand::parser and its own output vector, so no locking happens on the hot path; extracted values are returned as one vector per worker ('shards').

Two stream formats are supported, each sliced at a delimiter byte that cannot occur inside a JSON value, so a document is never split and boundaries are found with a single memchr:
 - whitespace_delimited (ndjson): cut just after a newline
 - json_sequence (RFC 7464): cut just before a record separator (0x1E) Because the dispatcher stays cheap, throughput scales with the parser threads (compute bound) or up to memory bandwidth (light workloads).


This is *EXPERIMENTAL*  for now. The goal is to scale to a high number of threads when processing large inputs.

cc @jaja360 