### PR TITLE
Remove unused add_overflow from all architecture backends

### DIFF
--- a/include/simdjson/arm64/bitmanipulation.h
+++ b/include/simdjson/arm64/bitmanipulation.h
@@ -102,15 +102,6 @@ simdjson_inline uint64_t zero_leading_bit(uint64_t rev_bits, int leading_zeroes)
 
 #endif
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
-#if SIMDJSON_REGULAR_VISUAL_STUDIO
-  *result = value1 + value2;
-  return *result < value1;
-#else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-#endif
-}
 
 } // unnamed namespace
 } // namespace arm64

--- a/include/simdjson/haswell/bitmanipulation.h
+++ b/include/simdjson/haswell/bitmanipulation.h
@@ -53,16 +53,6 @@ simdjson_inline long long int count_ones(uint64_t input_num) {
 }
 #endif
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
-                                uint64_t *result) {
-#if SIMDJSON_REGULAR_VISUAL_STUDIO
-  return _addcarry_u64(0, value1, value2,
-                       reinterpret_cast<unsigned __int64 *>(result));
-#else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-#endif
-}
 
 } // unnamed namespace
 } // namespace haswell

--- a/include/simdjson/icelake/bitmanipulation.h
+++ b/include/simdjson/icelake/bitmanipulation.h
@@ -52,16 +52,6 @@ simdjson_inline long long int count_ones(uint64_t input_num) {
 }
 #endif
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
-                                uint64_t *result) {
-#if SIMDJSON_REGULAR_VISUAL_STUDIO
-  return _addcarry_u64(0, value1, value2,
-                       reinterpret_cast<unsigned __int64 *>(result));
-#else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-#endif
-}
 
 } // unnamed namespace
 } // namespace icelake

--- a/include/simdjson/lasx/bitmanipulation.h
+++ b/include/simdjson/lasx/bitmanipulation.h
@@ -38,10 +38,6 @@ simdjson_inline int count_ones(uint64_t input_num) {
   return __lasx_xvpickve2gr_w(__lasx_xvpcnt_d(__m256i(v4u64{input_num, 0, 0, 0})), 0);
 }
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-}
 
 } // unnamed namespace
 } // namespace lasx

--- a/include/simdjson/lsx/bitmanipulation.h
+++ b/include/simdjson/lsx/bitmanipulation.h
@@ -38,10 +38,6 @@ simdjson_inline int count_ones(uint64_t input_num) {
   return __lsx_vpickve2gr_w(__lsx_vpcnt_d(__m128i(v2u64{input_num, 0})), 0);
 }
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2, uint64_t *result) {
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-}
 
 } // unnamed namespace
 } // namespace lsx

--- a/include/simdjson/ppc64/bitmanipulation.h
+++ b/include/simdjson/ppc64/bitmanipulation.h
@@ -60,16 +60,6 @@ simdjson_inline int count_ones(uint64_t input_num) {
 }
 #endif
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
-                                         uint64_t *result) {
-#if SIMDJSON_REGULAR_VISUAL_STUDIO
-  *result = value1 + value2;
-  return *result < value1;
-#else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-#endif
-}
 
 } // unnamed namespace
 } // namespace ppc64

--- a/include/simdjson/rvv-vls/bitmanipulation.h
+++ b/include/simdjson/rvv-vls/bitmanipulation.h
@@ -35,11 +35,6 @@ simdjson_inline long long int count_ones(uint64_t input_num) {
   return __builtin_popcountll(input_num);
 }
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
-                                uint64_t *result) {
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-}
 
 } // unnamed namespace
 } // namespace rvv_vls

--- a/include/simdjson/westmere/bitmanipulation.h
+++ b/include/simdjson/westmere/bitmanipulation.h
@@ -61,16 +61,6 @@ simdjson_inline long long int count_ones(uint64_t input_num) {
 }
 #endif
 
-simdjson_inline bool add_overflow(uint64_t value1, uint64_t value2,
-                                uint64_t *result) {
-#if SIMDJSON_REGULAR_VISUAL_STUDIO
-  return _addcarry_u64(0, value1, value2,
-                       reinterpret_cast<unsigned __int64 *>(result));
-#else
-  return __builtin_uaddll_overflow(value1, value2,
-                                   reinterpret_cast<unsigned long long *>(result));
-#endif
-}
 
 } // unnamed namespace
 } // namespace westmere


### PR DESCRIPTION
## Description

Removed the `add_overflow()` function from `bitmanipulation.h` across all 8 architecture backends (arm64, haswell, westmere, icelake, ppc64, rvv-vls, lasx, lsx). This function is defined in every backend but has zero call sites in the entire codebase — it is dead code.

Found while checking the C++ codebase during development of my java port.

## Type of change
- [ ] Bug fix
- [ ] Optimization
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

## How to verify / test
- Add additional tests to verify bugs or new features.
- If you claim performance gains, you should provide benchmark numbers using high quality benchmarking code.


Please read before contributing:
- CONTRIBUTING: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md
- HACKING: https://github.com/simdjson/simdjson/blob/master/HACKING.md
- AI Usage Policy: https://github.com/simdjson/simdjson/blob/master/AI_USAGE_POLICY.md


If you can, we recommend running our tests with the sanitizers turned on.
For non-Visual Studio users, it is as easy as doing:

```bash
cmake -B build -D SIMDJSON_SANITIZE=ON -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build
```

Our CI checks, among other things, for trailing whitespace. If a test fails for that reason,
use the "artifacts" button to download the artifact and inspect the problematic lines,
or run `scripts/remove_trailing_whitespace.sh` locally if you have a bash shell and `sed`.


## Checklist before submitting
- [x] I added/updated tests covering my change (if applicable)
- [x] Code builds locally and passes my check
- [x] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear
- [x] I linked the related issue (if applicable)

## Final notes
- For large PRs, prefer smaller incremental PRs or request staged review.

Thanks for the contribution!