### PR TITLE
Treat 20-digit positive overflows as big integers

### DIFF
--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -682,7 +682,7 @@ simdjson_warn_unused simdjson_inline error_code parse_number(const uint8_t *cons
     // - Therefore, if the number is positive and lower than that, it's overflow.
     // - The value we are looking at is less than or equal to INT64_MAX.
     //
-    }  else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INVALID_NUMBER(src); }
+    }  else if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return BIGINT_NUMBER(src); }
   }
 
   // Write unsigned if it does not fit in a signed integer.

--- a/tests/dom/big_integer_tests.cpp
+++ b/tests/dom/big_integer_tests.cpp
@@ -21,6 +21,14 @@ namespace big_integer_tests {
     TEST_SUCCEED();
   }
 
+  bool default_returns_bigint_error_20_digits() {
+    TEST_START();
+    dom::parser parser;
+    auto result = parser.parse(R"({"val":18446744073709551616})"_padded);
+    ASSERT_EQUAL(result.error(), BIGINT_ERROR);
+    TEST_SUCCEED();
+  }
+
   bool opt_in_parses_big_integer() {
     TEST_START();
     dom::parser parser;
@@ -53,6 +61,25 @@ namespace big_integer_tests {
     std::string_view digits;
     ASSERT_SUCCESS(val.get_bigint().get(digits));
     ASSERT_EQUAL(digits, "-12345678901234567890");
+    TEST_SUCCEED();
+  }
+
+  bool positive_20_digit_overflow() {
+    TEST_START();
+    dom::parser parser;
+    parser.number_as_string(true);
+    // Every 20 digit integer in [2^64, 10^20) is too large for uint64_t.
+    for (auto digits : {"18446744073709551616", "99999999999999999999"}) {
+      dom::element doc;
+      std::string json = std::string(R"({"val":)") + digits + "}";
+      ASSERT_SUCCESS(parser.parse(padded_string(json)).get(doc));
+      dom::element val;
+      ASSERT_SUCCESS(doc["val"].get(val));
+      ASSERT_EQUAL(val.type(), dom::element_type::BIGINT);
+      std::string_view parsed;
+      ASSERT_SUCCESS(val.get_bigint().get(parsed));
+      ASSERT_EQUAL(parsed, digits);
+    }
     TEST_SUCCEED();
   }
 
@@ -135,8 +162,10 @@ namespace big_integer_tests {
   bool run() {
     return option_off_by_default() &&
            default_returns_bigint_error() &&
+           default_returns_bigint_error_20_digits() &&
            opt_in_parses_big_integer() &&
            negative_big_integer() &&
+           positive_20_digit_overflow() &&
            big_integer_in_array() &&
            serialization_preserves_digits() &&
            normal_numbers_unaffected() &&

--- a/tests/ondemand/ondemand_number_tests.cpp
+++ b/tests/ondemand/ondemand_number_tests.cpp
@@ -517,6 +517,19 @@ namespace number_tests {
     TEST_SUCCEED();
   }
 
+  bool positive_big_int() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    padded_string docdata = R"(18446744073709551616)"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_ERROR(doc.get_number(), BIGINT_ERROR);
+    std::string_view my_big;
+    ASSERT_SUCCESS(doc.raw_json_token().get(my_big));
+    ASSERT_EQUAL(my_big, "18446744073709551616");
+    TEST_SUCCEED();
+  }
+
   bool negative_big_int() {
     TEST_START();
     ondemand::parser parser;
@@ -652,6 +665,7 @@ namespace number_tests {
            minus_zero() &&
            gigantic_big_int() &&
            big_int_not_zero() &&
+           positive_big_int() &&
            negative_big_int() &&
            issue2099() &&
            issue2093() &&


### PR DESCRIPTION
In the `digit_count == longest_digit_count` block of `parse_number`, the negative arm returns `BIGINT_NUMBER` on overflow while the positive arm returns `INVALID_NUMBER`, so every integer in `[2^64, 10^20)` comes back as a malformed number. The `digit_count > longest_digit_count` check above it already returns `BIGINT_NUMBER` for both signs, which is why 21 digits worked and 20 did not.

`doc/tape.md` uses `99999999999999999999` as its worked example of a big integer stored on the string tape. That literal is inside the broken window, so the example does not currently work.

This changes the positive arm to `BIGINT_NUMBER(src)`. The `// Positive overflow check:` comment above that branch already establishes that both cases it covers are overflow, so the only thing in question was which error to report.

`parse_number` is shared, so this also affects On Demand: `get_number()` on a positive 20-digit overflow returned `NUMBER_ERROR` while `get_number_type()` already reported `big_integer`. That is why one of the tests is in the On Demand suite.

Three tests in two files, each of which fails without the one-line change:

- `tests/dom/big_integer_tests.cpp` - the window boundaries `2^64` and `10^20 - 1` parse to the expected digit strings under `number_as_string(true)`; and default mode returns `BIGINT_ERROR` rather than `NUMBER_ERROR`.
- `tests/ondemand/ondemand_number_tests.cpp` - `positive_big_int`, mirroring the existing `negative_big_int` next to it.

`18446744073709551615` staying a `uint64_t` is already covered by `normal_numbers_unaffected`.

One behavior change: with `number_as_string` off, that range now yields `BIGINT_ERROR` instead of `NUMBER_ERROR`, matching the negative range and 21-digit numbers.

This has a second consequence. The bigint returns skip the `is_not_structural_or_whitespace(*p)` check that follows them, and the recovery in `tape_builder` rescans the digits without validating the next byte, so trailing garbage is accepted. That is pre-existing on the paths that already returned `BIGINT_NUMBER`, and this change extends it to the 20-digit window:

| input, `number_as_string(true)` | master | with this change |
| --- | --- | --- |
| `{"v":18446744073709551616x}` | `NUMBER_ERROR` | parses |
| `{"v":100000000000000000000x}` | parses | parses |
| `{"v":-18446744073709551616x}` | parses | parses |

Tightening that means validating the tail on all three bigint paths, which is wider than this issue and would reject inputs that parse today. Doing it for only the arm I touched would make it stricter than its siblings. Happy to take it here or separately, whichever you prefer. I have not pinned the current behavior with a test, since I do not think it is the behavior you want.

I compiled and ran `big_integer_tests`, `basictests`, `ondemand_number_tests`, `ondemand_wrong_type_error_tests` and `ondemand_parse_api_tests` against this change; all pass. I left `singleheader/` untouched.

As on the issue: investigation and drafting were AI-assisted. I have checked the change and reproduced every measurement above.

Fixes #2791
