### PR TITLE
arm64: test comparison masks with shrn+fcmp instead of a horizontal reduce

### DIFF
--- a/include/simdjson/arm64/simd.h
+++ b/include/simdjson/arm64/simd.h
@@ -104,6 +104,27 @@ namespace {
     }
   };
 
+  // True if at least one byte of `mask` is set. The caller must guarantee that
+  // `mask` is the result of a comparison, i.e. that each byte is either 0x00 or
+  // 0xFF.
+  //
+  // NEON has no movemask. vshrn_n_u16(..., 4) keeps bits [4:11] of each 16-bit
+  // lane, which is the high nibble of the even byte and the low nibble of the odd
+  // byte: four bits per byte, and no set byte can vanish as long as the bytes are
+  // 0x00 or 0xFF. (It would vanish for arbitrary data: 0x0001 narrows to 0x00.)
+  // Comparing the narrowed value as a double then keeps the answer in the FP
+  // register file, so this is shrn+fcmp and the branch reads NZCV directly: no
+  // across-lane reduction and no SIMD-to-general-purpose-register transfer.
+  //
+  // Two floating-point subtleties, both harmless here: fcmp treats -0.0 as zero,
+  // but 0x8000000000000000 needs a 0x80 byte, which a comparison mask cannot
+  // produce; and an all-ones narrowing is a quiet NaN, which compares unordered
+  // (so != 0.0 is true, as wanted) and raises no invalid-operation exception.
+  simdjson_inline bool any_mask_byte_set(const uint8x16_t mask) {
+    const uint8x8_t narrowed = vshrn_n_u16(vreinterpretq_u16_u8(mask), 4);
+    return vdupd_lane_f64(vreinterpret_f64_u8(narrowed), 0) != 0.0;
+  }
+
   // SIMD byte mask type (returned by things like eq and gt)
   template<>
   struct simd8<bool>: base_u8<bool> {
@@ -140,7 +161,9 @@ namespace {
       return vget_lane_u64(
           vreinterpret_u64_u8(vshrn_n_u16(vreinterpretq_u16_u8(*this), 4)), 0);
     }
-    simdjson_inline bool any() const { return vmaxvq_u32(vreinterpretq_u32_u8(*this)) != 0; }
+    // A simd8<bool> is only ever produced by a comparison, so its bytes are
+    // always 0x00 or 0xFF and any_mask_byte_set applies.
+    simdjson_inline bool any() const { return any_mask_byte_set(*this); }
   };
 
   // Unsigned bytes
@@ -216,7 +239,11 @@ namespace {
 
     // Bit-specific operations
     simdjson_inline simd8<bool> any_bits_set(simd8<uint8_t> bits) const { return vtstq_u8(*this, bits); }
-    simdjson_inline bool any_bits_set_anywhere() const { return vmaxvq_u32(vreinterpretq_u32_u8(*this)) != 0; }
+    // Unlike simd8<bool>, the bytes here are arbitrary, so we cannot narrow them
+    // directly: vtstq_u8 against itself first turns "byte is nonzero" into a
+    // comparison mask, which is one cheap instruction in exchange for dropping
+    // the across-lane reduction and the SIMD-to-GPR transfer.
+    simdjson_inline bool any_bits_set_anywhere() const { return any_mask_byte_set(vtstq_u8(*this, *this)); }
     simdjson_inline bool any_bits_set_anywhere(simd8<uint8_t> bits) const { return (*this & bits).any_bits_set_anywhere(); }
     template<int N>
     simdjson_inline simd8<uint8_t> shr() const { return vshrq_n_u8(*this, N); }

--- a/include/simdjson/generic/ondemand/key_selector.h
+++ b/include/simdjson/generic/ondemand/key_selector.h
@@ -720,6 +720,26 @@ build_phf_data(const std::array<std::string_view, N>& keys, const phf_result<N>&
 static_assert(SIMDJSON_PADDING > 63,
               "key_selector requires SIMDJSON_PADDING > 63 for its SIMD key reads");
 
+#if SIMDJSON_KEY_SELECTOR_HAS_NEON
+// True when every byte of `diff` is zero.
+//
+// `diff` holds arbitrary bytes (it is an XOR of two key windows), so we cannot
+// narrow it directly: vshrn_n_u16(..., 4) keeps only bits [4:11] of each 16-bit
+// lane, and a lone 0x01 in an even byte would be dropped. vtstq_u8 against
+// itself first maps "byte is nonzero" onto a comparison mask (bytes 0x00 or
+// 0xFF), for which the narrowing is lossless. Comparing the narrowed value as a
+// double then keeps the answer in the FP register file: cmtst+shrn+fcmp, with no
+// across-lane reduction and no SIMD-to-general-purpose-register transfer.
+//
+// fcmp treats -0.0 as zero, but 0x8000000000000000 would need a 0x80 byte, which
+// a comparison mask cannot produce, so that hazard is unreachable.
+simdjson_really_inline bool neon_all_bytes_zero(uint8x16_t diff) noexcept {
+    const uint8x8_t narrowed =
+        vshrn_n_u16(vreinterpretq_u16_u8(vtstq_u8(diff, diff)), 4);
+    return vdupd_lane_f64(vreinterpret_f64_u8(narrowed), 0) == 0.0;
+}
+#endif
+
 // Scan for the terminating '"' starting at p. Returns its byte offset (= key
 // length). Caller guarantees SIMDJSON_PADDING (== 64) bytes past the JSON buffer,
 // so reading whole 16-byte blocks up to offset 63 is always safe.
@@ -782,10 +802,7 @@ simdjson_really_inline bool compare_key_bytes(
         uint8x16_t vs = vld1q_u8(reinterpret_cast<const uint8_t*>(stored));
         uint8x16_t mask = vcltq_u8(vld1q_u8(idx16), vdupq_n_u8(static_cast<uint8_t>(len)));
         uint8x16_t diff = veorq_u8(vandq_u8(vp, mask), vs);
-        // A 32-bit-lane horizontal max is enough to decide "all bytes equal"
-        // (diff is zero iff every 32-bit word is zero) and is cheaper than a
-        // byte-wide reduction.
-        return vmaxvq_u32(vreinterpretq_u32_u8(diff)) == 0;
+        return neon_all_bytes_zero(diff);
 #elif SIMDJSON_KEY_SELECTOR_HAS_SSE2
         __m128i vp = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
         __m128i vs = _mm_loadu_si128(reinterpret_cast<const __m128i*>(stored));
@@ -818,7 +835,7 @@ simdjson_really_inline bool compare_key_bytes(
         uint8x16_t m_hi = vcltq_u8(vld1q_u8(idx32_hi), lenv);
         uint8x16_t d_lo = veorq_u8(vandq_u8(vp_lo, m_lo), vs_lo);
         uint8x16_t d_hi = veorq_u8(vandq_u8(vp_hi, m_hi), vs_hi);
-        return vmaxvq_u32(vreinterpretq_u32_u8(vorrq_u8(d_lo, d_hi))) == 0;
+        return neon_all_bytes_zero(vorrq_u8(d_lo, d_hi));
 #elif SIMDJSON_KEY_SELECTOR_HAS_SSE2
         __m128i vp_lo = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p));
         __m128i vp_hi = _mm_loadu_si128(reinterpret_cast<const __m128i*>(p + 16));
@@ -864,7 +881,7 @@ simdjson_really_inline bool compare_key_bytes(
             uint8x16_t mask = vcltq_u8(idxv, lenv);
             acc = vorrq_u8(acc, veorq_u8(vandq_u8(vp, mask), vs));
         }
-        return vmaxvq_u32(vreinterpretq_u32_u8(acc)) == 0;
+        return neon_all_bytes_zero(acc);
 #elif SIMDJSON_KEY_SELECTOR_HAS_SSE2
         __m128i base = _mm_load_si128(reinterpret_cast<const __m128i*>(idx16));
         __m128i lenv = _mm_set1_epi8(static_cast<char>(len));

--- a/src/arm64.cpp
+++ b/src/arm64.cpp
@@ -81,7 +81,11 @@ simdjson_inline json_character_block json_character_block::classify(const simd::
 
 simdjson_inline bool is_ascii(const simd8x64<uint8_t>& input) {
     simd8<uint8_t> bits = input.reduce_or();
-    return bits.max_val() < 0x80u;
+    // We only care whether some byte has its high bit set, so we turn that into a
+    // comparison mask (one vtstq_u8) and let any() do a shrn+fcmp. That is
+    // cheaper than max_val(), whose byte-wide across-lane reduction has to be
+    // moved to a general-purpose register before the branch can use it.
+    return !bits.any_bits_set(uint8_t(0x80)).any();
 }
 
 simdjson_unused simdjson_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {


### PR DESCRIPTION
On arm64 the recurring 'is this vector zero' question was answered with an across-lane reduce (vmaxvq_u8 / vmaxvq_u32) followed by an fmov to a general-purpose register before the branch could use it. Narrowing the mask to four bits per byte with vshrn_n_u16(..., 4) and comparing the result as a double keeps the answer in the FP register file, so the branch reads NZCV directly: umaxv+fmov+cmp becomes shrn+fcmp.

The narrowing keeps only bits [4:11] of each 16-bit lane, so it is lossless only when every byte is 0x00 or 0xFF. simd8<bool> satisfies that by construction; where the bytes are arbitrary (any_bits_set_anywhere, key_selector's XOR of key windows, is_ascii's high-bit test) a single vtstq_u8 maps them onto a comparison mask first, which is still cheaper than the reduce it replaces.

Applied to simd8<bool>::any(), simd8<uint8_t>::any_bits_set_anywhere(), is_ascii() (once per 64-byte block of UTF-8 validation and stage 1) and the three key_selector::compare_key_bytes windows.

