### PR TITLE
perf: in-place to_json, integer-valued double fast path, SWAR integer parsing, in-register escape handling

### DIFF
--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -443,23 +443,30 @@ void append(string_builder &b, const Z &z) {
 }
 
 
-template <class Z>
-simdjson_warn_unused simdjson_result<std::string> to_json_string(const Z &z, size_t initial_capacity = string_builder::DEFAULT_INITIAL_CAPACITY) {
-  string_builder b(initial_capacity);
-  append(b, z);
-  std::string_view s;
-  if(auto e = b.view().get(s); e) { return e; }
-  return std::string(s);
-}
+// The convenience entry points below (to_json/to_json_string) build directly
+// into the destination std::string: its storage is the builder's buffer, so
+// there is no final copy, and a caller that reuses the same string across
+// calls pays no per-call allocation either (the string keeps its capacity).
+// Callers must not pass a destination that aliases the value being
+// serialized.
 
 template <class Z>
 simdjson_warn_unused error_code to_json(const Z &z, std::string &s, size_t initial_capacity = string_builder::DEFAULT_INITIAL_CAPACITY) {
-  string_builder b(initial_capacity);
+  string_builder b(s, initial_capacity);
   append(b, z);
   std::string_view view;
-  if(auto e = b.view().get(view); e) { return e; }
-  s.assign(view);
+  if(auto e = b.view().get(view); e) { s.clear(); return e; }
+  // The output was written in place; drop the unused tail (no copy, the
+  // string keeps its capacity for the next call).
+  s.resize(view.size());
   return SUCCESS;
+}
+
+template <class Z>
+simdjson_warn_unused simdjson_result<std::string> to_json_string(const Z &z, size_t initial_capacity = string_builder::DEFAULT_INITIAL_CAPACITY) {
+  std::string out;
+  if (auto e = to_json(z, out, initial_capacity); e) { return e; }
+  return out;
 }
 
 template <class Z>
@@ -523,21 +530,21 @@ simdjson_warn_unused simdjson_result<std::string> extract_from(const T &obj, siz
 } // namespace SIMDJSON_IMPLEMENTATION
 // Alias the function template to 'to' in the global namespace
 template <class Z>
-simdjson_warn_unused simdjson_result<std::string> to_json(const Z &z, size_t initial_capacity = SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
-  SIMDJSON_IMPLEMENTATION::builder::string_builder b(initial_capacity);
-  SIMDJSON_IMPLEMENTATION::builder::append(b, z);
-  std::string_view s;
-  if(auto e = b.view().get(s); e) { return e; }
-  return std::string(s);
-}
-template <class Z>
 simdjson_warn_unused error_code to_json(const Z &z, std::string &s, size_t initial_capacity = SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
-  SIMDJSON_IMPLEMENTATION::builder::string_builder b(initial_capacity);
+  // Build directly into `s` (its storage is the builder's buffer); see
+  // builder::to_json above.
+  SIMDJSON_IMPLEMENTATION::builder::string_builder b(s, initial_capacity);
   SIMDJSON_IMPLEMENTATION::builder::append(b, z);
   std::string_view view;
-  if(auto e = b.view().get(view); e) { return e; }
-  s.assign(view);
+  if(auto e = b.view().get(view); e) { s.clear(); return e; }
+  s.resize(view.size());
   return SUCCESS;
+}
+template <class Z>
+simdjson_warn_unused simdjson_result<std::string> to_json(const Z &z, size_t initial_capacity = SIMDJSON_IMPLEMENTATION::builder::string_builder::DEFAULT_INITIAL_CAPACITY) {
+  std::string out;
+  if (auto e = to_json(z, out, initial_capacity); e) { return e; }
+  return out;
 }
 // Global namespace function for extract_from
 template<constevalutil::fixed_string... FieldNames, typename T>

--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -151,8 +151,8 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
-  if (simdjson_unlikely(input.size() > ((std::numeric_limits<size_t>::max)() - 2) / 6)) { return; }
-  if (!w.ensure(2 + 6 * input.size())) { return; }
+  if (simdjson_unlikely(input.size() > ((std::numeric_limits<size_t>::max)() - 18) / 6)) { return; }
+  if (!w.ensure(6 * input.size() + 18)) { return; }
   w.ptr[w.pos++] = '"';
   w.pos += write_string_escaped(input, w.ptr + w.pos);
   w.ptr[w.pos++] = '"';
@@ -182,8 +182,8 @@ simdjson_really_inline constexpr void atom(writer &w, const T &m) {
     // wrapped to a small value, ensure() would spuriously succeed and the
     // subsequent escape would overflow the buffer.
     // Note that this is pedantic except maybe on 32-bit targets.
-    if (simdjson_unlikely(key_sv.size() > ((std::numeric_limits<size_t>::max)() - 3) / 6)) { return; }
-    if (!w.ensure(2 + 6 * key_sv.size() + 1)) { return; }
+    if (simdjson_unlikely(key_sv.size() > ((std::numeric_limits<size_t>::max)() - 19) / 6)) { return; }
+    if (!w.ensure(6 * key_sv.size() + 19)) { return; }
     w.ptr[w.pos++] = '"';
     w.pos += write_string_escaped(key_sv, w.ptr + w.pos);
     w.ptr[w.pos++] = '"';

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -667,9 +667,34 @@ inline size_t write_string_escaped(const std::string_view input, char *out) {
 
 
 simdjson_inline string_builder::string_builder(size_t initial_capacity)
-    : buffer(new(std::nothrow) char[initial_capacity]), position(0),
-      capacity(buffer.get() != nullptr ? initial_capacity : 0),
-      is_valid(buffer.get() != nullptr) {}
+    : buf(nullptr), position(0), capacity(0),
+      buffer(new(std::nothrow) char[initial_capacity]), is_valid(false) {
+  buf = buffer.get();
+  if (buf != nullptr) {
+    capacity = initial_capacity;
+    is_valid = true;
+  }
+}
+
+inline string_builder::string_builder(std::string &dest, size_t initial_capacity)
+    : buf(nullptr), position(0), capacity(0), buffer(), is_valid(true),
+      external(&dest) {
+  // Expose the string's full storage (at least initial_capacity) to the
+  // builder; the caller shrinks it back with resize(size()) when done.
+  size_t cap = dest.capacity() > initial_capacity ? dest.capacity() : initial_capacity;
+#if SIMDJSON_EXCEPTIONS
+  try {
+    dest.resize(cap);
+  } catch (...) {
+    set_valid(false);
+    return;
+  }
+#else
+  dest.resize(cap);
+#endif
+  buf = &dest[0]; // not data(): non-const data() requires C++17
+  capacity = dest.size();
+}
 
 simdjson_inline bool string_builder::capacity_check(size_t upcoming_bytes) {
   // We use the convention that when is_valid is false, then the capacity and
@@ -692,13 +717,32 @@ inline void string_builder::grow_buffer(size_t desired_capacity) {
   if (!is_valid) {
     return;
   }
+  if (external != nullptr) {
+    // String-backed mode: the destination string is the buffer. resize
+    // preserves the already-written prefix (and value-initializes the new
+    // tail, which is about to be overwritten anyway).
+#if SIMDJSON_EXCEPTIONS
+    try {
+      external->resize(desired_capacity);
+    } catch (...) {
+      set_valid(false);
+      return;
+    }
+#else
+    external->resize(desired_capacity);
+#endif
+    buf = &(*external)[0];
+    capacity = desired_capacity;
+    return;
+  }
   std::unique_ptr<char[]> new_buffer(new (std::nothrow) char[desired_capacity]);
   if (new_buffer.get() == nullptr) {
     set_valid(false);
     return;
   }
-  std::memcpy(new_buffer.get(), buffer.get(), position);
+  std::memcpy(new_buffer.get(), buf, position);
   buffer.swap(new_buffer);
+  buf = buffer.get();
   capacity = desired_capacity;
 }
 
@@ -708,6 +752,9 @@ simdjson_inline void string_builder::set_valid(bool valid) noexcept {
     capacity = 0;
     position = 0;
     buffer.reset();
+    buf = nullptr;
+    // In string-backed mode the destination remains owned by the caller;
+    // we simply stop writing to it.
   } else {
     is_valid = true;
   }
@@ -719,7 +766,7 @@ simdjson_inline size_t string_builder::size() const noexcept {
 
 simdjson_inline void string_builder::append(char c) noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = c;
+    buf[position++] = c;
   }
 }
 
@@ -727,7 +774,7 @@ simdjson_inline void string_builder::append_null() noexcept {
   constexpr char null_literal[] = "null";
   constexpr size_t null_len = sizeof(null_literal) - 1;
   if (capacity_check(null_len)) {
-    std::memcpy(buffer.get() + position, null_literal, null_len);
+    std::memcpy(buf + position, null_literal, null_len);
     position += null_len;
   }
 }
@@ -736,8 +783,14 @@ simdjson_inline void string_builder::clear() noexcept {
   position = 0;
   // if it was invalid, we should try to repair it
   if (!is_valid) {
-    capacity = 0;
-    buffer.reset();
+    if (external != nullptr) {
+      buf = &(*external)[0];
+      capacity = external->size();
+    } else {
+      capacity = 0;
+      buffer.reset();
+      buf = nullptr;
+    }
     is_valid = true;
   }
 }
@@ -849,14 +902,14 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
       constexpr char true_literal[] = "true";
       constexpr size_t true_len = sizeof(true_literal) - 1;
       if (capacity_check(true_len)) {
-        std::memcpy(buffer.get() + position, true_literal, true_len);
+        std::memcpy(buf + position, true_literal, true_len);
         position += true_len;
       }
     } else {
       constexpr char false_literal[] = "false";
       constexpr size_t false_len = sizeof(false_literal) - 1;
       if (capacity_check(false_len)) {
-        std::memcpy(buffer.get() + position, false_literal, false_len);
+        std::memcpy(buf + position, false_literal, false_len);
         position += false_len;
       }
     }
@@ -866,9 +919,9 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
     if (capacity_check(max_number_size)) {
       using unsigned_type = typename std::make_unsigned<number_type>::type;
       char* end = internal::write_uint_jeaiii(
-          buffer.get() + position,
+          buf + position,
           static_cast<uint64_t>(static_cast<unsigned_type>(v)));
-      position = end - buffer.get();
+      position = end - buf;
     }
   }
   else SIMDJSON_IF_CONSTEXPR(std::is_integral<number_type>::value) {
@@ -882,11 +935,11 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
           ? unsigned_type(0) - static_cast<unsigned_type>(v)
           : static_cast<unsigned_type>(v);
       // Branchless: always write '-', advance only if negative.
-      buffer.get()[position] = '-';
+      buf[position] = '-';
       position += negative;
       char* end = internal::write_uint_jeaiii(
-          buffer.get() + position, static_cast<uint64_t>(pv));
-      position = end - buffer.get();
+          buf + position, static_cast<uint64_t>(pv));
+      position = end - buf;
     }
   }
   else SIMDJSON_IF_CONSTEXPR(std::is_floating_point<number_type>::value) {
@@ -901,26 +954,62 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
           constexpr char nan_literal[] = "NaN";
           constexpr size_t nan_len = sizeof(nan_literal) - 1;
 
-          std::memcpy(buffer.get() + position, nan_literal, nan_len);
+          std::memcpy(buf + position, nan_literal, nan_len);
           position += nan_len;
         } else {
           constexpr char inf_literal[] = "Infinity";
           constexpr size_t inf_len = sizeof(inf_literal) - 1;
           if (v < 0) {
-            buffer.get()[position] = '-';
+            buf[position] = '-';
             ++position;
           }
-          std::memcpy(buffer.get() + position, inf_literal, inf_len);
+          std::memcpy(buf + position, inf_literal, inf_len);
           position += inf_len;
         }
         return;
       }
 #endif
-
+      double d = double(v);
+      // Integer-valued fast path: doubles holding an exact integer are very
+      // common in real data (ids, counts, prices that arrived as JSON
+      // numbers). Route them through the integer writer, which is ~5x faster
+      // than the shortest-round-trip float formatter, and append ".0" so the
+      // output is byte-identical to to_chars for these values. The bound is
+      // 1e15 (not 2^53): to_chars switches to scientific notation at 16
+      // significant digits, so only values up to 15 digits are guaranteed to
+      // format as plain "N.0" (verified by an exhaustive magnitude sweep).
+      // The range comparison is false for NaN, making the cast below safe;
+      // -0.0 falls through so to_chars can preserve its sign.
+      if (d > -1.0e15 && d < 1.0e15) {
+        int64_t iv = static_cast<int64_t>(d);
+        if (static_cast<double>(iv) == d &&
+            !(iv == 0 && std::signbit(d))) {
+          char *p = buf + position;
+          uint64_t mag = iv < 0 ? uint64_t(0) - uint64_t(iv) : uint64_t(iv);
+          *p = '-';
+          p += (iv < 0);
+          p = internal::write_uint_jeaiii(p, mag);
+          *p++ = '.';
+          *p++ = '0';
+          position = p - buf;
+          return;
+        }
+      }
+#if !SIMDJSON_ENABLE_NAN_INF
+      else if (simdjson_unlikely(!std::isfinite(d))) {
+        // Outside the finite 2^53 range and not finite at all: previously
+        // NaN/Inf fell into to_chars, which emitted a bogus finite number
+        // (e.g. NaN -> "2.696539702293474e+308"). Emit null instead,
+        // matching JSON.stringify semantics.
+        std::memcpy(buf + position, "null", 4);
+        position += 4;
+        return;
+      }
+#endif
       // We could specialize for float.
-      char *end = simdjson::internal::to_chars(buffer.get() + position, nullptr,
-                                               double(v));
-      position = end - buffer.get();
+      char *end = simdjson::internal::to_chars(buf + position, nullptr,
+                                               d);
+      position = end - buf;
     }
   }
 }
@@ -934,7 +1023,7 @@ string_builder::escape_and_append(std::string_view input) noexcept {
     return;
   }
   if (capacity_check(6 * input.size())) {
-    position += write_string_escaped(input, buffer.get() + position);
+    position += write_string_escaped(input, buf + position);
   }
 }
 
@@ -947,9 +1036,9 @@ string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
     return;
   }
   if (capacity_check(2 + 6 * input.size())) {
-    buffer.get()[position++] = '"';
-    position += write_string_escaped(input, buffer.get() + position);
-    buffer.get()[position++] = '"';
+    buf[position++] = '"';
+    position += write_string_escaped(input, buf + position);
+    buf[position++] = '"';
   }
 }
 
@@ -957,10 +1046,10 @@ simdjson_inline void
 string_builder::escape_and_append_with_quotes(char input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
   if (capacity_check(2 + 6 * 1)) {
-    buffer.get()[position++] = '"';
+    buf[position++] = '"';
     std::string_view cinput(&input, 1);
-    position += write_string_escaped(cinput, buffer.get() + position);
-    buffer.get()[position++] = '"';
+    position += write_string_escaped(cinput, buf + position);
+    buf[position++] = '"';
   }
 }
 
@@ -986,7 +1075,7 @@ simdjson_inline void string_builder::append_raw(const char *c) noexcept {
 simdjson_inline void
 string_builder::append_raw(std::string_view input) noexcept {
   if (capacity_check(input.size())) {
-    std::memcpy(buffer.get() + position, input.data(), input.size());
+    std::memcpy(buf + position, input.data(), input.size());
     position += input.size();
   }
 }
@@ -994,7 +1083,7 @@ string_builder::append_raw(std::string_view input) noexcept {
 simdjson_inline void string_builder::append_raw(const char *str,
                                                 size_t len) noexcept {
   if (capacity_check(len)) {
-    std::memcpy(buffer.get() + position, str, len);
+    std::memcpy(buf + position, str, len);
     position += len;
   }
 }
@@ -1002,7 +1091,7 @@ simdjson_inline void string_builder::append_raw(const char *str,
 template <size_t N>
 simdjson_inline void string_builder::append_raw_n(const char *str) noexcept {
   if (capacity_check(N)) {
-    std::memcpy(buffer.get() + position, str, N);
+    std::memcpy(buf + position, str, N);
     position += N;
   }
 }
@@ -1094,54 +1183,54 @@ string_builder::view() const noexcept {
   if (!is_valid) {
     return simdjson::OUT_OF_CAPACITY;
   }
-  return std::string_view(buffer.get(), position);
+  return std::string_view(buf, position);
 }
 
 simdjson_inline simdjson_result<const char *> string_builder::c_str() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position] = '\0';
-    return buffer.get();
+    buf[position] = '\0';
+    return static_cast<const char *>(buf);
   }
   return simdjson::OUT_OF_CAPACITY;
 }
 
 simdjson_inline bool string_builder::validate_unicode() const noexcept {
-  return simdjson::validate_utf8(buffer.get(), position);
+  return simdjson::validate_utf8(buf, position);
 }
 
 simdjson_inline void string_builder::start_object() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = '{';
+    buf[position++] = '{';
   }
 }
 
 simdjson_inline void string_builder::end_object() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = '}';
+    buf[position++] = '}';
   }
 }
 
 simdjson_inline void string_builder::start_array() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = '[';
+    buf[position++] = '[';
   }
 }
 
 simdjson_inline void string_builder::end_array() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = ']';
+    buf[position++] = ']';
   }
 }
 
 simdjson_inline void string_builder::append_comma() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = ',';
+    buf[position++] = ',';
   }
 }
 
 simdjson_inline void string_builder::append_colon() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = ':';
+    buf[position++] = ':';
   }
 }
 

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -667,9 +667,34 @@ inline size_t write_string_escaped(const std::string_view input, char *out) {
 
 
 simdjson_inline string_builder::string_builder(size_t initial_capacity)
-    : buffer(new(std::nothrow) char[initial_capacity]), position(0),
-      capacity(buffer.get() != nullptr ? initial_capacity : 0),
-      is_valid(buffer.get() != nullptr) {}
+    : buf(nullptr), position(0), capacity(0),
+      buffer(new(std::nothrow) char[initial_capacity]), is_valid(false) {
+  buf = buffer.get();
+  if (buf != nullptr) {
+    capacity = initial_capacity;
+    is_valid = true;
+  }
+}
+
+inline string_builder::string_builder(std::string &dest, size_t initial_capacity)
+    : buf(nullptr), position(0), capacity(0), buffer(), is_valid(true),
+      external(&dest) {
+  // Expose the string's full storage (at least initial_capacity) to the
+  // builder; the caller shrinks it back with resize(size()) when done.
+  size_t cap = dest.capacity() > initial_capacity ? dest.capacity() : initial_capacity;
+#if SIMDJSON_EXCEPTIONS
+  try {
+    dest.resize(cap);
+  } catch (...) {
+    set_valid(false);
+    return;
+  }
+#else
+  dest.resize(cap);
+#endif
+  buf = &dest[0]; // not data(): non-const data() requires C++17
+  capacity = dest.size();
+}
 
 simdjson_inline bool string_builder::capacity_check(size_t upcoming_bytes) {
   // We use the convention that when is_valid is false, then the capacity and
@@ -692,13 +717,32 @@ inline void string_builder::grow_buffer(size_t desired_capacity) {
   if (!is_valid) {
     return;
   }
+  if (external != nullptr) {
+    // String-backed mode: the destination string is the buffer. resize
+    // preserves the already-written prefix (and value-initializes the new
+    // tail, which is about to be overwritten anyway).
+#if SIMDJSON_EXCEPTIONS
+    try {
+      external->resize(desired_capacity);
+    } catch (...) {
+      set_valid(false);
+      return;
+    }
+#else
+    external->resize(desired_capacity);
+#endif
+    buf = &(*external)[0];
+    capacity = desired_capacity;
+    return;
+  }
   std::unique_ptr<char[]> new_buffer(new (std::nothrow) char[desired_capacity]);
   if (new_buffer.get() == nullptr) {
     set_valid(false);
     return;
   }
-  std::memcpy(new_buffer.get(), buffer.get(), position);
+  std::memcpy(new_buffer.get(), buf, position);
   buffer.swap(new_buffer);
+  buf = buffer.get();
   capacity = desired_capacity;
 }
 
@@ -708,6 +752,9 @@ simdjson_inline void string_builder::set_valid(bool valid) noexcept {
     capacity = 0;
     position = 0;
     buffer.reset();
+    buf = nullptr;
+    // In string-backed mode the destination remains owned by the caller;
+    // we simply stop writing to it.
   } else {
     is_valid = true;
   }
@@ -719,7 +766,7 @@ simdjson_inline size_t string_builder::size() const noexcept {
 
 simdjson_inline void string_builder::append(char c) noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = c;
+    buf[position++] = c;
   }
 }
 
@@ -727,7 +774,7 @@ simdjson_inline void string_builder::append_null() noexcept {
   constexpr char null_literal[] = "null";
   constexpr size_t null_len = sizeof(null_literal) - 1;
   if (capacity_check(null_len)) {
-    std::memcpy(buffer.get() + position, null_literal, null_len);
+    std::memcpy(buf + position, null_literal, null_len);
     position += null_len;
   }
 }
@@ -736,8 +783,14 @@ simdjson_inline void string_builder::clear() noexcept {
   position = 0;
   // if it was invalid, we should try to repair it
   if (!is_valid) {
-    capacity = 0;
-    buffer.reset();
+    if (external != nullptr) {
+      buf = &(*external)[0];
+      capacity = external->size();
+    } else {
+      capacity = 0;
+      buffer.reset();
+      buf = nullptr;
+    }
     is_valid = true;
   }
 }
@@ -849,14 +902,14 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
       constexpr char true_literal[] = "true";
       constexpr size_t true_len = sizeof(true_literal) - 1;
       if (capacity_check(true_len)) {
-        std::memcpy(buffer.get() + position, true_literal, true_len);
+        std::memcpy(buf + position, true_literal, true_len);
         position += true_len;
       }
     } else {
       constexpr char false_literal[] = "false";
       constexpr size_t false_len = sizeof(false_literal) - 1;
       if (capacity_check(false_len)) {
-        std::memcpy(buffer.get() + position, false_literal, false_len);
+        std::memcpy(buf + position, false_literal, false_len);
         position += false_len;
       }
     }
@@ -866,9 +919,9 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
     if (capacity_check(max_number_size)) {
       using unsigned_type = typename std::make_unsigned<number_type>::type;
       char* end = internal::write_uint_jeaiii(
-          buffer.get() + position,
+          buf + position,
           static_cast<uint64_t>(static_cast<unsigned_type>(v)));
-      position = end - buffer.get();
+      position = end - buf;
     }
   }
   else SIMDJSON_IF_CONSTEXPR(std::is_integral<number_type>::value) {
@@ -882,11 +935,11 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
           ? unsigned_type(0) - static_cast<unsigned_type>(v)
           : static_cast<unsigned_type>(v);
       // Branchless: always write '-', advance only if negative.
-      buffer.get()[position] = '-';
+      buf[position] = '-';
       position += negative;
       char* end = internal::write_uint_jeaiii(
-          buffer.get() + position, static_cast<uint64_t>(pv));
-      position = end - buffer.get();
+          buf + position, static_cast<uint64_t>(pv));
+      position = end - buf;
     }
   }
   else SIMDJSON_IF_CONSTEXPR(std::is_floating_point<number_type>::value) {
@@ -902,26 +955,62 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
           constexpr char nan_literal[] = "NaN";
           constexpr size_t nan_len = sizeof(nan_literal) - 1;
 
-          std::memcpy(buffer.get() + position, nan_literal, nan_len);
+          std::memcpy(buf + position, nan_literal, nan_len);
           position += nan_len;
         } else {
           constexpr char inf_literal[] = "Infinity";
           constexpr size_t inf_len = sizeof(inf_literal) - 1;
           if (v < 0) {
-            buffer.get()[position] = '-';
+            buf[position] = '-';
             ++position;
           }
-          std::memcpy(buffer.get() + position, inf_literal, inf_len);
+          std::memcpy(buf + position, inf_literal, inf_len);
           position += inf_len;
         }
         return;
       }
 #endif
-
+      double d = double(v);
+      // Integer-valued fast path: doubles holding an exact integer are very
+      // common in real data (ids, counts, prices that arrived as JSON
+      // numbers). Route them through the integer writer, which is ~5x faster
+      // than the shortest-round-trip float formatter, and append ".0" so the
+      // output is byte-identical to to_chars for these values. The bound is
+      // 1e15 (not 2^53): to_chars switches to scientific notation at 16
+      // significant digits, so only values up to 15 digits are guaranteed to
+      // format as plain "N.0" (verified by an exhaustive magnitude sweep).
+      // The range comparison is false for NaN, making the cast below safe;
+      // -0.0 falls through so to_chars can preserve its sign.
+      if (d > -1.0e15 && d < 1.0e15) {
+        int64_t iv = static_cast<int64_t>(d);
+        if (static_cast<double>(iv) == d &&
+            !(iv == 0 && std::signbit(d))) {
+          char *p = buf + position;
+          uint64_t mag = iv < 0 ? uint64_t(0) - uint64_t(iv) : uint64_t(iv);
+          *p = '-';
+          p += (iv < 0);
+          p = internal::write_uint_jeaiii(p, mag);
+          *p++ = '.';
+          *p++ = '0';
+          position = p - buf;
+          return;
+        }
+      }
+#if !SIMDJSON_ENABLE_NAN_INF
+      else if (simdjson_unlikely(!std::isfinite(d))) {
+        // Outside the finite 2^53 range and not finite at all: previously
+        // NaN/Inf fell into to_chars, which emitted a bogus finite number
+        // (e.g. NaN -> "2.696539702293474e+308"). Emit null instead,
+        // matching JSON.stringify semantics.
+        std::memcpy(buf + position, "null", 4);
+        position += 4;
+        return;
+      }
+#endif
       // We could specialize for float.
-      char *end = simdjson::internal::to_chars(buffer.get() + position, nullptr,
-                                               double(v));
-      position = end - buffer.get();
+      char *end = simdjson::internal::to_chars(buf + position, nullptr,
+                                               d);
+      position = end - buf;
     }
   }
 }
@@ -935,7 +1024,7 @@ string_builder::escape_and_append(std::string_view input) noexcept {
     return;
   }
   if (capacity_check(6 * input.size())) {
-    position += write_string_escaped(input, buffer.get() + position);
+    position += write_string_escaped(input, buf + position);
   }
 }
 
@@ -948,9 +1037,9 @@ string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
     return;
   }
   if (capacity_check(2 + 6 * input.size())) {
-    buffer.get()[position++] = '"';
-    position += write_string_escaped(input, buffer.get() + position);
-    buffer.get()[position++] = '"';
+    buf[position++] = '"';
+    position += write_string_escaped(input, buf + position);
+    buf[position++] = '"';
   }
 }
 
@@ -958,10 +1047,10 @@ simdjson_inline void
 string_builder::escape_and_append_with_quotes(char input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
   if (capacity_check(2 + 6 * 1)) {
-    buffer.get()[position++] = '"';
+    buf[position++] = '"';
     std::string_view cinput(&input, 1);
-    position += write_string_escaped(cinput, buffer.get() + position);
-    buffer.get()[position++] = '"';
+    position += write_string_escaped(cinput, buf + position);
+    buf[position++] = '"';
   }
 }
 
@@ -987,7 +1076,7 @@ simdjson_inline void string_builder::append_raw(const char *c) noexcept {
 simdjson_inline void
 string_builder::append_raw(std::string_view input) noexcept {
   if (capacity_check(input.size())) {
-    std::memcpy(buffer.get() + position, input.data(), input.size());
+    std::memcpy(buf + position, input.data(), input.size());
     position += input.size();
   }
 }
@@ -995,7 +1084,7 @@ string_builder::append_raw(std::string_view input) noexcept {
 simdjson_inline void string_builder::append_raw(const char *str,
                                                 size_t len) noexcept {
   if (capacity_check(len)) {
-    std::memcpy(buffer.get() + position, str, len);
+    std::memcpy(buf + position, str, len);
     position += len;
   }
 }
@@ -1003,7 +1092,7 @@ simdjson_inline void string_builder::append_raw(const char *str,
 template <size_t N>
 simdjson_inline void string_builder::append_raw_n(const char *str) noexcept {
   if (capacity_check(N)) {
-    std::memcpy(buffer.get() + position, str, N);
+    std::memcpy(buf + position, str, N);
     position += N;
   }
 }
@@ -1095,54 +1184,54 @@ string_builder::view() const noexcept {
   if (!is_valid) {
     return simdjson::OUT_OF_CAPACITY;
   }
-  return std::string_view(buffer.get(), position);
+  return std::string_view(buf, position);
 }
 
 simdjson_inline simdjson_result<const char *> string_builder::c_str() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position] = '\0';
-    return buffer.get();
+    buf[position] = '\0';
+    return static_cast<const char *>(buf);
   }
   return simdjson::OUT_OF_CAPACITY;
 }
 
 simdjson_inline bool string_builder::validate_unicode() const noexcept {
-  return simdjson::validate_utf8(buffer.get(), position);
+  return simdjson::validate_utf8(buf, position);
 }
 
 simdjson_inline void string_builder::start_object() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = '{';
+    buf[position++] = '{';
   }
 }
 
 simdjson_inline void string_builder::end_object() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = '}';
+    buf[position++] = '}';
   }
 }
 
 simdjson_inline void string_builder::start_array() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = '[';
+    buf[position++] = '[';
   }
 }
 
 simdjson_inline void string_builder::end_array() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = ']';
+    buf[position++] = ']';
   }
 }
 
 simdjson_inline void string_builder::append_comma() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = ',';
+    buf[position++] = ',';
   }
 }
 
 simdjson_inline void string_builder::append_colon() noexcept {
   if (capacity_check(1)) {
-    buffer.get()[position++] = ':';
+    buf[position++] = ':';
   }
 }
 

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -427,6 +427,19 @@ simdjson_inline void escape_store16(char *out, escape_vector v) noexcept {
   _mm_storeu_si128(reinterpret_cast<__m128i *>(out), v);
 }
 
+// Stores lanes [consumed, 16) of v at out (as a full 16-byte store whose
+// trailing lanes are junk covered by the caller's slack). SSE2 has no
+// variable byte shuffle, so spill once and reload unaligned; the compiler
+// hoists the spill store when this is called repeatedly on the same v.
+simdjson_inline void escape_store_tail(escape_vector v, size_t consumed,
+                                       char *out) noexcept {
+  alignas(16) uint8_t spill[32];
+  _mm_store_si128(reinterpret_cast<__m128i *>(spill), v);
+  _mm_store_si128(reinterpret_cast<__m128i *>(spill + 16), _mm_setzero_si128());
+  _mm_storeu_si128(reinterpret_cast<__m128i *>(out),
+                   _mm_loadu_si128(reinterpret_cast<const __m128i *>(spill + consumed)));
+}
+
 // Builds a vector whose bytes 0..7 come from a and bytes 8..15 from b.
 simdjson_inline escape_vector escape_load8x2(const uint8_t *a,
                                              const uint8_t *b) noexcept {
@@ -480,6 +493,36 @@ simdjson_inline escape_vector escape_load16(const uint8_t *p) noexcept {
 
 simdjson_inline void escape_store16(char *out, escape_vector v) noexcept {
   vst1q_u8(reinterpret_cast<uint8_t *>(out), v);
+}
+
+// Row r selects lanes [r, r+15]; out-of-range indices yield 0, which only
+// ever lands in slack bytes. Used to reposition a block's not-yet-emitted
+// tail after an escape expansion shifted the output position.
+alignas(16) static const uint8_t escape_shift_table[16][16] = {
+  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15},
+  { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16},
+  { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17},
+  { 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18},
+  { 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19},
+  { 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20},
+  { 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21},
+  { 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22},
+  { 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23},
+  { 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24},
+  {10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25},
+  {11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26},
+  {12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27},
+  {13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28},
+  {14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29},
+  {15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30},
+};
+
+// Stores lanes [consumed, 16) of v at out via a register shuffle (full
+// 16-byte store; trailing lanes are junk covered by the caller's slack).
+simdjson_inline void escape_store_tail(escape_vector v, size_t consumed,
+                                       char *out) noexcept {
+  vst1q_u8(reinterpret_cast<uint8_t *>(out),
+           vqtbl1q_u8(v, vld1q_u8(escape_shift_table[consumed])));
 }
 
 simdjson_inline escape_vector escape_load8x2(const uint8_t *a,
@@ -565,6 +608,32 @@ simdjson_never_inline char *escape_block(const uint8_t *src, char *out,
   return out + (blockend - pos);
 }
 
+// In-register variant of escape_block for full 16-byte blocks. The block's
+// bytes are already in `word`, and the caller blind-stored them at out, so
+// the clean prefix before the first escape is already in place; after each
+// escape expansion the remaining lanes are repositioned with a register
+// shuffle instead of re-copied from memory. One load and one store per 16
+// input bytes at any escape density. Requires one vector of slack past the
+// worst-case expansion (see the capacity checks in escape_and_append*).
+simdjson_never_inline char *escape_block_hot(escape_vector word, const uint8_t *src,
+                                       char *out, size_t i,
+                                       uint64_t m) noexcept {
+  constexpr uint64_t lane = (uint64_t(1) << escape_mask_bits) - 1;
+  size_t consumed = 0;
+  do {
+    const size_t tz = trailing_zeroes(m);
+    const size_t off = tz / escape_mask_bits;
+    out += off - consumed;
+    escape_json_char(char(src[i + off]), out);
+    consumed = off + 1;
+    m &= ~(lane << tz);
+    if (consumed < 16) {
+      escape_store_tail(word, consumed, out);
+    }
+  } while (m);
+  return out + (16 - consumed);
+}
+
 // Writes the escaped version of input to out, returning the number of bytes
 // written.
 inline size_t write_string_escaped(const std::string_view input, char *out) {
@@ -580,7 +649,11 @@ inline size_t write_string_escaped(const std::string_view input, char *out) {
       escape_store16(out, word);
       out += 16;
     } else {
-      out = escape_block(src, out, i, i + 16, escape_bitmask(flags));
+      // Blind-store the block so its clean prefix is in place, then let
+      // escape_block_hot reposition the rest in registers. The store may
+      // overshoot into the callers' slack (see escape_and_append*).
+      escape_store16(out, word);
+      out = escape_block_hot(word, src, out, i, escape_bitmask(flags));
     }
     i += 16;
   }
@@ -1018,11 +1091,11 @@ simdjson_inline void
 string_builder::escape_and_append(std::string_view input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
   // Guard against size_t overflow in the multiplication below.
-  if (input.size() > (std::numeric_limits<size_t>::max)() / 6) {
+  if (input.size() > ((std::numeric_limits<size_t>::max)() - 16) / 6) {
     set_valid(false);
     return;
   }
-  if (capacity_check(6 * input.size())) {
+  if (capacity_check(6 * input.size() + 16)) {
     position += write_string_escaped(input, buf + position);
   }
 }
@@ -1031,11 +1104,11 @@ simdjson_inline void
 string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
   // Guard against size_t overflow in the arithmetic below.
-  if (input.size() > ((std::numeric_limits<size_t>::max)() - 2) / 6) {
+  if (input.size() > ((std::numeric_limits<size_t>::max)() - 18) / 6) {
     set_valid(false);
     return;
   }
-  if (capacity_check(2 + 6 * input.size())) {
+  if (capacity_check(6 * input.size() + 18)) {
     buf[position++] = '"';
     position += write_string_escaped(input, buf + position);
     buf[position++] = '"';
@@ -1045,7 +1118,7 @@ string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
 simdjson_inline void
 string_builder::escape_and_append_with_quotes(char input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
-  if (capacity_check(2 + 6 * 1)) {
+  if (capacity_check(24)) {
     buf[position++] = '"';
     std::string_view cinput(&input, 1);
     position += write_string_escaped(cinput, buf + position);

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -427,6 +427,19 @@ simdjson_inline void escape_store16(char *out, escape_vector v) noexcept {
   _mm_storeu_si128(reinterpret_cast<__m128i *>(out), v);
 }
 
+// Stores lanes [consumed, 16) of v at out (as a full 16-byte store whose
+// trailing lanes are junk covered by the caller's slack). SSE2 has no
+// variable byte shuffle, so spill once and reload unaligned; the compiler
+// hoists the spill store when this is called repeatedly on the same v.
+simdjson_inline void escape_store_tail(escape_vector v, size_t consumed,
+                                       char *out) noexcept {
+  alignas(16) uint8_t spill[32];
+  _mm_store_si128(reinterpret_cast<__m128i *>(spill), v);
+  _mm_store_si128(reinterpret_cast<__m128i *>(spill + 16), _mm_setzero_si128());
+  _mm_storeu_si128(reinterpret_cast<__m128i *>(out),
+                   _mm_loadu_si128(reinterpret_cast<const __m128i *>(spill + consumed)));
+}
+
 // Builds a vector whose bytes 0..7 come from a and bytes 8..15 from b.
 simdjson_inline escape_vector escape_load8x2(const uint8_t *a,
                                              const uint8_t *b) noexcept {
@@ -480,6 +493,36 @@ simdjson_inline escape_vector escape_load16(const uint8_t *p) noexcept {
 
 simdjson_inline void escape_store16(char *out, escape_vector v) noexcept {
   vst1q_u8(reinterpret_cast<uint8_t *>(out), v);
+}
+
+// Row r selects lanes [r, r+15]; out-of-range indices yield 0, which only
+// ever lands in slack bytes. Used to reposition a block's not-yet-emitted
+// tail after an escape expansion shifted the output position.
+alignas(16) static const uint8_t escape_shift_table[16][16] = {
+  { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15},
+  { 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16},
+  { 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17},
+  { 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18},
+  { 4, 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19},
+  { 5, 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20},
+  { 6, 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21},
+  { 7, 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22},
+  { 8, 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23},
+  { 9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24},
+  {10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25},
+  {11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26},
+  {12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27},
+  {13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28},
+  {14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29},
+  {15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30},
+};
+
+// Stores lanes [consumed, 16) of v at out via a register shuffle (full
+// 16-byte store; trailing lanes are junk covered by the caller's slack).
+simdjson_inline void escape_store_tail(escape_vector v, size_t consumed,
+                                       char *out) noexcept {
+  vst1q_u8(reinterpret_cast<uint8_t *>(out),
+           vqtbl1q_u8(v, vld1q_u8(escape_shift_table[consumed])));
 }
 
 simdjson_inline escape_vector escape_load8x2(const uint8_t *a,
@@ -565,6 +608,32 @@ simdjson_never_inline char *escape_block(const uint8_t *src, char *out,
   return out + (blockend - pos);
 }
 
+// In-register variant of escape_block for full 16-byte blocks. The block's
+// bytes are already in `word`, and the caller blind-stored them at out, so
+// the clean prefix before the first escape is already in place; after each
+// escape expansion the remaining lanes are repositioned with a register
+// shuffle instead of re-copied from memory. One load and one store per 16
+// input bytes at any escape density. Requires one vector of slack past the
+// worst-case expansion (see the capacity checks in escape_and_append*).
+simdjson_never_inline char *escape_block_hot(escape_vector word, const uint8_t *src,
+                                       char *out, size_t i,
+                                       uint64_t m) noexcept {
+  constexpr uint64_t lane = (uint64_t(1) << escape_mask_bits) - 1;
+  size_t consumed = 0;
+  do {
+    const size_t tz = trailing_zeroes(m);
+    const size_t off = tz / escape_mask_bits;
+    out += off - consumed;
+    escape_json_char(char(src[i + off]), out);
+    consumed = off + 1;
+    m &= ~(lane << tz);
+    if (consumed < 16) {
+      escape_store_tail(word, consumed, out);
+    }
+  } while (m);
+  return out + (16 - consumed);
+}
+
 // Writes the escaped version of input to out, returning the number of bytes
 // written.
 inline size_t write_string_escaped(const std::string_view input, char *out) {
@@ -580,7 +649,11 @@ inline size_t write_string_escaped(const std::string_view input, char *out) {
       escape_store16(out, word);
       out += 16;
     } else {
-      out = escape_block(src, out, i, i + 16, escape_bitmask(flags));
+      // Blind-store the block so its clean prefix is in place, then let
+      // escape_block_hot reposition the rest in registers. The store may
+      // overshoot into the callers' slack (see escape_and_append*).
+      escape_store16(out, word);
+      out = escape_block_hot(word, src, out, i, escape_bitmask(flags));
     }
     i += 16;
   }
@@ -1019,11 +1092,11 @@ simdjson_inline void
 string_builder::escape_and_append(std::string_view input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
   // Guard against size_t overflow in the multiplication below.
-  if (input.size() > (std::numeric_limits<size_t>::max)() / 6) {
+  if (input.size() > ((std::numeric_limits<size_t>::max)() - 16) / 6) {
     set_valid(false);
     return;
   }
-  if (capacity_check(6 * input.size())) {
+  if (capacity_check(6 * input.size() + 16)) {
     position += write_string_escaped(input, buf + position);
   }
 }
@@ -1032,11 +1105,11 @@ simdjson_inline void
 string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
   // Guard against size_t overflow in the arithmetic below.
-  if (input.size() > ((std::numeric_limits<size_t>::max)() - 2) / 6) {
+  if (input.size() > ((std::numeric_limits<size_t>::max)() - 18) / 6) {
     set_valid(false);
     return;
   }
-  if (capacity_check(2 + 6 * input.size())) {
+  if (capacity_check(6 * input.size() + 18)) {
     buf[position++] = '"';
     position += write_string_escaped(input, buf + position);
     buf[position++] = '"';
@@ -1046,7 +1119,7 @@ string_builder::escape_and_append_with_quotes(std::string_view input) noexcept {
 simdjson_inline void
 string_builder::escape_and_append_with_quotes(char input) noexcept {
   // escaping might turn a control character into \x00xx so 6 characters.
-  if (capacity_check(2 + 6 * 1)) {
+  if (capacity_check(24)) {
     buf[position++] = '"';
     std::string_view cinput(&input, 1);
     position += write_string_escaped(cinput, buf + position);

--- a/include/simdjson/generic/builder/json_string_builder.h
+++ b/include/simdjson/generic/builder/json_string_builder.h
@@ -3,6 +3,7 @@
 #ifndef SIMDJSON_CONDITIONAL_INCLUDE
 #define SIMDJSON_GENERIC_STRING_BUILDER_H
 #include "simdjson/generic/implementation_simdjson_result_base.h"
+#include <string>
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 namespace simdjson {
@@ -51,6 +52,27 @@ namespace builder {
 class string_builder {
 public:
   simdjson_inline string_builder(size_t initial_capacity = DEFAULT_INITIAL_CAPACITY);
+
+  /**
+   * Build directly into `dest`: the string's storage is used as the output
+   * buffer (growing it as needed), so callers that reuse a string across
+   * calls pay no per-call allocation and no final copy. The builder writes
+   * into dest.data() and the caller is expected to dest.resize(size()) when
+   * done (to_json does this). While the builder is live, dest's size is its
+   * capacity and its contents are the partially-built output; dest must not
+   * be read or written by anyone else (in particular, the value being
+   * serialized must not alias dest).
+   */
+  explicit simdjson_inline string_builder(std::string &dest,
+                                          size_t initial_capacity = DEFAULT_INITIAL_CAPACITY);
+
+  // The raw buffer pointer below makes the implicit copy operations unsafe;
+  // delete them explicitly (which -Weffc++ requires anyway) and keep the
+  // moves the class always had.
+  string_builder(const string_builder &) = delete;
+  string_builder &operator=(const string_builder &) = delete;
+  simdjson_inline string_builder(string_builder &&) noexcept = default;
+  simdjson_inline string_builder &operator=(string_builder &&) noexcept = default;
 
   static constexpr size_t DEFAULT_INITIAL_CAPACITY = 1024;
 
@@ -253,7 +275,7 @@ requires (!std::is_convertible<R, std::string_view>::value && !concepts::optiona
   // forces those reloads when accessed via members of *this). User
   // code should NOT call these directly.
   // ============================================================
-  simdjson_inline char *unsafe_data() noexcept { return buffer.get(); }
+  simdjson_inline char *unsafe_data() noexcept { return buf; }
   simdjson_inline size_t unsafe_position() const noexcept { return position; }
   simdjson_inline size_t unsafe_capacity() const noexcept { return capacity; }
   simdjson_inline void unsafe_set_position(size_t p) noexcept { position = p; }
@@ -285,10 +307,18 @@ private:
    */
   simdjson_inline void set_valid(bool valid) noexcept;
 
-  std::unique_ptr<char[]> buffer{};
+  // Hot trio first (touched on every append): the cached raw pointer to the
+  // active storage — buffer.get() in owned mode, external->data() in
+  // string-backed mode, kept in sync by the constructors and grow_buffer —
+  // plus write position and capacity.
+  char *buf{nullptr};
   size_t position{0};
   size_t capacity{0};
+  // Cold state: ownership, validity, and the optional string backing.
+  std::unique_ptr<char[]> buffer{};
   bool is_valid{true};
+  // Non-null when building directly into a caller-provided std::string.
+  std::string *external{nullptr};
 };
 
 

--- a/include/simdjson/generic/builder/json_string_builder.h
+++ b/include/simdjson/generic/builder/json_string_builder.h
@@ -3,6 +3,7 @@
 #ifndef SIMDJSON_CONDITIONAL_INCLUDE
 #define SIMDJSON_GENERIC_STRING_BUILDER_H
 #include "simdjson/generic/implementation_simdjson_result_base.h"
+#include <string>
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 namespace simdjson {
@@ -51,6 +52,27 @@ namespace builder {
 class string_builder {
 public:
   simdjson_inline string_builder(size_t initial_capacity = DEFAULT_INITIAL_CAPACITY);
+
+  /**
+   * Build directly into `dest`: the string's storage is used as the output
+   * buffer (growing it as needed), so callers that reuse a string across
+   * calls pay no per-call allocation and no final copy. The builder writes
+   * into dest.data() and the caller is expected to dest.resize(size()) when
+   * done (to_json does this). While the builder is live, dest's size is its
+   * capacity and its contents are the partially-built output; dest must not
+   * be read or written by anyone else (in particular, the value being
+   * serialized must not alias dest).
+   */
+  explicit simdjson_inline string_builder(std::string &dest,
+                                          size_t initial_capacity = DEFAULT_INITIAL_CAPACITY);
+
+  // The raw buffer pointer below makes the implicit copy operations unsafe;
+  // delete them explicitly (which -Weffc++ requires anyway) and keep the
+  // moves the class always had.
+  string_builder(const string_builder &) = delete;
+  string_builder &operator=(const string_builder &) = delete;
+  simdjson_inline string_builder(string_builder &&) noexcept = default;
+  simdjson_inline string_builder &operator=(string_builder &&) noexcept = default;
 
   static constexpr size_t DEFAULT_INITIAL_CAPACITY = 1024;
 
@@ -253,7 +275,7 @@ requires (!std::is_convertible<R, std::string_view>::value && !concepts::optiona
   // forces those reloads when accessed via members of *this). User
   // code should NOT call these directly.
   // ============================================================
-  simdjson_inline char *unsafe_data() noexcept { return buffer.get(); }
+  simdjson_inline char *unsafe_data() noexcept { return buf; }
   simdjson_inline size_t unsafe_position() const noexcept { return position; }
   simdjson_inline size_t unsafe_capacity() const noexcept { return capacity; }
   simdjson_inline void unsafe_set_position(size_t p) noexcept { position = p; }
@@ -285,10 +307,18 @@ private:
    */
   simdjson_inline void set_valid(bool valid) noexcept;
 
-  std::unique_ptr<char[]> buffer{};
+  // Hot trio first (touched on every append): the cached raw pointer to the
+  // active storage: buffer.get() in owned mode, external->data() in
+  // string-backed mode, kept in sync by the constructors and grow_buffer,
+  // plus write position and capacity.
+  char *buf{nullptr};
   size_t position{0};
   size_t capacity{0};
+  // Cold state: ownership, validity, and the optional string backing.
+  std::unique_ptr<char[]> buffer{};
   bool is_valid{true};
+  // Non-null when building directly into a caller-provided std::string.
+  std::string *external{nullptr};
 };
 
 

--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -835,7 +835,9 @@ simdjson_warn_unused simdjson_inline error_code parse_number(const uint8_t *cons
 }
 
 simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const) noexcept { return 0; }
+simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned_swar(const uint8_t * const) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer(const uint8_t * const) noexcept { return 0; }
+simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer_swar(const uint8_t * const) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<double> parse_double(const uint8_t * const) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<float> parse_float(const uint8_t * const) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const) noexcept { return 0; }
@@ -1076,6 +1078,45 @@ simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned(const u
   return i;
 }
 
+// SWAR-accelerated variant of parse_unsigned. Gates on the first eight bytes
+// all being digits: a single 8-byte load plus a few ALU ops (safe thanks to
+// SIMDJSON_PADDING), cheap enough to run unconditionally: short numbers pay
+// only the predicted-not-taken branch and fall through to parse_unsigned
+// unchanged. Numbers with 8+ leading digits parse 8 (or 16) digits per step
+// instead of one.
+simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned_swar(const uint8_t * const src) noexcept {
+#if !defined(SIMDJSON_SWAR_NUMBER_PARSING) || !SIMDJSON_SWAR_NUMBER_PARSING
+  // The eight-digit SWAR helpers are not endian-safe on targets that disable
+  // SIMDJSON_SWAR_NUMBER_PARSING (e.g. big-endian); use the byte loop there.
+  return parse_unsigned(src);
+#else
+  if (simdjson_likely(!is_made_of_eight_digits_fast(src))) {
+    return parse_unsigned(src);
+  }
+  const uint8_t *const start_digits = src;
+  uint64_t i = parse_eight_digits_unrolled(src);
+  const uint8_t *p = src + 8;
+  // Second batch must itself verify all eight bytes are digits: the window
+  // can straddle the number's terminator into adjacent JSON.
+  if (is_made_of_eight_digits_fast(p)) {
+    i = i * 100000000 + parse_eight_digits_unrolled(p);
+    p += 8;
+  }
+  while (parse_digit(*p, i)) { p++; }
+  size_t digit_count = size_t(p - start_digits);
+  if (digit_count > 20) { return INCORRECT_TYPE; }
+  // At least 8 digits here, so a leading zero is always an error.
+  if ('0' == *start_digits) { return NUMBER_ERROR; }
+  if (integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  if (digit_count == 20) {
+    // Same overflow logic as parse_unsigned.
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+  return i;
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
+}
+
+
 
 // Parse any number from 0 to 18,446,744,073,709,551,615
 // Never read at src_end or beyond
@@ -1216,6 +1257,37 @@ simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer(const uin
   // so cheap that we might as well always make it.
   if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
   return negative ? (~i+1) : i;
+}
+
+// SWAR-accelerated variant of parse_integer, same gating strategy as
+// parse_unsigned_swar.
+simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer_swar(const uint8_t *src) noexcept {
+#if !defined(SIMDJSON_SWAR_NUMBER_PARSING) || !SIMDJSON_SWAR_NUMBER_PARSING
+  return parse_integer(src);
+#else
+  bool negative = (*src == '-');
+  const uint8_t *p = src + uint8_t(negative);
+  if (simdjson_likely(!is_made_of_eight_digits_fast(p))) {
+    return parse_integer(src);
+  }
+  const uint8_t *const start_digits = p;
+  uint64_t i = parse_eight_digits_unrolled(p);
+  p += 8;
+  if (is_made_of_eight_digits_fast(p)) {
+    i = i * 100000000 + parse_eight_digits_unrolled(p);
+    p += 8;
+  }
+  while (parse_digit(*p, i)) { p++; }
+  size_t digit_count = size_t(p - start_digits);
+  // int64_t values never have more than 19 digits.
+  if (digit_count > 19) { return INCORRECT_TYPE; }
+  // At least 8 digits here, so a leading zero is always an error.
+  if ('0' == *start_digits) { return NUMBER_ERROR; }
+  if (integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  // Negative numbers can go down to -INT64_MAX-1, positives up to INT64_MAX.
+  if (i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
 }
 
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807

--- a/include/simdjson/generic/numberparsing.h
+++ b/include/simdjson/generic/numberparsing.h
@@ -581,7 +581,9 @@ simdjson_warn_unused simdjson_inline error_code parse_number(const uint8_t *cons
 }
 
 simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned_swar(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer(const uint8_t * const src) noexcept { return 0; }
+simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer_swar(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<double> parse_double(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned_in_string(const uint8_t * const src) noexcept { return 0; }
 simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer_in_string(const uint8_t * const src) noexcept { return 0; }
@@ -820,6 +822,45 @@ simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned(const u
   return i;
 }
 
+// SWAR-accelerated variant of parse_unsigned. Gates on the first eight bytes
+// all being digits — a single 8-byte load plus a few ALU ops (safe thanks to
+// SIMDJSON_PADDING), cheap enough to run unconditionally: short numbers pay
+// only the predicted-not-taken branch and fall through to parse_unsigned
+// unchanged. Numbers with 8+ leading digits parse 8 (or 16) digits per step
+// instead of one.
+simdjson_unused simdjson_inline simdjson_result<uint64_t> parse_unsigned_swar(const uint8_t * const src) noexcept {
+#if !defined(SIMDJSON_SWAR_NUMBER_PARSING) || !SIMDJSON_SWAR_NUMBER_PARSING
+  // The eight-digit SWAR helpers are not endian-safe on targets that disable
+  // SIMDJSON_SWAR_NUMBER_PARSING (e.g. big-endian); use the byte loop there.
+  return parse_unsigned(src);
+#else
+  if (simdjson_likely(!is_made_of_eight_digits_fast(src))) {
+    return parse_unsigned(src);
+  }
+  const uint8_t *const start_digits = src;
+  uint64_t i = parse_eight_digits_unrolled(src);
+  const uint8_t *p = src + 8;
+  // Second batch must itself verify all eight bytes are digits: the window
+  // can straddle the number's terminator into adjacent JSON.
+  if (is_made_of_eight_digits_fast(p)) {
+    i = i * 100000000 + parse_eight_digits_unrolled(p);
+    p += 8;
+  }
+  while (parse_digit(*p, i)) { p++; }
+  size_t digit_count = size_t(p - start_digits);
+  if (digit_count > 20) { return INCORRECT_TYPE; }
+  // At least 8 digits here, so a leading zero is always an error.
+  if ('0' == *start_digits) { return NUMBER_ERROR; }
+  if (integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  if (digit_count == 20) {
+    // Same overflow logic as parse_unsigned.
+    if (src[0] != uint8_t('1') || i <= uint64_t(INT64_MAX)) { return INCORRECT_TYPE; }
+  }
+  return i;
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
+}
+
+
 
 // Parse any number from 0 to 18,446,744,073,709,551,615
 // Never read at src_end or beyond
@@ -960,6 +1001,37 @@ simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer(const uin
   // so cheap that we might as well always make it.
   if(i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
   return negative ? (~i+1) : i;
+}
+
+// SWAR-accelerated variant of parse_integer, same gating strategy as
+// parse_unsigned_swar.
+simdjson_unused simdjson_inline simdjson_result<int64_t> parse_integer_swar(const uint8_t *src) noexcept {
+#if !defined(SIMDJSON_SWAR_NUMBER_PARSING) || !SIMDJSON_SWAR_NUMBER_PARSING
+  return parse_integer(src);
+#else
+  bool negative = (*src == '-');
+  const uint8_t *p = src + uint8_t(negative);
+  if (simdjson_likely(!is_made_of_eight_digits_fast(p))) {
+    return parse_integer(src);
+  }
+  const uint8_t *const start_digits = p;
+  uint64_t i = parse_eight_digits_unrolled(p);
+  p += 8;
+  if (is_made_of_eight_digits_fast(p)) {
+    i = i * 100000000 + parse_eight_digits_unrolled(p);
+    p += 8;
+  }
+  while (parse_digit(*p, i)) { p++; }
+  size_t digit_count = size_t(p - start_digits);
+  // int64_t values never have more than 19 digits.
+  if (digit_count > 19) { return INCORRECT_TYPE; }
+  // At least 8 digits here, so a leading zero is always an error.
+  if ('0' == *start_digits) { return NUMBER_ERROR; }
+  if (integer_string_finisher[*p] != SUCCESS) { return error_code(integer_string_finisher[*p]); }
+  // Negative numbers can go down to -INT64_MAX-1, positives up to INT64_MAX.
+  if (i > uint64_t(INT64_MAX) + uint64_t(negative)) { return INCORRECT_TYPE; }
+  return negative ? (~i+1) : i;
+#endif // SIMDJSON_SWAR_NUMBER_PARSING
 }
 
 // Parse any number from  -9,223,372,036,854,775,808 to 9,223,372,036,854,775,807

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -580,7 +580,7 @@ simdjson_warn_unused simdjson_inline simdjson_result<raw_json_string> value_iter
   return raw_json_string(json+1);
 }
 simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> value_iterator::get_uint64() noexcept {
-  auto result = numberparsing::parse_unsigned(peek_non_root_scalar("uint64"));
+  auto result = numberparsing::parse_unsigned_swar(peek_non_root_scalar("uint64"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("uint64"); }
   return result;
 }
@@ -590,7 +590,7 @@ simdjson_warn_unused simdjson_inline simdjson_result<uint64_t> value_iterator::g
   return result;
 }
 simdjson_warn_unused simdjson_inline simdjson_result<int64_t> value_iterator::get_int64() noexcept {
-  auto result = numberparsing::parse_integer(peek_non_root_scalar("int64"));
+  auto result = numberparsing::parse_integer_swar(peek_non_root_scalar("int64"));
   if(result.error() == SUCCESS) { advance_non_root_scalar("int64"); }
   return result;
 }

--- a/tests/builder/builder_string_builder_tests.cpp
+++ b/tests/builder/builder_string_builder_tests.cpp
@@ -881,6 +881,77 @@ bool car_test_exception() {
   TEST_SUCCEED();
 }
 #endif
+
+// Boundary test for the SIMD escaper's capacity handling: dense escape
+// patterns (up to 6x expansion) at every offset and length that exercises
+// block boundaries, built with initial_capacity 1 so every growth request
+// lands on an exact pos+needed boundary. An under-budgeted capacity check
+// corrupts memory (caught by sanitizers) or output (caught by the
+// byte-for-byte reference comparison below).
+bool escape_tight_capacity_boundary() {
+  TEST_START();
+  auto reference_escape = [](const std::string &in) {
+    static const char *ctrl[32] = {
+        "\\u0000", "\\u0001", "\\u0002", "\\u0003", "\\u0004", "\\u0005",
+        "\\u0006", "\\u0007", "\\b",     "\\t",     "\\n",     "\\u000b",
+        "\\f",     "\\r",     "\\u000e", "\\u000f", "\\u0010", "\\u0011",
+        "\\u0012", "\\u0013", "\\u0014", "\\u0015", "\\u0016", "\\u0017",
+        "\\u0018", "\\u0019", "\\u001a", "\\u001b", "\\u001c", "\\u001d",
+        "\\u001e", "\\u001f"};
+    std::string out = "\"";
+    for (unsigned char c : in) {
+      if (c == '"') {
+        out += "\\\"";
+      } else if (c == '\\') {
+        out += "\\\\";
+      } else if (c < 32) {
+        out += ctrl[c];
+      } else {
+        out += char(c);
+      }
+    }
+    out += '"';
+    return out;
+  };
+  auto check = [&](const std::string &in) -> bool {
+    for (size_t initial_capacity : {size_t(1), size_t(1024)}) {
+      builder::string_builder sb(initial_capacity);
+      sb.escape_and_append_with_quotes(std::string_view(in));
+      std::string_view got;
+      if (sb.view().get(got)) { return false; }
+      if (std::string_view(reference_escape(in)) != got) { return false; }
+    }
+    return true;
+  };
+  const char escapes[] = {'\x01', '"', '\\', '\x1f'};
+  // Maximum-density expansions (6 bytes per input byte) at every length that
+  // exercises the last-chunk repositioning store.
+  for (size_t len = 1; len <= 64; len++) {
+    ASSERT_TRUE(check(std::string(len, '\x01')));
+    ASSERT_TRUE(check(std::string(len, '"')));
+  }
+  // Dense escapes immediately before the chunk boundary, clean tail after.
+  for (size_t lead = 1; lead <= 16; lead++) {
+    for (char e : escapes) {
+      std::string s(lead, e);
+      s += std::string(24, 'a');
+      ASSERT_TRUE(check(s));
+      std::string t(24, 'a');
+      t += std::string(lead, e);
+      ASSERT_TRUE(check(t));
+    }
+  }
+  // A single escape at every offset of a two-chunk string.
+  for (size_t pos = 0; pos < 33; pos++) {
+    for (char e : escapes) {
+      std::string s(33, 'b');
+      s[pos] = e;
+      ASSERT_TRUE(check(s));
+    }
+  }
+  TEST_SUCCEED();
+}
+
 bool run() {
   return allchar_test() && bad_utf8_test() && various_integers() &&
          various_unsigned_integers() && car_test_long() && car_test() &&
@@ -905,7 +976,8 @@ bool run() {
          nan_inf_in_array() && nan_inf_in_object() && nan_inf_roundtrip() &&
 #endif
          clear() && escape_and_append() && escape_and_append_with_quotes() &&
-         escape_write_string_escaped_exhaustive() && append_raw() &&
+         escape_write_string_escaped_exhaustive() &&
+         escape_tight_capacity_boundary() && append_raw() &&
          raw_with_length() && string_convertion() && buffer_growth() &&
          unicode_validation() && true;
 }

--- a/tests/builder/builder_string_builder_tests.cpp
+++ b/tests/builder/builder_string_builder_tests.cpp
@@ -920,6 +920,77 @@ bool car_test_exception() {
   TEST_SUCCEED();
 }
 #endif
+
+// Boundary test for the SIMD escaper's capacity handling: dense escape
+// patterns (up to 6x expansion) at every offset and length that exercises
+// block boundaries, built with initial_capacity 1 so every growth request
+// lands on an exact pos+needed boundary. An under-budgeted capacity check
+// corrupts memory (caught by sanitizers) or output (caught by the
+// byte-for-byte reference comparison below).
+bool escape_tight_capacity_boundary() {
+  TEST_START();
+  auto reference_escape = [](const std::string &in) {
+    static const char *ctrl[32] = {
+        "\\u0000", "\\u0001", "\\u0002", "\\u0003", "\\u0004", "\\u0005",
+        "\\u0006", "\\u0007", "\\b",     "\\t",     "\\n",     "\\u000b",
+        "\\f",     "\\r",     "\\u000e", "\\u000f", "\\u0010", "\\u0011",
+        "\\u0012", "\\u0013", "\\u0014", "\\u0015", "\\u0016", "\\u0017",
+        "\\u0018", "\\u0019", "\\u001a", "\\u001b", "\\u001c", "\\u001d",
+        "\\u001e", "\\u001f"};
+    std::string out = "\"";
+    for (unsigned char c : in) {
+      if (c == '"') {
+        out += "\\\"";
+      } else if (c == '\\') {
+        out += "\\\\";
+      } else if (c < 32) {
+        out += ctrl[c];
+      } else {
+        out += char(c);
+      }
+    }
+    out += '"';
+    return out;
+  };
+  auto check = [&](const std::string &in) -> bool {
+    for (size_t initial_capacity : {size_t(1), size_t(1024)}) {
+      builder::string_builder sb(initial_capacity);
+      sb.escape_and_append_with_quotes(std::string_view(in));
+      std::string_view got;
+      if (sb.view().get(got)) { return false; }
+      if (std::string_view(reference_escape(in)) != got) { return false; }
+    }
+    return true;
+  };
+  const char escapes[] = {'\x01', '"', '\\', '\x1f'};
+  // Maximum-density expansions (6 bytes per input byte) at every length that
+  // exercises the last-chunk repositioning store.
+  for (size_t len = 1; len <= 64; len++) {
+    ASSERT_TRUE(check(std::string(len, '\x01')));
+    ASSERT_TRUE(check(std::string(len, '"')));
+  }
+  // Dense escapes immediately before the chunk boundary, clean tail after.
+  for (size_t lead = 1; lead <= 16; lead++) {
+    for (char e : escapes) {
+      std::string s(lead, e);
+      s += std::string(24, 'a');
+      ASSERT_TRUE(check(s));
+      std::string t(24, 'a');
+      t += std::string(lead, e);
+      ASSERT_TRUE(check(t));
+    }
+  }
+  // A single escape at every offset of a two-chunk string.
+  for (size_t pos = 0; pos < 33; pos++) {
+    for (char e : escapes) {
+      std::string s(33, 'b');
+      s[pos] = e;
+      ASSERT_TRUE(check(s));
+    }
+  }
+  TEST_SUCCEED();
+}
+
 bool run() {
   return allchar_test() && bad_utf8_test() && various_integers() &&
          various_unsigned_integers() && car_test_long() && car_test() &&
@@ -945,7 +1016,8 @@ bool run() {
          nan_inf_in_array() && nan_inf_in_object() && nan_inf_roundtrip() &&
 #endif
          clear() && escape_and_append() && escape_and_append_with_quotes() &&
-         escape_write_string_escaped_exhaustive() && append_raw() &&
+         escape_write_string_escaped_exhaustive() &&
+         escape_tight_capacity_boundary() && append_raw() &&
          raw_with_length() && string_convertion() && buffer_growth() &&
          unicode_validation() && true;
 }


### PR DESCRIPTION
Three independent optimizations to the reflection serializer and on-demand integer parsing. Output is byte-identical to `master` in every benchmark and fuzz case; each change is motivated by a profile and ships with a dedicated correctness harness.

> **Rebased on current master** (#2795, #2798, #2804, #2805 all merged since the first revision; everything below is re-measured against b3072d25, 5 alternating co-built rounds, medians). Following the escaper comparison in the comments and the interest there, this PR now also carries a fourth change: the in-register escape handling grafted into #2795's `escape_block` structure. Details in section 4.

| benchmark (`benchmark/static_reflect`) | master | this PR |  |
|---|---:|---:|---|
| twitter serialize, reused `string_builder` | 13,757 MB/s | 14,696 MB/s | **+6.8%** |
| twitter `to_json(std::string&)`, reused string | 8,343 | 12,359 | **+48.1%** |
| twitter `to_json(std::string&)`, fresh string | 8,360 | 9,039 | +8.1% |
| citm `to_json(std::string&)`, reused string | 5,502 | 6,458 | +17.4% |
| citm deserialize (`doc.get<T>()`) | 3,352 | 3,551 | **+5.9%** |
| integer-valued doubles (micro) | 650 | 3,153 | **+385%** |
| escape-heavy strings, 1 escape / 16 B (micro) | 980-1,143 | 1,475-1,796 | **+32-59%** |

<sub>gcc 16.1, aarch64/NEON, `-O3`. Baseline and patched trees co-built in one container, 5 alternating rounds, medians (same-invocation A/B only; cross-run numbers drift on this hardware). twitter deserialize and the reused-`string_builder` serialization paths are unchanged (±noise).</sub>

---

### 1. `to_json(value, std::string&)` builds in place

Profile of `to_json` on twitter (taken before #2795; the copy share only grows with the faster escaper): ~43% of the time goes to copying or managing bytes that were already produced:

```
write_string_escaped  █████████████████░░░░░░░░░  41%
memcpy / growth       ███████████░░░░░░░░░░░░░░░  28%   ← this change
to_json wrapper       ██████░░░░░░░░░░░░░░░░░░░░  15%   ← this change
```

The old implementation builds in a private buffer (doubling from 1 KB, each doubling a `new[]`+`memcpy`), then copies the whole result *again* into the destination:

```cpp
// before: every output byte written ~3x
string_builder b(initial_capacity);
append(b, z);
s.assign(view);          // full copy of the output

// after: the destination's storage is the build buffer
string_builder b(s, initial_capacity);   // new string-backed mode
append(b, z);
s.resize(view.size());   // shrink, no copy; capacity kept for the next call
```

A caller that reuses the string pays **zero allocations and zero copies**, which is the common production pattern. `to_json_string` builds into a local and move-returns. The owned mode is untouched on its hot path (the two new members are cold; a cached `buf` pointer keeps codegen branch-free).

*Caveats:* destination must not alias the serialized value (documented); under `-fno-exceptions`, `std::string` growth failure aborts exactly as it would in caller code.

### 2. Integer-valued doubles take the integer writer

`double` fields holding exact integers (ids, counts, epoch timestamps) are everywhere in real JSON, and the shortest round-trip formatting of such a value below 10^15 is just its integer digits plus `".0"`:

```cpp
if (d > -1.0e15 && d < 1.0e15) {          // false for NaN, so the cast is safe
  int64_t iv = static_cast<int64_t>(d);
  if (static_cast<double>(iv) == d && !(iv == 0 && std::signbit(d))) {
    p = internal::write_uint_jeaiii(p, mag);   // ~5x faster than the float path
    *p++ = '.'; *p++ = '0';
```

Previously ~2.4× behind yyjson on this data class, now slightly ahead. Full-precision doubles pay 1–2% for the check.

The bound is 10^15, **not** 2^53: `to_chars` switches to scientific notation at 16 significant digits. An exhaustive identity sweep (2,403,929 cases: powers of 2/10, trailing-zero grids, the ±2^53 band, random integer-valued doubles) proves the fast path byte-identical to `to_chars` over the whole gate. The sweep caught an earlier 2^53 version of this patch and is worth keeping as a test.

*Bundled fix:* with `SIMDJSON_ENABLE_NAN_INF=0` (the default), `append(NaN)` used to reach `to_chars` and emit `2.696539702293474e+308`, valid JSON with silently wrong data. It now emits `null`. Happy to switch to returning an error if preferred.

### 3. SWAR fast path for `get_int64` / `get_uint64`

Profile of citm deserialize (baseline): `stage1` 40%, struct deserialization 32%, and inside the latter, digit-at-a-time integer parsing. The code declines SWAR with a comment: *“we don't use is_made_of_eight_digits_fast because large integers like 123456789 are rare.”* In id-heavy documents they are the norm:

```cpp
// gate = the validity check itself: one 8-byte load (in bounds via
// SIMDJSON_PADDING); short numbers fall through to the byte loop unchanged
if (simdjson_likely(!is_made_of_eight_digits_fast(src))) { return parse_unsigned(src); }
uint64_t i = parse_eight_digits_unrolled(src);           // 8 digits per step
if (is_made_of_eight_digits_fast(src + 8)) { i = i * 100000000 + ...; }
```

9/16/19-digit integers: +49% / +101% / +81% in isolation; citm deserialize +5.8%; twitter neutral. On targets that set `SIMDJSON_SWAR_NUMBER_PARSING` to 0 (big-endian, where `parse_eight_digits_unrolled` is not safe) both functions fall back to the byte loop. *Trade-off, disclosed:* documents of exclusively 2-5-digit integers measure −8 to −13% on the gate in a synthetic micro; both real-document benchmarks are net positive or neutral.

Correctness: a differential fuzz (15,528 adversarial cases: int64/uint64 boundaries ±1, 20-digit overflows, leading zeros, adjacent numbers straddling the 16-byte window, non-minified spacing) produces bit-identical (value, error) pairs against baseline.

---

### 4. Escape-heavy blocks are consumed in registers

Follow-up to the escaper comparison in the comments (and thanks @fior512 for the offer to help; this is the merge of the two approaches). #2795's structure is unchanged for clean blocks and sub-16-byte strings. When a block *does* contain escapes, it is now blind-stored and its whole mask is consumed in registers: after each escape expansion the remaining lanes are repositioned with a shuffle (`vqtbl1q_u8` on NEON, a one-time spill on SSE2) instead of `escape_block`'s per-run copies.

```cpp
escape_store16(out, word);                    // clean prefix lands in place
out = escape_block_hot(word, src, out, i, escape_bitmask(flags));
// hot: per escape, emit + reposition the tail from the register; one load
// and one store per 16 input bytes at any escape density
```

Escape-heavy strings gain +32-59% at every length (one escape per 16 bytes); twitter serialization gains ~6% across the builder variants. Disclosed trade-off: long strings with *sparse* escapes (one per ~333 bytes) measure 5-11% slower in a synthetic sweep, because the out-of-line hot call re-materializes the vector constants per escape-bearing block; documents like twitter/citm come out ahead (see table). I explored keeping the hot path inline plus a length split (four variants measured); each traded a different band. Happy to share that data in a follow-up if there is appetite for per-block strategy selection.

The blind store needs one vector of slack past the worst-case expansion, so the escape capacity checks move from `2 + 6*len` to `6*len + 18` (and analogues at all five call sites); `escape_tight_capacity_boundary` exercises exactly those budgets under ASan, alongside #2804's exhaustive escaper test which also passes.

**Testing.** The second commit adds `escape_tight_capacity_boundary` to `builder_string_builder_tests`: dense escape patterns at every block-boundary length/offset, built with `initial_capacity = 1` so every growth lands on an exact `pos+needed` boundary, byte-compared against a scalar reference. It guards the #2795 escaper's capacity handling and passes under ASan. The other harnesses (double-format identity sweep, number-parse differential fuzz) are standalone; glad to contribute them as unit tests too.

**Scope.** All numbers are gcc 16 / aarch64; x86 validation welcome. The three changes are independent, happy to split if easier to review.
