### PR TITLE
Fix exception throw in get_next_key_and_json_path for unterminated bracket quote

### DIFF
--- a/include/simdjson/jsonpathutil.h
+++ b/include/simdjson/jsonpathutil.h
@@ -136,6 +136,10 @@ inline std::pair<std::string_view, std::string_view> get_next_key_and_json_path(
       ++i;
     }
 
+    if (i + 1 >= json_path.length() || json_path[i + 1] != ']') {
+      return {key, json_path};
+    }
+
     key = json_path.substr(key_start, i - key_start);
 
     i += 2;


### PR DESCRIPTION
**Description**
get_next_key_and_json_path in include/simdjson/jsonpathutil.h: line 141 advances index +2 without checking for closing bracket quote. Callers are noexcept so it terminates process. I added 3 LOC bounds check.

**Type of change**
- [x] Bug fix

**Test:**
```
#include "simdjson.h"
#include <iostream>
using namespace simdjson;

int main() {
  auto json = R"({"a": [1, 2, 3]})"_padded;
  const char *path = "$[\"a*";   // missing closing quote

  dom::parser parser;
  dom::element doc;
  if (parser.parse(json).get(doc)) { return 1; }

  std::cout << "calling at_path_with_wildcard" << std::endl;
  auto result = doc.at_path_with_wildcard(path);
  std::cout << "returned: " << result.error() << std::endl;
  return 0;
}
```
```
C:\..\test>cl /std:c++20 /EHsc /O2 test.cpp simdjson.cpp
```
Powershell:
```
PS C:\..\test> .\test.exe
calling at_path_with_wildcard
PS C:\..\test> $LASTEXITCODE
-1073740791
PS C:\..\test> "0x{0:X8}" -f $LASTEXITCODE
0xC0000409
```

**Change**
```
if (i + 1 >= json_path.length() || json_path[i + 1] != ']') {
  return {key, json_path};
}
```
return values in my change matches line 113 earlier in the same function.