### PR TITLE
Fix throw on unterminated bracket-quoted JSONPath keys in wildcard walks

### DIFF
--- a/include/simdjson/generic/ondemand/array-inl.h
+++ b/include/simdjson/generic/ondemand/array-inl.h
@@ -168,6 +168,12 @@ inline error_code array::for_each_at_path_with_wildcard(std::string_view json_pa
   auto result_pair = get_next_key_and_json_path(json_path);
   std::string_view key = result_pair.first;
   std::string_view remaining_path = result_pair.second;
+  // Empty key means the path segment could not be parsed (including malformed
+  // bracket-quoted keys). Without this check, an empty key is treated as index
+  // 0 and remaining_path may be unchanged, causing infinite recursion.
+  if (key.empty()) {
+    return INVALID_JSON_POINTER;
+  }
   // Wildcard case
   if (key=="*"){
     for(auto element: *this) {

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -335,6 +335,12 @@ inline error_code object::for_each_at_path_with_wildcard(std::string_view json_p
   auto result_pair = get_next_key_and_json_path(json_path);
   std::string_view key = result_pair.first;
   std::string_view remaining_path = result_pair.second;
+  // Empty key means the path segment could not be parsed (including malformed
+  // bracket-quoted keys). Match DOM at_path_with_wildcard and avoid treating
+  // "no progress" as a recursive lookup of "".
+  if (key.empty()) {
+    return INVALID_JSON_POINTER;
+  }
   // Handle when its the case for wildcard
   if (key == "*") {
     // Loop through each field in the object

--- a/include/simdjson/jsonpathutil.h
+++ b/include/simdjson/jsonpathutil.h
@@ -129,20 +129,28 @@ inline std::pair<std::string_view, std::string_view> get_next_key_and_json_path(
     }
 
     key = json_path.substr(key_start, i - key_start);
-  } else if ((i+1 < json_path.size()) && json_path[i] == '[' && (json_path[i+1] == '\'' || json_path[i+1] == '"')) {
+  } else if ((i + 1 < json_path.size()) && json_path[i] == '[' &&
+             (json_path[i + 1] == '\'' || json_path[i + 1] == '"')) {
+    // Bracket-quoted key: ['key'] or ["key"].
+    // Require a matching closing quote and a following ']'. If either is
+    // missing, return an empty key and the original path so callers can treat
+    // this as a parse failure (e.g. INVALID_JSON_POINTER) without advancing.
+    // Without this check, i += 2 can make i > size() and substr throws
+    // std::out_of_range, which aborts noexcept callers such as
+    // at_path_with_wildcard / for_each_at_path_with_wildcard.
+    const char quote = json_path[i + 1];
     i += 2;
-    size_t key_start = i;
-    while (i < json_path.length() && json_path[i] != '\'' && json_path[i] != '"') {
+    const size_t key_start = i;
+    while (i < json_path.length() && json_path[i] != quote) {
       ++i;
     }
-
-    if (i + 1 >= json_path.length() || json_path[i + 1] != ']') {
+    if (i >= json_path.length() ||               // missing closing quote
+        i + 1 >= json_path.length() ||           // missing ]
+        json_path[i + 1] != ']') {
       return {key, json_path};
     }
-
     key = json_path.substr(key_start, i - key_start);
-
-    i += 2;
+    i += 2; // past quote and ]
   } else if ((i+2 < json_path.size()) && json_path[i] == '[' && json_path[i+1] == '*' && json_path[i+2] == ']') { // i.e [*].additional_keys or [*]["additional_keys"]
     key = "*";
     i += 3;

--- a/include/simdjson/jsonpathutil.h
+++ b/include/simdjson/jsonpathutil.h
@@ -136,6 +136,10 @@ inline std::pair<std::string_view, std::string_view> get_next_key_and_json_path(
       ++i;
     }
 
+    if (i + 1 >= json_path.length() || json_path[i + 1] != ']') {
+      return {key, json_path};
+    }
+
     key = json_path.substr(key_start, i - key_start);
 
     i += 2;

--- a/tests/dom/json_path_tests.cpp
+++ b/tests/dom/json_path_tests.cpp
@@ -446,6 +446,129 @@ bool json_path_with_wildcard() {
   TEST_SUCCEED();
 }
 
+// https://github.com/simdjson/simdjson/pull/2800
+// Unterminated bracket-quoted keys used to throw std::out_of_range from
+// get_next_key_and_json_path, aborting noexcept at_path_with_wildcard.
+bool unterminated_bracket_quote_wildcard() {
+  std::cout << "Running unterminated_bracket_quote_wildcard test" << std::endl;
+  auto json = R"({"a": [1, 2, 3], "address": {"city": "Nara"}, "ok": 1})"_padded;
+  dom::parser parser;
+  dom::element doc;
+  ASSERT_SUCCESS(parser.parse(json).get(doc));
+
+  // Paths that contain '*' take the wildcard branch and call
+  // get_next_key_and_json_path. Malformed first-segment bracket-quotes must
+  // surface INVALID_JSON_POINTER (and must not abort).
+  const char *first_segment_malformed[] = {
+      R"($["a*)",
+      R"($['a*)",
+      R"($["a"*)",
+      R"($['a'*)",
+      R"($["unterminated*)",
+      R"($['unterminated*)",
+      R"($["*)",
+      R"($['*)",
+      R"($["a"*)", // quote closed but ']' missing before '*'
+  };
+  for (const char *path : first_segment_malformed) {
+    std::cout << "  malformed first segment: " << path << std::endl;
+    ASSERT_EQUAL(doc.at_path_with_wildcard(path).error(), INVALID_JSON_POINTER);
+  }
+
+  // When the first segment is valid but a later bracket-quote is not, child
+  // processing swallows the error and returns an empty result (SUCCESS).
+  // The important property is no throw/abort.
+  const char *later_segment_malformed[] = {
+      R"($["a"]["b*)",
+      R"($["a"]['b*)",
+      R"($["ok"].*)", // ok is a scalar; wildcard suffix yields empty
+  };
+  for (const char *path : later_segment_malformed) {
+    std::cout << "  later-segment / empty result path: " << path << std::endl;
+    std::vector<dom::element> values;
+    ASSERT_SUCCESS(doc.at_path_with_wildcard(path).get(values));
+    ASSERT_EQUAL(values.size(), 0);
+  }
+
+  // Well-formed bracket-quoted segments still work with wildcards.
+  std::vector<dom::element> values;
+  ASSERT_SUCCESS(doc.at_path_with_wildcard(R"($["address"].*)").get(values));
+  ASSERT_EQUAL(values.size(), 1);
+  std::string_view city;
+  ASSERT_SUCCESS(values[0].get(city));
+  ASSERT_EQUAL(city, "Nara");
+
+  ASSERT_SUCCESS(doc.at_path_with_wildcard(R"($['address'].*)").get(values));
+  ASSERT_EQUAL(values.size(), 1);
+  ASSERT_SUCCESS(values[0].get(city));
+  ASSERT_EQUAL(city, "Nara");
+
+  // Non-wildcard at_path uses json_path_to_pointer_conversion (already guarded
+  // for a missing ']'; quotes are not stripped there, so unterminated
+  // forms are still INVALID_JSON_POINTER).
+  ASSERT_EQUAL(doc.at_path(R"($["a")").error(), INVALID_JSON_POINTER);
+  ASSERT_EQUAL(doc.at_path(R"($['a')").error(), INVALID_JSON_POINTER);
+  int64_t ok_val = 0;
+  ASSERT_SUCCESS(doc.at_path("$.ok").get(ok_val));
+  ASSERT_EQUAL(ok_val, 1);
+
+  TEST_SUCCEED();
+}
+
+// Deterministic fuzz-style sweep of truncated / malformed JSONPath strings.
+// Ensures at_path_with_wildcard never aborts on incomplete bracket-quotes.
+bool json_path_malformed_deterministic_fuzz() {
+  std::cout << "Running json_path_malformed_deterministic_fuzz test" << std::endl;
+  auto json = R"({"a":{"b":[1,2,3]},"x":1,"*":true})"_padded;
+  dom::parser parser;
+  dom::element doc;
+  ASSERT_SUCCESS(parser.parse(json).get(doc));
+
+  // Seeds that exercise quote / bracket / wildcard combinations.
+  const char *seeds[] = {
+      R"($["a*)",
+      R"($['a*)",
+      R"($["a"][*])",
+      R"($['a'][*])",
+      R"($[*]["b*)",
+      R"($[*]['b*)",
+      R"($["a"]["b*)",
+      R"($["*")",
+      R"($["*"]*)",
+      R"($[*].*)",
+      R"($["a"*].*)",
+      R"($.a["b*)",
+      R"($[")",
+      R"($[')",
+      R"($["])",
+      R"($['])",
+      R"($[""])",
+      R"($[''])",
+      R"($["a])",
+      R"($['a])",
+  };
+
+  for (const char *seed : seeds) {
+    const std::string full(seed);
+    // Try every non-empty prefix so truncation of a once-valid path is covered.
+    for (size_t len = 1; len <= full.size(); len++) {
+      const std::string path = full.substr(0, len);
+      // Must return an error code (or empty success), never throw/abort.
+      auto result = doc.at_path_with_wildcard(path);
+      (void)result.error();
+    }
+  }
+
+  // A few fully valid paths mixed in to keep the happy path warm.
+  std::vector<dom::element> values;
+  ASSERT_SUCCESS(doc.at_path_with_wildcard("$.*").get(values));
+  ASSERT_TRUE(values.size() >= 1);
+  ASSERT_SUCCESS(doc.at_path_with_wildcard(R"($["a"].*)").get(values));
+  ASSERT_TRUE(values.size() >= 1);
+
+  TEST_SUCCEED();
+}
+
 // for 0.5 version and following (standard compliant)
 bool modern_support() {
 #if SIMDJSON_EXCEPTIONS
@@ -468,7 +591,8 @@ bool modern_support() {
 }
 
 int main() {
-  if (true && json_path_with_wildcard() && demo() && modern_support() &&
+  if (true && json_path_with_wildcard() && unterminated_bracket_quote_wildcard() &&
+      json_path_malformed_deterministic_fuzz() && demo() && modern_support() &&
       run_success_test(TEST_RFC_JSON, "$.foo", "[\"bar\",\"baz\"]") &&
       run_success_test(TEST_RFC_JSON, "$.foo[0]", "\"bar\"") &&
       run_success_test(TEST_RFC_JSON, "$.", "0") &&

--- a/tests/ondemand/ondemand_wildcard_tests.cpp
+++ b/tests/ondemand/ondemand_wildcard_tests.cpp
@@ -334,6 +334,115 @@ namespace wildcard_tests {
     TEST_SUCCEED();
   }
 
+  // https://github.com/simdjson/simdjson/pull/2800
+  // Unterminated bracket-quoted keys must return INVALID_JSON_POINTER, not abort.
+  bool unterminated_bracket_quote() {
+    TEST_START();
+    auto json = R"({"a": [1, 2, 3], "ok": 1, "address": {"city": "Nara"}})"_padded;
+    ondemand::parser parser;
+
+    const char *malformed[] = {
+        R"($["a*)",
+        R"($['a*)",
+        R"($["a")",
+        R"($['a')",
+        R"($["unterminated")",
+        R"($['unterminated')",
+        R"($["a"]["b")",
+        R"($["a"]['b')",
+        R"($[")",
+        R"($[')",
+        R"($["*)",
+        R"($['*)",
+    };
+    for (const char *path : malformed) {
+      std::cout << "  malformed path: " << path << std::endl;
+      auto doc = parser.iterate(json);
+      auto error = doc.for_each_at_path_with_wildcard(path, [](ondemand::value) {});
+      ASSERT_ERROR(error, INVALID_JSON_POINTER);
+    }
+
+    // Valid bracket-quoted path still works.
+    {
+      auto doc = parser.iterate(json);
+      int64_t got = 0;
+      size_t count = 0;
+      ASSERT_SUCCESS(doc.for_each_at_path_with_wildcard(R"($["ok"])", [&](ondemand::value v) {
+        count++;
+        if (v.get_int64().get(got) != SUCCESS) { got = -1; }
+      }));
+      ASSERT_EQUAL(count, 1);
+      ASSERT_EQUAL(got, 1);
+    }
+    {
+      auto doc = parser.iterate(json);
+      std::string_view city;
+      size_t count = 0;
+      ASSERT_SUCCESS(doc.for_each_at_path_with_wildcard(R"($['address'].city)", [&](ondemand::value v) {
+        count++;
+        if (v.get_string().get(city) != SUCCESS) { city = {}; }
+      }));
+      ASSERT_EQUAL(count, 1);
+      ASSERT_EQUAL(city, "Nara");
+    }
+
+    // Root-array document: empty/malformed key must not infinite-recurse as index 0.
+    {
+      auto arr_json = R"([{"name":"x"}])"_padded;
+      auto doc = parser.iterate(arr_json);
+      auto error = doc.for_each_at_path_with_wildcard(R"($["a*)", [](ondemand::value) {});
+      ASSERT_ERROR(error, INVALID_JSON_POINTER);
+    }
+
+    TEST_SUCCEED();
+  }
+
+  // Deterministic prefix-truncation sweep over bracket/wildcard seeds.
+  bool wildcard_malformed_deterministic_fuzz() {
+    TEST_START();
+    auto json = R"({"a":{"b":[1,2,3]},"x":1})"_padded;
+    ondemand::parser parser;
+
+    const char *seeds[] = {
+        R"($["a*)",
+        R"($['a*)",
+        R"($["a"][*])",
+        R"($['a'][*])",
+        R"($[*]["b*)",
+        R"($["a"]["b*)",
+        R"($[*].*)",
+        R"($.a["b*)",
+        R"($[")",
+        R"($[')",
+        R"($["a])",
+        R"($['a])",
+        R"($[""])",
+        R"($[''])",
+    };
+
+    for (const char *seed : seeds) {
+      const std::string full(seed);
+      for (size_t len = 1; len <= full.size(); len++) {
+        const std::string path = full.substr(0, len);
+        auto doc = parser.iterate(json);
+        // Must not throw/abort; any error code is acceptable for truncated paths.
+        (void)doc.for_each_at_path_with_wildcard(path, [](ondemand::value) {});
+      }
+    }
+
+    // Happy path still works after the sweep.
+    {
+      auto doc = parser.iterate(json);
+      size_t count = 0;
+      ASSERT_SUCCESS(doc.for_each_at_path_with_wildcard("$.a.b[*]", [&](ondemand::value) {
+        count++;
+      }));
+      ASSERT_EQUAL(count, 3);
+    }
+
+    TEST_SUCCEED();
+  }
+
   bool run() {
     return array_wildcard_basic() &&
            array_wildcard_numbers() &&
@@ -347,7 +456,9 @@ namespace wildcard_tests {
            mixed_types_in_array() &&
            wildcard_nonexistent_field() &&
            root_array_wildcard() &&
-           wildcard_raw_json_issue_2684();
+           wildcard_raw_json_issue_2684() &&
+           unterminated_bracket_quote() &&
+           wildcard_malformed_deterministic_fuzz();
   }
 }
 


### PR DESCRIPTION
### Description

Supersedes / builds on https://github.com/simdjson/simdjson/pull/2800 (thanks @alex9sm).

In `get_next_key_and_json_path` (`include/simdjson/jsonpathutil.h`), the
bracket-quoted key branch scanned for a quote then always did `i += 2` before
`json_path.substr(i)`. For unterminated forms such as `$["a*` or `$["a"`, `i`
could land past `size()`, so `substr` threw `std::out_of_range`. Callers are
`noexcept` (`dom::*::at_path_with_wildcard`,
`ondemand::*::for_each_at_path_with_wildcard`), so that becomes `std::terminate`
(on MSVC, `0xC0000409` / `STATUS_STACK_BUFFER_OVERRUN` as in the original report).

This is not a raw OOB read of the path buffer; it is a well-defined exception
escaping a `noexcept` boundary. The same failure mode exists with
`SIMDJSON_EXCEPTIONS=OFF` (abort instead of terminate).

### Fix

- Require a **matching** closing quote and a following `]` before extracting the
  key and advancing (same fail-closed idea as `json_path_to_pointer_conversion`
  returning the `"-1"` sentinel on a missing `]`).
- On failure, return an empty key and the **original** path (no progress),
  consistent with the empty-path early return in the same function.
- In ondemand wildcard walkers, treat an empty parsed key as
  `INVALID_JSON_POINTER` (DOM already did this). That documents the failure mode
  clearly and avoids treating “no progress” as index `0` / field `""`, which
  could recurse forever on array roots.

Valid paths such as `$["address"].*` / `$['address'].city` / `$[*]` are unchanged.

### Caller behaviour after the fix

| API | Malformed first segment (e.g. `$["a*`) |
|-----|----------------------------------------|
| DOM `at_path_with_wildcard` | `INVALID_JSON_POINTER` |
| Ondemand `for_each_at_path_with_wildcard` | `INVALID_JSON_POINTER` |

If an earlier segment is valid and a later bracket-quote is not (e.g.
`$["a"]["b*`), DOM child processing already swallows per-child errors and may
return an empty vector with `SUCCESS`. Ondemand returns `INVALID_JSON_POINTER`
when a later segment fails to parse. Neither path aborts.

### Tests

- DOM: `unterminated_bracket_quote_wildcard`,
  `json_path_malformed_deterministic_fuzz` in `tests/dom/json_path_tests.cpp`
- Ondemand: `unterminated_bracket_quote`,
  `wildcard_malformed_deterministic_fuzz` in
  `tests/ondemand/ondemand_wildcard_tests.cpp`

Cases cover `$["…`, `$['…`, missing `]` after a quote, nested failure, still-
working quoted segments, and a deterministic prefix-truncation sweep over
bracket/wildcard seeds (no crash/throw).

### Type of change

- [x] Bug fix

### Related

- Original report / minimal fix: #2800
- Found while looking for issues related to #368