### PR TITLE
Add newline_delimited, slice_at, and skip documents by delimiter

### DIFF
--- a/benchmark/bench_stream_formats.cpp
+++ b/benchmark/bench_stream_formats.cpp
@@ -1,5 +1,8 @@
 #include <benchmark/benchmark.h>
+#include <atomic>
 #include <string>
+#include <thread>
+#include <vector>
 #include "simdjson.h"
 
 using namespace simdjson;
@@ -9,6 +12,8 @@ namespace {
 enum class stream_case {
   ndjson_small,
   ndjson_large,
+  newline_small,
+  newline_large,
   rfc7464_small,
   rfc7464_large,
   comma_delimited_small,
@@ -33,6 +38,7 @@ std::string make_document(size_t id, size_t payload_size) {
 
 stream_dataset build_dataset(stream_case which) {
   const bool small = which == stream_case::ndjson_small ||
+                     which == stream_case::newline_small ||
                      which == stream_case::rfc7464_small ||
                      which == stream_case::comma_delimited_small;
   const bool rfc = which == stream_case::rfc7464_small ||
@@ -76,6 +82,10 @@ const stream_dataset &get_dataset(stream_case which) {
       return ndjson_small;
     case stream_case::ndjson_large:
       return ndjson_large;
+    case stream_case::newline_small:
+      return ndjson_small;
+    case stream_case::newline_large:
+      return ndjson_large;
     case stream_case::rfc7464_small:
       return rfc_small;
     case stream_case::rfc7464_large:
@@ -99,8 +109,11 @@ static void bench_ondemand(benchmark::State &state) {
   ondemand::parser parser;
   parser.threaded = threaded;
   stream_format format = stream_format::whitespace_delimited;
-  if constexpr (which == stream_case::rfc7464_small ||
-                which == stream_case::rfc7464_large) {
+  if constexpr (which == stream_case::newline_small ||
+                which == stream_case::newline_large) {
+    format = stream_format::newline_delimited;
+  } else if constexpr (which == stream_case::rfc7464_small ||
+                       which == stream_case::rfc7464_large) {
     format = stream_format::json_sequence;
   } else if constexpr (which == stream_case::comma_delimited_small ||
                        which == stream_case::comma_delimited_large) {
@@ -127,6 +140,52 @@ static void bench_ondemand(benchmark::State &state) {
       }
       sum += id;
     }
+    benchmark::DoNotOptimize(sum);
+  }
+  set_counters(state, dataset);
+}
+
+
+// Documents are independent, so a caller can cut the input with slice_at and
+// parse the pieces on as many threads as it likes.
+template <stream_case which>
+static void bench_sliced(benchmark::State &state) {
+  const auto &dataset = get_dataset(which);
+  const size_t threads = size_t(state.range(0));
+  const stream_format format =
+      (which == stream_case::newline_small || which == stream_case::newline_large)
+          ? stream_format::newline_delimited
+          : stream_format::whitespace_delimited;
+  auto view = padded_string_view(dataset.json);
+
+  for (const auto _ : state) {
+    std::atomic<size_t> next{0};
+    std::vector<uint64_t> sums(threads, 0);
+    std::vector<std::thread> pool;
+    pool.reserve(threads);
+    for (size_t t = 0; t < threads; t++) {
+      pool.emplace_back([&, t] {
+        ondemand::parser parser;
+        parser.threaded = false;
+        uint64_t local = 0;
+        for (;;) {
+          const size_t i = next.fetch_add(1, std::memory_order_relaxed);
+          if (i * BATCH_SIZE >= view.size()) { break; }
+          auto piece = slice_at(view, '\n', BATCH_SIZE, i);
+          if (piece.empty()) { continue; }
+          ondemand::document_stream docs;
+          if (parser.iterate_many(piece, piece.size(), format).get(docs)) { continue; }
+          for (auto doc : docs) {
+            uint64_t id;
+            if (!doc["id"].get_uint64().get(id)) { local += id; }
+          }
+        }
+        sums[t] = local;
+      });
+    }
+    for (auto &th : pool) { th.join(); }
+    uint64_t sum = 0;
+    for (uint64_t v : sums) { sum += v; }
     benchmark::DoNotOptimize(sum);
   }
   set_counters(state, dataset);
@@ -174,6 +233,27 @@ BENCHMARK(bench_ondemand<stream_case::ndjson_small>)
 BENCHMARK(bench_ondemand<stream_case::ndjson_large>)
     ->UseRealTime()
     ->DisplayAggregatesOnly(true);
+BENCHMARK(bench_ondemand<stream_case::newline_small>)
+    ->UseRealTime()
+    ->DisplayAggregatesOnly(true);
+BENCHMARK(bench_ondemand<stream_case::newline_large>)
+    ->UseRealTime()
+    ->DisplayAggregatesOnly(true);
+// The stage1/stage2 overlap thread caps out near 2x; slicing does not.
+BENCHMARK(bench_ondemand<stream_case::ndjson_small, false>)
+    ->UseRealTime()
+    ->DisplayAggregatesOnly(true);
+BENCHMARK(bench_ondemand<stream_case::newline_small, false>)
+    ->UseRealTime()
+    ->DisplayAggregatesOnly(true);
+BENCHMARK(bench_sliced<stream_case::ndjson_small>)
+    ->UseRealTime()
+    ->DisplayAggregatesOnly(true)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8);
+BENCHMARK(bench_sliced<stream_case::newline_small>)
+    ->UseRealTime()
+    ->DisplayAggregatesOnly(true)
+    ->Arg(1)->Arg(2)->Arg(4)->Arg(8);
 BENCHMARK(bench_ondemand<stream_case::rfc7464_small>)
     ->UseRealTime()
     ->DisplayAggregatesOnly(true);

--- a/doc/iterate_many.md
+++ b/doc/iterate_many.md
@@ -479,6 +479,7 @@ The `stream_format` enum has the following values:
 - `stream_format::json_sequence`: RFC 7464 format with RS delimiters
 - `stream_format::comma_delimited`: Comma-separated JSON documents
 - `stream_format::comma_delimited_array`: A single JSON array whose elements are iterated as comma-delimited documents (see below)
+- `stream_format::newline_delimited`: NDJSON/JSON Lines where each document occupies exactly one line (documents are separated by line feeds and no document contains a raw line feed). Same inputs as `whitespace_delimited`, but the stronger guarantee lets ondemand `iterate_many` find the end of a document without walking it—including skipping an unread remainder without structure-validating that remainder. Use `whitespace_delimited` if unsure. See [Parsing on many threads](#parsing-on-many-threads) for multi-thread slicing with `slice_at`.
 
 The trailing LF after each JSON text is optional but recommended by the RFC for robustness.
 

--- a/doc/iterate_many.md
+++ b/doc/iterate_many.md
@@ -113,6 +113,50 @@ You should be consistent. If you link against the simdjson library built for mul
 system (setting `SIMDJSON_THREADS_ENABLED=1` and linking against a thread library).
 
 A `document_stream` instance uses at most two threads: there is a main thread and a worker thread.
+That caps the gain near a factor of two.
+
+### Parsing on many threads
+
+Documents in a stream are independent, so you can cut the input yourself and parse
+the pieces on as many threads as you like. `simdjson::slice_at` does the cutting:
+it divides the input into blocks and moves each boundary forward to the next
+delimiter, so a document is never split.
+
+```C++
+simdjson::padded_string json = simdjson::padded_string::load("stream.ndjson");
+auto view = simdjson::padded_string_view(json);
+constexpr size_t block_size = 1 << 20;
+
+std::atomic<size_t> next{0};
+std::vector<std::thread> pool;
+for (size_t t = 0; t < std::thread::hardware_concurrency(); t++) {
+  pool.emplace_back([&] {
+    simdjson::ondemand::parser parser;
+    parser.threaded = false;
+    for (;;) {
+      size_t i = next.fetch_add(1);
+      if (i * block_size >= view.size()) { break; }
+      auto piece = simdjson::slice_at(view, '\n', block_size, i);
+      if (piece.empty()) { continue; }
+      simdjson::ondemand::document_stream docs;
+      if (parser.iterate_many(piece, piece.size(),
+                              simdjson::stream_format::newline_delimited).get(docs)) { continue; }
+      for (auto doc : docs) { /* ... */ }
+    }
+  });
+}
+for (auto &th : pool) { th.join(); }
+```
+
+Give each thread its own parser and set `parser.threaded = false`: the parallelism
+is across slices, so a stage-1 thread per parser would only oversubscribe.
+
+A slice is empty when its block falls entirely inside one document, which happens
+only if that document is longer than `block_size`; skip it and continue. Iterate
+while `i * block_size < view.size()` rather than stopping at the first empty slice.
+
+The delimiter must not occur inside a document: a line feed for NDJSON, or a
+record separator (`0x1E`) for RFC 7464.
 
 Support
 -------

--- a/doc/parse_many.md
+++ b/doc/parse_many.md
@@ -358,6 +358,7 @@ The `stream_format` enum has the following values:
 - `stream_format::json_sequence`: RFC 7464 format with RS delimiters
 - `stream_format::comma_delimited`: Comma-separated JSON documents
 - `stream_format::comma_delimited_array`: A single JSON array whose elements are iterated as comma-delimited documents (see below)
+- `stream_format::newline_delimited`: NDJSON/JSON Lines where each document occupies exactly one line (documents are separated by line feeds and no document contains a raw line feed). Same inputs as `whitespace_delimited`, but with a stronger contract. The delimiter-skip optimization that relies on that contract is implemented for ondemand `iterate_many`; DOM `parse_many` accepts the format and stages documents the same way as whitespace-delimited NDJSON. Use `whitespace_delimited` if unsure.
 
 The trailing LF after each JSON text is optional but recommended by the RFC for robustness.
 

--- a/include/simdjson/base.h
+++ b/include/simdjson/base.h
@@ -68,7 +68,10 @@ enum class stream_format {
                         ///< document contains a raw line feed. Same inputs as
                         ///< `whitespace_delimited`, but the stronger guarantee lets
                         ///< the parser find the end of a document without walking
-                        ///< it. Use `whitespace_delimited` if unsure.
+                        ///< it. On ondemand `iterate_many`, an unread remainder may
+                        ///< be skipped by jumping to the next line feed without
+                        ///< structure-validating that remainder. Use
+                        ///< `whitespace_delimited` if unsure.
 };
 
 namespace internal {

--- a/include/simdjson/base.h
+++ b/include/simdjson/base.h
@@ -57,12 +57,18 @@ enum class stream_format {
   whitespace_delimited, ///< Whitespace-delimited JSON documents (default, includes NDJSON/JSONL)
   json_sequence,        ///< RFC 7464 JSON text sequences (RS-delimited)
   comma_delimited,      ///< Comma-separated JSON documents (e.g., `{...},{...},{...}`)
-  comma_delimited_array ///< A single JSON array whose elements are iterated as
+  comma_delimited_array,///< A single JSON array whose elements are iterated as
                         ///< comma-separated documents (e.g., `[{...},{...},{...}]`).
                         ///< The parser strips the outer `[` / `]` plus any
                         ///< surrounding JSON whitespace (space, tab, LF, CR)
                         ///< and then behaves like `comma_delimited` over the
                         ///< remaining bytes.
+  newline_delimited     ///< NDJSON/JSON Lines where each document occupies exactly
+                        ///< one line: documents are separated by line feeds and no
+                        ///< document contains a raw line feed. Same inputs as
+                        ///< `whitespace_delimited`, but the stronger guarantee lets
+                        ///< the parser find the end of a document without walking
+                        ///< it. Use `whitespace_delimited` if unsure.
 };
 
 namespace internal {

--- a/include/simdjson/generic/ondemand/document_stream-inl.h
+++ b/include/simdjson/generic/ondemand/document_stream-inl.h
@@ -6,6 +6,8 @@
 #include "simdjson/generic/ondemand/document_stream.h"
 #include "simdjson/generic/ondemand/document-inl.h"
 #include "simdjson/generic/implementation_simdjson_result_base-inl.h"
+
+#include <cstring>
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 #include <algorithm>
@@ -109,11 +111,6 @@ simdjson_inline document_stream::document_stream(
     , use_thread(_parser.threaded) // we need to make a copy because _parser.threaded can change
     #endif
 {
-#ifdef SIMDJSON_THREADS_ENABLED
-  if(worker.get() == nullptr) {
-    error = MEMALLOC;
-  }
-#endif
 }
 
 simdjson_inline document_stream::document_stream() noexcept
@@ -232,6 +229,10 @@ inline void document_stream::start() noexcept {
   #ifdef SIMDJSON_THREADS_ENABLED
   if (use_thread && next_batch_start() < len) {
     // Kick off the first thread on next batch if needed
+    if (worker.get() == nullptr) {
+      worker.reset(new(std::nothrow) stage1_worker());
+      if (worker.get() == nullptr) { error = MEMALLOC; return; }
+    }
     error = stage1_thread_parser.allocate(batch_size);
     if (error) { return; }
     worker->start_thread();
@@ -311,7 +312,57 @@ inline void document_stream::next() noexcept {
   }
 }
 
+simdjson_inline uint8_t document_stream::document_delimiter() const noexcept {
+  switch (format) {
+    case stream_format::newline_delimited: return '\n';
+    case stream_format::json_sequence: return 0x1E;
+    default: return 0;
+  }
+}
+
+simdjson_inline bool document_stream::skip_to_delimiter(uint8_t delimiter) noexcept {
+  const uint8_t *const base = &buf[batch_start];
+  const token_position pos = doc.iter.position();
+  const token_position end = doc.iter.end_position();
+  if (pos >= end) { return false; }
+  const size_t here = size_t(doc.iter.token.peek(pos) - base);
+  const size_t batch_len =
+      (len - batch_start < batch_size) ? len - batch_start : batch_size;
+  if (here >= batch_len) { return false; }
+  const uint8_t *const found = static_cast<const uint8_t *>(
+      memchr(base + here, delimiter, batch_len - here));
+  if (found == nullptr) { return false; }
+
+  const uint32_t boundary = uint32_t(found - base);
+  // The answer is near `pos`: the delimiter ends the current document, while
+  // `end` spans the whole batch. Gallop first so the cost follows the distance
+  // rather than the size of the batch.
+  token_position lo = pos;
+  size_t hop = 1;
+  while (lo + hop < end && lo[hop] < boundary) { lo += hop; hop <<= 1; }
+  token_position hi = (lo + hop < end) ? lo + hop : end;
+  while (lo < hi) {
+    const token_position mid = lo + ((hi - lo) >> 1);
+    if (*mid < boundary) { lo = mid + 1; } else { hi = mid; }
+  }
+  doc.iter.token.set_position(lo);
+  return true;
+}
+
 inline void document_stream::next_document() noexcept {
+  // A delimiter that cannot occur inside a document tells us where the current
+  // one ends, so we can jump there instead of walking every structural. Only
+  // valid while the iterator is still inside the document: a consumed document
+  // already sits on the next one's first token, and skip_child() returns at
+  // once for it.
+  const uint8_t delimiter = document_delimiter();
+  if (delimiter != 0 && !error && doc.iter.depth() > 0 &&
+      skip_to_delimiter(delimiter)) {
+    doc.iter._depth = 1;
+    doc.iter._string_buf_loc = parser->string_buf.get();
+    doc.iter._root = doc.iter.position();
+    return;
+  }
   // Go to next place where depth=0 (document depth)
   error = doc.iter.skip_child(0);
   if (error) { return; }

--- a/include/simdjson/generic/ondemand/document_stream-inl.h
+++ b/include/simdjson/generic/ondemand/document_stream-inl.h
@@ -6,11 +6,10 @@
 #include "simdjson/generic/ondemand/document_stream.h"
 #include "simdjson/generic/ondemand/document-inl.h"
 #include "simdjson/generic/implementation_simdjson_result_base-inl.h"
-
-#include <cstring>
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 #include <algorithm>
+#include <cstring>
 #include <stdexcept>
 
 namespace simdjson {
@@ -330,7 +329,7 @@ simdjson_inline bool document_stream::skip_to_delimiter(uint8_t delimiter) noexc
       (len - batch_start < batch_size) ? len - batch_start : batch_size;
   if (here >= batch_len) { return false; }
   const uint8_t *const found = static_cast<const uint8_t *>(
-      memchr(base + here, delimiter, batch_len - here));
+      std::memchr(base + here, delimiter, batch_len - here));
   if (found == nullptr) { return false; }
 
   const uint32_t boundary = uint32_t(found - base);
@@ -355,6 +354,13 @@ inline void document_stream::next_document() noexcept {
   // valid while the iterator is still inside the document: a consumed document
   // already sits on the next one's first token, and skip_child() returns at
   // once for it.
+  //
+  // The jump does not structure-validate the unread remainder of the current
+  // document: under newline_delimited / json_sequence the next delimiter is
+  // assumed to be the true document boundary. Callers that leave depth() > 0
+  // while violating that contract (e.g. pretty multi-line JSON under
+  // newline_delimited) can mis-align following documents; use
+  // whitespace_delimited if unsure.
   const uint8_t delimiter = document_delimiter();
   if (delimiter != 0 && !error && doc.iter.depth() > 0 &&
       skip_to_delimiter(delimiter)) {

--- a/include/simdjson/generic/ondemand/document_stream.h
+++ b/include/simdjson/generic/ondemand/document_stream.h
@@ -272,11 +272,22 @@ private:
    */
   inline void next() noexcept;
 
-  /** Move the json_iterator of the document to the location of the next document in the stream. */
+  /**
+   * Move the json_iterator of the document to the location of the next document
+   * in the stream.
+   *
+   * For formats with a document delimiter (`newline_delimited`, `json_sequence`),
+   * when the iterator is still inside the current document (`depth() > 0`), this
+   * may jump to the next delimiter instead of walking remaining structurals. That
+   * jump does not structure-validate the unread remainder.
+   */
   inline void next_document() noexcept;
   /** Byte that ends a document under `format`, or 0 if there is none. */
   simdjson_inline uint8_t document_delimiter() const noexcept;
-  /** Position the iterator just past the next `delimiter`. */
+  /**
+   * Position the iterator at the first structural at or past the next
+   * `delimiter` in the current batch. Returns false if none is found.
+   */
   simdjson_inline bool skip_to_delimiter(uint8_t delimiter) noexcept;
 
   /** Get the next document index. */

--- a/include/simdjson/generic/ondemand/document_stream.h
+++ b/include/simdjson/generic/ondemand/document_stream.h
@@ -274,6 +274,10 @@ private:
 
   /** Move the json_iterator of the document to the location of the next document in the stream. */
   inline void next_document() noexcept;
+  /** Byte that ends a document under `format`, or 0 if there is none. */
+  simdjson_inline uint8_t document_delimiter() const noexcept;
+  /** Position the iterator just past the next `delimiter`. */
+  simdjson_inline bool skip_to_delimiter(uint8_t delimiter) noexcept;
 
   /** Get the next document index. */
   inline size_t next_batch_start() const noexcept;
@@ -314,7 +318,7 @@ private:
   /** The error returned from the stage 1 thread. */
   error_code stage1_thread_error{UNINITIALIZED};
   /** The thread used to run stage 1 against the next batch in the background. */
-  std::unique_ptr<stage1_worker> worker{new(std::nothrow) stage1_worker()};
+  std::unique_ptr<stage1_worker> worker{};
   /**
    * The parser used to run stage 1 in the background. Will be swapped
    * with the regular parser when finished.

--- a/include/simdjson/generic/ondemand/token_iterator.h
+++ b/include/simdjson/generic/ondemand/token_iterator.h
@@ -130,6 +130,7 @@ protected:
   token_position _position{};
 
   friend class json_iterator;
+  friend class document_stream;
   friend class value_iterator;
   friend class object;
   template <typename... Args>

--- a/include/simdjson/padded_string_view-inl.h
+++ b/include/simdjson/padded_string_view-inl.h
@@ -182,6 +182,25 @@ inline bool padded_input::needs_allocation(const char* buf, size_t len, size_t p
 }
 #endif // SIMDJSON_CPLUSPLUS17
 
+inline padded_string_view slice_at(padded_string_view data, char delimiter,
+                                   size_t block_size, size_t index) noexcept {
+  if (block_size == 0 || index > data.size() / block_size) { return {}; }
+  const size_t raw_begin = index * block_size;
+  if (raw_begin >= data.size()) { return {}; }
+
+  auto snap = [&](size_t want) -> size_t {
+    if (want >= data.size()) { return data.size(); }
+    const void *p = std::memchr(data.data() + want, delimiter, data.size() - want);
+    return p ? size_t(static_cast<const char *>(p) - data.data()) + 1 : data.size();
+  };
+
+  const size_t begin = (raw_begin == 0) ? 0 : snap(raw_begin);
+  const size_t end = snap(raw_begin + block_size);
+  if (begin >= end) { return {}; }
+  return padded_string_view(data.data() + begin, end - begin,
+                            data.capacity() - begin);
+}
+
 } // namespace simdjson
 
 

--- a/include/simdjson/padded_string_view.h
+++ b/include/simdjson/padded_string_view.h
@@ -171,6 +171,30 @@ inline padded_string_view pad(std::string& s) noexcept;
  */
 inline padded_string_view pad_with_reserve(std::string& s) noexcept;
 
+/**
+ * Return the index-th document-aligned slice of a delimited stream.
+ *
+ * The input is divided into blocks of block_size bytes and each boundary is
+ * moved forward to just past the next delimiter, so a document is never split.
+ * The delimiter must not occur inside a document: a line feed for NDJSON, a
+ * record separator (0x1E) for RFC 7464.
+ *
+ * Slices are contiguous and non-overlapping, and each may be parsed
+ * independently, so callers can process them on as many threads as they like.
+ *
+ * Iterate while index * block_size < data.size(). A slice is empty when its
+ * block falls entirely inside one document, which happens only if that document
+ * is longer than block_size; skip it and continue. With block_size larger than
+ * the longest document, no slice is ever empty.
+ *
+ * @param data       The padded input.
+ * @param delimiter  The byte that separates documents.
+ * @param block_size The nominal slice size, before snapping.
+ * @param index      Which slice to return, counting from zero.
+ */
+inline padded_string_view slice_at(padded_string_view data, char delimiter,
+                                   size_t block_size, size_t index) noexcept;
+
 } // namespace simdjson
 
 #endif // SIMDJSON_PADDED_STRING_VIEW_H

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -807,6 +807,128 @@ namespace document_stream_tests {
         TEST_SUCCEED();
     }
 
+    // newline_delimited and json_sequence let next_document() jump to the
+    // delimiter instead of walking the document. The shortcut is only taken
+    // while the iterator is inside the document, so both a partial read and a
+    // full read must give the same documents.
+    bool delimited_partial_read() {
+        TEST_START();
+        auto nd = R"({"a":1,"b":2}
+{"a":3,"b":4}
+{"a":5,"b":6})"_padded;
+        auto seq = "\x1E{\"a\":1,\"b\":2}\n\x1E{\"a\":3,\"b\":4}\n\x1E{\"a\":5,\"b\":6}\n"_padded;
+        struct { padded_string_view json; stream_format fmt; } cases[] = {
+            { nd, stream_format::newline_delimited },
+            { seq, stream_format::json_sequence },
+        };
+        for (auto &c : cases) {
+            ondemand::parser parser;
+            ondemand::document_stream stream;
+            ASSERT_SUCCESS( parser.iterate_many(c.json, c.json.size(), c.fmt).get(stream) );
+            size_t count = 0;
+            int64_t total = 0;
+            for (auto doc : stream) {
+                int64_t a;
+                ASSERT_SUCCESS( doc.find_field("a").get_int64().get(a) );
+                total += a; count++;
+            }
+            ASSERT_EQUAL( count, 3 );
+            ASSERT_EQUAL( total, 9 );
+        }
+        TEST_SUCCEED();
+    }
+
+    bool delimited_full_read() {
+        TEST_START();
+        auto json = R"({"a":1,"b":2}
+{"a":3,"b":4}
+{"a":5,"b":6})"_padded;
+        ondemand::parser parser;
+        ondemand::document_stream stream;
+        ASSERT_SUCCESS( parser.iterate_many(json, json.size(),
+                                            stream_format::newline_delimited).get(stream) );
+        size_t count = 0;
+        int64_t total = 0;
+        for (auto doc : stream) {
+            ondemand::object obj;
+            ASSERT_SUCCESS( doc.get_object().get(obj) );
+            for (auto field : obj) {
+                int64_t v;
+                ASSERT_SUCCESS( field.value().get_int64().get(v) );
+                total += v;
+            }
+            count++;
+        }
+        ASSERT_EQUAL( count, 3 );
+        ASSERT_EQUAL( total, 21 );
+        TEST_SUCCEED();
+    }
+
+    bool newline_delimited_edge_cases() {
+        TEST_START();
+        auto json = "{\"a\":1}\r\n{\"a\":2}\n\n{\"a\":3}\n"_padded;
+        ondemand::parser parser;
+        ondemand::document_stream stream;
+        ASSERT_SUCCESS( parser.iterate_many(json, json.size(),
+                                            stream_format::newline_delimited).get(stream) );
+        size_t count = 0;
+        int64_t total = 0;
+        for (auto doc : stream) {
+            int64_t a;
+            ASSERT_SUCCESS( doc.find_field("a").get_int64().get(a) );
+            total += a; count++;
+        }
+        ASSERT_EQUAL( count, 3 );
+        ASSERT_EQUAL( total, 6 );
+        TEST_SUCCEED();
+    }
+
+    bool newline_delimited_scalars() {
+        TEST_START();
+        auto json = "1\n2\n3\n4"_padded;
+        ondemand::parser parser;
+        ondemand::document_stream stream;
+        ASSERT_SUCCESS( parser.iterate_many(json, json.size(),
+                                            stream_format::newline_delimited).get(stream) );
+        size_t count = 0;
+        int64_t total = 0;
+        for (auto doc : stream) {
+            int64_t v;
+            ASSERT_SUCCESS( doc.get_int64().get(v) );
+            total += v; count++;
+        }
+        ASSERT_EQUAL( count, 4 );
+        ASSERT_EQUAL( total, 10 );
+        TEST_SUCCEED();
+    }
+
+    // Same documents as whitespace_delimited, including across batch
+    // boundaries where the fast path runs out of delimiters and falls back.
+    bool newline_delimited_agrees_with_default() {
+        TEST_START();
+        auto json = R"({"x":[1,2,3],"y":{"z":"s"}}
+{"x":[],"y":{"z":"t"}}
+{"x":[4],"y":{"z":"u"}})"_padded;
+        const stream_format formats[2] = {stream_format::whitespace_delimited,
+                                          stream_format::newline_delimited};
+        for (size_t batch : {size_t(64), size_t(128), json.size()}) {
+            std::vector<std::string> got[2];
+            for (int which = 0; which < 2; which++) {
+                ondemand::parser parser;
+                ondemand::document_stream stream;
+                ASSERT_SUCCESS( parser.iterate_many(json, batch, formats[which]).get(stream) );
+                for (auto doc : stream) {
+                    std::string_view z;
+                    ASSERT_SUCCESS( doc["y"]["z"].get_string().get(z) );
+                    got[which].emplace_back(z);
+                }
+            }
+            ASSERT_EQUAL( got[0].size(), got[1].size() );
+            for (size_t i = 0; i < got[0].size(); i++) { ASSERT_EQUAL( got[0][i], got[1][i] ); }
+        }
+        TEST_SUCCEED();
+    }
+
     bool stress_data_race() {
         TEST_START();
         // Correct JSON.
@@ -2420,6 +2542,11 @@ namespace document_stream_tests {
             adversarial_single_document_array() &&
             document_stream_test() &&
             document_stream_utf8_test() &&
+            delimited_partial_read() &&
+            delimited_full_read() &&
+            newline_delimited_edge_cases() &&
+            newline_delimited_scalars() &&
+            newline_delimited_agrees_with_default() &&
             stress_data_race() &&
             stress_data_race_with_error() &&
             true;

--- a/tests/padded_string_tests.cpp
+++ b/tests/padded_string_tests.cpp
@@ -129,11 +129,74 @@ static bool testPaddedStringBuilder() {
   TEST_SUCCEED();
 }
 
+
+bool testSliceAt() {
+  TEST_START();
+  simdjson::padded_string json = "{\"a\":1}\n{\"a\":2}\n{\"a\":3}\n"_padded;
+  auto view = simdjson::padded_string_view(json);
+
+  // A block size larger than the input yields the whole input, then nothing.
+  {
+    auto all = simdjson::slice_at(view, '\n', 1 << 20, 0);
+    ASSERT_EQUAL(all.size(), view.size());
+    ASSERT_TRUE(simdjson::slice_at(view, '\n', 1 << 20, 1).empty());
+  }
+
+  // Slices are contiguous, non-overlapping, and reassemble the input. A block
+  // that falls inside one document yields an empty slice, so iteration is
+  // bounded by the input size rather than by the first empty slice.
+  for (size_t block : {size_t(1), size_t(4), size_t(8), size_t(9), size_t(64)}) {
+    std::string rebuilt;
+    size_t previous_end = 0;
+    for (size_t i = 0; i * block < view.size(); i++) {
+      auto piece = simdjson::slice_at(view, '\n', block, i);
+      if (piece.empty()) { continue; }
+      size_t begin = size_t(piece.data() - view.data());
+      ASSERT_EQUAL(begin, previous_end);
+      previous_end = begin + piece.size();
+      ASSERT_TRUE(piece.capacity() >= piece.size() + simdjson::SIMDJSON_PADDING);
+      rebuilt.append(piece.data(), piece.size());
+    }
+    ASSERT_EQUAL(previous_end, view.size());
+    ASSERT_EQUAL(rebuilt, std::string(view.data(), view.size()));
+  }
+
+  // Every slice ends on a document boundary, so each parses on its own.
+  {
+    size_t documents = 0;
+    uint64_t sum = 0;
+    simdjson::ondemand::parser parser;
+    for (size_t i = 0;; i++) {
+      if (i * 8 >= view.size()) { break; }
+      auto piece = simdjson::slice_at(view, '\n', 8, i);
+      if (piece.empty()) { continue; }
+      simdjson::ondemand::document_stream docs;
+      ASSERT_SUCCESS(parser.iterate_many(piece, piece.size()).get(docs));
+      for (auto doc : docs) {
+        uint64_t a;
+        ASSERT_SUCCESS(doc["a"].get_uint64().get(a));
+        sum += a;
+        documents++;
+      }
+    }
+    ASSERT_EQUAL(documents, 3);
+    ASSERT_EQUAL(sum, 6);
+  }
+
+  // Degenerate inputs.
+  ASSERT_TRUE(simdjson::slice_at(view, '\n', 0, 0).empty());
+  ASSERT_TRUE(simdjson::slice_at(view, '\n', 8, 1000).empty());
+  TEST_SUCCEED();
+}
+
 int main() {
   if (!testNullString()) {
     return EXIT_FAILURE;
   }
   if (!testPaddedStringBuilder()) {
+    return EXIT_FAILURE;
+  }
+  if (!testSliceAt()) {
     return EXIT_FAILURE;
   }
   std::cout << "All tests passed!" << std::endl;


### PR DESCRIPTION
`next_document()` reaches the next document with `skip_child(0)`, which loads the input byte behind every remaining structural and branches on it. When the caller reads only part of each document, that walk covers the rest of it.

For a delimiter-framed stream the document ends at the next delimiter, so `memchr` plus a galloping search of the structural index gets there without touching the structurals in between. This applies to `json_sequence` and to a new `stream_format::newline_delimited`, where the caller guarantees one document per line. `whitespace_delimited` cannot use it: it permits several documents on one line and line feeds inside a document, so a line feed is *a* document boundary but not necessarily the next one.

The shortcut is gated on `depth() > 0`, which means the caller left the document part-read, so there is a walk worth avoiding, and the iterator is still inside the document, so the next delimiter terminates it.

`simdjson::slice_at` cuts a `padded_string_view` into document-aligned slices. Documents are independent, so callers can parse the slices on as many threads as they like instead of relying on the built-in stage-1 thread, which caps out near a factor of two. `doc/iterate_many.md` shows the pattern.

`document_stream` also allocated a `stage1_worker`, which holds a thread, a mutex and a condition variable, on every construction even with threading off. It is now allocated only when a stage-1 thread is started.

### Benchmarks

`benchmark/bench_stream_formats.cpp` now runs `whitespace_delimited` and `newline_delimited` side by side, plus a `bench_sliced` variant using `slice_at` across threads. On a 64-core Xeon Gold 6548N, small-document NDJSON:

| configuration | GiB/s |
| --- | --- |
| single thread | 2.42 |
| built-in stage-1 thread (2 threads) | 3.35 |
| `slice_at`, 2 threads | 4.40 |
| `slice_at`, 4 threads | 8.02 |
| `slice_at`, 8 threads | 14.36 |

### Testing

131/131 tests pass on x86-64 (Xeon Gold 6548N, GCC 14) and 118/118 on arm64 (Apple Silicon, clang). New tests cover partial and full document reads, blank lines and CRLF, scalar documents, agreement with `whitespace_delimited` across batch sizes, and `slice_at` reassembling its input exactly for a range of block sizes.

### Notes

`document_stream` now befriends `token_iterator` to reach `peek()` and `set_position()`. Narrow accessors may be preferable.

`slice_at` returns an empty view when a block falls entirely inside one document, which happens only if that document is longer than `block_size`. Callers should iterate while `index * block_size < size` and skip empty slices rather than stopping at the first one.
