### PR TITLE
Remove unused escape helpers and add write_string_escaped tests

### DIFF
--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -117,164 +117,6 @@ inline bool has_json_escapable_byte(uint64_t x) {
 
 **/
 
-SIMDJSON_CONSTEXPR_LAMBDA simdjson_inline bool
-simple_needs_escaping(std::string_view v) {
-  for (char c : v) {
-    // a table lookup is faster than a series of comparisons
-    if (json_quotable_character[static_cast<uint8_t>(c)]) {
-      return true;
-    }
-  }
-  return false;
-}
-
-#if SIMDJSON_EXPERIMENTAL_HAS_NEON
-simdjson_inline bool fast_needs_escaping(std::string_view view) {
-  if (view.size() < 16) {
-    return simple_needs_escaping(view);
-  }
-  size_t i = 0;
-  uint8x16_t running = vdupq_n_u8(0);
-  uint8x16_t v34 = vdupq_n_u8(34);
-  uint8x16_t v92 = vdupq_n_u8(92);
-
-  for (; i + 15 < view.size(); i += 16) {
-    uint8x16_t word = vld1q_u8((const uint8_t *)view.data() + i);
-    running = vorrq_u8(running, vceqq_u8(word, v34));
-    running = vorrq_u8(running, vceqq_u8(word, v92));
-    running = vorrq_u8(running, vcltq_u8(word, vdupq_n_u8(32)));
-  }
-  if (i < view.size()) {
-    uint8x16_t word =
-        vld1q_u8((const uint8_t *)view.data() + view.length() - 16);
-    running = vorrq_u8(running, vceqq_u8(word, v34));
-    running = vorrq_u8(running, vceqq_u8(word, v92));
-    running = vorrq_u8(running, vcltq_u8(word, vdupq_n_u8(32)));
-  }
-  const uint8x8_t narrowed = vshrn_n_u16(vreinterpretq_u16_u8(running), 4);
-  return vdupd_lane_f64(vreinterpret_f64_u8(narrowed), 0) != 0.0;
-}
-#elif SIMDJSON_EXPERIMENTAL_HAS_SSE2
-simdjson_inline bool fast_needs_escaping(std::string_view view) {
-  if (view.size() < 16) {
-    return simple_needs_escaping(view);
-  }
-  size_t i = 0;
-  __m128i running = _mm_setzero_si128();
-  for (; i + 15 < view.size(); i += 16) {
-
-    __m128i word =
-        _mm_loadu_si128(reinterpret_cast<const __m128i *>(view.data() + i));
-    running = _mm_or_si128(running, _mm_cmpeq_epi8(word, _mm_set1_epi8(34)));
-    running = _mm_or_si128(running, _mm_cmpeq_epi8(word, _mm_set1_epi8(92)));
-    running = _mm_or_si128(
-        running, _mm_cmpeq_epi8(_mm_subs_epu8(word, _mm_set1_epi8(31)),
-                                _mm_setzero_si128()));
-  }
-  if (i < view.size()) {
-    __m128i word = _mm_loadu_si128(
-        reinterpret_cast<const __m128i *>(view.data() + view.length() - 16));
-    running = _mm_or_si128(running, _mm_cmpeq_epi8(word, _mm_set1_epi8(34)));
-    running = _mm_or_si128(running, _mm_cmpeq_epi8(word, _mm_set1_epi8(92)));
-    running = _mm_or_si128(
-        running, _mm_cmpeq_epi8(_mm_subs_epu8(word, _mm_set1_epi8(31)),
-                                _mm_setzero_si128()));
-  }
-  return _mm_movemask_epi8(running) != 0;
-}
-#elif SIMDJSON_EXPERIMENTAL_HAS_LASX
-simdjson_inline bool fast_needs_escaping(std::string_view view) {
-  if (view.size() < 32) {
-    return simple_needs_escaping(view);
-  }
-  size_t i = 0;
-  __m256i running = __lasx_xvreplgr2vr_b(0);
-  __m256i v34 = __lasx_xvreplgr2vr_b(34);
-  __m256i v92 = __lasx_xvreplgr2vr_b(92);
-  __m256i v32 = __lasx_xvreplgr2vr_b(32);
-
-  for (; i + 31 < view.size(); i += 32) {
-    __m256i word =
-        __lasx_xvld(reinterpret_cast<const char *>(view.data() + i), 0);
-    __m256i chunk = __lasx_xvseq_b(word, v34);
-    chunk = __lasx_xvor_v(chunk, __lasx_xvseq_b(word, v92));
-    chunk = __lasx_xvor_v(chunk, __lasx_xvslt_bu(word, v32));
-    running = __lasx_xvor_v(running, chunk);
-  }
-  if (i < view.size()) {
-    __m256i word = __lasx_xvld(
-        reinterpret_cast<const char *>(view.data() + view.length() - 32), 0);
-    __m256i chunk = __lasx_xvseq_b(word, v34);
-    chunk = __lasx_xvor_v(chunk, __lasx_xvseq_b(word, v92));
-    chunk = __lasx_xvor_v(chunk, __lasx_xvslt_bu(word, v32));
-    running = __lasx_xvor_v(running, chunk);
-  }
-  return !__lasx_xbz_v(running);
-}
-#elif SIMDJSON_EXPERIMENTAL_HAS_LSX
-simdjson_inline bool fast_needs_escaping(std::string_view view) {
-  if (view.size() < 16) {
-    return simple_needs_escaping(view);
-  }
-  size_t i = 0;
-  __m128i running = __lsx_vreplgr2vr_b(0);
-  __m128i v34 = __lsx_vreplgr2vr_b(34);
-  __m128i v92 = __lsx_vreplgr2vr_b(92);
-  __m128i v32 = __lsx_vreplgr2vr_b(32);
-
-  for (; i + 15 < view.size(); i += 16) {
-    __m128i word =
-        __lsx_vld(reinterpret_cast<const char *>(view.data() + i), 0);
-    __m128i chunk = __lsx_vseq_b(word, v34);
-    chunk = __lsx_vor_v(chunk, __lsx_vseq_b(word, v92));
-    chunk = __lsx_vor_v(chunk, __lsx_vslt_bu(word, v32));
-    running = __lsx_vor_v(running, chunk);
-  }
-  if (i < view.size()) {
-    __m128i word = __lsx_vld(
-        reinterpret_cast<const char *>(view.data() + view.length() - 16), 0);
-    __m128i chunk = __lsx_vseq_b(word, v34);
-    chunk = __lsx_vor_v(chunk, __lsx_vseq_b(word, v92));
-    chunk = __lsx_vor_v(chunk, __lsx_vslt_bu(word, v32));
-    running = __lsx_vor_v(running, chunk);
-  }
-  return !__lsx_bz_v(running);
-}
-#elif SIMDJSON_EXPERIMENTAL_HAS_PPC64
-simdjson_inline bool fast_needs_escaping(std::string_view view) {
-  if (view.size() < 16) {
-    return simple_needs_escaping(view);
-  }
-  size_t i = 0;
-  __vector unsigned char running = vec_splats((unsigned char)0);
-  __vector unsigned char v34 = vec_splats((unsigned char)34);
-  __vector unsigned char v92 = vec_splats((unsigned char)92);
-  __vector unsigned char v32 = vec_splats((unsigned char)32);
-
-  for (; i + 15 < view.size(); i += 16) {
-    __vector unsigned char word =
-        vec_vsx_ld(0, reinterpret_cast<const unsigned char *>(view.data() + i));
-    running = vec_or(running, (__vector unsigned char)vec_cmpeq(word, v34));
-    running = vec_or(running, (__vector unsigned char)vec_cmpeq(word, v92));
-    running = vec_or(running,
-        (__vector unsigned char)vec_cmplt(word, v32));
-  }
-  if (i < view.size()) {
-    __vector unsigned char word = vec_vsx_ld(
-        0, reinterpret_cast<const unsigned char *>(view.data() + view.length() - 16));
-    running = vec_or(running, (__vector unsigned char)vec_cmpeq(word, v34));
-    running = vec_or(running, (__vector unsigned char)vec_cmpeq(word, v92));
-    running = vec_or(running,
-        (__vector unsigned char)vec_cmplt(word, v32));
-  }
-  return !vec_all_eq(running, vec_splats((unsigned char)0));
-}
-#else
-simdjson_inline bool fast_needs_escaping(std::string_view view) {
-  return simple_needs_escaping(view);
-}
-#endif
-
 // Scalar fallback for finding next quotable character
 SIMDJSON_CONSTEXPR_LAMBDA simdjson_inline size_t
 find_next_json_quotable_character_scalar(const std::string_view view,
@@ -783,7 +625,7 @@ inline size_t write_string_escaped(const std::string_view input, char *out) {
       out = escape_block(src, out, i, len, m);
     }
   }
-  return out - initout;
+  return size_t(out - initout);
 }
 
 #else // SIMDJSON_BUILDER_HAS_BLOCK_ESCAPE
@@ -817,10 +659,12 @@ inline size_t write_string_escaped(const std::string_view input, char *out) {
     escape_json_char(input[location], out);
     location += 1;
   }
-  return out - initout;
+  return size_t(out - initout);
 }
 
 #endif // SIMDJSON_BUILDER_HAS_BLOCK_ESCAPE
+#undef SIMDJSON_BUILDER_HAS_BLOCK_ESCAPE
+
 
 simdjson_inline string_builder::string_builder(size_t initial_capacity)
     : buffer(new(std::nothrow) char[initial_capacity]), position(0),

--- a/tests/builder/builder_string_builder_tests.cpp
+++ b/tests/builder/builder_string_builder_tests.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #if SIMDJSON_SUPPORTS_RANGES
 #include <ranges>
@@ -336,6 +337,106 @@ bool escape_and_append_with_quotes() {
   auto result = sb.view().get(p);
   ASSERT_SUCCESS(result);
   ASSERT_EQUAL(p, "\"Hello, \\\"world\\\"!\"");
+  TEST_SUCCEED();
+}
+
+// Scalar reference for JSON string-content escaping (matches escape_json_char).
+static std::string reference_escape(std::string_view in) {
+  static const char *const ctrl[32] = {
+      "\\u0000", "\\u0001", "\\u0002", "\\u0003", "\\u0004", "\\u0005", "\\u0006",
+      "\\u0007", "\\b",     "\\t",     "\\n",     "\\u000b", "\\f",     "\\r",
+      "\\u000e", "\\u000f", "\\u0010", "\\u0011", "\\u0012", "\\u0013", "\\u0014",
+      "\\u0015", "\\u0016", "\\u0017", "\\u0018", "\\u0019", "\\u001a", "\\u001b",
+      "\\u001c", "\\u001d", "\\u001e", "\\u001f"};
+  std::string out;
+  out.reserve(in.size() * 2);
+  for (unsigned char c : in) {
+    if (c == '"') {
+      out += "\\\"";
+    } else if (c == '\\') {
+      out += "\\\\";
+    } else if (c < 32) {
+      out += ctrl[c];
+    } else {
+      out.push_back(char(c));
+    }
+  }
+  return out;
+}
+
+static bool check_escape_matches_reference(std::string_view in) {
+  simdjson::builder::string_builder sb;
+  sb.escape_and_append(in);
+  std::string_view got;
+  if (sb.view().get(got)) {
+    std::cerr << "FAIL: escape_and_append view() error for len=" << in.size()
+              << std::endl;
+    return false;
+  }
+  const std::string expected = reference_escape(in);
+  if (got != expected) {
+    std::cerr << "FAIL: write_string_escaped mismatch for len=" << in.size()
+              << std::endl;
+    return false;
+  }
+  return true;
+}
+
+// Exercises every length class of the block-escape path (scalar <4, 4x2, 8x2,
+// full 16-byte blocks + last-16 tail), single quotable positions, all control
+// characters, dense escapes, and random mixes against a scalar reference.
+bool escape_write_string_escaped_exhaustive() {
+  TEST_START();
+
+  for (size_t n = 0; n <= 48; n++) {
+    ASSERT_TRUE(check_escape_matches_reference(std::string(n, 'a')));
+  }
+
+  const char specials[] = {'"',  '\\', '\n', '\t', '\r',
+                           '\b', '\f', char(0), char(1), char(31)};
+  for (size_t n = 1; n <= 40; n++) {
+    for (size_t pos = 0; pos < n; pos++) {
+      for (char sp : specials) {
+        std::string s(n, 'x');
+        s[pos] = sp;
+        ASSERT_TRUE(check_escape_matches_reference(s));
+      }
+    }
+  }
+
+  for (int c = 0; c < 32; c++) {
+    ASSERT_TRUE(check_escape_matches_reference(std::string(1, char(c))));
+  }
+
+  ASSERT_TRUE(check_escape_matches_reference(std::string(32, '"')));
+  ASSERT_TRUE(check_escape_matches_reference(std::string(32, '\\')));
+  ASSERT_TRUE(check_escape_matches_reference(std::string(17, '\n')));
+
+  // Deterministic LCG so CI is reproducible without depending on rand().
+  uint32_t state = 1;
+  auto next = [&state]() -> uint32_t {
+    state = state * 1664525u + 1013904223u;
+    return state;
+  };
+  for (int t = 0; t < 2000; t++) {
+    const size_t n = size_t(next() % 64);
+    std::string s(n, '\0');
+    for (size_t i = 0; i < n; i++) {
+      s[i] = char(next() & 0xff);
+    }
+    ASSERT_TRUE(check_escape_matches_reference(s));
+  }
+
+  // High bytes must pass through unescaped; mix with a quotable mid-string.
+  ASSERT_TRUE(check_escape_matches_reference(
+      std::string("\xc3\xa9\xe2\x82\xac\xf0\x9f\x98\x80")));
+  {
+    std::string mixed(20, char(0x80));
+    mixed.push_back('"');
+    mixed.append(5, char(0xff));
+    ASSERT_TRUE(check_escape_matches_reference(mixed));
+  }
+
   TEST_SUCCEED();
 }
 
@@ -804,8 +905,9 @@ bool run() {
          nan_inf_in_array() && nan_inf_in_object() && nan_inf_roundtrip() &&
 #endif
          clear() && escape_and_append() && escape_and_append_with_quotes() &&
-         append_raw() && raw_with_length() && string_convertion() &&
-         buffer_growth() && unicode_validation() && true;
+         escape_write_string_escaped_exhaustive() && append_raw() &&
+         raw_with_length() && string_convertion() && buffer_growth() &&
+         unicode_validation() && true;
 }
 
 } // namespace builder_tests


### PR DESCRIPTION
## Summary

Follow-up to #2795 (`write_string_escaped` single-pass block escaping):

- Delete unused `simple_needs_escaping` / `fast_needs_escaping` (no call sites).
- Add exhaustive `escape_and_append` tests against a scalar reference (length classes, control characters, dense escapes, random mixes).
- `#undef SIMDJSON_BUILDER_HAS_BLOCK_ESCAPE` after the block-escape section.
- Consistent `size_t` cast on `write_string_escaped` return paths.

This is the change from https://github.com/simdjson/simdjson/commit/611c5541daa3e56232a2e623a18021b8b16bf803, rebased onto current `master`.

## Test plan

- [x] `builder_string_builder_tests` (includes new `escape_write_string_escaped_exhaustive`)
- [ ] CI on this PR