### PR TITLE
perf: eliminate libc memcpy/memset/memmove calls in to_chars hotpath

### DIFF
--- a/include/simdjson/dom/serialization-inl.h
+++ b/include/simdjson/dom/serialization-inl.h
@@ -198,7 +198,8 @@ simdjson_inline void base_formatter<formatter>::number(double x) {
   }
 #endif
 
-  char number_buffer[24];
+  char number_buffer[40]; // emit at most 24 chars but write past them
+                          // (see src/to_chars::dragonbox())
   // Currently, passing the nullptr to the second argument is
   // safe because our implementation does not check the second
   // argument.

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -1046,7 +1046,9 @@ simdjson_inline void string_builder::append(number_type v) noexcept {
     }
   }
   else SIMDJSON_IF_CONSTEXPR(std::is_floating_point<number_type>::value) {
-    constexpr size_t max_number_size = 24;
+    // emit at most 24 chars but write past them
+    // (see src/to_chars::dragonbox())
+    constexpr size_t max_number_size = 40;
     if (capacity_check(max_number_size)) {
 #if SIMDJSON_ENABLE_NAN_INF
       // Check if the input might be NaN or infinity

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -3,6 +3,7 @@
 
 #include <base.h>
 
+#include <cstddef>
 #include <cstring>
 #include <cstdint>
 #include <cmath>
@@ -1010,8 +1011,11 @@ inline void dragonbox(char *buf, int &len, int &decimal_exponent,
       "4041424344454647484950515253545556575859"
       "6061626364656667686970717273747576777879"
       "8081828384858687888990919293949596979899";
-  char tmp[24];
-  char *p = tmp + sizeof(tmp); // write backward
+  constexpr int digit_area = 24;
+  char tmp[digit_area + 16]; // 16: for vmov inlined memcpy below
+                             // 1: for manual copy
+                             // remaining: margin to avoid overflow if n<17
+  char *p = tmp + digit_area; // write backward
   std::uint64_t s = dec.significand;
   while (s >= 100) {
     const std::uint32_t idx = static_cast<std::uint32_t>(s % 100) * 2;
@@ -1028,9 +1032,11 @@ inline void dragonbox(char *buf, int &len, int &decimal_exponent,
   } else {
     *--p = static_cast<char>('0' + s);
   }
-  const int n = static_cast<int>(tmp + sizeof(tmp) - p);
-  std::memcpy(buf, p, static_cast<size_t>(n));
-  len = n;
+  std::memcpy(buf, p, 16); //compile-time size let compiler inline
+                                         //and remove 3 branchs for size check
+                                         //16 to vectorize
+  buf[16] = p[16];                       //copy remaining value here
+  len = static_cast<int>(tmp + digit_area - p);
   decimal_exponent = dec.exponent;
 }
 
@@ -1084,7 +1090,7 @@ inline char *format_buffer(char *buf, int len, int decimal_exponent,
     // digits[000]
     // len <= max_exp + 2
 
-    std::memset(buf + k, '0', static_cast<size_t>(n) - static_cast<size_t>(k));
+    std::memset(buf + k, '0', 16);
     // Make it look like a floating-point number (#362, #378)
     buf[n + 0] = '.';
     buf[n + 1] = '0';
@@ -1094,8 +1100,9 @@ inline char *format_buffer(char *buf, int len, int decimal_exponent,
   if (0 < n && n <= max_exp) {
     // dig.its
     // len <= max_digits10 + 1
-    std::memmove(buf + (static_cast<size_t>(n) + 1), buf + n,
-                 static_cast<size_t>(k) - static_cast<size_t>(n));
+    char shifted[16];
+    std::memcpy(shifted, buf+static_cast<size_t>(n), 16);
+    std::memcpy(buf + (static_cast<size_t>(n) + 1), shifted, 16);
     buf[n] = '.';
     return buf + (static_cast<size_t>(k) + 1U);
   }

--- a/src/to_chars.cpp
+++ b/src/to_chars.cpp
@@ -3,7 +3,6 @@
 
 #include <base.h>
 
-#include <cstddef>
 #include <cstring>
 #include <cstdint>
 #include <cmath>


### PR DESCRIPTION
### Summary
`memcpy`, `memset`, and `memmove` inside `dragonbox()` and `format_buffer()` (in `src/to_chars.cpp`) were not inlined because the compiler didn't had access to size variable at compile time. Each call turned into a full libc dispatch that includes three branches (`cmp` + `jae`; choosing copy strategy). This sums to ~33% of the benchmark time.

The fix increases the temporary buffer from 24 bytes to 40 bytes. The first 24 bytes still hold the formatted number (max 24 chars), the extra 16 bytes serve as padding so all copy operations in `dragonbox` and `format_buffer` use a **constant** size (16 or 17 bytes). With a constant size, toolchains inline `mem*` calls as plain vector loads/stores, and the three branches disappear.

### Context

#### proofs
i ran:
```
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON -D CMAKE_BUILD_TYPE=Release
cmake --build build --target benchmark_car_builder -j
perf record -F 4000 -g --call-graph=dwarf ./build/benchmark/car_builder/benchmark_car_builder
perf report --no-children -g none
```
upstream top entries:
```
  30,19%  benchmark_car_b  benchmark_car_builder  [.] simdjson::internal::dtoa_impl::to_decimal(unsigned long, in
  25,98%  benchmark_car_b  libc.so.6              [.] 0x0000000000189cf7    <- HERE
  12,59%  benchmark_car_b  benchmark_car_builder  [.] simdjson::internal::to_chars(char*, char const*, double)   
  11,16%  benchmark_car_b  benchmark_car_builder  [.] serialize(simdjson::icelake::builder::string_builder&, std:
   9,83%  benchmark_car_b  benchmark_car_builder  [.] simdjson::icelake::builder::write_string_escaped(std::basic
   4,17%  benchmark_car_b  libc.so.6              [.] 0x0000000000189d02
   3,62%  benchmark_car_b  libc.so.6              [.] 0x0000000000189cfa
   0,75%  benchmark_car_b  libc.so.6              [.] cfree
```
showing that 1/3 of the bench is about unresolved libc address

following 0x189cf7, with:
```
objdump -d --start-address=0x189c80 --stop-address=0x189d10 /usr/lib/libc.so.6
```
we find:
```
189c90:  cmp    $0x20,%edx
189c93:  jae    189cd5        ; branch 1
189c95:  cmp    $0x10,%edx
189c98:  jae    189cc0        ; branch 2
189c9a:  cmp    $0x8,%edx
189c9d:  jae    189cf2        ; branch 3
...
189cc0:  vmovdqu (%rsi),%xmm0
189cd5:  vmovdqu64 (%rsi),%ymm16
```
which correspond to `__memmove_avx512_unaligned_erms`

with this PR we get <1.5% of libc in top entries:
```
  45,01%  benchmark_car_b  benchmark_car_builder  [.] simdjson::internal::to_chars(char*, char const*, double)
  37,75%  benchmark_car_b  benchmark_car_builder  [.] simdjson::internal::dtoa_impl::to_decimal(unsigned long, i
   9,65%  benchmark_car_b  benchmark_car_builder  [.] simdjson::icelake::builder::write_string_escaped(std::basi
   6,10%  benchmark_car_b  benchmark_car_builder  [.] serialize(simdjson::icelake::builder::string_builder&, std
   0,94%  benchmark_car_b  libc.so.6              [.] cfree
   0,18%  benchmark_car_b  libc.so.6              [.] 0x0000000000189c93
   0,14%  benchmark_car_b  libc.so.6              [.] malloc
```
#### bench and test
```
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON -D CMAKE_BUILD_TYPE=Release
cmake --build build --target benchmark_car_builder -j
./build/benchmark/car_builder/benchmark_car_builder
```
upstream:
```
1string_builder :    0.84 ns     1.19 GB/s     5.18 GHz     4.36 cycles/char    15.34 ins./char     3.52 i/c
2string_builder :    0.85 ns     1.18 GB/s     5.17 GHz     4.39 cycles/char    15.34 ins./char     3.50 i/c
3string_builder :    0.84 ns     1.19 GB/s     5.21 GHz     4.37 cycles/char    15.34 ins./char     3.51 i/c
```
this PR:
```
1string_builder :    0.81 ns     1.23 GB/s     5.24 GHz     4.26 cycles/char    13.99 ins./char     3.28 i/c
2string_builder :    0.81 ns     1.24 GB/s     5.29 GHz     4.28 cycles/char    13.99 ins./char     3.27 i/c
3string_builder :    0.81 ns     1.24 GB/s     5.29 GHz     4.28 cycles/char    13.99 ins./char     3.27 i/c
```
> CPU: AMD Ryzen 5 7600X (6cores)
> Governor: Performance
> Boost: ON

And 100% tests passed out of 131 with:
```
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build
```


Might close #1692 and close #1450