### PR TITLE
feat(ondemand): protect object iteration via state-based container locking

### DIFF
--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -43,12 +43,21 @@ simdjson_inline simdjson_result<value> object::find_field_unordered(const std::s
   return value(iter.child());
 }
 simdjson_inline simdjson_result<value> object::operator[](const std::string_view key) & noexcept {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  if (locked) return OUT_OF_ORDER_ITERATION;
+#endif
   return find_field_unordered(key);
 }
 simdjson_inline simdjson_result<value> object::operator[](const std::string_view key) && noexcept {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  if (locked) return OUT_OF_ORDER_ITERATION;
+#endif
   return std::forward<object>(*this).find_field_unordered(key);
 }
 simdjson_inline simdjson_result<value> object::find_field(const std::string_view key) & noexcept {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  if (locked) return OUT_OF_ORDER_ITERATION;
+#endif
   bool has_value;
   SIMDJSON_TRY( iter.find_field_raw(key).get(has_value) );
   if (!has_value) {
@@ -58,6 +67,9 @@ simdjson_inline simdjson_result<value> object::find_field(const std::string_view
   return value(iter.child());
 }
 simdjson_inline simdjson_result<value> object::find_field(const std::string_view key) && noexcept {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  if (locked) return OUT_OF_ORDER_ITERATION;
+#endif
   bool has_value;
   SIMDJSON_TRY( iter.find_field_raw(key).get(has_value) );
   if (!has_value) {
@@ -246,6 +258,9 @@ simdjson_warn_unused simdjson_inline error_code object::consume() noexcept {
 }
 
 simdjson_inline simdjson_result<std::string_view> object::raw_json() noexcept {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  if (locked) return OUT_OF_ORDER_ITERATION;
+#endif
   const uint8_t * starting_point{iter.peek_start()};
   auto error = consume();
   if(error) { return error; }
@@ -269,7 +284,8 @@ simdjson_inline object::object(const value_iterator &_iter) noexcept
 
 simdjson_inline simdjson_result<object_iterator> object::begin() noexcept {
 #if SIMDJSON_DEVELOPMENT_CHECKS
-  if (!iter.is_at_iterator_start()) { return OUT_OF_ORDER_ITERATION; }
+  if (!iter.is_at_iterator_start() || locked) { return OUT_OF_ORDER_ITERATION; }
+  return object_iterator(iter, this);
 #endif
   return object_iterator(iter);
 }
@@ -380,6 +396,9 @@ simdjson_inline simdjson_result<size_t> object::count_fields() & noexcept {
 }
 
 simdjson_inline simdjson_result<bool> object::is_empty() & noexcept {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  if (locked) return OUT_OF_ORDER_ITERATION;
+#endif
   bool is_not_empty;
   auto error = iter.reset_object().get(is_not_empty);
   if(error) { return error; }
@@ -387,8 +406,17 @@ simdjson_inline simdjson_result<bool> object::is_empty() & noexcept {
 }
 
 simdjson_inline simdjson_result<bool> object::reset() & noexcept {
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  if (locked) return OUT_OF_ORDER_ITERATION;
+#endif
   return iter.reset_object();
 }
+
+#if SIMDJSON_DEVELOPMENT_CHECKS
+simdjson_inline void object::set_locked(bool _locked) noexcept {
+  locked = _locked;
+}
+#endif
 
 #if SIMDJSON_SUPPORTS_CONCEPTS && SIMDJSON_STATIC_REFLECTION
 

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -473,10 +473,18 @@ protected:
   simdjson_warn_unused simdjson_inline error_code find_field_raw(const std::string_view key) noexcept;
 
   value_iterator iter{};
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  bool locked{false};
+  simdjson_inline void set_locked(bool _locked) noexcept;
+#endif
 
   friend class value;
   friend class document;
   friend struct simdjson_result<object>;
+#if SIMDJSON_DEVELOPMENT_CHECKS
+  friend class object_iterator;
+  friend struct simdjson_result<object_iterator>;
+#endif
 };
 
 } // namespace ondemand

--- a/include/simdjson/generic/ondemand/object_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/object_iterator-inl.h
@@ -20,6 +20,61 @@ simdjson_inline object_iterator::object_iterator(const value_iterator &_iter) no
   : iter{_iter}
 {}
 
+#if SIMDJSON_DEVELOPMENT_CHECKS
+simdjson_inline object_iterator::object_iterator(const value_iterator &_iter, object* _parent) noexcept
+  : parent{_parent}, iter{_iter}
+{
+  if (parent) parent->set_locked(true);
+}
+#endif
+
+#if SIMDJSON_DEVELOPMENT_CHECKS
+simdjson_inline object_iterator::~object_iterator() noexcept
+{
+  if (parent) parent->set_locked(false);
+}
+
+simdjson_inline object_iterator::object_iterator(object_iterator&& other) noexcept
+  : has_been_referenced{other.has_been_referenced},
+    parent{other.parent},
+    iter{std::move(other.iter)}
+{
+  other.parent = nullptr;
+}
+
+simdjson_inline object_iterator& object_iterator::operator=(object_iterator&& other) noexcept {
+  if (this != &other)
+  {
+    if (parent)
+      parent->set_locked(false);
+    has_been_referenced = other.has_been_referenced;
+    parent = other.parent;
+    iter = std::move(other.iter);
+
+    other.parent = nullptr;
+  }
+  return *this;
+}
+
+simdjson_inline object_iterator::object_iterator(const object_iterator& other) noexcept
+  : has_been_referenced{other.has_been_referenced},
+    parent{nullptr},
+    iter{other.iter}
+{}
+
+simdjson_inline object_iterator& object_iterator::operator=(const object_iterator& other) noexcept {
+  if (this != &other)
+  {
+    if (parent)
+      parent->set_locked(false);
+    has_been_referenced = other.has_been_referenced;
+    parent = nullptr;
+    iter = other.iter;
+  }
+  return *this;
+}
+#endif
+
 simdjson_inline simdjson_result<field> object_iterator::operator*() noexcept {
 #if SIMDJSON_DEVELOPMENT_CHECKS
   // We must call * once per iteration.

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -1,3 +1,4 @@
+#include "simdjson/common_defs.h"
 #ifndef SIMDJSON_GENERIC_ONDEMAND_OBJECT_ITERATOR_H
 
 #ifndef SIMDJSON_CONDITIONAL_INCLUDE
@@ -20,6 +21,15 @@ public:
    */
   simdjson_inline object_iterator() noexcept = default;
 
+#if SIMDJSON_DEVELOPMENT_CHECKS
+   simdjson_inline ~object_iterator() noexcept;
+
+   simdjson_inline object_iterator(object_iterator&&) noexcept;
+   simdjson_inline object_iterator& operator=(object_iterator&&) noexcept;
+   simdjson_inline object_iterator(const object_iterator&) noexcept;
+   simdjson_inline object_iterator& operator=(const object_iterator&) noexcept;
+#endif
+
   //
   // Iterator interface
   //
@@ -39,6 +49,9 @@ public:
 private:
 #if SIMDJSON_DEVELOPMENT_CHECKS
    bool has_been_referenced{false};
+   object* parent{nullptr};
+
+   simdjson_inline object_iterator(const value_iterator &_iter, object* _parent) noexcept;
 #endif
   /**
    * The underlying JSON iterator.

--- a/include/simdjson/generic/ondemand/object_iterator.h
+++ b/include/simdjson/generic/ondemand/object_iterator.h
@@ -1,4 +1,3 @@
-#include "simdjson/common_defs.h"
 #ifndef SIMDJSON_GENERIC_ONDEMAND_OBJECT_ITERATOR_H
 
 #ifndef SIMDJSON_CONDITIONAL_INCLUDE

--- a/tests/ondemand/ondemand_object_error_tests.cpp
+++ b/tests/ondemand/ondemand_object_error_tests.cpp
@@ -562,6 +562,42 @@ namespace object_error_tests {
     }));
     TEST_SUCCEED();
   }
+
+  bool reentrant_object_access_during_iteration_error() {
+    TEST_START();
+    auto json = R"({ "x": 1, "y": 2 })"_padded;
+    SUBTEST("operator[] mid-loop", test_ondemand_doc(json, [&](auto doc) {
+      ondemand::object obj;
+      ASSERT_SUCCESS( doc.get(obj) );
+      for (auto field : obj) {
+        ASSERT_SUCCESS(field);
+        ASSERT_ERROR( obj["x"], OUT_OF_ORDER_ITERATION );
+        break;
+      }
+      return true;
+    }));
+    SUBTEST("find_field mid-loop", test_ondemand_doc(json, [&](auto doc) {
+      ondemand::object obj;
+      ASSERT_SUCCESS( doc.get(obj) );
+      for (auto field : obj) {
+        ASSERT_SUCCESS(field);
+        ASSERT_ERROR( obj.find_field("y"), OUT_OF_ORDER_ITERATION );
+        break;
+      }
+      return true;
+    }));
+    SUBTEST("reset mid-loop", test_ondemand_doc(json, [&](auto doc) {
+      ondemand::object obj;
+      ASSERT_SUCCESS( doc.get(obj) );
+      for (auto field : obj) {
+        ASSERT_SUCCESS(field);
+        ASSERT_ERROR( obj.reset(), OUT_OF_ORDER_ITERATION );
+        break;
+      }
+      return true;
+    }));
+    TEST_SUCCEED();
+  }
 #endif
 
   bool run() {


### PR DESCRIPTION
Short title (summary):
protect object iteration safety via container state locking

Description
I introduced an internal locked state flag to ondemand::object that is managed dynamically by object_iterator using RAII under `SIMDJSON_DEVELOPMENT_CHECKS`.

Related issue: #2314

Type of change
- [ ] Bug fix
- [ ] Optimization
- [x] New feature
- [ ] Refactor / cleanup
- [x] Documentation / tests
- [ ] Other (please describe):

How to verify / test
Added mid-loop reentrancy unit tests inside `tests/ondemand/ondemand_object_error_tests.cpp`. These tests explicitly confirm that invoking `operator[]`, `find_field()`, or `reset()` inside an active object loop block safely returns `OUT_OF_ORDER_ITERATION`.


Checklist before submitting
- [x] I added/updated tests covering my change (if applicable)
- [x] Code builds locally and passes my check
- [ ] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear
- [x] I linked the related issue (if applicable)

**Note for Reviewers:** This is an intentional **Part 1** initial commit that strictly applies the container-locking validation design to `ondemand::object`. I am purposely leaving out `ondemand::array` and other relevant container classes for now to gather early feedback on this baseline architectural pattern. Once you approve this locking model, I will proceed with applying the identical copy-paste pattern to the remaining containers.
