### PR TITLE
Add FreeBSD CI

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,32 @@
+name: FreeBSD
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        release: ['14.3', '15.1']
+    steps:
+      - uses: actions/checkout@v6
+      - uses: vmactions/freebsd-vm@v1
+        name: Test
+        with:
+          release: ${{ matrix.release }}
+          usesh: true
+          copyback: false
+          cache-after-prepare: true
+          prepare: |
+            pkg install -y cmake git bash
+          run: |
+            cmake -DCMAKE_BUILD_TYPE=Release -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -B build
+            cmake --build build -j=$(sysctl -n hw.ncpu)
+            ctest --output-on-failure --test-dir build


### PR DESCRIPTION
Closes #2810.

Adds `.github/workflows/freebsd.yml`. Same three commands as `ppc64.yml`, run
in a FreeBSD VM booted under QEMU on a normal ubuntu-latest runner.

https://github.com/neilpang/simdjson/actions/runs/31066180881

```
FreeBSD 14.3   clang 19.1.7   120/120 passed   6m40s
FreeBSD 15.1   clang 19.1.7   120/120 passed   8m34s
```

No source changes needed.

Two versions rather than one because both are supported upstream, and the old
`.cirrus.yml` covered three. Drop the 14.3 row if that is too much.

cmake reports "Either git is unavailable or else it is too old. We are
disabling checkperf targets." in the VM, so checkperf is skipped there. The 120
tests are unaffected.
