### PR TITLE
fixing a typo in if-logic of perfdiff.cpp

### DIFF
--- a/benchmark/dom/perfdiff.cpp
+++ b/benchmark/dom/perfdiff.cpp
@@ -105,7 +105,7 @@ int main(int argc, const char *argv[]) {
       std::cerr << "You probably have a performance degradation." << std::endl;
       return EXIT_FAILURE;
     }
-    if(bestnewcode < worseref) {
+    if(bestnewcode > worseref) {
       std::cout << "You probably have a performance gain." << std::endl;
       return EXIT_SUCCESS;
     }


### PR DESCRIPTION
`benchmark/dom/perfdiff.cpp` had an inverted angle bracket inside an if statement, causing the program to only be able to say "Performance Degradation" or "no obvious performance difference" and never a positive answer.

PS: Metric used is GB/s, meaning higher-is-better