### PR TITLE
Batch long Ice Lake UTF-8 validation blocks

### DIFF
--- a/benchmark/bench_parse_call.cpp
+++ b/benchmark/bench_parse_call.cpp
@@ -1,4 +1,5 @@
 #include <benchmark/benchmark.h>
+#include <cstring>
 #include <iostream>
 #include "simdjson.h"
 using namespace simdjson;
@@ -96,6 +97,107 @@ static void unicode_validate_twitter(State& state) {
   state.counters["docs"] = Counter(double(state.iterations()), benchmark::Counter::kIsRate);
 }
 BENCHMARK(unicode_validate_twitter)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void add_utf8_rate_counter(State& state, size_t bytes) {
+  // Gigabyte: https://en.wikipedia.org/wiki/Gigabyte
+  state.counters["Gigabytes"] = benchmark::Counter(
+      double(bytes), benchmark::Counter::kIsRate,
+      benchmark::Counter::OneK::kIs1000); // For GiB : kIs1024
+}
+
+static void benchmark_validate_utf8(State& state, const padded_string& docdata, bool expected) {
+  const bool initial_result = simdjson::validate_utf8(docdata.data(), docdata.size());
+  if (initial_result != expected) {
+    state.SkipWithError("unexpected UTF-8 validation result");
+    return;
+  }
+
+  size_t bytes = 0;
+  for (simdjson_unused auto _ : state) {
+    const bool is_ok = simdjson::validate_utf8(docdata.data(), docdata.size());
+    bytes += docdata.size();
+    benchmark::DoNotOptimize(is_ok);
+  }
+  add_utf8_rate_counter(state, bytes);
+}
+
+static padded_string make_ascii_utf8_input(size_t size) {
+  padded_string input(size);
+  std::memset(input.data(), 'a', size);
+  return input;
+}
+
+static padded_string make_multilingual_utf8_input(size_t size) {
+  padded_string input(size);
+  for (size_t i = 0; i < size; i += 3) {
+    input.data()[i] = char(0xe2);
+    input.data()[i + 1] = char(0x82);
+    input.data()[i + 2] = char(0xac);
+  }
+  return input;
+}
+
+static void unicode_validate_ascii_4kb(State& state) {
+  const padded_string docdata = make_ascii_utf8_input(4 * 1024);
+  benchmark_validate_utf8(state, docdata, true);
+}
+BENCHMARK(unicode_validate_ascii_4kb)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void unicode_validate_ascii_64kb(State& state) {
+  const padded_string docdata = make_ascii_utf8_input(64 * 1024);
+  benchmark_validate_utf8(state, docdata, true);
+}
+BENCHMARK(unicode_validate_ascii_64kb)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void unicode_validate_ascii_1mb(State& state) {
+  const padded_string docdata = make_ascii_utf8_input(1024 * 1024);
+  benchmark_validate_utf8(state, docdata, true);
+}
+BENCHMARK(unicode_validate_ascii_1mb)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void unicode_validate_multilingual_1mb(State& state) {
+  const padded_string docdata = make_multilingual_utf8_input((1024 * 1024 / 3) * 3);
+  benchmark_validate_utf8(state, docdata, true);
+}
+BENCHMARK(unicode_validate_multilingual_1mb)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void unicode_validate_boundary_error_4kb(State& state) {
+  padded_string docdata = make_ascii_utf8_input(4 * 1024);
+  docdata.data()[63] = char(0xe2);
+  docdata.data()[64] = 'a';
+  benchmark_validate_utf8(state, docdata, false);
+}
+BENCHMARK(unicode_validate_boundary_error_4kb)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void unicode_validate_boundary_error_64kb(State& state) {
+  padded_string docdata = make_ascii_utf8_input(64 * 1024);
+  docdata.data()[63] = char(0xe2);
+  docdata.data()[64] = 'a';
+  benchmark_validate_utf8(state, docdata, false);
+}
+BENCHMARK(unicode_validate_boundary_error_64kb)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
+    return *(std::max_element(std::begin(v), std::end(v)));
+  })->DisplayAggregatesOnly(true);
+
+static void unicode_validate_boundary_error_1mb(State& state) {
+  padded_string docdata = make_ascii_utf8_input(1024 * 1024);
+  docdata.data()[63] = char(0xe2);
+  docdata.data()[64] = 'a';
+  benchmark_validate_utf8(state, docdata, false);
+}
+BENCHMARK(unicode_validate_boundary_error_1mb)->Repetitions(10)->ComputeStatistics("max", [](const std::vector<double>& v) -> double {
     return *(std::max_element(std::begin(v), std::end(v)));
   })->DisplayAggregatesOnly(true);
 

--- a/src/icelake.cpp
+++ b/src/icelake.cpp
@@ -99,6 +99,141 @@ simdjson_inline bool is_ascii(const simd8x64<uint8_t>& input) {
   return input.reduce_or().is_ascii();
 }
 
+// UTF-8 rules only look at the three preceding bytes. Keep the vector work for
+// each block independent, then reduce the three-byte boundary summaries.
+struct utf8_block_summary {
+  uint32_t suffix;
+  bool is_ascii;
+};
+
+constexpr size_t UTF8_BATCH_MIN_LENGTH = 64 * 1024;
+
+simdjson_inline uint32_t utf8_three_bytes(const uint8_t *input) {
+  return uint32_t(input[0]) | (uint32_t(input[1]) << 8) | (uint32_t(input[2]) << 16);
+}
+
+simdjson_inline simd8<uint8_t> utf8_errors(const simd8<uint8_t>& input, const simd8<uint8_t>& prev_input) {
+  const simd8<uint8_t> prev1 = input.prev<1>(prev_input);
+  const simd8<uint8_t> special_cases = utf8_validation::check_special_cases(input, prev1);
+  return utf8_validation::check_multibyte_lengths(input, prev_input, special_cases);
+}
+
+simdjson_inline simd8<uint8_t> utf8_previous_suffix(uint32_t suffix) {
+  const __m128i suffix_bytes = _mm_slli_si128(_mm_cvtsi32_si128(static_cast<int>(suffix)), 13);
+  return simd8<uint8_t>(_mm512_inserti32x4(_mm512_setzero_si512(), suffix_bytes, 3));
+}
+
+simdjson_never_inline bool validate_utf8_batched(const char *buf, size_t len) {
+  // The public entry point calls this only for long inputs.
+  SIMDJSON_ASSUME(len >= UTF8_BATCH_MIN_LENGTH);
+  stage1::buf_block_reader<64> reader(reinterpret_cast<const uint8_t *>(buf), len);
+  utf8_block_summary previous{ 0, true };
+  bool has_error = false;
+  const size_t full_block_count = (len - 1) / 64;
+  size_t full_blocks_done = 0;
+
+  // Load eight blocks before rebuilding their first predecessor lanes from a
+  // compact suffix summary. The remaining blocks use independently loaded
+  // neighbors, never a preceding validation result.
+  while (full_block_count - full_blocks_done >= 8) {
+    const uint8_t *input0 = reader.full_block(); reader.advance();
+    const uint8_t *input1 = reader.full_block(); reader.advance();
+    const uint8_t *input2 = reader.full_block(); reader.advance();
+    const uint8_t *input3 = reader.full_block(); reader.advance();
+    const uint8_t *input4 = reader.full_block(); reader.advance();
+    const uint8_t *input5 = reader.full_block(); reader.advance();
+    const uint8_t *input6 = reader.full_block(); reader.advance();
+    const uint8_t *input7 = reader.full_block(); reader.advance();
+    full_blocks_done += 8;
+
+    const simd8<uint8_t> block0(input0);
+    const simd8<uint8_t> block1(input1);
+    const simd8<uint8_t> block2(input2);
+    const simd8<uint8_t> block3(input3);
+    const simd8<uint8_t> block4(input4);
+    const simd8<uint8_t> block5(input5);
+    const simd8<uint8_t> block6(input6);
+    const simd8<uint8_t> block7(input7);
+    const bool ascii0 = block0.is_ascii();
+    const bool ascii1 = block1.is_ascii();
+    const bool ascii2 = block2.is_ascii();
+    const bool ascii3 = block3.is_ascii();
+    const bool ascii4 = block4.is_ascii();
+    const bool ascii5 = block5.is_ascii();
+    const bool ascii6 = block6.is_ascii();
+    const bool ascii7 = block7.is_ascii();
+    if (ascii0 && ascii1 && ascii2 && ascii3 && ascii4 && ascii5 && ascii6 && ascii7 && previous.is_ascii) {
+      previous = { utf8_three_bytes(input7 + 61), true };
+    } else {
+      const simd8<uint8_t> error0 = (!ascii0 || !previous.is_ascii) ?
+          utf8_errors(block0, utf8_previous_suffix(previous.suffix)) : simd8<uint8_t>();
+      const simd8<uint8_t> error1 = (!ascii1 || !ascii0) ? utf8_errors(block1, block0) : simd8<uint8_t>();
+      const simd8<uint8_t> error2 = (!ascii2 || !ascii1) ? utf8_errors(block2, block1) : simd8<uint8_t>();
+      const simd8<uint8_t> error3 = (!ascii3 || !ascii2) ? utf8_errors(block3, block2) : simd8<uint8_t>();
+      const simd8<uint8_t> error4 = (!ascii4 || !ascii3) ? utf8_errors(block4, block3) : simd8<uint8_t>();
+      const simd8<uint8_t> error5 = (!ascii5 || !ascii4) ? utf8_errors(block5, block4) : simd8<uint8_t>();
+      const simd8<uint8_t> error6 = (!ascii6 || !ascii5) ? utf8_errors(block6, block5) : simd8<uint8_t>();
+      const simd8<uint8_t> error7 = (!ascii7 || !ascii6) ? utf8_errors(block7, block6) : simd8<uint8_t>();
+      has_error |= (error0 | error1 | error2 | error3 | error4 | error5 | error6 | error7).any_bits_set_anywhere();
+      previous = { utf8_three_bytes(input7 + 61), ascii7 };
+    }
+  }
+
+  // Load four blocks before rebuilding their predecessor lanes from compact
+  // suffix summaries. The expensive vector checks share no result dependency.
+  while (full_block_count - full_blocks_done >= 4) {
+    const uint8_t *input0 = reader.full_block(); reader.advance();
+    const uint8_t *input1 = reader.full_block(); reader.advance();
+    const uint8_t *input2 = reader.full_block(); reader.advance();
+    const uint8_t *input3 = reader.full_block(); reader.advance();
+    full_blocks_done += 4;
+
+    const simd8<uint8_t> block0(input0);
+    const simd8<uint8_t> block1(input1);
+    const simd8<uint8_t> block2(input2);
+    const simd8<uint8_t> block3(input3);
+    const bool ascii0 = block0.is_ascii();
+    const bool ascii1 = block1.is_ascii();
+    const bool ascii2 = block2.is_ascii();
+    const bool ascii3 = block3.is_ascii();
+    if (ascii0 && ascii1 && ascii2 && ascii3 && previous.is_ascii) {
+      previous = { utf8_three_bytes(input3 + 61), true };
+    } else {
+      const simd8<uint8_t> error0 = (!ascii0 || !previous.is_ascii) ?
+          utf8_errors(block0, utf8_previous_suffix(previous.suffix)) : simd8<uint8_t>();
+      const simd8<uint8_t> error1 = (!ascii1 || !ascii0) ? utf8_errors(block1, block0) : simd8<uint8_t>();
+      const simd8<uint8_t> error2 = (!ascii2 || !ascii1) ? utf8_errors(block2, block1) : simd8<uint8_t>();
+      const simd8<uint8_t> error3 = (!ascii3 || !ascii2) ? utf8_errors(block3, block2) : simd8<uint8_t>();
+      has_error |= (error0 | error1 | error2 | error3).any_bits_set_anywhere();
+      previous = { utf8_three_bytes(input3 + 61), ascii3 };
+    }
+  }
+
+  while (full_blocks_done < full_block_count) {
+    const uint8_t *input = reader.full_block();
+    reader.advance();
+    ++full_blocks_done;
+    const simd8<uint8_t> block(input);
+    const bool block_is_ascii = block.is_ascii();
+    if (!block_is_ascii || !previous.is_ascii) {
+      has_error |= utf8_errors(block, utf8_previous_suffix(previous.suffix)).any_bits_set_anywhere();
+    }
+    previous = { utf8_three_bytes(input + 61), block_is_ascii };
+  }
+
+  uint8_t remainder[64]{};
+  reader.get_remainder(remainder);
+  const simd8<uint8_t> last_block(remainder);
+  const bool last_is_ascii = last_block.is_ascii();
+  if (!last_is_ascii || !previous.is_ascii) {
+    has_error |= utf8_errors(last_block, utf8_previous_suffix(previous.suffix)).any_bits_set_anywhere();
+  }
+  if (!last_is_ascii) {
+    has_error |= utf8_validation::is_incomplete(last_block).any_bits_set_anywhere();
+  }
+  return !has_error;
+}
+
 simdjson_unused simdjson_inline simd8<bool> must_be_continuation(const simd8<uint8_t> prev1, const simd8<uint8_t> prev2, const simd8<uint8_t> prev3) {
   simd8<uint8_t> is_second_byte = prev1.saturating_sub(0xc0u-1); // Only 11______ will be > 0
   simd8<uint8_t> is_third_byte  = prev2.saturating_sub(0xe0u-1); // Only 111_____ will be > 0
@@ -182,6 +317,10 @@ simdjson_warn_unused error_code dom_parser_implementation::stage1(const uint8_t 
 }
 
 simdjson_warn_unused bool implementation::validate_utf8(const char *buf, size_t len) const noexcept {
+  // Keep short requests on the stateful path; the batch setup amortizes after 64 KiB.
+  if (len >= UTF8_BATCH_MIN_LENGTH) {
+    return validate_utf8_batched(buf, len);
+  }
   return icelake::stage1::generic_validate_utf8(buf,len);
 }
 

--- a/tests/unicode_tests.cpp
+++ b/tests/unicode_tests.cpp
@@ -1,8 +1,11 @@
 #include "simdjson.h"
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <random>
+#include <vector>
 
 class RandomUTF8 final {
 public:
@@ -184,6 +187,101 @@ void brute_force_tests() {
   printf("tests ok.\n");
 }
 
+void expect_utf8_result(const simdjson::implementation *target, const simdjson::implementation *fallback,
+                        const std::vector<uint8_t> &input, bool expected, const char *description) {
+  const bool fallback_result = fallback->validate_utf8(reinterpret_cast<const char *>(input.data()), input.size());
+  const bool target_result = target->validate_utf8(reinterpret_cast<const char *>(input.data()), input.size());
+  if (fallback_result != expected || target_result != expected) {
+    std::cerr << "UTF-8 " << description << " test failed at length " << input.size()
+              << ": fallback=" << fallback_result << ", icelake=" << target_result
+              << ", expected=" << expected << std::endl;
+    abort();
+  }
+}
+
+void batched_boundary_tests() {
+  const simdjson::implementation *fallback = simdjson::get_available_implementations()["fallback"];
+  const simdjson::implementation *icelake = simdjson::get_available_implementations()["icelake"];
+  if (!fallback || !icelake || !icelake->supported_by_runtime_system()) {
+    return;
+  }
+
+  printf("running batched UTF-8 boundary tests... ");
+  fflush(NULL);
+  constexpr size_t batch_min_length = 64 * 1024;
+  constexpr size_t length = batch_min_length + 37;
+  constexpr uint8_t two_byte_utf8[] = { 0xc2, 0x80 };
+  constexpr uint8_t three_byte_utf8[] = { 0xe0, 0xa0, 0x80 };
+  constexpr uint8_t four_byte_utf8[] = { 0xf0, 0x90, 0x80, 0x80 };
+  const uint8_t *const sequences[] = { two_byte_utf8, three_byte_utf8, four_byte_utf8 };
+  const size_t sequence_lengths[] = { sizeof(two_byte_utf8), sizeof(three_byte_utf8), sizeof(four_byte_utf8) };
+
+  // Exercise every block join, including the eight-block batch joins, with
+  // each multibyte width starting at every possible cross-boundary position.
+  for (size_t join = 64; join + sizeof(four_byte_utf8) < length; join += 64) {
+    for (size_t sequence = 0; sequence < sizeof(sequences) / sizeof(sequences[0]); ++sequence) {
+      for (size_t bytes_before_join = 1; bytes_before_join < sequence_lengths[sequence]; ++bytes_before_join) {
+        const size_t position = join - bytes_before_join;
+        std::vector<uint8_t> input(length, 'a');
+        std::memcpy(input.data() + position, sequences[sequence], sequence_lengths[sequence]);
+        expect_utf8_result(icelake, fallback, input, true, "valid boundary");
+
+        input[position + sequence_lengths[sequence] - 1] = 'a';
+        expect_utf8_result(icelake, fallback, input, false, "truncated boundary");
+      }
+    }
+  }
+
+  // Cover every byte offset in an independently validated block and check the
+  // range restrictions on the first continuation byte as well as a bad lead.
+  for (size_t offset = 0; offset < 64; ++offset) {
+    const size_t position = 512 + offset;
+    std::vector<uint8_t> input(length, 'a');
+    std::memcpy(input.data() + position, four_byte_utf8, sizeof(four_byte_utf8));
+    expect_utf8_result(icelake, fallback, input, true, "valid offset");
+
+    input[position + 1] = 0x80;
+    expect_utf8_result(icelake, fallback, input, false, "overlong offset");
+
+    input[position] = 0xf5;
+    expect_utf8_result(icelake, fallback, input, false, "out-of-range offset");
+  }
+
+  // The padded final reader block must preserve valid endings and reject every
+  // truncated length, for each possible remainder length at the batch cutoff.
+  for (size_t remainder = 0; remainder < 64; ++remainder) {
+    std::vector<uint8_t> input(batch_min_length + remainder, 'a');
+    std::memcpy(input.data() + input.size() - sizeof(four_byte_utf8), four_byte_utf8, sizeof(four_byte_utf8));
+    expect_utf8_result(icelake, fallback, input, true, "valid EOF");
+    for (size_t partial_length = 1; partial_length < sizeof(four_byte_utf8); ++partial_length) {
+      std::fill(input.begin(), input.end(), uint8_t('a'));
+      std::memcpy(input.data() + input.size() - partial_length, four_byte_utf8, partial_length);
+      expect_utf8_result(icelake, fallback, input, false, "truncated EOF");
+    }
+  }
+
+  // A seven-byte stride places a dense four-byte sequence at every vector lane
+  // over the set of inputs. Mutate several sequences independently to keep the
+  // fallback differential check sensitive to errors throughout a long input.
+  for (size_t offset = 0; offset < 64; ++offset) {
+    std::vector<uint8_t> input(length + offset, 'a');
+    size_t sequence_count = 0;
+    for (size_t position = offset; position + sizeof(four_byte_utf8) <= input.size(); position += 7) {
+      std::memcpy(input.data() + position, four_byte_utf8, sizeof(four_byte_utf8));
+      ++sequence_count;
+    }
+    expect_utf8_result(icelake, fallback, input, true, "dense valid input");
+    for (size_t mutation = 0; mutation < 8; ++mutation) {
+      std::vector<uint8_t> invalid = input;
+      const size_t sequence = (mutation * 97) % sequence_count;
+      const size_t position = offset + sequence * 7;
+      invalid[position + sizeof(four_byte_utf8) - 1] = 'a';
+      expect_utf8_result(icelake, fallback, invalid, false, "dense invalid input");
+    }
+  }
+  printf("tests ok.\n");
+}
+
 void test() {
   printf("running hard-coded UTF-8 tests... ");
   fflush(NULL);
@@ -268,6 +366,7 @@ void puzzler() {
 int main() {
   puzzler();
   brute_force_tests();
+  batched_boundary_tests();
   test();
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

Batch long UTF-8 validation requests in the Ice Lake implementation. For inputs of at least 64 KiB, the validator loads groups of 64-byte blocks and checks each block against its physical predecessor instead of carrying validation results through every vector operation. It retains only a three-byte suffix and an ASCII summary between groups, preserving checks at block joins and in the padded final block. Shorter requests continue to use the existing stateful path to avoid batch setup overhead.

## Performance

On workload `Ice Lake 64 KiB ASCII UTF-8 validation`, median metric `cpu_time_ns` changed from 1376 to 1084; paired median delta -288.5 (-21% of baseline; at least 19/20 confidence interval -302.1 to -275 from 10 pairs).

On workload `Ice Lake 1 MiB ASCII UTF-8 validation`, median metric `cpu_time_ns` changed from 22664 to 17813; paired median delta -5016 (-22.1% of baseline; at least 19/20 confidence interval -5616 to -4324 from 10 pairs).

On workload `Ice Lake 1 MiB multilingual UTF-8 validation`, median metric `cpu_time_ns` changed from 68800 to 56998; paired median delta -11844 (-17.2% of baseline; at least 19/20 confidence interval -12787 to -10885 from 10 pairs).

On workload `Ice Lake 64 KiB malformed UTF-8 at a 64-byte boundary`, median metric `cpu_time_ns` changed from 1173 to 981.3; paired median delta -190.4 (-16.2% of baseline; at least 19/20 confidence interval -202.7 to -174.9 from 10 pairs).

On workload `Ice Lake 1 MiB malformed UTF-8 at a 64-byte boundary`, median metric `cpu_time_ns` changed from 19502 to 17171; paired median delta -2303 (-11.8% of baseline; at least 19/20 confidence interval -3343 to -1654 from 10 pairs).

## Testing

Added differential coverage against the fallback implementation for long inputs, block boundaries, padded tails, dense multibyte data, and invalid mutations. Ran the CMake CTest suite with the Ice Lake implementation forced.

The declared correctness check passed.

---

Authored and verified by [Perfloop](https://app.perfloop.ai): every claim above was co-measured on both trees and independently re-verified before submission — the full record is public: [case_pg5w1h5y4k](https://app.perfloop.ai/t/oss/case_pg5w1h5y4k). Replies from this account are human-approved, and a human operator is accountable for this contribution.