### PR TITLE
fix: prevent parse_unpadded 1-byte OOB on truncated nested JSON

### DIFF
--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -14652,10 +14652,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -21044,10 +21058,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -27431,10 +27459,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -34089,10 +34131,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -41309,10 +41365,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -47560,10 +47630,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -53715,10 +53799,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -60289,10 +60387,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -64340,10 +64452,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -14652,21 +14652,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -21055,21 +21044,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -27453,21 +27431,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -34122,21 +34089,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -41353,21 +41309,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -47615,21 +47560,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -53781,21 +53715,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -60366,21 +60289,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);
@@ -64428,21 +64340,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
-  const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural)];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
-  }
-  return &buf[idx];
+  return &buf[*(next_structural++)];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -14652,10 +14652,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -21058,10 +21055,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -27459,10 +27453,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -34131,10 +34122,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -41365,10 +41353,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -47630,10 +47615,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -53799,10 +53781,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -60387,10 +60366,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;
@@ -64452,10 +64428,7 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // Sentinel index `len` is only readable with padding; dummy for unpadded (#2815).
   const uint32_t idx = *(next_structural);
   if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
     static constexpr uint8_t unpadded_eof_sentinel = 0;

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -42,7 +42,10 @@ public:
    *
    * - increment_count(iter) - each time a value is found in an array or object.
    */
-  template<bool STREAMING, typename V>
+  // UNPADDED is a compile-time constant chosen once per document in
+  // tape_builder::parse_document (from the runtime _unpadded flag). The padded
+  // instantiation of walk_document / peek / advance has no unpadded branches.
+  template<bool STREAMING, bool UNPADDED, typename V>
   simdjson_warn_unused simdjson_inline error_code walk_document(V &visitor) noexcept;
 
   /**
@@ -58,7 +61,11 @@ public:
    * Tokens can be strings, numbers, booleans, null, or operators (`[{]},:`)).
    *
    * They may include invalid JSON as well (such as `1.2.3` or `ture`).
+   *
+   * When UNPADDED is true, a stage-1 sentinel index of value `len` returns a
+   * static dummy byte instead of reading past the buffer (#2815).
    */
+  template<bool UNPADDED>
   simdjson_inline const uint8_t *peek() const noexcept;
   /**
    * Advance to the next token.
@@ -66,7 +73,11 @@ public:
    * Tokens can be strings, numbers, booleans, null, or operators (`[{]},:`)).
    *
    * They may include invalid JSON as well (such as `1.2.3` or `ture`).
+   *
+   * When UNPADDED is true, a stage-1 sentinel index of value `len` returns a
+   * static dummy byte instead of reading past the buffer (#2815).
    */
+  template<bool UNPADDED>
   simdjson_inline const uint8_t *advance() noexcept;
   /**
    * Get the remaining length of the document, from the start of the current token.
@@ -115,7 +126,7 @@ public:
   simdjson_warn_unused simdjson_inline error_code visit_primitive(V &visitor, const uint8_t *value) noexcept;
 };
 
-template<bool STREAMING, typename V>
+template<bool STREAMING, bool UNPADDED, typename V>
 simdjson_warn_unused simdjson_inline error_code json_iterator::walk_document(V &visitor) noexcept {
   logger::log_start();
 
@@ -130,7 +141,7 @@ simdjson_warn_unused simdjson_inline error_code json_iterator::walk_document(V &
   // Read first value
   //
   {
-    auto value = advance();
+    auto value = advance<UNPADDED>();
 
     // Make sure the outer object or array is closed before continuing; otherwise, there are ways we
     // could get into memory corruption. See https://github.com/simdjson/simdjson/issues/906
@@ -142,8 +153,8 @@ simdjson_warn_unused simdjson_inline error_code json_iterator::walk_document(V &
     }
 
     switch (*value) {
-      case '{': if (*peek() == '}') { advance(); log_value("empty object"); SIMDJSON_TRY( visitor.visit_empty_object(*this) ); break; } goto object_begin;
-      case '[': if (*peek() == ']') { advance(); log_value("empty array"); SIMDJSON_TRY( visitor.visit_empty_array(*this) ); break; } goto array_begin;
+      case '{': if (*peek<UNPADDED>() == '}') { advance<UNPADDED>(); log_value("empty object"); SIMDJSON_TRY( visitor.visit_empty_object(*this) ); break; } goto object_begin;
+      case '[': if (*peek<UNPADDED>() == ']') { advance<UNPADDED>(); log_value("empty array"); SIMDJSON_TRY( visitor.visit_empty_array(*this) ); break; } goto array_begin;
       default: SIMDJSON_TRY( visitor.visit_root_primitive(*this, value) ); break;
     }
   }
@@ -160,29 +171,29 @@ object_begin:
   SIMDJSON_TRY( visitor.visit_object_start(*this) );
 
   {
-    auto key = advance();
+    auto key = advance<UNPADDED>();
     if (*key != '"') { log_error("Object does not start with a key"); return TAPE_ERROR; }
     SIMDJSON_TRY( visitor.increment_count(*this) );
     SIMDJSON_TRY( visitor.visit_key(*this, key) );
   }
 
 object_field:
-  if (simdjson_unlikely( *advance() != ':' )) { log_error("Missing colon after key in object"); return TAPE_ERROR; }
+  if (simdjson_unlikely( *advance<UNPADDED>() != ':' )) { log_error("Missing colon after key in object"); return TAPE_ERROR; }
   {
-    auto value = advance();
+    auto value = advance<UNPADDED>();
     switch (*value) {
-      case '{': if (*peek() == '}') { advance(); log_value("empty object"); SIMDJSON_TRY( visitor.visit_empty_object(*this) ); break; } goto object_begin;
-      case '[': if (*peek() == ']') { advance(); log_value("empty array"); SIMDJSON_TRY( visitor.visit_empty_array(*this) ); break; } goto array_begin;
+      case '{': if (*peek<UNPADDED>() == '}') { advance<UNPADDED>(); log_value("empty object"); SIMDJSON_TRY( visitor.visit_empty_object(*this) ); break; } goto object_begin;
+      case '[': if (*peek<UNPADDED>() == ']') { advance<UNPADDED>(); log_value("empty array"); SIMDJSON_TRY( visitor.visit_empty_array(*this) ); break; } goto array_begin;
       default: SIMDJSON_TRY( visitor.visit_primitive(*this, value) ); break;
     }
   }
 
 object_continue:
-  switch (*advance()) {
+  switch (*advance<UNPADDED>()) {
     case ',':
       SIMDJSON_TRY( visitor.increment_count(*this) );
       {
-        auto key = advance();
+        auto key = advance<UNPADDED>();
         if (simdjson_unlikely( *key != '"' )) { log_error("Key string missing at beginning of field in object"); return TAPE_ERROR; }
         SIMDJSON_TRY( visitor.visit_key(*this, key) );
       }
@@ -210,16 +221,16 @@ array_begin:
 
 array_value:
   {
-    auto value = advance();
+    auto value = advance<UNPADDED>();
     switch (*value) {
-      case '{': if (*peek() == '}') { advance(); log_value("empty object"); SIMDJSON_TRY( visitor.visit_empty_object(*this) ); break; } goto object_begin;
-      case '[': if (*peek() == ']') { advance(); log_value("empty array"); SIMDJSON_TRY( visitor.visit_empty_array(*this) ); break; } goto array_begin;
+      case '{': if (*peek<UNPADDED>() == '}') { advance<UNPADDED>(); log_value("empty object"); SIMDJSON_TRY( visitor.visit_empty_object(*this) ); break; } goto object_begin;
+      case '[': if (*peek<UNPADDED>() == ']') { advance<UNPADDED>(); log_value("empty array"); SIMDJSON_TRY( visitor.visit_empty_array(*this) ); break; } goto array_begin;
       default: SIMDJSON_TRY( visitor.visit_primitive(*this, value) ); break;
     }
   }
 
 array_continue:
-  switch (*advance()) {
+  switch (*advance<UNPADDED>()) {
     case ',': SIMDJSON_TRY( visitor.increment_count(*this) ); goto array_value;
     case ']': log_end_value("array"); SIMDJSON_TRY( visitor.visit_array_end(*this) ); goto scope_end;
     default: log_error("Missing comma between array values"); return TAPE_ERROR;
@@ -247,23 +258,30 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
     dom_parser{_dom_parser} {
 }
 
+template<bool UNPADDED>
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
   // Stage 1 plants a sentinel structural index of value `len` after the last
   // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
-  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  // valid with SIMDJSON_PADDING. For the UNPADDED=true instantiation, return a
+  // static dummy so walk_document can report TAPE_ERROR without a 1-byte heap
+  // OOB (#2815). The UNPADDED=false (padded) instantiation has no check.
   const uint32_t idx = *(next_structural);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
+  SIMDJSON_IF_CONSTEXPR (UNPADDED) {
+    if (simdjson_unlikely(idx >= dom_parser.len)) {
+      static constexpr uint8_t unpadded_eof_sentinel = 0;
+      return &unpadded_eof_sentinel;
+    }
   }
   return &buf[idx];
 }
+template<bool UNPADDED>
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
   const uint32_t idx = *(next_structural++);
-  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
-    static constexpr uint8_t unpadded_eof_sentinel = 0;
-    return &unpadded_eof_sentinel;
+  SIMDJSON_IF_CONSTEXPR (UNPADDED) {
+    if (simdjson_unlikely(idx >= dom_parser.len)) {
+      static constexpr uint8_t unpadded_eof_sentinel = 0;
+      return &unpadded_eof_sentinel;
+    }
   }
   return &buf[idx];
 }

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -248,10 +248,24 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
 }
 
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  return &buf[*(next_structural)];
+  // Stage 1 plants a sentinel structural index of value `len` after the last
+  // real structural (json_structural_indexer::finish). Reading buf[len] is only
+  // valid with SIMDJSON_PADDING. For parse_unpadded, return a static dummy so
+  // walk_document can report TAPE_ERROR without a 1-byte heap OOB (#2815).
+  const uint32_t idx = *(next_structural);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline const uint8_t *json_iterator::advance() noexcept {
-  return &buf[*(next_structural++)];
+  const uint32_t idx = *(next_structural++);
+  if (simdjson_unlikely(dom_parser._unpadded && idx >= dom_parser.len)) {
+    static constexpr uint8_t unpadded_eof_sentinel = 0;
+    return &unpadded_eof_sentinel;
+  }
+  return &buf[idx];
 }
 simdjson_inline size_t json_iterator::remaining_len() const noexcept {
   return dom_parser.len - *(next_structural-1);

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -42,9 +42,6 @@ public:
    *
    * - increment_count(iter) - each time a value is found in an array or object.
    */
-  // UNPADDED is a compile-time constant chosen once per document in
-  // tape_builder::parse_document (from the runtime _unpadded flag). The padded
-  // instantiation of walk_document / peek / advance has no unpadded branches.
   template<bool STREAMING, bool UNPADDED, typename V>
   simdjson_warn_unused simdjson_inline error_code walk_document(V &visitor) noexcept;
 
@@ -61,9 +58,6 @@ public:
    * Tokens can be strings, numbers, booleans, null, or operators (`[{]},:`)).
    *
    * They may include invalid JSON as well (such as `1.2.3` or `ture`).
-   *
-   * When UNPADDED is true, a stage-1 sentinel index of value `len` returns a
-   * static dummy byte instead of reading past the buffer (#2815).
    */
   template<bool UNPADDED>
   simdjson_inline const uint8_t *peek() const noexcept;
@@ -73,9 +67,6 @@ public:
    * Tokens can be strings, numbers, booleans, null, or operators (`[{]},:`)).
    *
    * They may include invalid JSON as well (such as `1.2.3` or `ture`).
-   *
-   * When UNPADDED is true, a stage-1 sentinel index of value `len` returns a
-   * static dummy byte instead of reading past the buffer (#2815).
    */
   template<bool UNPADDED>
   simdjson_inline const uint8_t *advance() noexcept;
@@ -258,13 +249,10 @@ simdjson_inline json_iterator::json_iterator(dom_parser_implementation &_dom_par
     dom_parser{_dom_parser} {
 }
 
+// Stage 1 leaves a sentinel index of value `len`; reading buf[len] requires
+// padding. For UNPADDED, return a dummy so walk_document can fail cleanly (#2815).
 template<bool UNPADDED>
 simdjson_inline const uint8_t *json_iterator::peek() const noexcept {
-  // Stage 1 plants a sentinel structural index of value `len` after the last
-  // real structural (json_structural_indexer::finish). Reading buf[len] is only
-  // valid with SIMDJSON_PADDING. For the UNPADDED=true instantiation, return a
-  // static dummy so walk_document can report TAPE_ERROR without a 1-byte heap
-  // OOB (#2815). The UNPADDED=false (padded) instantiation has no check.
   const uint32_t idx = *(next_structural);
   SIMDJSON_IF_CONSTEXPR (UNPADDED) {
     if (simdjson_unlikely(idx >= dom_parser.len)) {

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -111,12 +111,14 @@ struct tape_builder {
       dom_parser_implementation &dom_parser, dom::document &doc) noexcept {
     dom_parser.doc = &doc;
     json_iterator iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
+    // One runtime branch on _unpadded; inside the walk, UNPADDED is a
+    // compile-time constant for both the visitor and peek/advance.
     if (dom_parser._unpadded) {
       tape_builder_impl<true> builder(doc);
-      return iter.walk_document<STREAMING>(builder);
+      return iter.walk_document<STREAMING, true>(builder);
     } else {
       tape_builder_impl<false> builder(doc);
-      return iter.walk_document<STREAMING>(builder);
+      return iter.walk_document<STREAMING, false>(builder);
     }
   }
 };

--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -111,8 +111,6 @@ struct tape_builder {
       dom_parser_implementation &dom_parser, dom::document &doc) noexcept {
     dom_parser.doc = &doc;
     json_iterator iter(dom_parser, STREAMING ? dom_parser.next_structural_index : 0);
-    // One runtime branch on _unpadded; inside the walk, UNPADDED is a
-    // compile-time constant for both the visitor and peek/advance.
     if (dom_parser._unpadded) {
       tape_builder_impl<true> builder(doc);
       return iter.walk_document<STREAMING, true>(builder);

--- a/tests/dom/unpadded_tests.cpp
+++ b/tests/dom/unpadded_tests.cpp
@@ -379,6 +379,30 @@ bool degenerate_inputs() {
   TEST_SUCCEED();
 }
 
+// Regression for https://github.com/simdjson/simdjson/issues/2815:
+// when the last real structural is a nested closing bracket/brace and the
+// outer container is still open, stage2's array_continue / object_continue
+// advance() past the final structural index. Stage 1 plants a sentinel index
+// equal to `len` there; reading buf[len] is a 1-byte OOB on an exact-size
+// (unpadded) buffer. Under ASAN this must not crash, and padded/unpadded must
+// agree on TAPE_ERROR (or equivalent).
+bool truncated_nested_containers() {
+  TEST_START();
+  // The three cases from the issue report:
+  //   "[[]"      -- array path  (json_iterator array_continue)
+  //   "{\"a\":{}" -- object path (json_iterator object_continue)
+  //   "{\"a\":{ }" -- same object path with whitespace before EOF
+  const std::vector<std::string> docs = {
+    "[[]",
+    "{\"a\":{}",
+    "{\"a\":{ }",
+  };
+  for (const auto &d : docs) {
+    if (!check_matches(d)) { return false; }
+  }
+  TEST_SUCCEED();
+}
+
 #if SIMDJSON_ENABLE_NAN_INF
 // Only built with -DSIMDJSON_ENABLE_NAN_INF=ON. The non-root inf validator does
 // an 8-byte 'infinity' compare; a malformed inf-spelling at the very end of an
@@ -413,6 +437,7 @@ bool run() {
          surrogate_pair_deep_lookahead_at_chunk_boundary() &&
          assorted_documents() &&
          degenerate_inputs() &&
+         truncated_nested_containers() &&
          random_documents() &&
          real_files() &&
          api_overloads();

--- a/tests/dom/unpadded_tests.cpp
+++ b/tests/dom/unpadded_tests.cpp
@@ -379,19 +379,9 @@ bool degenerate_inputs() {
   TEST_SUCCEED();
 }
 
-// Regression for https://github.com/simdjson/simdjson/issues/2815:
-// when the last real structural is a nested closing bracket/brace and the
-// outer container is still open, stage2's array_continue / object_continue
-// advance() past the final structural index. Stage 1 plants a sentinel index
-// equal to `len` there; reading buf[len] is a 1-byte OOB on an exact-size
-// (unpadded) buffer. Under ASAN this must not crash, and padded/unpadded must
-// agree on TAPE_ERROR (or equivalent).
+// Truncated nested containers (issue #2815): must not over-read unpadded input.
 bool truncated_nested_containers() {
   TEST_START();
-  // The three cases from the issue report:
-  //   "[[]"      -- array path  (json_iterator array_continue)
-  //   "{\"a\":{}" -- object path (json_iterator object_continue)
-  //   "{\"a\":{ }" -- same object path with whitespace before EOF
   const std::vector<std::string> docs = {
     "[[]",
     "{\"a\":{}",


### PR DESCRIPTION
## Summary

Fixes #2815.

`dom::parser::parse_unpadded()` is documented to never read past `buf + len`. Stage 1 always plants a **sentinel structural index of value `len`** after the last real structural character. On the normal padded path, `buf[len]` is in the padding region and is safe to read. On the unpadded path it is a **1-byte heap-buffer-overflow**.

That path is hit when stage2 still needs another token after the final real structural — specifically when a nested `]`/`}` has closed an inner container but the outer one is still open:

| Input | Stage2 state |
|-------|----------------|
| `[[]` | `array_continue` after empty/inner close |
| `{"a":{}` | `object_continue` after inner close |
| `{"a":{ }` | same, with trailing whitespace |

ASan reports the read exactly on the red zone at `buf + len`. The padded `parse()` path does not crash; it returns `TAPE_ERROR`.

### Fix

In `json_iterator::peek()` / `advance()`, when `_unpadded` is set and the structural index is `>= len`, return a pointer to a static dummy byte (`0`) instead of `&buf[idx]`. The walk then falls into the usual `default` branches and returns `TAPE_ERROR`, matching padded parse.

The padded hot path only pays a predictably-false `simdjson_unlikely(_unpadded && …)` check.

### Tests

New `truncated_nested_containers` in `tests/dom/unpadded_tests.cpp` covers the three issue cases via `check_matches` (exact-size `std::vector` buffer + ASan-friendly over-read detection, and agreement with padded parse).

## Test plan

- [x] `./build/tests/dom/unpadded_tests` (includes new regression)
- [x] ASan standalone repro of the three PoCs: no heap-buffer-overflow; `TAPE_ERROR`
- [x] Valid controls `[[]]` / `{"a":{}}` still succeed unpadded under ASan
- [ ] CI (including address-sanitizer job)