### PR TITLE
fix: LTO workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,24 @@ if(WIN32 AND BUILD_SHARED_LIBS)
   )
 endif()
 
+
+# MSVC doesn't support shared-lib + LTO.
+# This is a workaround to make sure both are never used together
+if(SIMDJSON_WINDOWS_DLL) # MSVC + Shared; defined in developer-options.cmake
+  if(CMAKE_INTERPROCEDURAL_OPTIMIZATION
+      OR CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG
+      OR CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE
+      OR CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO
+      OR CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL)
+    message(WARNING "simdjson: MSVC does not support a shared library with LTO, \
+    turning INTERPROCEDURAL_OPTIMIZATION off.")
+  endif()
+  # turn off outside of previous block because BUILD_SHARED_LIBS + SIMDJSON_BUILD_STATIC (see l:36)
+  foreach(config IN ITEMS "" _DEBUG _RELEASE _RELWITHDEBINFO _MINSIZEREL)
+    set_property(TARGET simdjson PROPERTY INTERPROCEDURAL_OPTIMIZATION${config} OFF)
+  endforeach()
+endif()
+
 simdjson_add_props(
     target_include_directories
     PUBLIC "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,6 @@ if(SIMDJSON_WINDOWS_DLL) # MSVC + Shared; defined in developer-options.cmake
     message(WARNING "simdjson: MSVC does not support a shared library with LTO, \
     turning INTERPROCEDURAL_OPTIMIZATION off.")
   endif()
-  # turn off outside of previous block because BUILD_SHARED_LIBS + SIMDJSON_BUILD_STATIC (see l:36)
   foreach(config IN ITEMS "" _DEBUG _RELEASE _RELWITHDEBINFO _MINSIZEREL)
     set_property(TARGET simdjson PROPERTY INTERPROCEDURAL_OPTIMIZATION${config} OFF)
   endforeach()

--- a/HACKING.md
+++ b/HACKING.md
@@ -32,6 +32,9 @@ It is similar for Visual Studio users, please see the CMake or Visual Studio doc
 
 By default the library is built in Release mode.
 
+IPO available through `-D CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON`.
+Option is unavailable for a shared library under Visual Studio, where we turn it back off and warn. (MSVC incompatibility)
+
 
 Assertions and development checks
 ------------------------------

--- a/cmake/developer-options.cmake
+++ b/cmake/developer-options.cmake
@@ -138,13 +138,6 @@ if(SIMDJSON_STRUCTURAL_INDEXER_STEP)
   message(STATUS "Setting SIMDJSON_STRUCTURAL_INDEXER_STEP to ${SIMDJSON_STRUCTURAL_INDEXER_STEP}.")
   add_compile_definitions(SIMDJSON_STRUCTURAL_INDEXER_STEP=${SIMDJSON_STRUCTURAL_INDEXER_STEP})
 endif()
-# LTO seems to create all sorts of fun problems. Let us
-# disable temporarily.
-#include(CheckIPOSupported)
-#check_ipo_supported(RESULT ltoresult)
-#if(ltoresult)
-#  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
-#endif()
 
 option(SIMDJSON_VISUAL_STUDIO_BUILD_WITH_DEBUG_INFO_FOR_PROFILING "\
 Under Visual Studio, add Zi to the compile flag and DEBUG to the link file to \


### PR DESCRIPTION
### Summary

This PR adds a guard, when MSVC builds the shared library, INTERPROCEDURAL_OPTIMIZATION (IPO) is forced off on the simdjson target and a warning is emitted. The user's IPO setting is left alone; so MSVC static builds, other targets, and every other toolchain still get LTO.

The issue (#451) was MSVC's `/GL` (LTO) optimization produces non-COFF objects that bindexplib (used by `WINDOWS_EXPORT_ALL_SYMBOLS`) can't read, causing empty export tables and link errors (only affecting DLL).


### What This PR does not
1) It does not solve #451 (MSVC + DLL + LTO), but only make it usable everywhere else
2) It doesn't add/update any CI


### Bench
Serialization benchmark with twitter.json 
| Benchmark | noLTO (MB/s) | LTO (MB/s) | % Change |
|-----------|--------------|-----------|----------|
| static_reflection | 10,965.87 | 11,707.39 | +6.76% |
| reuse_buffer | 14,246.01 | 15,452.13 | +8.47% |
| to | 9,657.98 | 10,123.93 | +4.82% |
| to_reuse | 9,697.22 | 10,060.99 | +3.75% |
| reflect_cpp | 1,698.18 | 1,723.98 | +1.52% |
| Binary Size (bloaty) | 1.41 Mi | 819 Ki | -41.91% |

> CPU: AMD Ryzen 5 7600X (6cores)
> Governor: Performance
> Boost: ON

---
I made the documentation lightweight for users, happy to expand it based on your feedback !!

Furthermore, I could only test this on g++ and clang, release developer-mode build with `-D CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` compiles and passes tests. 

Two things need eyes on Windows (i was not able to test myself):
 - the guard itself, i.e.: `cmake -B build -D BUILD_SHARED_LIBS=ON -D CMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` now produces a working DLL instead of failing;
 - `BUILD_SHARED_LIBS=ON` + `SIMDJSON_BUILD_STATIC_LIB=ON` scenario, where simdjson loses LTO but simdjson_static keeps it.