### PR TITLE
Reject malformed big integers with trailing non-structural characters

### DIFF
--- a/src/generic/stage2/tape_builder.h
+++ b/src/generic/stage2/tape_builder.h
@@ -239,6 +239,9 @@ simdjson_warn_unused simdjson_inline error_code tape_builder_impl<UNPADDED>::vis
     const uint8_t *p = num;
     if (*p == '-') p++;
     while (numberparsing::is_digit(*p)) p++;
+    // The digit run must be terminated by a structural or whitespace character; otherwise the
+    // token is malformed (e.g. "123456789123456789123x").
+    if (jsoncharutils::is_not_structural_or_whitespace(*p)) { return NUMBER_ERROR; }
     size_t len = size_t(p - num);
     tape.append(current_string_buf_loc - iter.dom_parser.doc->string_buf.get(), internal::tape_type::BIGINT);
     uint8_t *dst = current_string_buf_loc + sizeof(uint32_t);

--- a/tests/dom/big_integer_tests.cpp
+++ b/tests/dom/big_integer_tests.cpp
@@ -159,6 +159,21 @@ namespace big_integer_tests {
     TEST_SUCCEED();
   }
 
+  bool rejects_trailing_garbage() {
+    TEST_START();
+    dom::parser parser;
+    parser.number_as_string(true);
+    // A big integer whose digit run is followed by a non-structural, non-whitespace character is
+    // a malformed token and must be rejected, just as it is for numbers that fit in 64 bits.
+    ASSERT_ERROR(parser.parse(R"({"val":123456789012345678901x})"_padded), NUMBER_ERROR);
+    ASSERT_ERROR(parser.parse(R"({"val":-123456789012345678901x})"_padded), NUMBER_ERROR);
+    // Same at the top level of a document.
+    ASSERT_ERROR(parser.parse("123456789012345678901x"_padded), NUMBER_ERROR);
+    // A well-formed big integer terminated by a structural character is still accepted.
+    ASSERT_SUCCESS(parser.parse(R"({"val":123456789012345678901})"_padded));
+    TEST_SUCCEED();
+  }
+
   bool run() {
     return option_off_by_default() &&
            default_returns_bigint_error() &&
@@ -170,7 +185,8 @@ namespace big_integer_tests {
            serialization_preserves_digits() &&
            normal_numbers_unaffected() &&
            type_checks() &&
-           element_type_output();
+           element_type_output() &&
+           rejects_trailing_garbage();
   }
 
 } // namespace big_integer_tests


### PR DESCRIPTION
Short title (summary): Reject malformed big integers with trailing non-structural characters

Description
When `number_as_string` is enabled, `visit_number` writes a big integer's digit run to the string buffer without validating the character that follows it. As a result, malformed tokens such as `123456789123456789123x` are silently accepted as valid JSON.

`parse_number` performs an `is_not_structural_or_whitespace` terminator check for numbers that fit in 64 bits (returning `NUMBER_ERROR` otherwise), but the big-integer path returns `BIGINT_NUMBER` before reaching it, so nothing validates the terminator for big integers.

This adds the same terminator check to the big-integer branch of `visit_number`.

Motivation
ClickHouse uses `number_as_string` to support big integers in its `JSON` data type. Without this check, invalid JSON where a big integer is followed by garbage is accepted. We need this fix for: https://github.com/ClickHouse/ClickHouse/pull/114379

Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to verify / test
I added a regression test (`rejects_trailing_garbage`) covering object, negative, and root-level trailing garbage, as well as a valid case.

Please read before contributing:
- CONTRIBUTING: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md
- HACKING: https://github.com/simdjson/simdjson/blob/master/HACKING.md
- AI Usage Policy: https://github.com/simdjson/simdjson/blob/master/AI_USAGE_POLICY.md


If you can, we recommend running our tests with the sanitizers turned on.
For non-Visual Studio users, it is as easy as doing:



```bash
cmake -B build -D SIMDJSON_SANITIZE=ON -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build
```


Our CI checks, among other things, for trailing whitespace. If a test fails for that reason,
use the "artifacts" button to download the artifact and inspect the problematic lines,
or run `scripts/remove_trailing_whitespace.sh` locally if you have a bash shell and `sed`.


Checklist before submitting
- [ ] I added/updated tests covering my change (if applicable)
- [ ] Code builds locally and passes my check
- [ ] Documentation / README updated if needed
- [ ] Commits are atomic and messages are clear
- [ ] I linked the related issue (if applicable)

Final notes
- For large PRs, prefer smaller incremental PRs or request staged review.

Thanks for the contribution!

