### PR TITLE
Fix failing just_ascii test (em dashes in comments)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -558,8 +558,9 @@ if(FIND_CMD AND FILE_CMD AND GREP_CMD)
       NAME just_ascii
       COMMAND sh -c "\
 non_ascii=$(${FIND_CMD} include src windows tools singleheader tests examples benchmark \
-  -path benchmark/checkperf-reference -prune -name '*.h' -o -name '*.cpp' \
-  -type f -exec ${FILE_CMD} '{}' \; | ${GREP_CMD} -v ASCII); \
+  -path benchmark/checkperf-reference -prune -o \
+  '(' -type f '(' -name '*.h' -o -name '*.cpp' ')' -exec ${FILE_CMD} '{}' \; ')' \
+  | ${GREP_CMD} -v ASCII); \
 if [ -n \"$non_ascii\" ]; then \
   echo 'The following files contain non-ASCII characters:'; \
   echo \"$non_ascii\"; \

--- a/benchmark/partial_tweets/simdjson_ondemand_key_selector.h
+++ b/benchmark/partial_tweets/simdjson_ondemand_key_selector.h
@@ -13,7 +13,7 @@ struct simdjson_ondemand_key_selector {
 
   ondemand::parser parser{};
 
-  // Compile-time selectors — all PHF tables are static constexpr, so every
+  // Compile-time selectors -- all PHF tables are static constexpr, so every
   // call to match_raw fully inlines.
   using tweet_sel_t = ondemand::key_selector<
       "created_at", "id", "text", "in_reply_to_status_id",

--- a/include/simdjson/annotations.h
+++ b/include/simdjson/annotations.h
@@ -16,7 +16,7 @@
 
 namespace simdjson {
 
-// Structural compile-time string — char array avoids the pointer-based
+// Structural compile-time string -- char array avoids the pointer-based
 // 'reflect_constant failed' that occurs with const char* / string_view members.
 template <size_t N>
 struct fixed_string {

--- a/include/simdjson/dom/parser.h
+++ b/include/simdjson/dom/parser.h
@@ -555,7 +555,7 @@ public:
    * example, a padded_memory_map), with no extra copy. Without this overload,
    * passing a padded_string_view would silently bind to the padded_string
    * overload via an implicit conversion, allocating and copying the input, and
-   * — because that temporary is destroyed at the end of the full-expression —
+   * -- because that temporary is destroyed at the end of the full-expression --
    * leaving the returned document_stream pointing at freed memory. */
   inline simdjson_result<document_stream> parse_many(const padded_string_view &v, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
 

--- a/include/simdjson/dom/serialization-inl.h
+++ b/include/simdjson/dom/serialization-inl.h
@@ -480,7 +480,7 @@ inline void string_builder<serializer>::append(simdjson::dom::element value) {
       format.string(iter.get_string_view());
       break;
     case tape_type::BIGINT: {
-      // Big integer stored as string — output raw digits (no quotes)
+      // Big integer stored as string -- output raw digits (no quotes)
       auto sv = iter.get_string_view();
       format.chars(sv.data(), sv.data() + sv.size());
       break;

--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -139,7 +139,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -147,7 +147,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -353,7 +353,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>

--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -765,7 +765,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.

--- a/include/simdjson/padded_string-inl.h
+++ b/include/simdjson/padded_string-inl.h
@@ -432,7 +432,7 @@ simdjson_inline padded_memory_map::~padded_memory_map() noexcept {
 // Windows zero-copy implementation using placeholder virtual memory.
 //
 // We use the modern Windows memory APIs (VirtualAlloc2, CreateFileMapping2,
-// MapViewOfFile3 — available since Windows 10 1803) to map the file into a
+// MapViewOfFile3 -- available since Windows 10 1803) to map the file into a
 // contiguous virtual address range that includes at least SIMDJSON_PADDING
 // zero bytes after the file content, with no data copies.
 //

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -318,7 +318,7 @@ using std::size_t;
 // the Windows version macros, and the link library themselves.
 //
 // If the opt-in conditions are not met on Windows, `padded_memory_map`
-// simply does not exist — any attempt to use it fails at compile time
+// simply does not exist -- any attempt to use it fails at compile time
 // with an "unknown identifier" diagnostic rather than silently degrading.
 //
 // The SIMDJSON_HAS_PADDED_MEMORY_MAP macro reflects whether the class is

--- a/singleheader/simdjson.cpp
+++ b/singleheader/simdjson.cpp
@@ -506,7 +506,7 @@ using std::size_t;
 // the Windows version macros, and the link library themselves.
 //
 // If the opt-in conditions are not met on Windows, `padded_memory_map`
-// simply does not exist — any attempt to use it fails at compile time
+// simply does not exist -- any attempt to use it fails at compile time
 // with an "unknown identifier" diagnostic rather than silently degrading.
 //
 // The SIMDJSON_HAS_PADDED_MEMORY_MAP macro reflects whether the class is

--- a/singleheader/simdjson.h
+++ b/singleheader/simdjson.h
@@ -526,7 +526,7 @@ using std::size_t;
 // the Windows version macros, and the link library themselves.
 //
 // If the opt-in conditions are not met on Windows, `padded_memory_map`
-// simply does not exist — any attempt to use it fails at compile time
+// simply does not exist -- any attempt to use it fails at compile time
 // with an "unknown identifier" diagnostic rather than silently degrading.
 //
 // The SIMDJSON_HAS_PADDED_MEMORY_MAP macro reflects whether the class is
@@ -5440,7 +5440,7 @@ simdjson_inline padded_memory_map::~padded_memory_map() noexcept {
 // Windows zero-copy implementation using placeholder virtual memory.
 //
 // We use the modern Windows memory APIs (VirtualAlloc2, CreateFileMapping2,
-// MapViewOfFile3 — available since Windows 10 1803) to map the file into a
+// MapViewOfFile3 -- available since Windows 10 1803) to map the file into a
 // contiguous virtual address range that includes at least SIMDJSON_PADDING
 // zero bytes after the file content, with no data copies.
 //
@@ -6588,7 +6588,7 @@ public:
    * example, a padded_memory_map), with no extra copy. Without this overload,
    * passing a padded_string_view would silently bind to the padded_string
    * overload via an implicit conversion, allocating and copying the input, and
-   * — because that temporary is destroyed at the end of the full-expression —
+   * -- because that temporary is destroyed at the end of the full-expression --
    * leaving the returned document_stream pointing at freed memory. */
   inline simdjson_result<document_stream> parse_many(const padded_string_view &v, size_t batch_size = dom::DEFAULT_BATCH_SIZE) noexcept;
 
@@ -11501,7 +11501,7 @@ inline void string_builder<serializer>::append(simdjson::dom::element value) {
       format.string(iter.get_string_view());
       break;
     case tape_type::BIGINT: {
-      // Big integer stored as string — output raw digits (no quotes)
+      // Big integer stored as string -- output raw digits (no quotes)
       auto sv = iter.get_string_view();
       format.chars(sv.data(), sv.data() + sv.size());
       break;
@@ -40199,7 +40199,7 @@ simdjson_inline implementation_simdjson_result_base<T>::implementation_simdjson_
 
 namespace simdjson {
 
-// Structural compile-time string — char array avoids the pointer-based
+// Structural compile-time string -- char array avoids the pointer-based
 // 'reflect_constant failed' that occurs with const char* / string_view members.
 template <size_t N>
 struct fixed_string {
@@ -41645,7 +41645,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -41653,7 +41653,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -41859,7 +41859,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -42955,7 +42955,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -44131,7 +44131,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -44139,7 +44139,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -44345,7 +44345,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -45441,7 +45441,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -47094,7 +47094,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -47102,7 +47102,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -47308,7 +47308,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -48404,7 +48404,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -50057,7 +50057,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -50065,7 +50065,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -50271,7 +50271,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -51367,7 +51367,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -53135,7 +53135,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -53143,7 +53143,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -53349,7 +53349,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -54445,7 +54445,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -56520,7 +56520,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -56528,7 +56528,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -56734,7 +56734,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -57830,7 +57830,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -59395,7 +59395,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -59403,7 +59403,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -59609,7 +59609,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -60705,7 +60705,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -62293,7 +62293,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -62301,7 +62301,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -62507,7 +62507,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -63603,7 +63603,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.
@@ -65194,7 +65194,7 @@ template <class T>
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Inline the escape path through the writer so we never round-trip
   // pos through memory for string fields (Twitter is dominated by
-  // these — sync/reload around each string was a real cost).
+  // these -- sync/reload around each string was a real cost).
   std::string_view input;
   if constexpr (std::is_same_v<T, char>) {
     input = std::string_view(&t, 1);
@@ -65202,7 +65202,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &t) {
     input = std::string_view(t);
   }
   // Worst-case escape: every byte expands to \uXXXX (6 chars), plus 2 quotes.
-  // Guard against 2 + 6 * input.size() wrapping for huge inputs — if it
+  // Guard against 2 + 6 * input.size() wrapping for huge inputs -- if it
   // wrapped to a small value, ensure() would spuriously succeed and the
   // subsequent escape would overflow the buffer.
   // Note that this is pedantic except maybe on 32-bit targets.
@@ -65408,7 +65408,7 @@ simdjson_really_inline constexpr void atom(writer &w, const T &container) {
   w.ptr[w.pos++] = ']';
 }
 
-// append() — top-level entry. Each overload constructs a stack-local
+// append() -- top-level entry. Each overload constructs a stack-local
 // writer, runs atom(w, t) through the inlined call chain, then syncs
 // the local position back into the string_builder.
 template <class T>
@@ -66504,7 +66504,7 @@ static const char decimal_table[200] = {
 };
 
 // Forward unsigned-int writer (cascade-on-magnitude, no upfront digit_count).
-// Built from a non-recursive DAG of always_inline helpers — gcc and MSVC
+// Built from a non-recursive DAG of always_inline helpers -- gcc and MSVC
 // refuse to inline recursive `always_inline`/`__forceinline` functions.
 // Caller must guarantee at least 20 bytes available at p. All helpers
 // return pointer past the last digit written.


### PR DESCRIPTION
The `just_ascii` test is currently failing on `master`, and therefore on every open pull request (e.g. #2819, #2820). It is not caused by any of those PRs.

## Symptom

```
The following files contain non-ASCII characters:
singleheader/simdjson.cpp: C source, Unicode text, UTF-8 text
1 - just_ascii (Failed)
```

Reproduced on master run [31504358553](https://github.com/simdjson/simdjson/actions/runs/31504358553) (Ubuntu 22.04 CI, CLANG 14).

## Cause

Eight source files contain U+2014 EM DASH (`—`) in comments:

| File | Lines |
| --- | --- |
| `include/simdjson/annotations.h` | 19 |
| `include/simdjson/portability.h` | 321 |
| `include/simdjson/padded_string-inl.h` | 435 |
| `include/simdjson/dom/parser.h` | 558 |
| `include/simdjson/dom/serialization-inl.h` | 483 |
| `include/simdjson/generic/builder/json_builder.h` | 142, 150, 356 |
| `include/simdjson/generic/builder/json_string_builder-inl.h` | 768 |
| `benchmark/partial_tweets/simdjson_ondemand_key_selector.h` | 16 |

The em dash is the only non-ASCII character anywhere in the scanned tree. Those headers get amalgamated into `singleheader/simdjson.cpp`, which is what the test reported.

## Fix

Replace each em dash with an ASCII `--`, in the eight sources and in the checked-in amalgamation (`singleheader/simdjson.{h,cpp}` — the repeated hits there are just the per-implementation copies of the same comments, so the edit matches what regeneration produces).

## Also: a `find` precedence bug that hid this

```sh
find ... -path X -prune -name "*.h" -o -name "*.cpp" -type f -exec file {} \;
```

`-o` binds looser than the implicit `-a`, so this parsed as:

```sh
( -path X -a -prune -a -name "*.h" ) -o ( -name "*.cpp" -a -type f -a -exec file {} \; )
```

Only `.cpp` files were ever handed to `file(1)`, and the prune branch could never match (a directory is not named `*.h`). Headers could carry non-ASCII indefinitely and were caught only indirectly, once amalgamated into a `.cpp`.

Parenthesizing the name tests restores the intent. The scan now covers **530** files instead of **150**, and the prune actually prunes.

## Verification

Ran the generated `ctest` target against the patched tree:

- passes on the fixed tree;
- appending a single em dash to `include/simdjson/portability.h` makes it fail with `include/simdjson/portability.h: c program text, Unicode text, UTF-8 text`, confirming headers are now genuinely checked (before this change that canary was invisible);
- surveyed `file(1)` output across all 530 newly-in-scope files: every one reports `ASCII text`, and there are no empty files (which `file` would report as `empty` and trip the grep).

Verified with BSD `find`; the `-path ... -prune -o ( ... )` form is the standard POSIX idiom and behaves identically under GNU findutils, which CI will confirm.