### PR TITLE
feat: serialize/deserialize std::chrono::system_clock::time_point (#2447)

### DIFF
--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -9,7 +9,10 @@
 #if SIMDJSON_STATIC_REFLECTION
 
 #include <charconv>
+#include <chrono>
+#include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <meta>
 #include <memory>
 #include <optional>
@@ -195,6 +198,43 @@ simdjson_really_inline constexpr void atom(writer &w, const T &m) {
 }
 
 
+template <typename T>
+inline constexpr bool is_system_clock_time_point_v = false;
+template <typename Duration>
+inline constexpr bool is_system_clock_time_point_v<
+    std::chrono::time_point<std::chrono::system_clock, Duration>> = true;
+
+// Serialize std::chrono::system_clock::time_point as an ISO 8601 UTC string
+// with second precision, e.g. "2024-01-15T10:30:00Z" (see #2447).
+template <typename Duration>
+simdjson_really_inline void atom(
+    writer &w,
+    const std::chrono::time_point<std::chrono::system_clock, Duration> &tp) {
+  using clock = std::chrono::system_clock;
+  const auto secs = std::chrono::time_point_cast<std::chrono::seconds>(tp);
+  const std::time_t tt = clock::to_time_t(secs);
+  std::tm tm_buf{};
+#if defined(_WIN32)
+  if (gmtime_s(&tm_buf, &tt) != 0) {
+    return;
+  }
+#else
+  if (gmtime_r(&tt, &tm_buf) == nullptr) {
+    return;
+  }
+#endif
+  // "YYYY-MM-DDTHH:MM:SSZ" is 20 characters.
+  char buf[32];
+  const int n = std::snprintf(
+      buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02dZ", tm_buf.tm_year + 1900,
+      tm_buf.tm_mon + 1, tm_buf.tm_mday, tm_buf.tm_hour, tm_buf.tm_min,
+      tm_buf.tm_sec);
+  if (n != 20) {
+    return;
+  }
+  atom(w, std::string_view(buf, static_cast<size_t>(n)));
+}
+
 template<typename number_type,
          typename = typename std::enable_if<std::is_arithmetic<number_type>::value && !std::is_same_v<number_type, char>>::type>
 simdjson_really_inline constexpr void atom(writer &w, const number_type t) {
@@ -241,7 +281,8 @@ template <class T>
            !std::is_same_v<T, std::string> &&
            !std::is_same_v<T, std::string_view> &&
            !std::is_same_v<T, const char*> &&
-           !std::is_same_v<T, char> && !require_custom_serialization<T>)
+           !std::is_same_v<T, char> && !require_custom_serialization<T> &&
+           !is_system_clock_time_point_v<T>)
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   // Per-field block: ensure key+value worst case, then write key + value
   // through the writer's local pos. For arithmetic fields, the integer
@@ -411,6 +452,15 @@ simdjson_inline void append(string_builder &b, const T &t) {
 }
 
 // works for struct
+template <typename Duration>
+simdjson_inline void append(
+    string_builder &b,
+    const std::chrono::time_point<std::chrono::system_clock, Duration> &tp) {
+  writer w(b);
+  atom(w, tp);
+  w.sync();
+}
+
 template <class Z>
   requires(std::is_class_v<Z> && !concepts::container_but_not_string<Z> &&
            !concepts::string_view_keyed_map<Z> &&
@@ -420,7 +470,8 @@ template <class Z>
            !std::is_same_v<Z, std::string> &&
            !std::is_same_v<Z, std::string_view> &&
            !std::is_same_v<Z, const char*> &&
-           !std::is_same_v<Z, char> && !require_custom_serialization<Z>)
+           !std::is_same_v<Z, char> && !require_custom_serialization<Z> &&
+           !is_system_clock_time_point_v<Z>)
 simdjson_inline void append(string_builder &b, const Z &z) {
   writer w(b);
   atom(w, z);

--- a/include/simdjson/generic/ondemand/std_deserialize.h
+++ b/include/simdjson/generic/ondemand/std_deserialize.h
@@ -9,6 +9,7 @@
 #include "simdjson/annotations.h"
 #endif // SIMDJSON_CONDITIONAL_INCLUDE
 
+#include <chrono>
 #include <concepts>
 #include <limits>
 #if SIMDJSON_STATIC_REFLECTION
@@ -19,9 +20,102 @@
 
 namespace simdjson {
 
+namespace chrono_deserialize_detail {
+
+// Parse a 2-digit decimal field. Returns false if either character is not a digit.
+simdjson_inline bool parse_2(const char *p, int &out) noexcept {
+  if (p[0] < '0' || p[0] > '9' || p[1] < '0' || p[1] > '9') {
+    return false;
+  }
+  out = (p[0] - '0') * 10 + (p[1] - '0');
+  return true;
+}
+
+simdjson_inline bool parse_4(const char *p, int &out) noexcept {
+  int hi = 0;
+  int lo = 0;
+  if (!parse_2(p, hi) || !parse_2(p + 2, lo)) {
+    return false;
+  }
+  out = hi * 100 + lo;
+  return true;
+}
+
+// Parse ISO 8601 UTC timestamps such as "2024-01-15T10:30:00Z".
+// Optional fractional seconds (e.g. ".123") are accepted and truncated to whole seconds.
+template <typename Duration>
+simdjson_inline bool parse_iso8601_utc(
+    std::string_view s,
+    std::chrono::time_point<std::chrono::system_clock, Duration> &out) noexcept {
+  if (s.size() < 20) {
+    return false;
+  }
+  const char *p = s.data();
+  if (p[4] != '-' || p[7] != '-' || p[10] != 'T' || p[13] != ':' || p[16] != ':') {
+    return false;
+  }
+  int year = 0;
+  int month = 0;
+  int day = 0;
+  int hour = 0;
+  int minute = 0;
+  int second = 0;
+  if (!parse_4(p, year) || !parse_2(p + 5, month) || !parse_2(p + 8, day) ||
+      !parse_2(p + 11, hour) || !parse_2(p + 14, minute) || !parse_2(p + 17, second)) {
+    return false;
+  }
+  if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59 ||
+      second > 60) {
+    return false;
+  }
+  size_t pos = 19;
+  if (pos < s.size() && s[pos] == '.') {
+    ++pos;
+    if (pos >= s.size() || s[pos] < '0' || s[pos] > '9') {
+      return false;
+    }
+    while (pos < s.size() && s[pos] >= '0' && s[pos] <= '9') {
+      ++pos;
+    }
+  }
+  if (pos >= s.size() || (s[pos] != 'Z' && s[pos] != 'z')) {
+    return false;
+  }
+  if (pos + 1 != s.size()) {
+    return false;
+  }
+  const std::chrono::year_month_day ymd{std::chrono::year{year},
+                                        std::chrono::month{static_cast<unsigned>(month)},
+                                        std::chrono::day{static_cast<unsigned>(day)}};
+  if (!ymd.ok()) {
+    return false;
+  }
+  const std::chrono::sys_days days{ymd};
+  const auto tp = days + std::chrono::hours{hour} + std::chrono::minutes{minute} +
+                  std::chrono::seconds{second};
+  out = std::chrono::time_point_cast<Duration>(tp);
+  return true;
+}
+
+} // namespace chrono_deserialize_detail
+
 //////////////////////////////
 // Number deserialization
 //////////////////////////////
+
+// Deserialize std::chrono::system_clock::time_point from an ISO 8601 UTC string
+// (second precision), e.g. "2024-01-15T10:30:00Z" (see #2447).
+template <typename Duration, typename ValT>
+error_code tag_invoke(
+    deserialize_tag, ValT &val,
+    std::chrono::time_point<std::chrono::system_clock, Duration> &out) noexcept {
+  std::string_view s;
+  SIMDJSON_TRY(val.get_string().get(s));
+  if (!chrono_deserialize_detail::parse_iso8601_utc(s, out)) {
+    return INCORRECT_TYPE;
+  }
+  return SUCCESS;
+}
 
 template <std::unsigned_integral T>
 error_code tag_invoke(deserialize_tag, auto &val, T &out) noexcept {
@@ -264,9 +358,15 @@ error_code tag_invoke(deserialize_tag, auto &val, T &out) noexcept(nothrow_deser
 
 
 template <typename T>
+constexpr bool is_system_clock_time_point_v = false;
+template <typename Duration>
+constexpr bool is_system_clock_time_point_v<
+    std::chrono::time_point<std::chrono::system_clock, Duration>> = true;
+
+template <typename T>
 constexpr bool user_defined_type = (std::is_class_v<T>
 && !std::is_same_v<T, std::string> && !std::is_same_v<T, std::string_view> && !concepts::optional_type<T> &&
-!concepts::appendable_containers<T>);
+!concepts::appendable_containers<T> && !is_system_clock_time_point_v<T>);
 
 
 // key_selector_reflection_detail is defined unconditionally (it only requires

--- a/tests/builder/CMakeLists.txt
+++ b/tests/builder/CMakeLists.txt
@@ -9,6 +9,7 @@ if(SIMDJSON_STATIC_REFLECTION_ENABLED)
   add_cpp_test(static_reflection_enum_tests              LABELS ondemand acceptance per_implementation)
   add_cpp_test(static_reflection_fractured_json_tests    LABELS ondemand acceptance per_implementation)
   add_cpp_test(static_reflection_annotations_tests       LABELS ondemand acceptance per_implementation)
+  add_cpp_test(static_reflection_chrono_tests            LABELS ondemand acceptance per_implementation)
 endif(SIMDJSON_STATIC_REFLECTION_ENABLED)
 # Copy the simdjson dll into the tests directory
 if(MSVC AND BUILD_SHARED_LIBS)

--- a/tests/builder/static_reflection_chrono_tests.cpp
+++ b/tests/builder/static_reflection_chrono_tests.cpp
@@ -1,0 +1,98 @@
+#include "simdjson.h"
+#include "test_builder.h"
+#include <chrono>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace simdjson;
+
+namespace builder_tests {
+
+#if SIMDJSON_STATIC_REFLECTION
+
+struct Meeting {
+  std::string title;
+  std::chrono::system_clock::time_point start_time;
+  std::vector<std::string> attendees;
+  std::optional<std::string> location;
+  bool is_recurring;
+};
+
+bool test_meeting_roundtrip() {
+  TEST_START();
+  // Truncate to whole seconds so ISO-8601 second precision round-trips exactly.
+  const auto start = std::chrono::time_point_cast<std::chrono::seconds>(
+      std::chrono::system_clock::from_time_t(1705314600)); // 2024-01-15T10:30:00Z
+  Meeting original{.title = "CppCon Planning",
+                   .start_time = start,
+                   .attendees = {"Alice", "Bob", "Charlie"},
+                   .location = "Denver",
+                   .is_recurring = true};
+
+  std::string json;
+  ASSERT_SUCCESS(to_json(original).get(json));
+  ASSERT_TRUE(json.find("\"2024-01-15T10:30:00Z\"") != std::string::npos);
+
+  ondemand::parser parser;
+  auto doc = parser.iterate(pad(json));
+  ASSERT_SUCCESS(doc);
+  Meeting deserialized;
+  ASSERT_SUCCESS(doc.get(deserialized));
+
+  ASSERT_EQUAL(deserialized.title, original.title);
+  ASSERT_EQUAL(deserialized.is_recurring, original.is_recurring);
+  ASSERT_TRUE(deserialized.location.has_value());
+  ASSERT_EQUAL(deserialized.location.value(), original.location.value());
+  ASSERT_EQUAL(deserialized.attendees.size(), original.attendees.size());
+  for (size_t i = 0; i < original.attendees.size(); i++) {
+    ASSERT_EQUAL(deserialized.attendees[i], original.attendees[i]);
+  }
+  ASSERT_TRUE(deserialized.start_time == original.start_time);
+  TEST_SUCCEED();
+}
+
+bool test_time_point_alone() {
+  TEST_START();
+  const auto tp = std::chrono::time_point_cast<std::chrono::seconds>(
+      std::chrono::system_clock::from_time_t(0)); // 1970-01-01T00:00:00Z
+  std::string json;
+  ASSERT_SUCCESS(to_json(tp).get(json));
+  ASSERT_EQUAL(json, "\"1970-01-01T00:00:00Z\"");
+
+  ondemand::parser parser;
+  auto doc = parser.iterate(pad(json));
+  ASSERT_SUCCESS(doc);
+  std::chrono::system_clock::time_point out;
+  ASSERT_SUCCESS(doc.get(out));
+  ASSERT_TRUE(out == tp);
+  TEST_SUCCEED();
+}
+
+bool test_reject_bad_timestamp() {
+  TEST_START();
+  auto json = R"("not-a-timestamp")"_padded;
+  ondemand::parser parser;
+  auto doc = parser.iterate(json);
+  ASSERT_SUCCESS(doc);
+  std::chrono::system_clock::time_point out;
+  ASSERT_ERROR(doc.get(out), INCORRECT_TYPE);
+  TEST_SUCCEED();
+}
+
+#endif // SIMDJSON_STATIC_REFLECTION
+
+bool run() {
+#if SIMDJSON_STATIC_REFLECTION
+  return test_meeting_roundtrip() && test_time_point_alone() &&
+         test_reject_bad_timestamp();
+#else
+  return true;
+#endif
+}
+
+} // namespace builder_tests
+
+int main(int argc, char *argv[]) {
+  return test_main(argc, argv, builder_tests::run);
+}


### PR DESCRIPTION
## Summary

Adds automatic serialize/deserialize support for `std::chrono::system_clock::time_point` under the reflection / concepts APIs (issue #2447).

## Format

ISO 8601 UTC with **second** precision, e.g. `"2024-01-15T10:30:00Z"`.

- Serialize: `system_clock::time_point` → quoted ISO 8601 string (`Z` suffix)
- Deserialize: same string form back to `time_point` (optional fractional seconds are accepted and truncated to whole seconds)
- Invalid timestamps yield `INCORRECT_TYPE`

This matches the interchange format discussed on the issue. Sub-second defaults / annotation-selected precision can be layered later without breaking this string form.

## Changes

- `json_builder.h`: writer `atom` / `append` overloads for `system_clock::time_point`
- `std_deserialize.h`: `tag_invoke(deserialize_tag, …)` using C++20 `chrono` calendar types
- `static_reflection_chrono_tests.cpp`: round-trip + rejection tests

Fixes #2447
