### PR TITLE
docs: fix cmake -B build directory in HACKING.md

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -23,7 +23,7 @@ Build Quickstart
 For non-Windows system,
 
 ```bash
-cmake -B -D SIMDJSON_DEVELOPER_MODE=ON ..
+cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON .
 cmake --build build
 ctest --test-dir build
 ```
@@ -65,7 +65,7 @@ During development, if you system supports it, we recommend configuring
 the project with `-D SIMDJSON_SANITIZE=ON`.
 
 ```bash
-cmake -B -D SIMDJSON_SANITIZE=ON -D SIMDJSON_DEVELOPER_MODE=ON ..
+cmake -B build -D SIMDJSON_SANITIZE=ON -D SIMDJSON_DEVELOPER_MODE=ON .
 cmake --build build
 ctest --test-dir build
 ```


### PR DESCRIPTION
## Summary

Fixes broken CMake quickstart commands in `HACKING.md`.

`-B` requires a build-directory argument. The previous examples used `cmake -B -D …`, so CMake treated `-D` as the build directory name and the documented flow could not work.

## Change

Use the standard out-of-tree form:

```bash
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON .
cmake --build build
ctest --test-dir build
```

Same correction for the sanitizer quickstart block.
