### PR TITLE
Simplify and deduplicate `backslash_and_quote` across the SIMD kernels

### DIFF
--- a/include/simdjson/arm64/stringparsing_defs.h
+++ b/include/simdjson/arm64/stringparsing_defs.h
@@ -19,11 +19,8 @@ public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote

--- a/include/simdjson/fallback/stringparsing_defs.h
+++ b/include/simdjson/fallback/stringparsing_defs.h
@@ -15,13 +15,17 @@ public:
   static constexpr uint32_t BYTES_PROCESSED = 1;
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return c == '"'; }
-  simdjson_inline bool has_backslash() { return c == '\\'; }
-  simdjson_inline int quote_index() { return c == '"' ? 0 : 1; }
-  simdjson_inline int backslash_index() { return c == '\\' ? 0 : 1; }
-
   uint8_t c;
 }; // struct backslash_and_quote
+
+// The scalar fallback processes one byte per chunk, so its accessors inspect the
+// single stored byte rather than bitmasks. These non-template overloads are
+// preferred over the shared bitmask templates in src/generic/stage2/stringparsing.h
+// (which require `bs_bits`/`quote_bits` members that fallback does not have).
+simdjson_inline bool has_quote_first(const backslash_and_quote &b) { return b.c == '"'; }
+simdjson_inline bool has_backslash(const backslash_and_quote &b) { return b.c == '\\'; }
+simdjson_inline int quote_index(const backslash_and_quote &b) { return b.c == '"' ? 0 : 1; }
+simdjson_inline int backslash_index(const backslash_and_quote &b) { return b.c == '\\' ? 0 : 1; }
 
 simdjson_inline backslash_and_quote backslash_and_quote::copy_and_find(const uint8_t *src, uint8_t *dst) {
   // store to dest unconditionally - we can overwrite the bits we don't like later

--- a/include/simdjson/haswell/stringparsing_defs.h
+++ b/include/simdjson/haswell/stringparsing_defs.h
@@ -19,11 +19,8 @@ public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote

--- a/include/simdjson/haswell/stringparsing_defs.h
+++ b/include/simdjson/haswell/stringparsing_defs.h
@@ -20,7 +20,7 @@ public:
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }
+  simdjson_inline bool has_backslash() { return bs_bits != 0; }
   simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
   simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
 

--- a/include/simdjson/icelake/stringparsing_defs.h
+++ b/include/simdjson/icelake/stringparsing_defs.h
@@ -20,7 +20,7 @@ public:
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }
+  simdjson_inline bool has_backslash() { return bs_bits != 0; }
   simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
   simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
 

--- a/include/simdjson/icelake/stringparsing_defs.h
+++ b/include/simdjson/icelake/stringparsing_defs.h
@@ -19,11 +19,8 @@ public:
   static constexpr uint32_t BYTES_PROCESSED = 64;
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint64_t bs_bits;
   uint64_t quote_bits;
 }; // struct backslash_and_quote

--- a/include/simdjson/lasx/stringparsing_defs.h
+++ b/include/simdjson/lasx/stringparsing_defs.h
@@ -19,11 +19,8 @@ public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote

--- a/include/simdjson/lsx/stringparsing_defs.h
+++ b/include/simdjson/lsx/stringparsing_defs.h
@@ -19,11 +19,8 @@ public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote

--- a/include/simdjson/ppc64/stringparsing_defs.h
+++ b/include/simdjson/ppc64/stringparsing_defs.h
@@ -20,17 +20,8 @@ public:
   simdjson_inline backslash_and_quote
   copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() {
-    return ((bs_bits - 1) & quote_bits) != 0;
-  }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() {
-    return trailing_zeroes(quote_bits);
-  }
-  simdjson_inline int backslash_index() {
-    return trailing_zeroes(bs_bits);
-  }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote

--- a/include/simdjson/rvv-vls/stringparsing_defs.h
+++ b/include/simdjson/rvv-vls/stringparsing_defs.h
@@ -17,11 +17,8 @@ public:
   static constexpr uint64_t BYTES_PROCESSED = sizeof(simd8<uint8_t>);
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint64_t bs_bits;
   uint64_t quote_bits;
 }; // struct backslash_and_quote

--- a/include/simdjson/rvv-vls/stringparsing_defs.h
+++ b/include/simdjson/rvv-vls/stringparsing_defs.h
@@ -18,7 +18,7 @@ public:
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
   simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return ((quote_bits - 1) & bs_bits) != 0; }
+  simdjson_inline bool has_backslash() { return bs_bits != 0; }
   simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
   simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
 

--- a/include/simdjson/westmere/stringparsing_defs.h
+++ b/include/simdjson/westmere/stringparsing_defs.h
@@ -1,8 +1,11 @@
 #ifndef SIMDJSON_WESTMERE_STRINGPARSING_DEFS_H
 #define SIMDJSON_WESTMERE_STRINGPARSING_DEFS_H
 
-#include "simdjson/westmere/bitmanipulation.h"
+#ifndef SIMDJSON_CONDITIONAL_INCLUDE
+#include "simdjson/westmere/base.h"
 #include "simdjson/westmere/simd.h"
+#include "simdjson/westmere/bitmanipulation.h"
+#endif // SIMDJSON_CONDITIONAL_INCLUDE
 
 namespace simdjson {
 namespace westmere {
@@ -16,11 +19,8 @@ public:
   static constexpr uint32_t BYTES_PROCESSED = 32;
   simdjson_inline backslash_and_quote copy_and_find(const uint8_t *src, uint8_t *dst);
 
-  simdjson_inline bool has_quote_first() { return ((bs_bits - 1) & quote_bits) != 0; }
-  simdjson_inline bool has_backslash() { return bs_bits != 0; }
-  simdjson_inline int quote_index() { return trailing_zeroes(quote_bits); }
-  simdjson_inline int backslash_index() { return trailing_zeroes(bs_bits); }
-
+  // Position logic is shared: see the free accessor templates in
+  // src/generic/stage2/stringparsing.h.
   uint32_t bs_bits;
   uint32_t quote_bits;
 }; // struct backslash_and_quote

--- a/src/generic/stage2/stringparsing.h
+++ b/src/generic/stage2/stringparsing.h
@@ -16,6 +16,55 @@ namespace {
 /// @private
 namespace stringparsing {
 
+/**
+ * Shared accessor logic for `backslash_and_quote`, the per-implementation helper
+ * that locates unescaped quotes and backslashes in a processed chunk.
+ *
+ * Each SIMD kernel keeps only the raw bitmasks (`bs_bits`, `quote_bits`) plus its
+ * architecture-specific `copy_and_find()`. The byte-identical position logic
+ * below lives here, once, instead of being duplicated once per kernel.
+ *
+ * These are free-function templates so they resolve correctly for every kernel
+ * (the mask type is `uint32_t` where 32 bytes are processed per chunk and
+ * `uint64_t` where 64 bytes are processed). The scalar `fallback` implementation
+ * has a structurally different `backslash_and_quote` (a single byte rather than
+ * bitmasks); it provides its own non-template overloads in its kernel namespace,
+ * which overload resolution prefers over these templates.
+ */
+// `has_quote_first()` is true iff the lowest bit set in quote_bits precedes the
+// lowest bit set in bs_bits.
+template <typename T>
+simdjson_inline bool has_quote_first(const T &b) {
+  // This is the number of bits of quotes before the first backslash: if it is
+  // nonzero, the first quote comes before the first backslash.
+  return ((b.bs_bits - 1) & b.quote_bits) != 0;
+}
+
+/**
+ * True iff there is at least one backslash in the chunk.
+ *
+ * `has_quote_first()` and `has_backslash()` are exact complements whenever any
+ * backslash or quote is present. The string parsing loops call
+ * `has_quote_first()` first and return immediately on a leading quote, so
+ * `has_backslash()` is only evaluated when no quote precedes any backslash; in
+ * that state the position-aware mask `((quote_bits - 1) & bs_bits)` reduces to
+ * `bs_bits != 0`.
+ */
+template <typename T>
+simdjson_inline bool has_backslash(const T &b) { return b.bs_bits != 0; }
+
+// Returns the position (in bytes) of the first quote in the chunk.
+template <typename T>
+simdjson_inline int quote_index(const T &b) {
+  return trailing_zeroes(b.quote_bits);
+}
+
+// Returns the position (in bytes) of the first backslash in the chunk.
+template <typename T>
+simdjson_inline int backslash_index(const T &b) {
+  return trailing_zeroes(b.bs_bits);
+}
+
 // begin copypasta
 // These chars yield themselves: " \ /
 // b -> backspace, f -> formfeed, n -> newline, r -> cr, t -> horizontal tab
@@ -154,13 +203,13 @@ simdjson_warn_unused simdjson_inline uint8_t *parse_string(const uint8_t *src, u
     auto b = backslash_and_quote{};
     auto bs_quote = b.copy_and_find(src, dst);
     // If the next thing is the end quote, copy and return
-    if (bs_quote.has_quote_first()) {
+    if (has_quote_first(bs_quote)) {
       // we encountered quotes first. Move dst to point to quotes and exit
-      return dst + bs_quote.quote_index();
+      return dst + quote_index(bs_quote);
     }
-    if (bs_quote.has_backslash()) {
+    if (has_backslash(bs_quote)) {
       /* find out where the backspace is */
-      auto bs_dist = bs_quote.backslash_index();
+      auto bs_dist = backslash_index(bs_quote);
       uint8_t escape_char = src[bs_dist + 1];
       /* we encountered backslash first. Handle backslash */
       if (escape_char == 'u') {
@@ -223,11 +272,11 @@ simdjson_warn_unused simdjson_inline uint8_t *parse_string_safe(const uint8_t *s
   while (src + SIMDJSON_PADDING + 12 <= buf_end) {
     auto b = backslash_and_quote{};
     auto bs_quote = b.copy_and_find(src, dst);
-    if (bs_quote.has_quote_first()) {
-      return dst + bs_quote.quote_index();
+    if (has_quote_first(bs_quote)) {
+      return dst + quote_index(bs_quote);
     }
-    if (bs_quote.has_backslash()) {
-      auto bs_dist = bs_quote.backslash_index();
+    if (has_backslash(bs_quote)) {
+      auto bs_dist = backslash_index(bs_quote);
       uint8_t escape_char = src[bs_dist + 1];
       if (escape_char == 'u') {
         src += bs_dist;
@@ -271,13 +320,13 @@ simdjson_warn_unused simdjson_inline uint8_t *parse_wobbly_string(const uint8_t 
     auto b = backslash_and_quote{};
     auto bs_quote = b.copy_and_find(src, dst);
     // If the next thing is the end quote, copy and return
-    if (bs_quote.has_quote_first()) {
+    if (has_quote_first(bs_quote)) {
       // we encountered quotes first. Move dst to point to quotes and exit
-      return dst + bs_quote.quote_index();
+      return dst + quote_index(bs_quote);
     }
-    if (bs_quote.has_backslash()) {
+    if (has_backslash(bs_quote)) {
       /* find out where the backspace is */
-      auto bs_dist = bs_quote.backslash_index();
+      auto bs_dist = backslash_index(bs_quote);
       uint8_t escape_char = src[bs_dist + 1];
       /* we encountered backslash first. Handle backslash */
       if (escape_char == 'u') {


### PR DESCRIPTION
## Description

Simplified `has_backslash()` to use the plain `bs_bits != 0` form in `haswell`, `icelake`, and `rvv-vls` (matching the other kernels), then deduplicated the four byte-identical `backslash_and_quote` accessor methods (`has_quote_first`, `has_backslash`, `quote_index`, `backslash_index`) across all eight SIMD kernels into free-function templates in the generic consumer header `src/generic/stage2/stringparsing.h`. Each SIMD struct is now pure data (`bs_bits`/`quote_bits` + `copy_and_find()`), and `fallback` keeps its scalar semantics via non-template overloads that win overload resolution.

## Type of change

- [ ] Bug fix
- [ ] Optimization
- [ ] New feature
- [x] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

## How to verify / test

- Behavior is unchanged: the shared template bodies are character-for-character identical to the code they replace, and `fallback`'s non-template overloads preserve its scalar path.
- Native `arm64` and `fallback` builds compile clean, and a correctness harness covering escapes (`\n`, `\t`, `\"`, `\\`), `\uXXXX` unicode, surrogate pairs (emoji), and mixed nested documents passes on both the default and forced-`fallback` paths.
- The remaining kernels (`haswell`, `icelake`, `westmere`, `ppc64`, `lasx`, `lsx`, `rvv-vls`) are natively compiled and tested by the existing CI matrix (x86, aarch64, ppc64le, loongarch64, riscv64 / rvv) on every pull request.

Please read before contributing:
- CONTRIBUTING: https://github.com/simdjson/simdjson/blob/master/CONTRIBUTING.md
- HACKING: https://github.com/simdjson/simdjson/blob/master/HACKING.md
- AI Usage Policy: https://github.com/simdjson/simdjson/blob/master/AI_USAGE_POLICY.md

If you can, we recommend running our tests with the sanitizers turned on.
For non-Visual Studio users, it is as easy as doing:

```bash
cmake -B build -D SIMDJSON_SANITIZE=ON -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build
```

Our CI checks, among other things, for trailing whitespace. If a test fails for that reason,
use the "artifacts" button to download the artifact and inspect the problematic lines,
or run `scripts/remove_trailing_whitespace.sh` locally if you have a bash shell and `sed`.

## Checklist before submitting

- [ ] I added/updated tests covering my change (if applicable)
- [x] Code builds locally and passes my check
- [ ] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear
- [ ] I linked the related issue (if applicable)

## Final notes

- For large PRs, prefer smaller incremental PRs or request staged review.

Thanks for the contribution!