### PR TITLE
Fix ambiguous atom()/append() on optional serialization (#2827)

### DIFF
--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -138,9 +138,15 @@ concept string_like =
 // Concept that checks if a type is a container but not a string (because
 // strings handling must be handled differently)
 // Now uses iterator-based approach for broader container support
+//
+// Optional types are excluded on purpose. Since C++26 (P3168), std::optional
+// is itself a range, so without the exclusion an std::optional would match
+// both this concept and optional_type, making the container and the optional
+// overloads of atom()/append() ambiguous. See issue 2827.
 template <typename T>
 concept container_but_not_string =
-  std::ranges::input_range<T> && !string_like<T> && !concepts::string_view_keyed_map<T>;
+  std::ranges::input_range<T> && !string_like<T> && !concepts::string_view_keyed_map<T>
+  && !concepts::optional_type<T>;
 
 
 

--- a/include/simdjson/generic/builder/json_builder.h
+++ b/include/simdjson/generic/builder/json_builder.h
@@ -108,7 +108,7 @@ simdjson_really_inline void call_through_string_builder(writer &w, F &&f) noexce
 }
 
 template <class T>
-  requires(concepts::container_but_not_string<T> && ! concepts::optional_type<T> && !require_custom_serialization<T>)
+  requires(concepts::container_but_not_string<T> && !require_custom_serialization<T>)
 simdjson_really_inline constexpr void atom(writer &w, const T &t) {
   auto it = t.begin();
   auto end = t.end();

--- a/tests/builder/builder_string_builder_tests.cpp
+++ b/tests/builder/builder_string_builder_tests.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <limits>
 #include <map>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -737,6 +738,44 @@ bool serialize_optional() {
   ASSERT_EQUAL(p, "null");
   TEST_SUCCEED();
 }
+
+// https://github.com/simdjson/simdjson/issues/2827
+// Since C++26 (P3168), std::optional is itself a range, so an optional
+// used to match both the container and the optional serialization overloads.
+// These calls must compile and pick the optional overload.
+bool issue2827_optional_serialization() {
+  TEST_START();
+  std::string json;
+
+  std::optional<std::string> optional_string = "bar";
+  ASSERT_SUCCESS(simdjson::to_json(optional_string, json));
+  ASSERT_EQUAL(json, "\"bar\"");
+
+  std::optional<std::string> empty_string = std::nullopt;
+  ASSERT_SUCCESS(simdjson::to_json(empty_string, json));
+  ASSERT_EQUAL(json, "null");
+
+  std::optional<int> optional_int = 3;
+  ASSERT_SUCCESS(simdjson::to_json(optional_int, json));
+  ASSERT_EQUAL(json, "3");
+
+  std::optional<int> empty_int = std::nullopt;
+  ASSERT_SUCCESS(simdjson::to_json(empty_int, json));
+  ASSERT_EQUAL(json, "null");
+
+  std::vector<std::optional<int>> vector_of_optionals = {1, std::nullopt, 3};
+  ASSERT_SUCCESS(simdjson::to_json(vector_of_optionals, json));
+  ASSERT_EQUAL(json, "[1,null,3]");
+
+  std::optional<std::vector<int>> optional_vector = std::vector<int>{1, 2};
+  ASSERT_SUCCESS(simdjson::to_json(optional_vector, json));
+  ASSERT_EQUAL(json, "[1,2]");
+
+  std::optional<std::vector<int>> empty_vector = std::nullopt;
+  ASSERT_SUCCESS(simdjson::to_json(empty_vector, json));
+  ASSERT_EQUAL(json, "null");
+  TEST_SUCCEED();
+}
 #endif
 
 #if SIMDJSON_SUPPORTS_RANGES && SIMDJSON_SUPPORTS_CONCEPTS
@@ -897,6 +936,7 @@ bool run() {
 #endif
 #if SIMDJSON_SUPPORTS_CONCEPTS
          issue2549() && car_test_template() && serialize_optional() &&
+         issue2827_optional_serialization() &&
 #endif
          append_char() && append_integer() && append_float() && append_null() &&
 #if SIMDJSON_ENABLE_NAN_INF

--- a/tests/builder/static_reflection_edge_cases_tests.cpp
+++ b/tests/builder/static_reflection_edge_cases_tests.cpp
@@ -202,11 +202,65 @@ namespace builder_tests {
   }
 
 
+  // https://github.com/simdjson/simdjson/issues/2827
+  // Since C++26, std::optional is a range, so it used to match both the
+  // container and the optional serialization overloads.
+  bool test_issue2827_optional() {
+    TEST_START();
+#if SIMDJSON_STATIC_REFLECTION
+    struct Foo {
+      std::optional<std::string> maybe{};
+    };
+
+    Foo foo{"bar"};
+    std::string json;
+    ASSERT_SUCCESS(simdjson::to_json(foo).get(json));
+    ASSERT_EQUAL(json, "{\"maybe\":\"bar\"}");
+
+    Foo empty;
+    ASSERT_SUCCESS(simdjson::to_json(empty).get(json));
+    ASSERT_EQUAL(json, "{\"maybe\":null}");
+
+    // Optionals used directly, not as a struct member.
+    std::optional<std::string> optional_string = "bar";
+    ASSERT_SUCCESS(simdjson::to_json(optional_string).get(json));
+    ASSERT_EQUAL(json, "\"bar\"");
+
+    std::optional<std::string> empty_string = std::nullopt;
+    ASSERT_SUCCESS(simdjson::to_json(empty_string).get(json));
+    ASSERT_EQUAL(json, "null");
+
+    std::optional<Foo> optional_struct = Foo{"x"};
+    ASSERT_SUCCESS(simdjson::to_json(optional_struct).get(json));
+    ASSERT_EQUAL(json, "{\"maybe\":\"x\"}");
+
+    std::vector<std::optional<int>> vector_of_optionals = {1, std::nullopt, 3};
+    ASSERT_SUCCESS(simdjson::to_json(vector_of_optionals).get(json));
+    ASSERT_EQUAL(json, "[1,null,3]");
+
+    std::optional<std::vector<int>> optional_vector = std::vector<int>{1, 2};
+    ASSERT_SUCCESS(simdjson::to_json(optional_vector).get(json));
+    ASSERT_EQUAL(json, "[1,2]");
+
+    // Round-trip the struct.
+    ondemand::parser parser;
+    std::string document = "{\"maybe\":\"bar\"}";
+    auto doc_result = parser.iterate(pad(document));
+    ASSERT_SUCCESS(doc_result);
+    Foo deserialized;
+    ASSERT_SUCCESS(doc_result.get<Foo>().get(deserialized));
+    ASSERT_TRUE(deserialized.maybe.has_value());
+    ASSERT_EQUAL(*deserialized.maybe, "bar");
+#endif
+    TEST_SUCCEED();
+  }
+
   bool run() {
     return test_empty_values() &&
            test_special_characters() &&
            test_numeric_limits() &&
-           test_nested_structures();
+           test_nested_structures() &&
+           test_issue2827_optional();
   }
 
 } // namespace builder_tests


### PR DESCRIPTION
Fixes #2827.

## Problem

Since C++26 ([P3168](https://wg21.link/p3168), *Give `std::optional` Range Support*), `std::optional` is itself a range. `simdjson::concepts::container_but_not_string` is defined as `std::ranges::input_range<T> && !string_like<T> && !string_view_keyed_map<T>`, so it started matching `std::optional`. The container overload and the optional overload of `builder::atom()` then became equally good candidates, and reflection-based serialization of any struct holding an `std::optional` failed to compile under GCC 16 with `-std=c++26`:

```
error: call of overloaded 'atom(string_builder&, const std::optional<std::string>&)' is ambiguous
```

Master already carried a partial fix: a `!concepts::optional_type<T>` guard bolted onto the `atom()` container overload. But the corresponding `append()` container overload never got the same guard, so a top-level `simdjson::to_json(std::optional<T>)` was still ambiguous:

```
error: call of overloaded 'append(string_builder&, const std::optional<std::string>&)' is ambiguous
  candidate 1: append(string_builder&, const T&)  [optional overload]
  candidate 2: append(string_builder&, const Z&)  [container overload]
```

## Fix

Address the root cause rather than patching each overload: exclude optional types from `container_but_not_string`. An optional is never serialized as a JSON array, so it has no business satisfying a "this is a container" concept. That covers every overload keyed off the concept -- `atom()`, `append()`, and any future use -- so the bolted-on guard in `atom()` is removed as redundant.

Every overload that uses `!container_but_not_string<T>` as a *negative* guard (the struct and appendable-container overloads) already carries its own `!concepts::optional_type<T>`, so widening `!container_but_not_string` for optionals does not open a new ambiguity there.

## Tests

- `tests/builder/builder_string_builder_tests.cpp` (compiled with and without reflection): top-level `to_json` of `optional<string>`, `optional<int>`, `nullopt`, `vector<optional<int>>`, `optional<vector<int>>`.
- `tests/builder/static_reflection_edge_cases_tests.cpp` (reflection only): the exact reproducer from the issue -- a struct with an `std::optional<std::string>` member -- plus `optional<struct>`, the nested vector/optional combinations, and a deserialization round trip.

## Verification

- GCC 16.1.0, `-std=c++26 -freflection`, `SIMDJSON_STATIC_REFLECTION=ON`: full build clean, `ctest` 137/137 pass.
- Host clang (no reflection): full build clean, `ctest` 119/119 pass.
- The issue's reproducer now emits `{"maybe":"bar"}`; `to_json(std::optional<std::string>{"bar"})` emits `"bar"` and `std::nullopt` emits `null`.