### PR TITLE
Add get_float() to the On-Demand API

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -499,7 +499,7 @@ support for users who avoid exceptions. See [the simdjson error handling documen
 * **Extracting Values:** You can cast a JSON element to a native type:
   `double(element)`. This works for `std::string_view`, double, uint64_t, int64_t, bool,
   ondemand::object and ondemand::array. We also have explicit methods such as `get_string()`, `get_double()`,
-  `get_uint64()`, `get_int64()`, `get_uint32()`, `get_int32()`, `get_bool()`, `get_object()` and `get_array()`. After a cast or an explicit method,
+  `get_uint64()`, `get_int64()`, `get_uint32()`, `get_int32()`, `get_float()`, `get_bool()`, `get_object()` and `get_array()`. After a cast or an explicit method,
   the number, string or boolean will be parsed, or the initial `{` or `[` will be verified for `ondemand::object` and `ondemand::array`. An exception may be thrown if
   the cast is not possible: the error code is `simdjson::INCORRECT_TYPE` (see [Error handling](#error-handling)). Importantly, when getting an ondemand::object or ondemand::array instance, its content is
   not validated: you are only guaranteed that the corresponding initial character (`{` or `[`) is present. Thus,
@@ -509,10 +509,12 @@ support for users who avoid exceptions. See [the simdjson error handling documen
   pass `true` (`get_string(true)`) as a parameter to get replacement characters where errors
   occur. If you somehow need to access non-UTF-8 strings in a lossless manner
   (e.g., if you strings contain unpaired surrogates), you may use the `get_wobbly_string()` function to get a string in the [WTF-8 format](https://simonsapin.github.io/wtf-8).
-  When calling `get_uint64()`, `get_int64()`, `get_uint32()` or `get_int32()`, if the number does not fit in the
-  corresponding integer type, it is also considered an error (`NUMBER_OUT_OF_RANGE`). When parsing numbers or other scalar values, the library checks
+  When calling `get_uint64()`, `get_int64()`, `get_uint32()`, `get_int32()` or `get_float()`, if the number does not fit in the
+  corresponding type, it is also considered an error (`NUMBER_OUT_OF_RANGE`). When parsing numbers or other scalar values, the library checks
   that the value is followed by an expected character, thus you *may* get a number parsing error when accessing the digits
   as an integer in the following strings: `{"number":12332a`, `{"number":12332\0`, `{"number":12332` (the digits appear at the end). We always abide by the [RFC 8259](https://www.tbray.org/ongoing/When/201x/2017/12/14/rfc8259.html) JSON specification so that, for example, numbers prefixed by the `+` sign are in error.
+  Note that `get_float()` first parses the value as a double and then narrows it to a float: in rare cases very close to a float
+  rounding boundary, this can produce a different (but still correctly rounded for double) result than parsing directly to a float would.
 
   > IMPORTANT NOTE: values can only be parsed once. Since documents are *iterators*, once you have
   > parsed a value (such as by casting to double), you cannot get at it again. It is an error to call

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -151,6 +151,17 @@ simdjson_inline simdjson_result<double> document::get_double() noexcept {
 simdjson_inline simdjson_result<double> document::get_double_in_string() noexcept {
   return get_root_value_iterator().get_root_double_in_string(true);
 }
+simdjson_inline simdjson_result<float> document::get_float() noexcept {
+  double result;
+  SIMDJSON_TRY(get_double().get(result));
+  constexpr double float_max = double((std::numeric_limits<float>::max)());
+  if (result > float_max || result < -float_max) {
+    if (result != std::numeric_limits<double>::infinity() && result != -std::numeric_limits<double>::infinity()) {
+      return NUMBER_OUT_OF_RANGE;
+    }
+  }
+  return static_cast<float>(result);
+}
 simdjson_inline simdjson_result<std::string_view> document::get_string(bool allow_replacement) noexcept {
   return get_root_value_iterator().get_root_string(true, allow_replacement);
 }
@@ -176,6 +187,7 @@ template<> simdjson_inline simdjson_result<object> document::get() & noexcept { 
 template<> simdjson_inline simdjson_result<raw_json_string> document::get() & noexcept { return get_raw_json_string(); }
 template<> simdjson_inline simdjson_result<std::string_view> document::get() & noexcept { return get_string(false); }
 template<> simdjson_inline simdjson_result<double> document::get() & noexcept { return get_double(); }
+template<> simdjson_inline simdjson_result<float> document::get() & noexcept { return get_float(); }
 template<> simdjson_inline simdjson_result<uint64_t> document::get() & noexcept { return get_uint64(); }
 template<> simdjson_inline simdjson_result<int64_t> document::get() & noexcept { return get_int64(); }
 template<> simdjson_inline simdjson_result<uint32_t> document::get() & noexcept { return get_uint32(); }
@@ -188,6 +200,7 @@ template<> simdjson_warn_unused simdjson_inline error_code document::get(object&
 template<> simdjson_warn_unused simdjson_inline error_code document::get(raw_json_string& out) & noexcept { return get_raw_json_string().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(std::string_view& out) & noexcept { return get_string(false).get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(double& out) & noexcept { return get_double().get(out); }
+template<> simdjson_warn_unused simdjson_inline error_code document::get(float& out) & noexcept { return get_float().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(uint64_t& out) & noexcept { return get_uint64().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(int64_t& out) & noexcept { return get_int64().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(uint32_t& out) & noexcept { return get_uint32().get(out); }
@@ -544,6 +557,10 @@ simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION:
   if (error()) { return error(); }
   return first.get_double_in_string();
 }
+simdjson_inline simdjson_result<float> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_float() noexcept {
+  if (error()) { return error(); }
+  return first.get_float();
+}
 simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_string(bool allow_replacement) noexcept {
   if (error()) { return error(); }
   return first.get_string(allow_replacement);
@@ -783,6 +800,17 @@ simdjson_inline simdjson_result<int32_t> document_reference::get_int32() noexcep
 }
 simdjson_inline simdjson_result<double> document_reference::get_double() noexcept { return doc->get_root_value_iterator().get_root_double(false); }
 simdjson_inline simdjson_result<double> document_reference::get_double_in_string() noexcept { return doc->get_root_value_iterator().get_root_double(false); }
+simdjson_inline simdjson_result<float> document_reference::get_float() noexcept {
+  double result;
+  SIMDJSON_TRY(doc->get_root_value_iterator().get_root_double(false).get(result));
+  constexpr double float_max = double((std::numeric_limits<float>::max)());
+  if (result > float_max || result < -float_max) {
+    if (result != std::numeric_limits<double>::infinity() && result != -std::numeric_limits<double>::infinity()) {
+      return NUMBER_OUT_OF_RANGE;
+    }
+  }
+  return static_cast<float>(result);
+}
 simdjson_inline simdjson_result<std::string_view> document_reference::get_string(bool allow_replacement) noexcept { return doc->get_root_value_iterator().get_root_string(false, allow_replacement); }
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code document_reference::get_string(string_type& receiver, bool allow_replacement) noexcept { return doc->get_root_value_iterator().get_root_string(receiver, false, allow_replacement); }
@@ -796,6 +824,7 @@ template<> simdjson_inline simdjson_result<object> document_reference::get() & n
 template<> simdjson_inline simdjson_result<raw_json_string> document_reference::get() & noexcept { return get_raw_json_string(); }
 template<> simdjson_inline simdjson_result<std::string_view> document_reference::get() & noexcept { return get_string(false); }
 template<> simdjson_inline simdjson_result<double> document_reference::get() & noexcept { return get_double(); }
+template<> simdjson_inline simdjson_result<float> document_reference::get() & noexcept { return get_float(); }
 template<> simdjson_inline simdjson_result<uint64_t> document_reference::get() & noexcept { return get_uint64(); }
 template<> simdjson_inline simdjson_result<int64_t> document_reference::get() & noexcept { return get_int64(); }
 template<> simdjson_inline simdjson_result<uint32_t> document_reference::get() & noexcept { return get_uint32(); }
@@ -952,6 +981,10 @@ simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION:
 simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_double_in_string() noexcept {
   if (error()) { return error(); }
   return first.get_double_in_string();
+}
+simdjson_inline simdjson_result<float> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_float() noexcept {
+  if (error()) { return error(); }
+  return first.get_float();
 }
 simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_string(bool allow_replacement) noexcept {
   if (error()) { return error(); }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -112,6 +112,23 @@ public:
    */
   simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
   /**
+   * Cast this JSON value to a 32-bit float.
+   *
+   * Calls get_double() and checks that the result fits in a float.
+   *
+   * @warning This first parses the number as a double and then narrows it to a float. This is
+   *          not always identical to parsing the number as a float directly: the intermediate
+   *          rounding to double can, in rare cases very close to a float rounding boundary,
+   *          produce a different (still correctly-rounded-for-double) result than a direct
+   *          decimal-to-float conversion would. This does not affect whether the value fits;
+   *          only the exact bit pattern in rare edge cases.
+   *
+   * @returns A 32-bit float.
+   * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
+   * @returns NUMBER_OUT_OF_RANGE If the value does not fit in a float.
+   */
+  simdjson_inline simdjson_result<float> get_float() noexcept;
+  /**
    * Cast this JSON value to a string.
    *
    * The string is guaranteed to be valid UTF-8.
@@ -856,6 +873,7 @@ public:
   simdjson_inline simdjson_result<int32_t> get_int32() noexcept;
   simdjson_inline simdjson_result<double> get_double() noexcept;
   simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;
@@ -1017,6 +1035,7 @@ public:
   simdjson_inline simdjson_result<int32_t> get_int32() noexcept;
   simdjson_inline simdjson_result<double> get_double() noexcept;
   simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;
@@ -1112,6 +1131,7 @@ public:
   simdjson_inline simdjson_result<int32_t> get_int32() noexcept;
   simdjson_inline simdjson_result<double> get_double() noexcept;
   simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -62,6 +62,19 @@ simdjson_inline simdjson_result<double> value::get_double() noexcept {
 simdjson_inline simdjson_result<double> value::get_double_in_string() noexcept {
   return iter.get_double_in_string();
 }
+simdjson_inline simdjson_result<float> value::get_float() noexcept {
+  double result;
+  SIMDJSON_TRY(get_double().get(result));
+  constexpr double float_max = double((std::numeric_limits<float>::max)());
+  if (result > float_max || result < -float_max) {
+    // A genuine Infinity is not an overflow; NaN fails the comparisons above
+    // and falls through to the cast unaffected.
+    if (result != std::numeric_limits<double>::infinity() && result != -std::numeric_limits<double>::infinity()) {
+      return NUMBER_OUT_OF_RANGE;
+    }
+  }
+  return static_cast<float>(result);
+}
 simdjson_inline simdjson_result<uint64_t> value::get_uint64() noexcept {
   return iter.get_uint64();
 }
@@ -99,6 +112,7 @@ template<> simdjson_inline simdjson_result<raw_json_string> value::get() noexcep
 template<> simdjson_inline simdjson_result<std::string_view> value::get() noexcept { return get_string(false); }
 template<> simdjson_inline simdjson_result<number> value::get() noexcept { return get_number(); }
 template<> simdjson_inline simdjson_result<double> value::get() noexcept { return get_double(); }
+template<> simdjson_inline simdjson_result<float> value::get() noexcept { return get_float(); }
 template<> simdjson_inline simdjson_result<uint64_t> value::get() noexcept { return get_uint64(); }
 template<> simdjson_inline simdjson_result<int64_t> value::get() noexcept { return get_int64(); }
 template<> simdjson_inline simdjson_result<uint32_t> value::get() noexcept { return get_uint32(); }
@@ -112,6 +126,7 @@ template<> simdjson_warn_unused simdjson_inline error_code value::get(raw_json_s
 template<> simdjson_warn_unused simdjson_inline error_code value::get(std::string_view& out) noexcept { return get_string(false).get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(number& out) noexcept { return get_number().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(double& out) noexcept { return get_double().get(out); }
+template<> simdjson_warn_unused simdjson_inline error_code value::get(float& out) noexcept { return get_float().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(uint64_t& out) noexcept { return get_uint64().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(int64_t& out) noexcept { return get_int64().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(uint32_t& out) noexcept { return get_uint32().get(out); }
@@ -440,6 +455,10 @@ simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION:
 simdjson_inline simdjson_result<double> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_double_in_string() noexcept {
   if (error()) { return error(); }
   return first.get_double_in_string();
+}
+simdjson_inline simdjson_result<float> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_float() noexcept {
+  if (error()) { return error(); }
+  return first.get_float();
 }
 simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string(bool allow_replacement) noexcept {
   if (error()) { return error(); }

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -200,6 +200,24 @@ public:
   simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
 
   /**
+   * Cast this JSON value to a 32-bit float.
+   *
+   * Calls get_double() and checks that the result fits in a float.
+   *
+   * @warning This first parses the number as a double and then narrows it to a float. This is
+   *          not always identical to parsing the number as a float directly: the intermediate
+   *          rounding to double can, in rare cases very close to a float rounding boundary,
+   *          produce a different (still correctly-rounded-for-double) result than a direct
+   *          decimal-to-float conversion would. This does not affect whether the value fits;
+   *          only the exact bit pattern in rare edge cases.
+   *
+   * @returns A 32-bit float.
+   * @returns INCORRECT_TYPE If the JSON value is not a valid floating-point number.
+   * @returns NUMBER_OUT_OF_RANGE If the value does not fit in a float.
+   */
+  simdjson_inline simdjson_result<float> get_float() noexcept;
+
+  /**
    * Cast this JSON value to a string.
    *
    * The string is guaranteed to be valid UTF-8.
@@ -780,6 +798,7 @@ public:
   simdjson_inline simdjson_result<int32_t> get_int32() noexcept;
   simdjson_inline simdjson_result<double> get_double() noexcept;
   simdjson_inline simdjson_result<double> get_double_in_string() noexcept;
+  simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;

--- a/tests/ondemand/ondemand_document_stream_tests.cpp
+++ b/tests/ondemand/ondemand_document_stream_tests.cpp
@@ -1061,6 +1061,18 @@ namespace document_stream_tests {
         TEST_SUCCEED();
     }
 
+    bool float_with_trailing() {
+        TEST_START();
+        auto json = R"( 133 badstuff )"_padded;
+        ondemand::parser parser;
+        ondemand::document_stream doc;
+        ASSERT_SUCCESS(parser.iterate_many(json).get(doc));
+        float x;
+        ASSERT_SUCCESS((*doc.begin()).get_float().get(x));
+        ASSERT_EQUAL(x,133.0f);
+        TEST_SUCCEED();
+    }
+
 
     bool bool_with_trailing() {
         TEST_START();
@@ -2515,6 +2527,7 @@ namespace document_stream_tests {
             int64_with_trailing() &&
             uint32_with_trailing() &&
             int32_with_trailing() &&
+            float_with_trailing() &&
             bool_with_trailing() &&
             null_with_trailing() &&
             truncated_utf8() &&

--- a/tests/ondemand/ondemand_error_tests.cpp
+++ b/tests/ondemand/ondemand_error_tests.cpp
@@ -221,6 +221,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -230,6 +231,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
@@ -248,6 +250,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -257,6 +260,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
@@ -274,6 +278,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -283,6 +288,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
@@ -300,6 +306,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -309,6 +316,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
@@ -331,6 +339,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -340,6 +349,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
@@ -358,6 +368,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -367,6 +378,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
@@ -383,6 +395,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -392,6 +405,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
@@ -408,6 +422,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
@@ -417,6 +432,7 @@ namespace error_tests {
       ASSERT_ERROR( val.get_uint32(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_int64(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_uint64(), INCORRECT_TYPE );
+      ASSERT_ERROR( val.get_float(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_double(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_string(), INCORRECT_TYPE );
       ASSERT_ERROR( val.get_array(), INCORRECT_TYPE );

--- a/tests/ondemand/ondemand_number_tests.cpp
+++ b/tests/ondemand/ondemand_number_tests.cpp
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <limits>
 #include "simdjson.h"
 #include "test_ondemand.h"
 
@@ -659,9 +660,84 @@ namespace number_tests {
     TEST_SUCCEED();
   }
 
+  bool get_float_values() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    float val;
+    padded_string docdata;
+
+    // Valid float values
+    docdata = "0"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_SUCCESS(doc.get_float().get(val));
+    ASSERT_EQUAL(val, 0.0f);
+
+    docdata = "42"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_SUCCESS(doc.get_float().get(val));
+    ASSERT_EQUAL(val, 42.0f);
+
+    docdata = "-1"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_SUCCESS(doc.get_float().get(val));
+    ASSERT_EQUAL(val, -1.0f);
+
+    docdata = "3.5"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_SUCCESS(doc.get_float().get(val));
+    ASSERT_EQUAL(val, 3.5f);
+
+    docdata = "3.4028234663852886e38"_padded; // FLT_MAX
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_SUCCESS(doc.get_float().get(val));
+    ASSERT_EQUAL(val, (std::numeric_limits<float>::max)());
+
+    // Underflow: matches static_cast<float>/strtof semantics, not an error
+    docdata = "1e-300"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_SUCCESS(doc.get_float().get(val));
+    ASSERT_EQUAL(val, 0.0f);
+
+    // Out of range
+    docdata = "1e300"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_ERROR(doc.get_float(), NUMBER_OUT_OF_RANGE);
+
+    docdata = "-1e300"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_ERROR(doc.get_float(), NUMBER_OUT_OF_RANGE);
+
+    // Test via value path
+    auto json = R"({"x": 42})"_padded;
+    ASSERT_SUCCESS(parser.iterate(json).get(doc));
+    ASSERT_SUCCESS(doc["x"].get_float().get(val));
+    ASSERT_EQUAL(val, 42.0f);
+
+    TEST_SUCCEED();
+  }
+
+  // Input sits just above the exact double-to-float rounding midpoint: direct
+  // decimal-to-float would round up, but rounding to double first lands exactly
+  // on the midpoint, and round-half-even then rounds down. Documents get_float()'s
+  // known double-rounding tradeoff; update this if it ever parses float directly.
+  bool get_float_double_rounding() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    float val;
+    auto docdata = "1.000000059604644775390625"_padded;
+    ASSERT_SUCCESS(parser.iterate(docdata).get(doc));
+    ASSERT_SUCCESS(doc.get_float().get(val));
+    ASSERT_EQUAL(val, 1.0f);
+    TEST_SUCCEED();
+  }
+
   bool run() {
     return get_int32_values() &&
            get_uint32_values() &&
+           get_float_values() &&
+           get_float_double_rounding() &&
            minus_zero() &&
            gigantic_big_int() &&
            big_int_not_zero() &&


### PR DESCRIPTION
Adds `get_float()` to the On-Demand API. `get_double()` was the only way to read a floating-point value, so callers needing a 4-byte float had to `static_cast` it themselves, which silently overflows to +-infinity for magnitudes beyond `FLT_MAX` with no diagnostic.

**Root cause:** no dedicated 32-bit float accessor exists in the On-Demand API, and the naive `static_cast<float>(get_double())` workaround has no overflow check.

**What changed:** `get_float()` on `ondemand::value`, `ondemand::document`, `document_reference`, and their `simdjson_result` wrappers. It parses as a double, then range-checks before narrowing: a finite value beyond `FLT_MAX` returns `NUMBER_OUT_OF_RANGE`, matching the behavior requested in the issue. A genuine `Infinity` (under `SIMDJSON_ENABLE_NAN_INF`) passes through unchanged, since it isn't an overflow. `document_reference::get_float()` calls `get_root_value_iterator().get_root_double(false)` directly rather than delegating to `document::get_float()`, so a value followed by more content (the next document in an `iterate_many` stream) isn't rejected as trailing garbage.

**Why this approach:** this mirrors `get_uint32()`/`get_int32()` (#2638), the closest prior art for this exact shape of addition. I discussed an alternative with @lemire: `get_float()` here parses through `get_double()` rather than the digits directly, which can occasionally produce a different (still correctly-rounded-for-double) result than a direct decimal-to-float conversion very close to a float rounding boundary. Confirmed this is real but noted it's the same tradeoff already accepted for the DOM API, as long as it's documented. I've done that in both the doc comments and `doc/basics.md`, and a test pins the current, known behavior on a constructed boundary case. Exact string-to-float parsing came up as a possible follow-up (`src/from_chars.cpp` already has a generic `binary_format<T>`, only `<double>` is specialized); but wasn't followed through.

**Tests:** new `get_float_values()` covering in-range values, the `FLT_MAX` boundary, overflow (`NUMBER_OUT_OF_RANGE`), and underflow (`1e-300` -> `0.0f`, not an error); `float_with_trailing()` for the streaming case; `INCORRECT_TYPE` coverage added alongside the existing `get_double()` checks in all 8 wrong-type blocks; and a test documenting the double-rounding tradeoff on a constructed input. Full suite (119/119) and the `ondemand`-labeled suite (58/58) pass, along with a C++17 build (no concepts path), a `SIMDJSON_ENABLE_NAN_INF=1` build, and a sanitizer build. I also confirmed the tests fail to compile without the implementation, by temporarily removing just the header changes.

**Limitations:** tested locally on macOS (Apple clang, arm64) only; I haven't verified other compilers/platforms locally and am relying on CI for that coverage.

Used AI assistance (Claude) moderately during development, mainly for boilerplate across the repeated `value`/`document`/`document_reference`/`simdjson_result` call sites and for double-checking the double-rounding analysis.

Closes #1792