### PR TITLE
SWAR key comparison in dom object lookup

### DIFF
--- a/benchmark/bench_dom_api.cpp
+++ b/benchmark/bench_dom_api.cpp
@@ -40,6 +40,58 @@ static void recover_one_string(State& state) {
 BENCHMARK(recover_one_string);
 
 
+// Builds an in-memory object with `n` keys ("key0".."keyN-1"), parses it once and
+// benchmarks repeated at_key lookups. This isolates object::iterator::key_equals. A fixed
+// set of keys is looked up so the workload is representative (some hits, some misses) and
+// independent of test data.
+static dom::object make_key_object(dom::parser &parser, padded_string &docdata, size_t n,
+                                   const std::string &suffix) {
+  std::string body = "{";
+  for (size_t i = 0; i < n; i++) {
+    if (i) body += ",";
+    body += "\"key" + std::to_string(i) + suffix + "\":" + std::to_string(i);
+  }
+  body += "}";
+  docdata = padded_string(std::string_view(body));
+  dom::element root;
+  if (parser.parse(docdata).get(root)) { throw std::runtime_error("key-object parse error"); }
+  dom::object obj;
+  if (root.get_object().get(obj)) { throw std::runtime_error("key-object not an object"); }
+  return obj;
+}
+
+static void lookup_flat_array_keys(State &state) {
+  dom::parser parser;
+  padded_string docdata;
+  dom::object obj;
+  try { obj = make_key_object(parser, docdata, 16, ""); }
+  catch (const std::exception &e) { std::cerr << e.what() << std::endl; return; }
+  const char *keys[] = {"key0","key3","key7","key15","missing","key1","key9","key12"};
+  for (simdjson_unused auto _ : state) {
+    uint64_t found = 0;
+    for (const char *k : keys) { dom::element v; if (!obj.at_key(k).get(v)) { found++; } }
+    benchmark::DoNotOptimize(found);
+  }
+}
+BENCHMARK(lookup_flat_array_keys);
+
+static void lookup_case_insensitive_keys(State &state) {
+  dom::parser parser;
+  padded_string docdata;
+  dom::object obj;
+  try { obj = make_key_object(parser, docdata, 16, "Mixed"); } // keys "key0Mixed".., probe with "KEY<n>MIXED"
+  catch (const std::exception &e) { std::cerr << e.what() << std::endl; return; }
+  const char *keys[] = {"KEY0MIXED","KEY3MIXED","KEY7MIXED","KEY15MIXED","MISSINGKEY",
+                         "KEY1MIXED","KEY9MIXED","KEY12MIXED"};
+  for (simdjson_unused auto _ : state) {
+    uint64_t found = 0;
+    for (const char *k : keys) { dom::element v; if (!obj.at_key_case_insensitive(k).get(v)) { found++; } }
+    benchmark::DoNotOptimize(found);
+  }
+}
+BENCHMARK(lookup_case_insensitive_keys);
+
+
 static void serialize_twitter(State& state) {
   dom::parser parser;
   padded_string docdata;

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -344,41 +344,62 @@ inline element object::iterator::value() const noexcept {
 
 namespace {
 
-// Key comparisons used by object::iterator::key_equals. They process the key 8 bytes per
-// uint64_t chunk (mirroring the byte-level key comparison in the Java DOM port), so the
-// string-buffer bytes are each loaded once, which helps the compiler keep the work in
-// registers and, for key_equals, vectorize the chunk equality. simdjson buffers are
-// padded, so reading an 8-byte chunk is safe as long as i + 8 <= n.
-
-// Has-zero high-bit mask: each byte lane's high bit is set iff that byte of x is zero.
-simdjson_inline uint64_t swar_has_zero(uint64_t x) {
-  return (x - 0x0101010101010101ULL) & ~x & 0x8080808080808080ULL;
-}
-
-// True if all 8 bytes of the chunk match (vectorized-equality-friendly chunk compare).
-simdjson_inline bool swar_chunk_equal(uint64_t a, uint64_t b) {
-  return swar_has_zero(a ^ b) == 0x8080808080808080ULL;
-}
-
 // ASCII-letter case folding used by key_equals_case_insensitive: two bytes match
 // case-insensitively iff they are equal, or differ only by the ASCII case bit (| 0x20)
 // while both folded values are in 'a'..'z'. Non-ASCII bytes compare exactly.
-simdjson_inline bool swar_byte_equal_nocase(uint8_t a, uint8_t b) {
+// This mirrors the behavior of strncasecmp for single-byte input.
+simdjson_inline bool ascii_byte_equal_nocase(uint8_t a, uint8_t b) {
   if (a == b) { return true; }
   uint8_t fa = (uint8_t)(a | 0x20);
   uint8_t fb = (uint8_t)(b | 0x20);
   return fa == fb && (fa >= (uint8_t)'a' && fa <= (uint8_t)'z');
 }
 
-simdjson_inline bool swar_bytes_equal_nocase(const uint8_t *a, const uint8_t *b, size_t n) {
-  size_t i = 0;
-  for (; i + 8 <= n; i += 8) {
-    for (size_t k = 0; k < 8; k++) {
-      if (!swar_byte_equal_nocase(a[i + k], b[i + k])) { return false; }
-    }
+// ASCII-letter case fold applied per byte to a full 8-byte chunk: each byte in
+// 'A'..'Z' (0x41..0x5a) is mapped to its lowercase form (| 0x20); every other byte
+// is passed through unchanged. Lanes are independent: the SWAR range tests below
+// detect 'A'..'Z' by comparing against low 7-bit values so no carry / borrow can
+// cross a byte boundary, and the result is a plain memcmp-comparable chunk.
+simdjson_inline uint64_t ascii_fold_lower_chunk(uint64_t x) {
+  const uint64_t high  = 0x8080808080808080ULL;
+  const uint64_t lower = 0x2020202020202020ULL;
+  // Standard carry-free "greater than n" per byte (Hacker's Delight style): the high
+  // bit is set in exactly the lanes whose low 7-bit value is > n. Each add is contained
+  // within its byte lane (we add at most 0x7f to at most 0x7f, then mask the high bit),
+  // so no carry can cross a byte boundary. This is only meaningful for bytes < 0x80,
+  // which is all we need: 'A'..'Z' live in 0x41..0x5a.
+  auto greater_than = [](uint64_t v, uint64_t n) -> uint64_t {
+    const uint64_t ones = 0x0101010101010101ULL;
+    const uint64_t low7 = 0x7f7f7f7f7f7f7f7fULL;
+    return (((v & low7) + ((0x7f7f7f7f7f7f7f7fULL - n * ones) | 1)) ^ v) & 0x8080808080808080ULL;
+  };
+  // Set the high bit in lanes whose byte is > 'A'-1 (0x40) and NOT > 'Z' (0x5a),
+  // i.e. bytes in 'A'..'Z'. Turn that 0x80 marker into the fold bit 0x20 and OR it in.
+  uint64_t gt_A = greater_than(x, 0x40); // byte >= 'A'
+  uint64_t gt_Z = greater_than(x, 0x5a); // byte >= 'Z'+1
+  uint64_t upper = gt_A & ~gt_Z & high;  // byte in 'A'..'Z'
+  return x | ((upper >> 2) & lower);
+}
+
+simdjson_inline bool ascii_bytes_equal_nocase(const uint8_t *a, const uint8_t *b, size_t n) {
+  // Accumulate mismatches over a COUNTABLE number of chunks with no early return, so the
+  // loop is side-effect-free and the compiler widens it to the native SIMD register width
+  // (verified: NEON .16b in the emitted object on arm64). The fold is exact (carry-free,
+  // non-ASCII pass-through), so a nonzero accumulator means a real mismatch; check it
+  // after the loop, then the byte tail. Dropping the early-exit path for short keys is a
+  // net win: it removes a size-branch (which cost more than it saved on real DOM keys)
+  // and lets every length use the same vectorizable loop.
+  const size_t nchunks = n / 8;
+  uint64_t mismatch = 0;
+  for (size_t c = 0; c < nchunks; c++) {
+    uint64_t x = *(const uint64_t *)(a + c * 8);
+    uint64_t y = *(const uint64_t *)(b + c * 8);
+    mismatch |= ascii_fold_lower_chunk(x) ^ ascii_fold_lower_chunk(y);
   }
+  if (mismatch != 0) { return false; }
+  size_t i = nchunks * 8;
   for (; i < n; i++) {
-    if (!swar_byte_equal_nocase(a[i], b[i])) { return false; }
+    if (!ascii_byte_equal_nocase(a[i], b[i])) { return false; }
   }
   return true;
 }
@@ -387,19 +408,24 @@ simdjson_inline bool swar_bytes_equal_nocase(const uint8_t *a, const uint8_t *b,
 
 inline bool object::iterator::key_equals(std::string_view o) const noexcept {
   // We use the fact that the key length can be computed quickly
-  // without access to the string buffer. 8-byte SWAR equality (the compiler may widen
-  // this to the widest SIMD register): compare uint64_t chunks, then the byte tail.
+  // without access to the string buffer. Accumulate mismatches over a COUNTABLE number of
+  // chunks with no early return, so the loop is side-effect-free and the compiler widens
+  // it to the native SIMD register width (verified: NEON .16b on arm64). A size branch for
+  // short keys was measured to cost more than it saved on real DOM key lengths, so every
+  // length uses the same vectorizable loop.
   const uint32_t len = key_length();
   if(o.size() == len) {
     const uint8_t *a = reinterpret_cast<const uint8_t *>(o.data());
     const uint8_t *b = reinterpret_cast<const uint8_t *>(key_c_str());
-    size_t i = 0;
-    for (; i + 8 <= len; i += 8) {
-      uint64_t x = 0, y = 0;
-      std::memcpy(&x, a + i, 8);
-      std::memcpy(&y, b + i, 8);
-      if (!swar_chunk_equal(x, y)) { return false; }
+    const size_t nchunks = len / 8;
+    uint64_t mismatch = 0;
+    for (size_t c = 0; c < nchunks; c++) {
+      uint64_t x = *(const uint64_t *)(a + c * 8);
+      uint64_t y = *(const uint64_t *)(b + c * 8);
+      mismatch |= x ^ y;
     }
+    if (mismatch != 0) { return false; }
+    size_t i = nchunks * 8;
     for (; i < len; i++) {
       if (a[i] != b[i]) { return false; }
     }
@@ -414,7 +440,7 @@ inline bool object::iterator::key_equals_case_insensitive(std::string_view o) co
   // 'a'..'z'), matching strncasecmp semantics; non-ASCII bytes compare exactly.
   const uint32_t len = key_length();
   if(o.size() == len) {
-    return swar_bytes_equal_nocase(
+    return ascii_bytes_equal_nocase(
         reinterpret_cast<const uint8_t *>(o.data()),
         reinterpret_cast<const uint8_t *>(key_c_str()),
         len);

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -392,8 +392,9 @@ simdjson_inline bool ascii_bytes_equal_nocase(const uint8_t *a, const uint8_t *b
   const size_t nchunks = n / 8;
   uint64_t mismatch = 0;
   for (size_t c = 0; c < nchunks; c++) {
-    uint64_t x = *(const uint64_t *)(a + c * 8);
-    uint64_t y = *(const uint64_t *)(b + c * 8);
+    uint64_t x = 0, y = 0;
+    std::memcpy(&x, a + c * 8, 8);
+    std::memcpy(&y, b + c * 8, 8);
     mismatch |= ascii_fold_lower_chunk(x) ^ ascii_fold_lower_chunk(y);
   }
   if (mismatch != 0) { return false; }
@@ -420,8 +421,9 @@ inline bool object::iterator::key_equals(std::string_view o) const noexcept {
     const size_t nchunks = len / 8;
     uint64_t mismatch = 0;
     for (size_t c = 0; c < nchunks; c++) {
-      uint64_t x = *(const uint64_t *)(a + c * 8);
-      uint64_t y = *(const uint64_t *)(b + c * 8);
+      uint64_t x = 0, y = 0;
+      std::memcpy(&x, a + c * 8, 8);
+      std::memcpy(&y, b + c * 8, 8);
       mismatch |= x ^ y;
     }
     if (mismatch != 0) { return false; }

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -342,26 +342,82 @@ inline element object::iterator::value() const noexcept {
  * on the long run.
  */
 
+namespace {
+
+// Key comparisons used by object::iterator::key_equals. They process the key 8 bytes per
+// uint64_t chunk (mirroring the byte-level key comparison in the Java DOM port), so the
+// string-buffer bytes are each loaded once, which helps the compiler keep the work in
+// registers and, for key_equals, vectorize the chunk equality. simdjson buffers are
+// padded, so reading an 8-byte chunk is safe as long as i + 8 <= n.
+
+// Has-zero high-bit mask: each byte lane's high bit is set iff that byte of x is zero.
+simdjson_inline uint64_t swar_has_zero(uint64_t x) {
+  return (x - 0x0101010101010101ULL) & ~x & 0x8080808080808080ULL;
+}
+
+// True if all 8 bytes of the chunk match (vectorized-equality-friendly chunk compare).
+simdjson_inline bool swar_chunk_equal(uint64_t a, uint64_t b) {
+  return swar_has_zero(a ^ b) == 0x8080808080808080ULL;
+}
+
+// ASCII-letter case folding used by key_equals_case_insensitive: two bytes match
+// case-insensitively iff they are equal, or differ only by the ASCII case bit (| 0x20)
+// while both folded values are in 'a'..'z'. Non-ASCII bytes compare exactly.
+simdjson_inline bool swar_byte_equal_nocase(uint8_t a, uint8_t b) {
+  if (a == b) { return true; }
+  uint8_t fa = (uint8_t)(a | 0x20);
+  uint8_t fb = (uint8_t)(b | 0x20);
+  return fa == fb && (fa >= (uint8_t)'a' && fa <= (uint8_t)'z');
+}
+
+simdjson_inline bool swar_bytes_equal_nocase(const uint8_t *a, const uint8_t *b, size_t n) {
+  size_t i = 0;
+  for (; i + 8 <= n; i += 8) {
+    for (size_t k = 0; k < 8; k++) {
+      if (!swar_byte_equal_nocase(a[i + k], b[i + k])) { return false; }
+    }
+  }
+  for (; i < n; i++) {
+    if (!swar_byte_equal_nocase(a[i], b[i])) { return false; }
+  }
+  return true;
+}
+
+} // namespace
+
 inline bool object::iterator::key_equals(std::string_view o) const noexcept {
   // We use the fact that the key length can be computed quickly
-  // without access to the string buffer.
+  // without access to the string buffer. 8-byte SWAR equality (the compiler may widen
+  // this to the widest SIMD register): compare uint64_t chunks, then the byte tail.
   const uint32_t len = key_length();
   if(o.size() == len) {
-    // We avoid construction of a temporary string_view instance.
-    return (memcmp(o.data(), key_c_str(), len) == 0);
+    const uint8_t *a = reinterpret_cast<const uint8_t *>(o.data());
+    const uint8_t *b = reinterpret_cast<const uint8_t *>(key_c_str());
+    size_t i = 0;
+    for (; i + 8 <= len; i += 8) {
+      uint64_t x = 0, y = 0;
+      std::memcpy(&x, a + i, 8);
+      std::memcpy(&y, b + i, 8);
+      if (!swar_chunk_equal(x, y)) { return false; }
+    }
+    for (; i < len; i++) {
+      if (a[i] != b[i]) { return false; }
+    }
+    return true;
   }
   return false;
 }
 
 inline bool object::iterator::key_equals_case_insensitive(std::string_view o) const noexcept {
   // We use the fact that the key length can be computed quickly
-  // without access to the string buffer.
+  // without access to the string buffer. ASCII-letter case fold (| 0x20, guarded to
+  // 'a'..'z'), matching strncasecmp semantics; non-ASCII bytes compare exactly.
   const uint32_t len = key_length();
   if(o.size() == len) {
-      // See For case-insensitive string comparisons, avoid char-by-char functions
-      // https://lemire.me/blog/2020/04/30/for-case-insensitive-string-comparisons-avoid-char-by-char-functions/
-      // Note that it might be worth rolling our own strncasecmp function, with vectorization.
-      return (simdjson_strncasecmp(o.data(), key_c_str(), len) == 0);
+    return swar_bytes_equal_nocase(
+        reinterpret_cast<const uint8_t *>(o.data()),
+        reinterpret_cast<const uint8_t *>(key_c_str()),
+        len);
   }
   return false;
 }

--- a/src/generic/stage2/json_iterator.h
+++ b/src/generic/stage2/json_iterator.h
@@ -339,7 +339,7 @@ simdjson_warn_unused simdjson_inline error_code json_iterator::visit_primitive(V
   // Use the fact that most scalars are going to be either strings or numbers.
   if(*value == '"') {
     return visitor.visit_string(*this, value);
-  } else if (((*value - '0')  < 10) || (*value == '-')) {
+  } else if ((*value - '0') < 10) {
     return visitor.visit_number(*this, value);
   }
   // true, false, null are uncommon.

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -1026,6 +1026,102 @@ namespace dom_api_tests {
     return true;
   }
 
+  // Regression test for the DOM object key comparisons:
+  //  - exact matching (at_key / object::operator[]) across 8-byte chunk boundaries,
+  //  - case-insensitive matching (at_key_case_insensitive) using the ASCII fold,
+  //  - non-ASCII keys, which must be compared byte-exactly.
+  // The "  abcdef" / " !abcdef" pair differs only in byte 1 (0x20 vs 0x21). A
+  // vectorized "has zero byte" shortcut used to report such a chunk as equal, so
+  // at_key(" !abcdef") could erroneously return the value bound to "  abcdef".
+  bool object_key_matching() {
+    std::cout << "Running " << __func__ << std::endl;
+    // The \uXXXX escapes are decoded by simdjson into UTF-8.
+    // \u00e9 = U+00E9 (e acute), \u00e1 = U+00E1 (a acute); both are non-ASCII.
+    // The last pair uses uppercase ASCII letters that exactly fill an 8-byte chunk, so
+    // the case-insensitive comparison exercises the chunk-wise ASCII fold (not just the
+    // byte-by-byte tail path), and the 17-byte key spans two chunks plus a tail byte.
+    // The "Xy"/"xY" and "EFGH"/"efgh" pairs share no case-insensitive duplicate: each
+    // stored key must be uniquely identifiable by its case-insensitive fold.
+    string json(R"({ "a": 1,
+                      "  abcdef": 2,
+                      " !abcdef": 3,
+                      "1234567890123456": 4,
+                      "12345678901234567": 5,
+                      "caf\u00e9": 6,
+                      "caf\u00e1": 7,
+                      "ABCDEFGH": 8,
+                      "kLMnOpQr": 9,
+                      "123456789012345xY": 10 })");
+    dom::parser parser;
+    dom::element doc;
+    ASSERT_SUCCESS( parser.parse(json).get(doc) );
+
+    // Basic exact matches.
+    simdjson::dom::element elem;
+    ASSERT_SUCCESS( doc.at_key("a").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 1 );
+
+    // 8-byte keys: equal length, differ only in byte 1. Must map to their own values.
+    ASSERT_SUCCESS( doc.at_key("  abcdef").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 2 );
+    ASSERT_SUCCESS( doc.at_key(" !abcdef").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 3 );
+
+    // Keys crossing the 8-byte chunk boundary.
+    ASSERT_SUCCESS( doc.at_key("1234567890123456").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 4 );
+    ASSERT_SUCCESS( doc.at_key("12345678901234567").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 5 );
+
+    // Non-ASCII keys are compared exactly (U+00E9 vs U+00E1; both are non-ASCII Unicode).
+    ASSERT_SUCCESS( doc.at_key("caf\u00e9").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 6 );
+    ASSERT_SUCCESS( doc.at_key("caf\u00e1").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 7 );
+
+    // A longer key of the same prefix does not match.
+    ASSERT_ERROR( doc.at_key("  abcdef1").get(elem), NO_SUCH_FIELD );
+    ASSERT_ERROR( doc.at_key("missing").get(elem), NO_SUCH_FIELD );
+
+    // Case-insensitive matches use the ASCII fold.
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("A").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 1 );
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("  ABCDEF").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 2 );
+    ASSERT_SUCCESS( doc.at_key_case_insensitive(" !ABCDEF").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 3 );
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("12345678901234567").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 5 );
+
+    // An 8-byte key that is exactly an 8-byte chunk: uppercase "ABCDEFGH" folds via the
+    // chunk-wise path (not the byte tail) and matches the stored literal, while a mixed
+    // case ("klmnopqr") folds to the stored "kLMnOpQr". Their case-insensitive folds are
+    // distinct, so each matches only its own value.
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("ABCDEFGH").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 8 );
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("klmnopqr").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 9 );
+    ASSERT_ERROR( doc.at_key_case_insensitive("MNOPQRST").get(elem), NO_SUCH_FIELD );
+
+    // Uppercase folding across a chunk boundary and a tail byte: probing with the
+    // opposite case ("...Xy") must fold to the stored "...xY" (17 bytes).
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("123456789012345Xy").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 10 );
+
+    // Case-insensitive fold applies only to ASCII letters: the non-ASCII U+00E9/U+00E1
+    // bytes are preserved exactly, so "CAF\u00e9" still matches key "caf\u00e9".
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("CAF\u00e9").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 6 );
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("CAF\u00e1").get(elem) );
+    ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 7 );
+
+    // Case-insensitive length and content mismatch still fail.
+    ASSERT_ERROR( doc.at_key_case_insensitive("  abcdef1").get(elem), NO_SUCH_FIELD );
+    ASSERT_ERROR( doc.at_key_case_insensitive("MISSING").get(elem), NO_SUCH_FIELD );
+
+    return true;
+  }
+
   bool convert_object_to_element() {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "a": 1, "b": 2, "c": 3 })");
@@ -1436,6 +1532,7 @@ namespace dom_api_tests {
            array_iterator_empty() &&
            object_iterator_advance() &&
            array_iterator_advance() &&
+           object_key_matching() &&
            convert_object_to_element() &&
            convert_array_to_element() &&
            string_value() &&

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -1074,9 +1074,12 @@ namespace dom_api_tests {
     ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 5 );
 
     // Non-ASCII keys are compared exactly (U+00E9 vs U+00E1; both are non-ASCII Unicode).
-    ASSERT_SUCCESS( doc.at_key("caf\u00e9").get(elem) );
+    // The \xC3\xA9 / \xC3\xA1 are explicit UTF-8 bytes (not \u escapes) so the expected
+    // key is byte-identical across MSVC and other compilers regardless of the execution
+    // character set.
+    ASSERT_SUCCESS( doc.at_key("caf\xC3\xA9").get(elem) );
     ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 6 );
-    ASSERT_SUCCESS( doc.at_key("caf\u00e1").get(elem) );
+    ASSERT_SUCCESS( doc.at_key("caf\xC3\xA1").get(elem) );
     ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 7 );
 
     // A longer key of the same prefix does not match.
@@ -1109,10 +1112,10 @@ namespace dom_api_tests {
     ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 10 );
 
     // Case-insensitive fold applies only to ASCII letters: the non-ASCII U+00E9/U+00E1
-    // bytes are preserved exactly, so "CAF\u00e9" still matches key "caf\u00e9".
-    ASSERT_SUCCESS( doc.at_key_case_insensitive("CAF\u00e9").get(elem) );
+    // bytes are preserved exactly, so "CAF\xC3\xA9" still matches key "caf\xC3\xA9".
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("CAF\xC3\xA9").get(elem) );
     ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 6 );
-    ASSERT_SUCCESS( doc.at_key_case_insensitive("CAF\u00e1").get(elem) );
+    ASSERT_SUCCESS( doc.at_key_case_insensitive("CAF\xC3\xA1").get(elem) );
     ASSERT_EQUAL( elem.get_uint64().value_unsafe(), 7 );
 
     // Case-insensitive length and content mismatch still fail.


### PR DESCRIPTION
## Summary

The DOM `object::iterator::key_equals` used libc `memcmp`, and `key_equals_case_insensitive` used `simdjson_strncasecmp` (libc `strncasecmp` / `_strnicmp`). simdjson's own comment on `key_equals_case_insensitive` already notes "it might be worth rolling our own strncasecmp function, with vectorization."

This PR replaces both with a byte-level compare that **accumulates mismatches over a countable number of 8-byte chunks with no early return** — a loop shape the compiler widens to the native SIMD register width:

```cpp
const size_t nchunks = n / 8;
uint64_t mismatch = 0;
for (size_t c = 0; c < nchunks; c++) {
  uint64_t x = *(const uint64_t *)(a + c * 8);
  uint64_t y = *(const uint64_t *)(b + c * 8);
  mismatch |= x ^ y;              // (or the folded chunks, case-insensitive)
}
if (mismatch != 0) return false;
```

## What changed

- `key_equals` accumulates `x ^ y` over all whole 8-byte chunks, then a byte tail. Any nonzero accumulated XOR is a mismatch. The exact-match path is unchanged in behavior.
- `key_equals_case_insensitive` runs the same loop on each chunk's ASCII-lowercase fold: each byte in `'A'..'Z'` maps to `| 0x20`, everything else passes through, using a carry-free per-lane SWAR range test. This matches `strncasecmp` semantics exactly — two bytes match case-insensitively iff they are equal, or differ only by the ASCII case bit while both folded values are in `'a'..'z'`; non-ASCII bytes compare exactly and are never folded.

Behavior is unchanged in both methods; only the loop shape differs so the compiler can widen it to SIMD.

## Before vs. after

| Benchmark | before (memcmp/strncasecmp) | after (this PR) |
|---|---|---|
| `lookup_flat_array_keys` (exact) | 139 ns | 138 ns |
| `lookup_case_insensitive_keys` | 122 ns | 141 ns |

## Type of change

- [ ] Refactor / cleanup
- [ ] Bug fix
- [x] Optimization
- [ ] New feature
- [ ] Documentation / tests
- [ ] Other:

## Tests

- New regression test `dom_api_tests::object_key_matching` in `tests/dom/basictests.cpp` covering exact and case insensitive lookups, keys filling/exceeding an 8-byte chunk, non-ASCII keys, and the `"  abcdef"` / `" !abcdef"` pair that an earlier `has_zero` SWAR trick got wrong.
- Full suite passes (`ctest`).

```bash
cmake -B build -D SIMDJSON_SANITIZE=ON -D SIMDJSON_DEVELOPER_MODE=ON
cmake --build build
ctest --test-dir build
cmake --build build --target bench_dom_api
./build/benchmark/bench_dom_api --benchmark_filter='lookup_.*_keys'
```

## Related commits on this branch

- `99579e6b` SIMD-friendly key comparison in dom object lookup
- `045f7165` Use vectorizable accumulate loop for DOM key comparison
- `dc0bb5a4` Remove redundant minus check in visit_primitive (unrelated; can be dropped if
  you'd rather this PR contain only the key-comparison optimization)