### PR TITLE
ondemand: json_type::unknown has no ostream arm

### DIFF
--- a/include/simdjson/generic/ondemand/json_type-inl.h
+++ b/include/simdjson/generic/ondemand/json_type-inl.h
@@ -19,7 +19,7 @@ inline std::ostream& operator<<(std::ostream& out, json_type type) noexcept {
         case json_type::string: out << "string"; break;
         case json_type::boolean: out << "boolean"; break;
         case json_type::null: out << "null"; break;
-        default: SIMDJSON_UNREACHABLE();
+        case json_type::unknown: out << "unknown"; break;
     }
     return out;
 }

--- a/tests/ondemand/ondemand_unknown_tests.cpp
+++ b/tests/ondemand/ondemand_unknown_tests.cpp
@@ -2,6 +2,7 @@
 #include "test_ondemand.h"
 
 #include <cmath>
+#include <sstream>
 
 using namespace simdjson;
 
@@ -18,6 +19,19 @@ namespace unknown_tests {
         std::string_view str;
         ASSERT_SUCCESS( doc_result.raw_json_token().get(str) );
         ASSERT_EQUAL( str, "NaN");
+        return true;
+    }));
+    TEST_SUCCEED();
+  }
+  bool root_value_type_ostream() {
+    TEST_START();
+    padded_string json = "NaN"_padded;
+    ASSERT_TRUE(test_ondemand_doc(json, [&](auto doc_result) {
+        simdjson::ondemand::json_type type;
+        ASSERT_SUCCESS( doc_result.type().get(type) );
+        std::ostringstream os;
+        os << type;
+        ASSERT_EQUAL( os.str(), "unknown" );
         return true;
     }));
     TEST_SUCCEED();
@@ -76,6 +90,7 @@ namespace unknown_tests {
   bool run() {
     return
            root_value_type() &&
+           root_value_type_ostream() &&
            object_value_type() &&
 #if SIMDJSON_EXCEPTIONS
            object_value_type_exception() &&


### PR DESCRIPTION
This fixes undefined behaviour when printing a `json_type::unknown` value, and adds a regression test.

`document::type()` and `value::type()` can return `json_type::unknown` together with `SUCCESS` when a token doesn't start a JSON value, which is documented behaviour (`doc/basics.md:471`, since 4.0). The problem is that `operator<<(std::ostream&, json_type)` only has cases for the other six enumerators, so `unknown` falls into `default: SIMDJSON_UNREACHABLE()` at `json_type-inl.h:22`, which is `__builtin_unreachable()` in any build with NDEBUG or optimizations on. Printing the type of a malformed token is therefore UB.

The worst part is that this can fail completely silently:

```cpp
ondemand::parser parser;
auto json = R"({"key": NaN})"_padded;
auto doc = parser.iterate(json);
std::cout << doc["key"].type() << std::endl;
```

On gcc 13.3 with `-O2 -DNDEBUG` this prints `null` and exits 0, so the malformed token gets reported as a perfectly valid JSON null and nothing ever indicates an error.

Since it's UB, the failure mode changes with compiler and context:

- gcc 13.3, `-O2 -DNDEBUG`, streaming the same value into a `std::ostringstream` instead: SIGSEGV, 5 out of 5 runs
- Apple clang 17, `-O2 -DNDEBUG`: writes 327,680 bytes of out-of-bounds data into the stream (all NUL in my build, but the pointer and the length both come from the same out-of-bounds table read, so what you actually get depends on link layout)
- built with neither NDEBUG nor optimizations: assertion failure at `json_type-inl.h:22`
- `SIMDJSON_DEVELOPMENT_CHECKS=1` under NDEBUG: writes nothing, exits 0

UBSan flags it on both platforms: `execution reached an unreachable program point` at `json_type-inl.h:22:18`.

## Root cause

`unknown` was introduced in #2416 (`1ebf115b`, Aug 2025), which changed `value_iterator::type()` from returning `TAPE_ERROR` to returning the new enumerator. The stream operator covered all six enumerators that existed at the time and never got updated, so this has been reachable since v4.0.0. No existing test hits it either: the only test that streams a `json_type` on a success path uses valid input, and `ASSERT_EQUAL` only streams its operands after something has already failed.

## Fix

Add the missing `unknown` case and remove the `default:` label. Dropping `default:` also matters going forward: it was suppressing `-Wswitch`, so if an eighth enumerator is ever added, the build now fails in developer mode instead of compiling silently.

I also checked a few similar-looking spots and left them unchanged: `operator<<(std::ostream&, number_type)` has the same shape but covers all four of its enumerators, `dom/serialization-inl.h:517` guards a real tape invariant, and `singleheader/` is generated.

## Testing

The new test parses `NaN`, streams the resulting type into an `ostringstream` and compares the output. It fails if the header change is reverted.

```
cmake -B build -D SIMDJSON_DEVELOPER_MODE=ON .
cmake --build build
ctest --test-dir build -LE explicitonly
100% tests passed out of 119
```

Same 119/119 with `SIMDJSON_SANITIZE_UNDEFINED=ON`. Ran on macOS arm64 and Linux x86-64; the other kernels and the Windows builds still need CI.

## Type of change

- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

## Checklist before submitting

- [x] I added/updated tests covering my change (if applicable)
- [x] Code builds locally and passes my check
- [ ] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear
- [ ] I linked the related issue (if applicable)