### PR TITLE
cmake: do not enable SIMDJSON_DEVELOPMENT_CHECKS in Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,9 +372,7 @@ if(
       $<$<CONFIG:DEBUG>:-Og>
   )
   # -Og defines __OPTIMIZE__, so the header would not auto-enable
-  # SIMDJSON_DEVELOPMENT_CHECKS in Debug. Keep the checks in Debug only;
-  # a bare define here leaked into Release and RelWithDebInfo on
-  # GCC/Clang (since #2590).
+  # SIMDJSON_DEVELOPMENT_CHECKS in Debug. Keep the checks in Debug only.
   simdjson_add_props(
       target_compile_definitions PUBLIC
       $<$<CONFIG:DEBUG>:SIMDJSON_DEVELOPMENT_CHECKS>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,12 +371,15 @@ if(
       target_compile_options PRIVATE
       $<$<CONFIG:DEBUG>:-Og>
   )
-  # We still want to enable development checks in Debug mode
+  # -Og defines __OPTIMIZE__, so the header would not auto-enable
+  # SIMDJSON_DEVELOPMENT_CHECKS in Debug. Keep the checks in Debug only;
+  # a bare define here leaked into Release and RelWithDebInfo on
+  # GCC/Clang (since #2590).
   simdjson_add_props(
       target_compile_definitions PUBLIC
-      SIMDJSON_DEVELOPMENT_CHECKS
+      $<$<CONFIG:DEBUG>:SIMDJSON_DEVELOPMENT_CHECKS>
   )
-  endif()
+endif()
 
 if(SIMDJSON_ENABLE_THREADS)
   find_package(Threads REQUIRED)


### PR DESCRIPTION
## Rationale

This is a bug fix. Since #2590, CMake has been compiling **Release** (and RelWithDebInfo) GCC/Clang builds with `-DSIMDJSON_DEVELOPMENT_CHECKS`, which is supposed to be Debug-only.

The CMake **option** `SIMDJSON_DEVELOPMENT_CHECKS` is still `OFF` by default. That only controls one `if(SIMDJSON_DEVELOPMENT_CHECKS)` block. A second, unconditional `simdjson_add_props(target_compile_definitions PUBLIC SIMDJSON_DEVELOPMENT_CHECKS)` sits in the GCC/Clang `-Og` block. The `-Og` flag is correctly gated with `$<$<CONFIG:DEBUG>:...>`; the define was not.

The headers already auto-enable checks in Debug (`!__OPTIMIZE__ && !NDEBUG`). They never get the chance: CMake defines the macro first, so the `#ifndef SIMDJSON_DEVELOPMENT_CHECKS` guard in `common_defs.h` is skipped even with `NDEBUG`.

A four-year ondemand history on an Intel Xeon Gold 6548N (GCC 14, CMake Release) showed a persistent step at #2590 (`feb1e7fe`, 2026-01-17): `large_random` 1.20 → 1.16 GB/s, with matching drops in amazon/json2msgpack/kostya/top_tweet. Those iterator safety rails (`has_been_referenced` on `operator*` / `operator++`) were compiling into Release.

## Fix

Restrict the extra define to Debug, the same way `-Og` already is:

```cmake
$<$<CONFIG:DEBUG>:SIMDJSON_DEVELOPMENT_CHECKS>
```

Debug still needs this because `-Og` sets `__OPTIMIZE__`, which would otherwise disable the header auto-enable. Release, RelWithDebInfo, and MinSizeRel no longer get it. `-DSIMDJSON_DEVELOPMENT_CHECKS=ON` still forces the checks in any config.

## Latest release

**Yes, v4.6.7 is affected** (CMake + GCC/Clang/AppleClang only).

| Who | Affected? |
|---|---|
| CMake + GCC/Clang/AppleClang, Release, v4.3.0–v4.6.7 | **yes** |
| Single-header (`simdjson.h`) without that `-D` | no |
| MSVC | no (the block is GCC/Clang only) |
| v4.2.4 and earlier | no |

First release with the leak is **v4.3.0**. A 4.6.x backport would be v4.6.8 if wanted.

## Tests

CMake-flag fix; no runtime test added. Existing tests still pass with the define in Debug and without it in Release.