### PR TITLE
fix at_path bug

### DIFF
--- a/include/simdjson/generic/ondemand/raw_json_string-inl.h
+++ b/include/simdjson/generic/ondemand/raw_json_string-inl.h
@@ -74,13 +74,9 @@ simdjson_inline bool raw_json_string::unsafe_is_equal(std::string_view target) c
   if(target.size() <= SIMDJSON_PADDING) {
     return (raw()[target.size()] == '"') && !memcmp(raw(), target.data(), target.size());
   }
-  const char * r{raw()};
-  size_t pos{0};
-  for(;pos < target.size();pos++) {
-    if(r[pos] != target[pos]) { return false; }
-  }
-  if(r[pos] != '"') { return false; }
-  return true;
+  // Past SIMDJSON_PADDING we can no longer rely on the padding to keep the
+  // comparison in bounds, so we must stop at the quote terminating the key.
+  return is_equal(target);
 }
 
 simdjson_inline bool raw_json_string::is_equal(std::string_view target) const noexcept {

--- a/tests/ondemand/ondemand_json_path_tests.cpp
+++ b/tests/ondemand/ondemand_json_path_tests.cpp
@@ -129,6 +129,47 @@ namespace json_path_tests {
         TEST_SUCCEED();
     }
 
+    // A key longer than SIMDJSON_PADDING must not be compared past the quote
+    // that terminates the key in the document.
+    bool long_key() {
+        TEST_START();
+        ondemand::parser parser;
+        ondemand::document doc;
+        ondemand::value val;
+
+        // The key "aaa" ends at offset 5, so a target that keeps matching the
+        // bytes that follow it runs into the padding and then out of the buffer.
+        auto small_json = R"({"aaa":1})"_padded;
+        std::string overrun("aaa\":1}");
+        overrun.append(SIMDJSON_PADDING, '\0');
+        ASSERT_SUCCESS(parser.iterate(small_json).get(doc));
+        ASSERT_ERROR(doc.at_path("." + overrun).get(val), NO_SUCH_FIELD);
+
+        // Matching keys longer than SIMDJSON_PADDING still resolve.
+        const std::string long_name(SIMDJSON_PADDING + 16, 'k');
+        auto long_json = padded_string(R"({")" + long_name + R"(":42})");
+        uint64_t number;
+        ASSERT_SUCCESS(parser.iterate(long_json).get(doc));
+        ASSERT_SUCCESS(doc.at_path("." + long_name).get(val));
+        ASSERT_SUCCESS(val.get_uint64().get(number));
+        ASSERT_EQUAL(number, 42);
+
+        // A target that is a prefix of the key, or an extension of it, does not.
+        ASSERT_SUCCESS(parser.iterate(long_json).get(doc));
+        ASSERT_ERROR(doc.at_path("." + long_name.substr(1)).get(val), NO_SUCH_FIELD);
+        ASSERT_SUCCESS(parser.iterate(long_json).get(doc));
+        ASSERT_ERROR(doc.at_path("." + long_name + "k").get(val), NO_SUCH_FIELD);
+
+        // An escaped quote inside a long key is part of the key, not its end.
+        const std::string escaped_name = long_name + R"(\")";
+        auto escaped_json = padded_string(R"({")" + escaped_name + R"(":7})");
+        ASSERT_SUCCESS(parser.iterate(escaped_json).get(doc));
+        ASSERT_SUCCESS(doc.at_path("." + escaped_name).get(val));
+        ASSERT_SUCCESS(val.get_uint64().get(number));
+        ASSERT_EQUAL(number, 7);
+        TEST_SUCCEED();
+    }
+
     bool document_as_scalar() {
         TEST_START();
         auto number_json = R"( 1 )"_padded;
@@ -556,6 +597,7 @@ namespace json_path_tests {
                 run_failure_test(TEST_JSON, "./~01abc.-", INDEX_OUT_OF_BOUNDS) &&
                 many_json_paths() &&
                 document_as_scalar() &&
+                long_key() &&
                 true;
     }
 }   // json_path_tests


### PR DESCRIPTION
`raw_json_string::unsafe_is_equal(std::string_view)` compares the target against the document one byte at a time with no bound when the target is longer than `SIMDJSON_PADDING`. If the bytes following the key in the buffer keep matching the target, the loop reads past the end of the allocation.

Reachable from on-demand `at_path()`, `at_pointer()` and `find_field()` whenever the key comes from the caller, e.g.

```cpp
auto json = "{\"aaa\":1}"_padded;
std::string key = std::string("aaa\":1}") + std::string(SIMDJSON_PADDING, '\0');
ondemand::parser parser;
ondemand::document doc = parser.iterate(json);
doc.at_path("." + key); // heap-buffer-overflow
```

The key is quote-terminated inside the buffer, so the fix is to stop the comparison at that quote. Escaped quotes stay part of the key.

Adds a regression test.

https://claude.ai/code/session_01S4sf2z7qo55TzRv4TEtMD8