### PR TITLE
Add C++20 char8_t string accessors to the On-Demand API (#2731)

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -462,9 +462,6 @@ Because `std::u8string_view` points inside the parser (just like `std::string_vi
 it is invalidated when you parse another document or destroy the parser. Note also that the
 standard library does not let you print a `std::u8string_view` with `std::cout`.
 
-The DOM API offers `get_u8string()` and `get<std::u8string_view>()` on `dom::element`. It
-does not offer `std::u8string` since it does not offer `std::string` either.
-
 Avoiding pitfalls: enable development checks
 --------------------
 

--- a/doc/basics.md
+++ b/doc/basics.md
@@ -15,6 +15,7 @@ separate document](https://github.com/simdjson/simdjson/blob/master/doc/builder.
 - [Documents are iterators](#documents-are-iterators)
   * [Parser, document and JSON scope](#parser-document-and-json-scope)
 - [string_view](#string_view)
+- [u8string_view and u8string (C++20)](#u8string_view-and-u8string-c20)
 - [Avoiding pitfalls: enable development checks](#avoiding-pitfalls-enable-development-checks)
 - [Using the parsed JSON](#using-the-parsed-json)
   * [Using the parsed JSON: additional examples](#using-the-parsed-json-additional-examples)
@@ -418,6 +419,51 @@ offer the same API, irrespective of the compiler and standard library. The macro
 Some users prefer to use non-JSON native encoding formats such as UTF-16 or UTF-32. Users may
 transcode the UTF-8 strings produced by the simdjson library to other formats. See the
 [simdutf library](https://github.com/simdutf/simdutf), for example.
+
+u8string_view and u8string (C++20)
+-------------
+
+C++20 introduced the `char8_t` type, along with `std::u8string_view` and `std::u8string`,
+to represent UTF-8 data in the type system. Because every string that simdjson produces is
+valid UTF-8, we offer `char8_t` variants of our string accessors. They are available when
+the macro `SIMDJSON_SUPPORTS_CHAR8_T` is set (it is set automatically when the compiler
+defines `__cpp_char8_t`). They are exact aliases of the `char`-based accessors: the same
+bytes, at the same address, with no copy and no conversion.
+
+| `char` accessor           | `char8_t` accessor          | Available on                                        |
+|:--------------------------|:----------------------------|:----------------------------------------------------|
+| `get_string()`            | `get_u8string()`            | `ondemand::value`, `ondemand::document`, `dom::element` |
+| `field.unescaped_key()`   | `field.unescaped_u8key()`   | `ondemand::field`                                   |
+| `field.escaped_key()`     | `field.escaped_u8key()`     | `ondemand::field`                                   |
+| `get<std::string_view>()` | `get<std::u8string_view>()` | `ondemand::value`, `ondemand::document`, `dom::element` |
+
+```C++
+auto json = R"({ "make": "Toyota", "model": "Camry" })"_padded;
+ondemand::parser parser;
+ondemand::document doc = parser.iterate(json);
+std::u8string_view make = doc["make"].get_u8string();
+```
+
+On-demand also accepts `std::u8string_view` and `std::u8string` wherever it accepts
+`std::string_view` and `std::string`: as a template parameter to `get<T>()`, as the
+receiver of `get_string()` and `unescaped_key()`, and as the element type of a
+container (C++20 deserialization).
+
+```C++
+std::u8string owned;
+auto error = doc["make"].get_string(owned);            // stores a copy
+auto tags = doc["tags"].get<std::vector<std::u8string>>();
+```
+
+The receiver overloads (`get_string(receiver)` and `unescaped_key(receiver)`) accept both
+`std::u8string` (which stores a copy) and `std::u8string_view` (which does not).
+
+Because `std::u8string_view` points inside the parser (just like `std::string_view` does),
+it is invalidated when you parse another document or destroy the parser. Note also that the
+standard library does not let you print a `std::u8string_view` with `std::cout`.
+
+The DOM API offers `get_u8string()` and `get<std::u8string_view>()` on `dom::element`. It
+does not offer `std::u8string` since it does not offer `std::string` either.
 
 Avoiding pitfalls: enable development checks
 --------------------

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -171,7 +171,7 @@ Once you have an element, you can navigate it with idiomatic C++ iterators, oper
   `double x = json_element`. This works for double, uint64_t, int64_t, bool,
   dom::object and dom::array. An exception (`simdjson::simdjson_error`) is thrown if the cast is not possible.
 * **Extracting Values (without exceptions):** You can use a variant usage of `get()` with error codes to avoid exceptions. You first declare the variable of the appropriate type (`double`, `uint64_t`, `int64_t`, `bool`, `std::string_view`,
-  `dom::object` and `dom::array`) and pass it by reference to `get()` which gives you back an error code: e.g.,
+  `std::u8string_view` (C++20), `dom::object` and `dom::array`) and pass it by reference to `get()` which gives you back an error code: e.g.,
   ```cpp
   simdjson::error_code error;
   // _padded returns an simdjson::padded_string instance

--- a/include/simdjson/base.h
+++ b/include/simdjson/base.h
@@ -12,6 +12,11 @@
 #include "simdjson/concepts.h"
 #include "simdjson/constevalutil.h"
 
+#if SIMDJSON_SUPPORTS_CHAR8_T
+#include <string>
+#include <string_view>
+#endif
+
 /**
  * @brief The top level simdjson namespace, containing everything the library provides.
  */
@@ -83,6 +88,52 @@ class escape_json_string;
 class tape_ref;
 struct value128;
 enum class tape_type;
+
+#if SIMDJSON_SUPPORTS_CHAR8_T
+/**
+ * Reinterpret a UTF-8 string as a C++20 std::u8string_view. No byte is copied
+ * or modified: char8_t and char have the same size, representation and
+ * alignment. Every string that simdjson produces is valid UTF-8, so this is a
+ * lossless view over the very same memory.
+ * @private
+ */
+simdjson_inline std::u8string_view as_u8string_view(std::string_view v) noexcept {
+  return std::u8string_view(reinterpret_cast<const char8_t *>(v.data()), v.size());
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
+
+/**
+ * Assign a UTF-8 string to a string-like receiver. The general case simply
+ * assigns the std::string_view: it covers std::string and any user type that
+ * can be assigned from a std::string_view.
+ * @private
+ */
+template <typename string_type>
+simdjson_inline void assign_utf8(string_type &receiver, std::string_view content) noexcept {
+  receiver = content;
+}
+
+#if SIMDJSON_SUPPORTS_CHAR8_T
+/**
+ * Assign a UTF-8 string to a char8_t-based string (e.g., std::u8string). This
+ * overload is more specialized than the general one, so overload resolution
+ * prefers it whenever the receiver holds char8_t.
+ * @private
+ */
+template <typename traits_type, typename allocator_type>
+simdjson_inline void assign_utf8(std::basic_string<char8_t, traits_type, allocator_type> &receiver, std::string_view content) noexcept {
+  receiver.assign(reinterpret_cast<const char8_t *>(content.data()), content.size());
+}
+
+/**
+ * Assign a UTF-8 string to a char8_t-based string view (e.g., std::u8string_view).
+ * @private
+ */
+template <typename traits_type>
+simdjson_inline void assign_utf8(std::basic_string_view<char8_t, traits_type> &receiver, std::string_view content) noexcept {
+  receiver = std::basic_string_view<char8_t, traits_type>(reinterpret_cast<const char8_t *>(content.data()), content.size());
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 
 } // namespace internal
 } // namespace simdjson

--- a/include/simdjson/compiler_check.h
+++ b/include/simdjson/compiler_check.h
@@ -147,6 +147,17 @@
 #define SIMDJSON_SUPPORTS_DESERIALIZATION 0
 #endif
 
+// The C++20 char8_t type (and std::u8string/std::u8string_view) is available.
+// Because all strings that simdjson produces are valid UTF-8, we can offer
+// char8_t variants of our string accessors when this macro is set.
+#if !defined(SIMDJSON_SUPPORTS_CHAR8_T)
+#if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+#define SIMDJSON_SUPPORTS_CHAR8_T 1
+#else
+#define SIMDJSON_SUPPORTS_CHAR8_T 0
+#endif
+#endif // !defined(SIMDJSON_SUPPORTS_CHAR8_T)
+
 
 #if !defined(SIMDJSON_CONSTEVAL)
 #if defined(__cpp_consteval) && __cpp_consteval >= 201811L && defined(__cpp_lib_constexpr_string) && __cpp_lib_constexpr_string >= 201907L

--- a/include/simdjson/concepts.h
+++ b/include/simdjson/concepts.h
@@ -3,6 +3,7 @@
 #if SIMDJSON_SUPPORTS_CONCEPTS
 
 #include <concepts>
+#include <string_view>
 #include <type_traits>
 
 namespace simdjson {
@@ -43,6 +44,19 @@ template<typename T>
 concept constructible_from_string_view = std::is_constructible_v<T, std::string_view>
                                         && !std::is_same_v<T, std::string_view>
                                         && std::is_default_constructible_v<T>;
+
+#if SIMDJSON_SUPPORTS_CHAR8_T
+/**
+ * A C++20 char8_t string type such as std::u8string. Such types cannot be built
+ * from a std::string_view (the character types differ), so they need their own
+ * deserialization path, going through the u8 string accessors.
+ */
+template<typename T>
+concept constructible_from_u8string_view = std::is_constructible_v<T, std::u8string_view>
+                                        && !std::is_same_v<T, std::u8string_view>
+                                        && !std::is_constructible_v<T, std::string_view>
+                                        && std::is_default_constructible_v<T>;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 
 template<typename M>
 concept string_view_keyed_map = string_view_like<typename M::key_type>

--- a/include/simdjson/dom/element-inl.h
+++ b/include/simdjson/dom/element-inl.h
@@ -65,7 +65,7 @@ simdjson_inline simdjson_result<std::string_view> simdjson_result<dom::element>:
   if (error()) { return error(); }
   return first.get_string();
 }
-#if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+#if SIMDJSON_SUPPORTS_CHAR8_T
 simdjson_inline simdjson_result<std::u8string_view> simdjson_result<dom::element>::get_u8string() const noexcept {
   if (error()) { return error(); }
   return first.get_u8string();
@@ -269,11 +269,11 @@ inline simdjson_result<std::string_view> element::get_string() const noexcept {
       return INCORRECT_TYPE;
   }
 }
-#if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+#if SIMDJSON_SUPPORTS_CHAR8_T
 inline simdjson_result<std::u8string_view> element::get_u8string() const noexcept {
   std::string_view v;
   SIMDJSON_TRY(get_string().get(v));
-  return std::u8string_view(reinterpret_cast<const char8_t*>(v.data()), v.size());
+  return internal::as_u8string_view(v);
 }
 #endif
 inline simdjson_result<uint64_t> element::get_uint64() const noexcept {
@@ -371,6 +371,9 @@ template<> inline simdjson_result<array> element::get<array>() const noexcept { 
 template<> inline simdjson_result<object> element::get<object>() const noexcept { return get_object(); }
 template<> inline simdjson_result<const char *> element::get<const char *>() const noexcept { return get_c_str(); }
 template<> inline simdjson_result<std::string_view> element::get<std::string_view>() const noexcept { return get_string(); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template<> inline simdjson_result<std::u8string_view> element::get<std::u8string_view>() const noexcept { return get_u8string(); }
+#endif
 template<> inline simdjson_result<int64_t> element::get<int64_t>() const noexcept { return get_int64(); }
 template<> inline simdjson_result<uint64_t> element::get<uint64_t>() const noexcept { return get_uint64(); }
 template<> inline simdjson_result<double> element::get<double>() const noexcept { return get_double(); }

--- a/include/simdjson/dom/element.h
+++ b/include/simdjson/dom/element.h
@@ -93,7 +93,7 @@ public:
    */
   inline simdjson_result<std::string_view> get_string() const noexcept;
 
-  #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+  #if SIMDJSON_SUPPORTS_CHAR8_T
   /**
    * Cast this element to a C++20 UTF-8 string.
    *
@@ -211,7 +211,7 @@ public:
    * Supported types:
    * - Boolean: bool
    * - Number: double, uint64_t, int64_t
-   * - String: std::string_view, const char *
+   * - String: std::string_view, const char *, std::u8string_view (C++20)
    * - Array: dom::array
    * - Object: dom::object
    *
@@ -226,7 +226,7 @@ public:
    * Supported types:
    * - Boolean: bool
    * - Number: double, uint64_t, int64_t
-   * - String: std::string_view, const char *
+   * - String: std::string_view, const char *, std::u8string_view (C++20)
    * - Array: dom::array
    * - Object: dom::object
    *
@@ -256,7 +256,7 @@ public:
    * Supported types:
    * - Boolean: bool
    * - Number: double, uint64_t, int64_t
-   * - String: std::string_view, const char *
+   * - String: std::string_view, const char *, std::u8string_view (C++20)
    * - Array: dom::array
    * - Object: dom::object
    *
@@ -275,7 +275,7 @@ public:
    * Supported types:
    * - Boolean: bool
    * - Number: double, uint64_t, int64_t
-   * - String: std::string_view, const char *
+   * - String: std::string_view, const char *, std::u8string_view (C++20)
    * - Array: dom::array
    * - Object: dom::object
    *
@@ -559,7 +559,7 @@ public:
   simdjson_inline simdjson_result<const char *> get_c_str() const noexcept;
   simdjson_inline simdjson_result<size_t> get_string_length() const noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string() const noexcept;
-  #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+  #if SIMDJSON_SUPPORTS_CHAR8_T
   simdjson_inline simdjson_result<std::u8string_view> get_u8string() const noexcept;
   #endif
   simdjson_inline simdjson_result<int64_t> get_int64() const noexcept;

--- a/include/simdjson/generic/ondemand/deserialize.h
+++ b/include/simdjson/generic/ondemand/deserialize.h
@@ -22,6 +22,9 @@ template <> struct is_builtin_deserializable<SIMDJSON_IMPLEMENTATION::ondemand::
 template <> struct is_builtin_deserializable<SIMDJSON_IMPLEMENTATION::ondemand::value> : std::true_type {};
 template <> struct is_builtin_deserializable<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> : std::true_type {};
 template <> struct is_builtin_deserializable<std::string_view> : std::true_type {};
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template <> struct is_builtin_deserializable<std::u8string_view> : std::true_type {};
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 
 template <typename T>
 concept is_builtin_deserializable_v = is_builtin_deserializable<T>::value;

--- a/include/simdjson/generic/ondemand/document-inl.h
+++ b/include/simdjson/generic/ondemand/document-inl.h
@@ -160,6 +160,13 @@ simdjson_inline simdjson_result<float> document::get_float_in_string() noexcept 
 simdjson_inline simdjson_result<std::string_view> document::get_string(bool allow_replacement) noexcept {
   return get_root_value_iterator().get_root_string(true, allow_replacement);
 }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> document::get_u8string(bool allow_replacement) noexcept {
+  std::string_view content;
+  SIMDJSON_TRY( get_string(allow_replacement).get(content) );
+  return internal::as_u8string_view(content);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code document::get_string(string_type& receiver, bool allow_replacement) noexcept {
   return get_root_value_iterator().get_root_string(receiver, true, allow_replacement);
@@ -181,6 +188,9 @@ template<> simdjson_inline simdjson_result<array> document::get() & noexcept { r
 template<> simdjson_inline simdjson_result<object> document::get() & noexcept { return get_object(); }
 template<> simdjson_inline simdjson_result<raw_json_string> document::get() & noexcept { return get_raw_json_string(); }
 template<> simdjson_inline simdjson_result<std::string_view> document::get() & noexcept { return get_string(false); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template<> simdjson_inline simdjson_result<std::u8string_view> document::get() & noexcept { return get_u8string(false); }
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template<> simdjson_inline simdjson_result<double> document::get() & noexcept { return get_double(); }
 template<> simdjson_inline simdjson_result<float> document::get() & noexcept { return get_float(); }
 template<> simdjson_inline simdjson_result<uint64_t> document::get() & noexcept { return get_uint64(); }
@@ -194,6 +204,9 @@ template<> simdjson_warn_unused simdjson_inline error_code document::get(array& 
 template<> simdjson_warn_unused simdjson_inline error_code document::get(object& out) & noexcept { return get_object().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(raw_json_string& out) & noexcept { return get_raw_json_string().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(std::string_view& out) & noexcept { return get_string(false).get(out); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template<> simdjson_warn_unused simdjson_inline error_code document::get(std::u8string_view& out) & noexcept { return get_u8string(false).get(out); }
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template<> simdjson_warn_unused simdjson_inline error_code document::get(double& out) & noexcept { return get_double().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(float& out) & noexcept { return get_float().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code document::get(uint64_t& out) & noexcept { return get_uint64().get(out); }
@@ -205,6 +218,9 @@ template<> simdjson_warn_unused simdjson_inline error_code document::get(value& 
 
 template<> simdjson_deprecated simdjson_inline simdjson_result<raw_json_string> document::get() && noexcept { return get_raw_json_string(); }
 template<> simdjson_deprecated simdjson_inline simdjson_result<std::string_view> document::get() && noexcept { return get_string(false); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template<> simdjson_deprecated simdjson_inline simdjson_result<std::u8string_view> document::get() && noexcept { return get_u8string(false); }
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template<> simdjson_deprecated simdjson_inline simdjson_result<double> document::get() && noexcept { return std::forward<document>(*this).get_double(); }
 template<> simdjson_deprecated simdjson_inline simdjson_result<float> document::get() && noexcept { return std::forward<document>(*this).get_float(); }
 template<> simdjson_deprecated simdjson_inline simdjson_result<uint64_t> document::get() && noexcept { return std::forward<document>(*this).get_uint64(); }
@@ -565,6 +581,12 @@ simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLE
   if (error()) { return error(); }
   return first.get_string(allow_replacement);
 }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_u8string(bool allow_replacement) noexcept {
+  if (error()) { return error(); }
+  return first.get_u8string(allow_replacement);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document>::get_string(string_type& receiver, bool allow_replacement) noexcept {
   if (error()) { return error(); }
@@ -803,6 +825,13 @@ simdjson_inline simdjson_result<double> document_reference::get_double_in_string
 simdjson_inline simdjson_result<float> document_reference::get_float() noexcept { return doc->get_root_value_iterator().get_root_float(false); }
 simdjson_inline simdjson_result<float> document_reference::get_float_in_string() noexcept { return doc->get_root_value_iterator().get_root_float_in_string(false); }
 simdjson_inline simdjson_result<std::string_view> document_reference::get_string(bool allow_replacement) noexcept { return doc->get_root_value_iterator().get_root_string(false, allow_replacement); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> document_reference::get_u8string(bool allow_replacement) noexcept {
+  std::string_view content;
+  SIMDJSON_TRY( get_string(allow_replacement).get(content) );
+  return internal::as_u8string_view(content);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code document_reference::get_string(string_type& receiver, bool allow_replacement) noexcept { return doc->get_root_value_iterator().get_root_string(receiver, false, allow_replacement); }
 simdjson_inline simdjson_result<std::string_view> document_reference::get_wobbly_string() noexcept { return doc->get_root_value_iterator().get_root_wobbly_string(false); }
@@ -814,6 +843,9 @@ template<> simdjson_inline simdjson_result<array> document_reference::get() & no
 template<> simdjson_inline simdjson_result<object> document_reference::get() & noexcept { return get_object(); }
 template<> simdjson_inline simdjson_result<raw_json_string> document_reference::get() & noexcept { return get_raw_json_string(); }
 template<> simdjson_inline simdjson_result<std::string_view> document_reference::get() & noexcept { return get_string(false); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template<> simdjson_inline simdjson_result<std::u8string_view> document_reference::get() & noexcept { return get_u8string(false); }
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template<> simdjson_inline simdjson_result<double> document_reference::get() & noexcept { return get_double(); }
 template<> simdjson_inline simdjson_result<float> document_reference::get() & noexcept { return get_float(); }
 template<> simdjson_inline simdjson_result<uint64_t> document_reference::get() & noexcept { return get_uint64(); }
@@ -985,6 +1017,12 @@ simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLE
   if (error()) { return error(); }
   return first.get_string(allow_replacement);
 }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_u8string(bool allow_replacement) noexcept {
+  if (error()) { return error(); }
+  return first.get_u8string(allow_replacement);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::document_reference>::get_string(string_type& receiver, bool allow_replacement) noexcept {
   if (error()) { return error(); }

--- a/include/simdjson/generic/ondemand/document.h
+++ b/include/simdjson/generic/ondemand/document.h
@@ -146,6 +146,24 @@ public:
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  /**
+   * Cast this JSON value to a C++20 UTF-8 string.
+   *
+   * The string is guaranteed to be valid UTF-8.
+   *
+   * Equivalent to get<std::u8string_view>(). This is a zero-copy alias of
+   * get_string(): the very same bytes are returned, viewed as char8_t.
+   *
+   * Important: Calling get_u8string() twice on the same document is an error.
+   *
+   * @param allow_replacement Whether to allow a replacement character for unmatched surrogate pairs.
+   * @returns An UTF-8 string. The string is stored in the parser and will be invalidated the next
+   *          time it parses a document or when it is destroyed.
+   * @returns INCORRECT_TYPE if the JSON value is not a string.
+   */
+  simdjson_inline simdjson_result<std::u8string_view> get_u8string(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   /**
    * Attempts to fill the provided std::string reference with the parsed value of the current string.
    *
@@ -883,6 +901,9 @@ public:
   simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<float> get_float_in_string() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  simdjson_inline simdjson_result<std::u8string_view> get_u8string(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;
   simdjson_inline simdjson_result<std::string_view> get_wobbly_string() noexcept;
@@ -1047,6 +1068,9 @@ public:
   simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<float> get_float_in_string() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  simdjson_inline simdjson_result<std::u8string_view> get_u8string(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;
   simdjson_inline simdjson_result<std::string_view> get_wobbly_string() noexcept;
@@ -1144,6 +1168,9 @@ public:
   simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<float> get_float_in_string() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  simdjson_inline simdjson_result<std::u8string_view> get_u8string(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;
   simdjson_inline simdjson_result<std::string_view> get_wobbly_string() noexcept;

--- a/include/simdjson/generic/ondemand/field-inl.h
+++ b/include/simdjson/generic/ondemand/field-inl.h
@@ -38,11 +38,19 @@ simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> field::un
   return answer;
 }
 
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_warn_unused simdjson_result<std::u8string_view> field::unescaped_u8key(bool allow_replacement) noexcept {
+  std::string_view key;
+  SIMDJSON_TRY( unescaped_key(allow_replacement).get(key) );
+  return internal::as_u8string_view(key);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
+
 template <typename string_type>
 simdjson_inline simdjson_warn_unused error_code field::unescaped_key(string_type& receiver, bool allow_replacement) noexcept {
   std::string_view key;
   SIMDJSON_TRY( unescaped_key(allow_replacement).get(key) );
-  receiver = key;
+  internal::assign_utf8(receiver, key);
   return SUCCESS;
 }
 
@@ -63,6 +71,12 @@ simdjson_inline std::string_view field::escaped_key() const noexcept {
   while(*end_quote != '"') end_quote--;
   return std::string_view(reinterpret_cast<const char*>(first.buf), end_quote - first.buf);
 }
+
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline std::u8string_view field::escaped_u8key() const noexcept {
+  return internal::as_u8string_view(escaped_key());
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 
 simdjson_inline value &field::value() & noexcept {
   return second;
@@ -108,10 +122,24 @@ simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLE
   return first.escaped_key();
 }
 
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::escaped_u8key() noexcept {
+  if (error()) { return error(); }
+  return first.escaped_u8key();
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
+
 simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::unescaped_key(bool allow_replacement) noexcept {
   if (error()) { return error(); }
   return first.unescaped_key(allow_replacement);
 }
+
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::unescaped_u8key(bool allow_replacement) noexcept {
+  if (error()) { return error(); }
+  return first.unescaped_u8key(allow_replacement);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 
 template<typename string_type>
 simdjson_warn_unused simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::field>::unescaped_key(string_type &receiver, bool allow_replacement) noexcept {

--- a/include/simdjson/generic/ondemand/field.h
+++ b/include/simdjson/generic/ondemand/field.h
@@ -37,6 +37,16 @@ public:
    * call it again nor can you call key().
    */
   simdjson_inline simdjson_warn_unused simdjson_result<std::string_view> unescaped_key(bool allow_replacement = false) noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  /**
+   * Get the key as a C++20 u8string_view. This is a zero-copy alias of
+   * unescaped_key(): the very same bytes are returned, viewed as char8_t.
+   *
+   * This consumes the key: once you have called unescaped_u8key(), you cannot
+   * call it again nor can you call key().
+   */
+  simdjson_inline simdjson_warn_unused simdjson_result<std::u8string_view> unescaped_u8key(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   /**
    * Get the key as a string_view (for higher speed, consider raw_key).
    * We deliberately use a more cumbersome name (unescaped_key) to force users
@@ -69,6 +79,16 @@ public:
    * you can safely call it repeatedly. Use unescaped_key() to get the unescaped key.
    */
   simdjson_inline std::string_view escaped_key() const noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  /**
+   * Get the key as a C++20 u8string_view. This is a zero-copy alias of
+   * escaped_key(): the very same bytes are returned, viewed as char8_t.
+   * The string is unprocessed, so it may contain escape characters
+   * (e.g., \uXXXX or \n). It does not count as a consumption of the content:
+   * you can safely call it repeatedly.
+   */
+  simdjson_inline std::u8string_view escaped_u8key() const noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   /**
    * Get the field value.
    */
@@ -100,11 +120,17 @@ public:
   simdjson_inline simdjson_result() noexcept = default;
 
   simdjson_inline simdjson_result<std::string_view> unescaped_key(bool allow_replacement = false) noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  simdjson_inline simdjson_result<std::u8string_view> unescaped_u8key(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   template<typename string_type>
   simdjson_inline error_code unescaped_key(string_type &receiver, bool allow_replacement = false) noexcept;
   simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::raw_json_string> key() noexcept;
   simdjson_inline simdjson_result<std::string_view> key_raw_json_token() noexcept;
   simdjson_inline simdjson_result<std::string_view> escaped_key() noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  simdjson_inline simdjson_result<std::u8string_view> escaped_u8key() noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   simdjson_inline simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value> value() noexcept;
 };
 

--- a/include/simdjson/generic/ondemand/std_deserialize.h
+++ b/include/simdjson/generic/ondemand/std_deserialize.h
@@ -88,6 +88,18 @@ error_code tag_invoke(deserialize_tag, ValT &val, T &out) noexcept(std::is_nothr
   return SUCCESS;
 }
 
+#if SIMDJSON_SUPPORTS_CHAR8_T
+// any C++20 char8_t string-like type (can be constructed from std::u8string_view),
+// such as std::u8string
+template <concepts::constructible_from_u8string_view T, typename ValT>
+error_code tag_invoke(deserialize_tag, ValT &val, T &out) noexcept(std::is_nothrow_constructible_v<T, std::u8string_view>) {
+  std::u8string_view str;
+  SIMDJSON_TRY(val.get_u8string().get(str));
+  out = T{str};
+  return SUCCESS;
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
+
 
 /**
  * STL containers have several constructors including one that takes a single

--- a/include/simdjson/generic/ondemand/std_deserialize.h
+++ b/include/simdjson/generic/ondemand/std_deserialize.h
@@ -284,7 +284,15 @@ error_code tag_invoke(deserialize_tag, auto &val, T &out) noexcept(nothrow_deser
 
 template <typename T>
 constexpr bool user_defined_type = (std::is_class_v<T>
-&& !std::is_same_v<T, std::string> && !std::is_same_v<T, std::string_view> && !concepts::optional_type<T> &&
+&& !std::is_same_v<T, std::string> && !std::is_same_v<T, std::string_view>
+#if SIMDJSON_SUPPORTS_CHAR8_T
+// The char8_t string types are class types with no reflectable members, so
+// without this they would be taken for user structs and the reflection
+// overload below would compete with the u8 string overload in
+// std_deserialize.h, making every tag_invoke call on them ambiguous.
+&& !std::is_same_v<T, std::u8string> && !std::is_same_v<T, std::u8string_view>
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
+&& !concepts::optional_type<T> &&
 !concepts::appendable_containers<T>);
 
 

--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -49,6 +49,13 @@ simdjson_inline simdjson_result<raw_json_string> value::get_raw_json_string() no
 simdjson_inline simdjson_result<std::string_view> value::get_string(bool allow_replacement) noexcept {
   return iter.get_string(allow_replacement);
 }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> value::get_u8string(bool allow_replacement) noexcept {
+  std::string_view content;
+  SIMDJSON_TRY( get_string(allow_replacement).get(content) );
+  return internal::as_u8string_view(content);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template <typename string_type>
 simdjson_warn_unused simdjson_inline error_code value::get_string(string_type& receiver, bool allow_replacement) noexcept {
   return iter.get_string(receiver, allow_replacement);
@@ -103,6 +110,9 @@ template<> simdjson_inline simdjson_result<array> value::get() noexcept { return
 template<> simdjson_inline simdjson_result<object> value::get() noexcept { return get_object(); }
 template<> simdjson_inline simdjson_result<raw_json_string> value::get() noexcept { return get_raw_json_string(); }
 template<> simdjson_inline simdjson_result<std::string_view> value::get() noexcept { return get_string(false); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template<> simdjson_inline simdjson_result<std::u8string_view> value::get() noexcept { return get_u8string(false); }
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template<> simdjson_inline simdjson_result<number> value::get() noexcept { return get_number(); }
 template<> simdjson_inline simdjson_result<double> value::get() noexcept { return get_double(); }
 template<> simdjson_inline simdjson_result<float> value::get() noexcept { return get_float(); }
@@ -117,6 +127,9 @@ template<> simdjson_warn_unused simdjson_inline error_code value::get(array& out
 template<> simdjson_warn_unused simdjson_inline error_code value::get(object& out) noexcept { return get_object().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(raw_json_string& out) noexcept { return get_raw_json_string().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(std::string_view& out) noexcept { return get_string(false).get(out); }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+template<> simdjson_warn_unused simdjson_inline error_code value::get(std::u8string_view& out) noexcept { return get_u8string(false).get(out); }
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template<> simdjson_warn_unused simdjson_inline error_code value::get(number& out) noexcept { return get_number().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(double& out) noexcept { return get_double().get(out); }
 template<> simdjson_warn_unused simdjson_inline error_code value::get(float& out) noexcept { return get_float().get(out); }
@@ -329,6 +342,10 @@ template <typename Func>
 template <typename Func>
 #endif
 inline error_code value::for_each_at_path_with_wildcard(std::string_view json_path, Func&& callback) noexcept {
+  // Every recursive step of for_each_at_path_with_wildcard goes through this
+  // function, and each one descends one level into the document. A path with
+  // many segments applied to a deeply nested document would otherwise recurse
+  // without bound and overflow the stack.
   if (size_t(iter.depth()) >= iter.json_iter().parser->max_depth()) { return DEPTH_ERROR; }
   json_type t;
   SIMDJSON_TRY(type().get(t));
@@ -462,6 +479,12 @@ simdjson_inline simdjson_result<std::string_view> simdjson_result<SIMDJSON_IMPLE
   if (error()) { return error(); }
   return first.get_string(allow_replacement);
 }
+#if SIMDJSON_SUPPORTS_CHAR8_T
+simdjson_inline simdjson_result<std::u8string_view> simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_u8string(bool allow_replacement) noexcept {
+  if (error()) { return error(); }
+  return first.get_u8string(allow_replacement);
+}
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 template <typename string_type>
 simdjson_inline error_code simdjson_result<SIMDJSON_IMPLEMENTATION::ondemand::value>::get_string(string_type& receiver, bool allow_replacement) noexcept {
   if (error()) { return error(); }

--- a/include/simdjson/generic/ondemand/value.h
+++ b/include/simdjson/generic/ondemand/value.h
@@ -31,7 +31,7 @@ public:
   /**
    * Get this value as the given type.
    *
-   * Supported types: object, array, raw_json_string, string_view, uint64_t, int64_t, uint32_t, int32_t, double, float, bool
+   * Supported types: object, array, raw_json_string, string_view, u8string_view (C++20), uint64_t, int64_t, uint32_t, int32_t, double, float, bool
    *
    * You may use get_double(), get_float(), get_bool(), get_uint64(), get_int64(),
    * get_uint32(), get_int32(),
@@ -59,7 +59,7 @@ public:
   /**
    * Get this value as the given type.
    *
-   * Supported types: object, array, raw_json_string, string_view, uint64_t, int64_t, uint32_t, int32_t, double, float, bool
+   * Supported types: object, array, raw_json_string, string_view, u8string_view (C++20), uint64_t, int64_t, uint32_t, int32_t, double, float, bool
    * If the macro SIMDJSON_SUPPORTS_CONCEPTS is set, then custom types are also supported.
    *
    * @param out This is set to a value of the given type, parsed from the JSON. If there is an error, this may not be initialized.
@@ -249,6 +249,26 @@ public:
    * @returns INCORRECT_TYPE if the JSON value is not a string.
    */
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
+
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  /**
+   * Cast this JSON value to a C++20 UTF-8 string.
+   *
+   * The string is guaranteed to be valid UTF-8.
+   *
+   * Equivalent to get<std::u8string_view>(). This is a zero-copy alias of
+   * get_string(): the very same bytes are returned, viewed as char8_t.
+   *
+   * Important: a value should be consumed once. Calling get_u8string() twice on the same
+   * value is an error.
+   *
+   * @param allow_replacement Whether to allow a replacement character for unmatched surrogate pairs.
+   * @returns An UTF-8 string. The string is stored in the parser and will be invalidated the next
+   *          time it parses a document or when it is destroyed.
+   * @returns INCORRECT_TYPE if the JSON value is not a string.
+   */
+  simdjson_inline simdjson_result<std::u8string_view> get_u8string(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
 
   /**
    * Attempts to fill the provided std::string reference with the parsed value of the current string.
@@ -807,6 +827,9 @@ public:
   simdjson_inline simdjson_result<float> get_float() noexcept;
   simdjson_inline simdjson_result<float> get_float_in_string() noexcept;
   simdjson_inline simdjson_result<std::string_view> get_string(bool allow_replacement = false) noexcept;
+#if SIMDJSON_SUPPORTS_CHAR8_T
+  simdjson_inline simdjson_result<std::u8string_view> get_u8string(bool allow_replacement = false) noexcept;
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
   template <typename string_type>
   simdjson_warn_unused simdjson_inline error_code get_string(string_type& receiver, bool allow_replacement = false) noexcept;
   simdjson_inline simdjson_result<std::string_view> get_wobbly_string() noexcept;

--- a/include/simdjson/generic/ondemand/value_iterator-inl.h
+++ b/include/simdjson/generic/ondemand/value_iterator-inl.h
@@ -556,7 +556,7 @@ simdjson_warn_unused simdjson_inline error_code value_iterator::get_string(strin
   auto saved_string_buf_loc = _json_iter->string_buf_loc();
   auto err = get_string(allow_replacement).get(content);
   if (err) { return err; }
-  receiver = content;
+  internal::assign_utf8(receiver, content);
   // Restore the string buffer location, effectively discarding any temporary string storage
   _json_iter->string_buf_loc() = saved_string_buf_loc;
   return SUCCESS;
@@ -721,7 +721,7 @@ simdjson_warn_unused simdjson_inline error_code value_iterator::get_root_string(
   auto saved_string_buf_loc = _json_iter->string_buf_loc();
   auto err = get_root_string(check_trailing, allow_replacement).get(content);
   if (err) { return err; }
-  receiver = content;
+  internal::assign_utf8(receiver, content);
   // Restore the string buffer location, effectively discarding any temporary string storage
   _json_iter->string_buf_loc() = saved_string_buf_loc;
   return SUCCESS;

--- a/tests/dom/basictests.cpp
+++ b/tests/dom/basictests.cpp
@@ -918,7 +918,7 @@ namespace dom_api_tests {
 #endif // SIMDJSON_ENABLE_DEPRECATED_API
 
   SIMDJSON_POP_DISABLE_WARNINGS
-  #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+  #if SIMDJSON_SUPPORTS_CHAR8_T
   bool u8string_value() {
     std::cout << "Running " << __func__ << std::endl;
     string json(R"({ "str": "hello u8" })");
@@ -931,6 +931,29 @@ namespace dom_api_tests {
 
     ASSERT_EQUAL( u8_val.size(), 8 );
     ASSERT_TRUE( u8_val == u8"hello u8" );
+    return true;
+  }
+
+  bool u8string_value_get_template() {
+    std::cout << "Running " << __func__ << std::endl;
+    // The key holds an escaped U+00E9, so the unescaped value is five bytes long.
+    string json(R"({ "str": "caf\u00e9", "n": 1 })");
+    dom::parser parser;
+    dom::object object;
+    ASSERT_SUCCESS( parser.parse(json).get(object) );
+
+    std::u8string_view u8_val;
+    ASSERT_SUCCESS( object["str"].get<std::u8string_view>().get(u8_val) );
+    ASSERT_EQUAL( u8_val.size(), 5 );
+    ASSERT_TRUE( u8_val == u8"caf\u00e9" );
+
+    // get(T&), is<T>() and the error path come along with the specialization.
+    std::u8string_view other;
+    ASSERT_SUCCESS( object["str"].get(other) );
+    ASSERT_TRUE( other == u8_val );
+    ASSERT_TRUE( object["str"].is<std::u8string_view>() );
+    ASSERT_FALSE( object["n"].is<std::u8string_view>() );
+    ASSERT_ERROR( object["n"].get<std::u8string_view>(), INCORRECT_TYPE );
     return true;
   }
   #endif
@@ -1442,8 +1465,9 @@ namespace dom_api_tests {
 
   bool run() {
     return
-    #if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L
+    #if SIMDJSON_SUPPORTS_CHAR8_T
            u8string_value() &&
+           u8string_value_get_template() &&
     #endif
     #if SIMDJSON_ENABLE_DEPRECATED_API
         ParsedJson_Iterator_test() &&

--- a/tests/ondemand/CMakeLists.txt
+++ b/tests/ondemand/CMakeLists.txt
@@ -35,6 +35,7 @@ add_cpp_test(ondemand_readme_examples                LABELS ondemand acceptance 
 add_cpp_test(ondemand_scalar_tests                   LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_to_string                      LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_twitter_tests                  LABELS ondemand acceptance per_implementation)
+add_cpp_test(ondemand_u8string_tests                 LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_wrong_type_error_tests         LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_iterate_many_csv               LABELS ondemand acceptance per_implementation)
 add_cpp_test(ondemand_custom_types_tests             LABELS ondemand acceptance per_implementation)

--- a/tests/ondemand/ondemand_u8string_tests.cpp
+++ b/tests/ondemand/ondemand_u8string_tests.cpp
@@ -1,0 +1,338 @@
+#include "simdjson.h"
+#include "test_ondemand.h"
+
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <vector>
+
+using namespace simdjson;
+
+// The C++20 char8_t variants of our string accessors are only available when the
+// compiler provides char8_t. Under C++17 (and earlier), this whole file is a no-op.
+//
+// Note: we keep this source file pure ASCII. Non-ASCII characters are spelled out
+// with \u escapes, both in the JSON inputs and in the expected u8 literals.
+namespace u8string_tests {
+#if SIMDJSON_SUPPORTS_CHAR8_T
+
+  // { "make": "Toyota", "key": "caf\u00e9", "tags": ["a", "b"] }
+  const padded_string BASIC_JSON =
+      "{ \"make\": \"Toyota\", \"key\": \"caf\\u00e9\", \"tags\": [\"a\", \"b\"] }"_padded;
+
+  bool value_get_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::u8string_view view;
+    ASSERT_SUCCESS( doc["make"].get_u8string().get(view) );
+    ASSERT_TRUE( view == u8"Toyota" );
+    ASSERT_EQUAL( view.size(), 6 );
+    TEST_SUCCEED();
+  }
+
+  // "caf\u00e9" unescapes to five UTF-8 bytes: "caf" followed by U+00E9.
+  bool value_get_u8string_unicode() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::u8string_view view;
+    ASSERT_SUCCESS( doc["key"].get_u8string().get(view) );
+    ASSERT_TRUE( view == u8"caf\u00e9" );
+    ASSERT_EQUAL( view.size(), 5 );
+    TEST_SUCCEED();
+  }
+
+  // The u8 accessors are a pure reinterpretation: they must hand back exactly the
+  // bytes that get_string() hands back.
+  bool value_get_u8string_same_bytes() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::string_view narrow;
+    ASSERT_SUCCESS( doc["key"].get_string().get(narrow) );
+    doc.rewind();
+    std::u8string_view wide;
+    ASSERT_SUCCESS( doc["key"].get_u8string().get(wide) );
+    ASSERT_EQUAL( wide.size(), narrow.size() );
+    ASSERT_TRUE( std::equal(narrow.begin(), narrow.end(), wide.begin(),
+                            [](char a, char8_t b) { return static_cast<unsigned char>(a) == b; }) );
+    TEST_SUCCEED();
+  }
+
+  bool value_get_u8string_incorrect_type() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"({ "n": 1 })"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    ASSERT_ERROR( doc["n"].get_u8string(), INCORRECT_TYPE );
+    TEST_SUCCEED();
+  }
+
+  // The allow_replacement flag is forwarded, just like it is by get_string().
+  bool value_get_u8string_replacement() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "{ \"deviceId\": \"431924697b\\udff0L\\u0001Y\" }"_padded;
+    {
+      ondemand::document doc;
+      ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+      ASSERT_ERROR( doc["deviceId"].get_u8string(), STRING_ERROR );
+    }
+    {
+      ondemand::document doc;
+      ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+      std::u8string_view view;
+      ASSERT_SUCCESS( doc["deviceId"].get_u8string(true).get(view) );
+      // The unpaired surrogate becomes the replacement character U+FFFD.
+      ASSERT_TRUE( view.find(u8"\ufffd") != std::u8string_view::npos );
+    }
+    TEST_SUCCEED();
+  }
+
+  bool document_get_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("a document that is just a string")"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    std::u8string_view view;
+    ASSERT_SUCCESS( doc.get_u8string().get(view) );
+    ASSERT_TRUE( view == u8"a document that is just a string" );
+    TEST_SUCCEED();
+  }
+
+  // simdjson_result<document> forwards get_u8string(), error included.
+  bool document_result_get_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("hello")"_padded;
+    std::u8string_view view;
+    ASSERT_SUCCESS( parser.iterate(json).get_u8string().get(view) );
+    ASSERT_TRUE( view == u8"hello" );
+    auto empty = ""_padded;
+    ASSERT_ERROR( parser.iterate(empty).get_u8string(), EMPTY );
+    TEST_SUCCEED();
+  }
+
+  // iterate_many hands out document_reference instances.
+  bool document_reference_get_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("one" "two" "three")"_padded;
+    ondemand::document_stream stream;
+    ASSERT_SUCCESS( parser.iterate_many(json).get(stream) );
+    const std::u8string_view expected[3] = { u8"one", u8"two", u8"three" };
+    size_t count = 0;
+    for (auto doc : stream) {
+      ASSERT_TRUE( count < 3 );
+      std::u8string_view view;
+      ASSERT_SUCCESS( doc.get_u8string().get(view) );
+      ASSERT_TRUE( view == expected[count] );
+      count++;
+    }
+    ASSERT_EQUAL( count, 3 );
+    TEST_SUCCEED();
+  }
+
+  bool field_u8key() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = "{ \"caf\\u00e9\": \"value\" }"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    ondemand::object object;
+    ASSERT_SUCCESS( doc.get_object().get(object) );
+    size_t count = 0;
+    for (auto field : object) {
+      // escaped_u8key() hands back the raw, still escaped key.
+      std::u8string_view escaped;
+      ASSERT_SUCCESS( field.escaped_u8key().get(escaped) );
+      ASSERT_TRUE( escaped == u8"caf\\u00e9" );
+      // unescaped_u8key() hands back the unescaped key.
+      std::u8string_view unescaped;
+      ASSERT_SUCCESS( field.unescaped_u8key().get(unescaped) );
+      ASSERT_TRUE( unescaped == u8"caf\u00e9" );
+      count++;
+    }
+    ASSERT_EQUAL( count, 1 );
+    TEST_SUCCEED();
+  }
+
+  // The templated receiver overloads must accept a std::u8string.
+  bool receiver_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    ondemand::object object;
+    ASSERT_SUCCESS( doc.get_object().get(object) );
+    std::u8string value;
+    ASSERT_SUCCESS( object["make"].get_string(value) );
+    ASSERT_TRUE( value == u8"Toyota" );
+    doc.rewind();
+    ASSERT_SUCCESS( doc.get_object().get(object) );
+    for (auto field : object) {
+      std::u8string key;
+      ASSERT_SUCCESS( field.unescaped_key(key) );
+      ASSERT_TRUE( key == u8"make" );
+      break;
+    }
+    TEST_SUCCEED();
+  }
+
+  bool document_receiver_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"("root")"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    std::u8string value;
+    ASSERT_SUCCESS( doc.get_string(value) );
+    ASSERT_TRUE( value == u8"root" );
+    doc.rewind();
+    std::u8string_view view;
+    ASSERT_SUCCESS( doc.get_string(view) );
+    ASSERT_TRUE( view == u8"root" );
+    TEST_SUCCEED();
+  }
+
+  bool get_u8string_view_template() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::u8string_view view;
+    ASSERT_SUCCESS( doc["make"].get<std::u8string_view>().get(view) );
+    ASSERT_TRUE( view == u8"Toyota" );
+    // and on the document itself
+    auto json = R"("root")"_padded;
+    ondemand::document doc2;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc2) );
+    std::u8string_view root;
+    ASSERT_SUCCESS( doc2.get<std::u8string_view>().get(root) );
+    ASSERT_TRUE( root == u8"root" );
+    TEST_SUCCEED();
+  }
+
+#if SIMDJSON_SUPPORTS_DESERIALIZATION
+  bool get_u8string_template() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::u8string value;
+    ASSERT_SUCCESS( doc["make"].get<std::u8string>().get(value) );
+    ASSERT_TRUE( value == u8"Toyota" );
+    TEST_SUCCEED();
+  }
+
+  bool container_of_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::vector<std::u8string> tags;
+    ASSERT_SUCCESS( doc["tags"].get<std::vector<std::u8string>>().get(tags) );
+    ASSERT_EQUAL( tags.size(), 2 );
+    ASSERT_TRUE( tags[0] == u8"a" );
+    ASSERT_TRUE( tags[1] == u8"b" );
+    doc.rewind();
+    std::vector<std::u8string_view> views;
+    ASSERT_SUCCESS( doc["tags"].get<std::vector<std::u8string_view>>().get(views) );
+    ASSERT_EQUAL( views.size(), 2 );
+    ASSERT_TRUE( views[0] == u8"a" );
+    ASSERT_TRUE( views[1] == u8"b" );
+    TEST_SUCCEED();
+  }
+
+  bool optional_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    auto json = R"({ "a": "x", "b": null })"_padded;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(json).get(doc) );
+    std::optional<std::u8string> a;
+    ASSERT_SUCCESS( doc["a"].get<std::optional<std::u8string>>().get(a) );
+    ASSERT_TRUE( a.has_value() );
+    ASSERT_TRUE( *a == u8"x" );
+    doc.rewind();
+    std::optional<std::u8string> b;
+    ASSERT_SUCCESS( doc["b"].get<std::optional<std::u8string>>().get(b) );
+    ASSERT_TRUE( !b.has_value() );
+    TEST_SUCCEED();
+  }
+
+  // Adding the char8_t overloads must not disturb the char-based ones.
+  bool narrow_types_still_work() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::string value;
+    ASSERT_SUCCESS( doc["make"].get<std::string>().get(value) );
+    ASSERT_EQUAL( value, "Toyota" );
+    doc.rewind();
+    std::vector<std::string> tags;
+    ASSERT_SUCCESS( doc["tags"].get<std::vector<std::string>>().get(tags) );
+    ASSERT_EQUAL( tags.size(), 2 );
+    ASSERT_EQUAL( tags[0], "a" );
+    doc.rewind();
+    std::string receiver;
+    ASSERT_SUCCESS( doc["make"].get_string(receiver) );
+    ASSERT_EQUAL( receiver, "Toyota" );
+    TEST_SUCCEED();
+  }
+#endif // SIMDJSON_SUPPORTS_DESERIALIZATION
+
+#if SIMDJSON_EXCEPTIONS
+  bool exceptions_u8string() {
+    TEST_START();
+    ondemand::parser parser;
+    ondemand::document doc;
+    ASSERT_SUCCESS( parser.iterate(BASIC_JSON).get(doc) );
+    std::u8string_view view = doc["make"].get_u8string();
+    ASSERT_TRUE( view == u8"Toyota" );
+    TEST_SUCCEED();
+  }
+#endif // SIMDJSON_EXCEPTIONS
+
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
+
+  bool run() {
+    return
+#if SIMDJSON_SUPPORTS_CHAR8_T
+      value_get_u8string() &&
+      value_get_u8string_unicode() &&
+      value_get_u8string_same_bytes() &&
+      value_get_u8string_incorrect_type() &&
+      value_get_u8string_replacement() &&
+      document_get_u8string() &&
+      document_result_get_u8string() &&
+      document_reference_get_u8string() &&
+      field_u8key() &&
+      receiver_u8string() &&
+      document_receiver_u8string() &&
+      get_u8string_view_template() &&
+#if SIMDJSON_SUPPORTS_DESERIALIZATION
+      get_u8string_template() &&
+      container_of_u8string() &&
+      optional_u8string() &&
+      narrow_types_still_work() &&
+#endif // SIMDJSON_SUPPORTS_DESERIALIZATION
+#if SIMDJSON_EXCEPTIONS
+      exceptions_u8string() &&
+#endif // SIMDJSON_EXCEPTIONS
+#endif // SIMDJSON_SUPPORTS_CHAR8_T
+      true;
+  }
+
+} // namespace u8string_tests
+
+int main(int argc, char *argv[]) {
+  return test_main(argc, argv, u8string_tests::run);
+}


### PR DESCRIPTION
Short title (summary): Add C++20 `char8_t` string accessors to the On-Demand API

## Description

[PR #2786](https://github.com/simdjson/simdjson/pull/2786) added `get_u8string()` to `dom::element`. This PR extends the same idea to the **On-Demand API**, and makes `std::u8string_view` and `std::u8string` first-class types in `get<T>()` on both APIs. Closes #2731.

Every string simdjson produces is valid UTF-8, so all of the new accessors are zero-copy aliases of their `char`-based counterparts: the same bytes, at the same address, no conversion.

### New accessors

| `char` accessor | `char8_t` accessor | On |
|:--|:--|:--|
| `get_string()` | `get_u8string()` | `ondemand::value`, `ondemand::document`, `ondemand::document_reference` (+ `simdjson_result<>` forwarders) |
| `field.unescaped_key()` | `field.unescaped_u8key()` | `ondemand::field` (+ forwarder) |
| `field.escaped_key()` | `field.escaped_u8key()` | `ondemand::field` (+ forwarder) |

### Type-based access

- `get<std::u8string_view>()` on `ondemand::value`, `ondemand::document`, `ondemand::document_reference` and `dom::element` — the DOM specialization also brings `dom::element::get(std::u8string_view&)` and `is<std::u8string_view>()` along for free.
- `get<std::u8string>()`, plus containers and optionals of it (`std::vector<std::u8string>`, `std::optional<std::u8string>`, …), through the C++20 deserialization path. This is a new `concepts::constructible_from_u8string_view` concept and a matching `tag_invoke` overload; `std::u8string` cannot use the existing `constructible_from_string_view` path because the character types differ.
- The templated receiver overloads `get_string(receiver)` and `unescaped_key(receiver)` now accept a `std::u8string` or `std::u8string_view` receiver. Previously they did not compile for those types, because the implementation did a plain `receiver = content;` from a `char`-based `std::string_view`. That single assignment is now routed through an `internal::assign_utf8()` helper whose general (unconstrained) overload is the old code verbatim, so no existing receiver type changes behavior.

### Notes

- A new `SIMDJSON_SUPPORTS_CHAR8_T` macro in `compiler_check.h` replaces the raw `#if defined(__cpp_char8_t) && __cpp_char8_t >= 201811L` feature test that PR #2786 repeated at every call site. It follows the style of the neighbouring `SIMDJSON_SUPPORTS_CONCEPTS` / `SIMDJSON_SUPPORTS_DESERIALIZATION` macros, and is user-overridable.
- Everything is purely additive and guarded, so C++11/14/17 builds are byte-for-byte unaffected.
- **`get_wobbly_string()` deliberately has no u8 variant.** Wobbly strings may be invalid UTF-8 (WTF-8), so they have no business in a `std::u8string_view`.
- No serialization/builder changes: this issue is about string *access*.

## Type of change

- [ ] Bug fix
- [ ] Optimization
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other

## How to verify / test

- New test target `tests/ondemand/ondemand_u8string_tests.cpp` (17 tests): value/document/document_reference/field accessors, the `allow_replacement` flag, `INCORRECT_TYPE` and error forwarding, `iterate_many`, `get<T>` for both u8 types, containers and optionals, u8 receivers, a byte-for-byte check that the u8 view matches `get_string()`, and a regression check that the `char`-based paths still behave.
- `tests/dom/basictests.cpp` gains `u8string_value_get_template()` covering `dom::element::get<std::u8string_view>()`, `get(T&)`, `is<T>()` and the error path.
- Full suite passes under both standards on Apple clang 17 (arm64): **121/121 with `SIMDJSON_CXX_STANDARD=20`** and **121/121 with `SIMDJSON_CXX_STANDARD=17`** (where the whole feature compiles out).
- Also compiled the library and a driver under `-std=c++11`, `-std=c++14`, `-std=c++17` and with `-DSIMDJSON_EXCEPTIONS=0`.

## Checklist before submitting

- [x] I added/updated tests covering my change
- [x] Code builds locally and passes my check
- [x] Documentation / README updated if needed (new `u8string_view and u8string (C++20)` section in `doc/basics.md`, note in `doc/dom.md`)
- [x] Commits are atomic and messages are clear
- [x] I linked the related issue

https://claude.ai/code/session_01EKoa1vNn8ZKwJH4qaZTU2M
