### PR TITLE
fix wildcard path recursion depth

### DIFF
--- a/include/simdjson/generic/ondemand/value-inl.h
+++ b/include/simdjson/generic/ondemand/value-inl.h
@@ -329,6 +329,7 @@ template <typename Func>
 template <typename Func>
 #endif
 inline error_code value::for_each_at_path_with_wildcard(std::string_view json_path, Func&& callback) noexcept {
+  if (size_t(iter.depth()) >= iter.json_iter().parser->max_depth()) { return DEPTH_ERROR; }
   json_type t;
   SIMDJSON_TRY(type().get(t));
   switch (t) {

--- a/tests/ondemand/ondemand_wildcard_tests.cpp
+++ b/tests/ondemand/ondemand_wildcard_tests.cpp
@@ -443,6 +443,53 @@ namespace wildcard_tests {
     TEST_SUCCEED();
   }
 
+  // A wildcard path recurses one level per segment, so a long path applied to a
+  // deeply nested document must stop at the parser's depth limit rather than
+  // recursing until the stack runs out.
+  bool deeply_nested_wildcard() {
+    TEST_START();
+    ondemand::parser parser;
+
+    // Well within the default depth limit: still resolves.
+    {
+      const size_t n = 100;
+      std::string json = std::string(n, '[') + "1" + std::string(n, ']');
+      std::string path = "$";
+      for (size_t i = 0; i < n; i++) { path += "[*]"; }
+      auto padded = padded_string(json);
+      auto doc = parser.iterate(padded);
+      size_t count = 0;
+      ASSERT_SUCCESS(doc.for_each_at_path_with_wildcard(path, [&](ondemand::value) { count++; }));
+      ASSERT_EQUAL(count, 1);
+    }
+
+    // Past the depth limit: a clean error, no stack exhaustion.
+    for (size_t n : {2000, 50000}) {
+      std::cout << "  depth " << n << std::endl;
+      std::string json = std::string(n, '[') + "1" + std::string(n, ']');
+      std::string path = "$";
+      for (size_t i = 0; i < n; i++) { path += "[*]"; }
+      auto padded = padded_string(json);
+      auto doc = parser.iterate(padded);
+      ASSERT_ERROR(doc.for_each_at_path_with_wildcard(path, [](ondemand::value) {}), DEPTH_ERROR);
+    }
+
+    // Same for objects.
+    {
+      const size_t n = 50000;
+      std::string json, tail;
+      for (size_t i = 0; i < n; i++) { json += R"({"a":)"; tail += "}"; }
+      json += "1" + tail;
+      std::string path = "$";
+      for (size_t i = 0; i < n; i++) { path += ".a"; }
+      auto padded = padded_string(json);
+      auto doc = parser.iterate(padded);
+      ASSERT_ERROR(doc.for_each_at_path_with_wildcard(path, [](ondemand::value) {}), DEPTH_ERROR);
+    }
+
+    TEST_SUCCEED();
+  }
+
   bool run() {
     return array_wildcard_basic() &&
            array_wildcard_numbers() &&
@@ -458,7 +505,8 @@ namespace wildcard_tests {
            root_array_wildcard() &&
            wildcard_raw_json_issue_2684() &&
            unterminated_bracket_quote() &&
-           wildcard_malformed_deterministic_fuzz();
+           wildcard_malformed_deterministic_fuzz() &&
+           deeply_nested_wildcard();
   }
 }
 


### PR DESCRIPTION
`for_each_at_path_with_wildcard()` recurses once per path segment (`array` → `value` → `array` → …) and never checked the parser's depth limit, so recursion was bounded only by the input.

With a long wildcard path applied to a deeply nested document:

- under `SIMDJSON_DEVELOPMENT_CHECKS`, it trips the `size_t(depth) < parser->max_depth()` assertion in `json_iterator::set_start_position()`;
- in a plain `-O2` release build with default settings, it exhausts the stack and segfaults (around 50k levels on an 8 MB stack);
- short of that, it walks past `max_depth` and returns `SUCCESS` — the limit was simply never applied on this path.

```cpp
size_t n = 50000;
std::string json = std::string(n, '[') + "1" + std::string(n, ']');
std::string path = "$"; for (size_t i = 0; i < n; i++) { path += "[*]"; }
auto padded = padded_string(json);
ondemand::parser parser;
auto doc = parser.iterate(padded);
doc.for_each_at_path_with_wildcard(path, [](ondemand::value) {}); // segfault
```

Every recursive step goes through `value::for_each_at_path_with_wildcard()` and each one descends exactly one level, so a single check there bounds the whole recursion. Past the limit it now returns `DEPTH_ERROR`. Paths within `max_depth` are unaffected.

Adds a regression test.

https://claude.ai/code/session_01S4sf2z7qo55TzRv4TEtMD8