### PR TITLE
doc: recommend restricting max_depth to protect recursive user code

### DIFF
--- a/doc/basics.md
+++ b/doc/basics.md
@@ -59,6 +59,7 @@ separate document](https://github.com/simdjson/simdjson/blob/master/doc/builder.
   * [Raw JSON string for objects and arrays](#raw-json-string-for-objects-and-arrays)
 - [Storing directly into an existing string instance](#storing-directly-into-an-existing-string-instance)
 - [Thread safety](#thread-safety)
+- [Limiting the maximum depth](#limiting-the-maximum-depth)
 - [Standard compliance](#standard-compliance)
 - [Backwards compatibility](#backwards-compatibility)
 - [Examples](#examples)
@@ -3700,6 +3701,55 @@ issues. If you expect such problems, you may consider using [std::quick_exit](ht
 
 In a threaded environment, stack space is often limited. Running code like simdjson in debug mode may require hundreds of kilobytes of stack memory. Thus stack overflows are a possibility. We recommend you turn on optimization when working in an environment where stack space is limited. If you must run your code in debug mode, we recommend you configure your system to have more stack space. We discourage you from running production code based on a debug build.
 
+
+Limiting the maximum depth
+--------------------------
+
+JSON documents can be nested arbitrarily deeply (`[[[[[[ ... ]]]]]]`). The simdjson
+library handles such documents iteratively: however deep the document is, parsing it
+costs the library no stack space.
+
+Code that walks the result is another matter. A recursive function applied to a document
+nested a thousand levels deep needs a thousand stack frames. Running out of stack is not
+a recoverable error: there is no exception and no error code, just a crash. A hostile
+input of a few kilobytes (`[[[[[[...`) is enough to cause one.
+
+So decide how deeply nested a document you are willing to accept, and tell the parser:
+
+```cpp
+ondemand::parser parser;
+// We will not go more than 30 levels deep.
+auto error = parser.allocate(0, 30);
+if (error) { /* allocation failure */ }
+```
+
+The first argument to `allocate` is a capacity to reserve up front, not a limit: passing
+zero is fine, and the parser still grows its buffers by itself as documents are passed
+to it. If you know how large your documents are, you can skip the initial reallocations
+by reserving the capacity, e.g., `parser.allocate(1024 * 1024, 30)`. To put a hard limit
+on the document size, use `parser.set_max_capacity(1024 * 1024)`.
+
+The depth limit bounds the recursion the library does on your behalf:
+`for_each_at_path_with_wildcard()` descends one level per path segment, and returns
+`DEPTH_ERROR` rather than going past `max_depth`. It is also verified at every step when
+you enable [development checks](#avoiding-pitfalls-enable-development-checks).
+
+Even if you do not limit the depth at the simdjson parser level, you can avoid deep
+recursion in your own code by calling `current_depth()`. It is available on the document
+and on its values, it is inexpensive, and it reports how deep the iterator currently
+sits:
+
+```cpp
+void recursive_print_json(ondemand::value element) {
+  if (element.current_depth() > 30) { throw std::runtime_error("too deep"); }
+  // ...
+}
+```
+
+Real-world JSON is rarely nested more than a handful of levels, so a limit like 30 is
+generous, and it keeps a recursive traversal to a few tens of kilobytes of stack. The
+default is 1024 (`simdjson::DEFAULT_MAX_DEPTH`). You can query the current setting with
+`parser.max_depth()`.
 
 Standard compliance
 --------------------

--- a/doc/dom.md
+++ b/doc/dom.md
@@ -17,6 +17,7 @@ separate document](https://github.com/simdjson/simdjson/blob/master/doc/builder.
   * [Error Handling Example](#error-handling-example)
   * [Exceptions](#exceptions)
 * [Tree Walking and JSON Element Types](#tree-walking-and-json-element-types)
+* [Limiting the maximum depth](#limiting-the-maximum-depth)
 * [Reusing the parser for maximum efficiency](#reusing-the-parser-for-maximum-efficiency)
 * [Server Loops: Long-Running Processes and Memory Capacity](#server-loops-long-running-processes-and-memory-capacity)
 * [Best Use of the DOM API](#best-use-of-the-dom-api)
@@ -794,6 +795,42 @@ void basics_treewalk_1() {
 Notice that we do not include `dom::element_type::BIGINT` in this example
 as `dom::element_type::BIGINT` type is only generated if the parser was
 set to support big integers (`parser.number_as_string(true)`).
+
+
+Limiting the maximum depth
+--------------------------
+
+JSON documents can be nested arbitrarily deeply (`[[[[[[ ... ]]]]]]`). The simdjson
+library parses such documents iteratively: however deep the document is, parsing it
+costs the library no stack space.
+
+Code that walks the result is another matter. A recursive function applied to a document
+nested a thousand levels deep needs a thousand stack frames. Running out of stack is not
+a recoverable error: there is no exception and no error code, just a crash. A hostile
+input of a few kilobytes (`[[[[[[...`) is enough to cause one.
+
+So decide how deeply nested a document you are willing to accept, and tell the parser.
+The DOM parser refuses to parse a document nested more deeply than its `max_depth`, and
+reports `DEPTH_ERROR`:
+
+```cpp
+dom::parser parser;
+// We refuse documents nested more than 30 levels deep.
+auto error = parser.allocate(0, 30);
+if (error) { /* allocation failure */ }
+auto result = parser.parse(json); // DEPTH_ERROR if json is nested too deeply
+```
+
+The first argument to `allocate` is a capacity to reserve up front, not a limit: passing
+zero is fine, and the parser still grows its buffers by itself as documents are passed
+to it. If you know how large your documents are, you can skip the initial reallocations
+by reserving the capacity, e.g., `parser.allocate(1024 * 1024, 30)`. To put a hard limit
+on the document size, use `parser.set_max_capacity(1024 * 1024)`.
+
+The default depth limit is 1024 (`simdjson::DEFAULT_MAX_DEPTH`). Real-world JSON is
+rarely nested more than a handful of levels, so a limit like 30 is generous, and it
+keeps a recursive traversal to a few tens of kilobytes of stack. You can query the
+current setting with `parser.max_depth()`.
 
 
 Reusing the parser for maximum efficiency


### PR DESCRIPTION
### Why

simdjson parses deeply nested JSON **iteratively**. Neither the DOM parser nor the On-Demand parser recurses over the document, so a document nested a thousand levels deep costs simdjson no stack at all.

Code that *consumes* the result is usually a different story. The natural way to walk a JSON tree is a recursive function, and that is where deeply nested documents become dangerous: a thousand levels of recursion is more stack than a program can count on, especially in an unoptimized build, and stack exhaustion is not recoverable. There is no exception and no error code, just a crash. A hostile input of a few kilobytes of `[` is enough.

This is not hypothetical for the library either: `for_each_at_path_with_wildcard()` descends one level per path segment, and its recursion is bounded by the parser's `max_depth` (#2844). With the default `max_depth` of 1024, that bound is well beyond what a Windows debug build can afford, which is how the `ondemand_wildcard_tests` segfault on VS18-CLANG-CI came about.

### What this PR does

Documentation only, no functional change.

Adds a **"Limiting the maximum depth"** section to each front-end's documentation, each covering only its own front-end:

- **`doc/dom.md`**, right after the recursive `print_json` example: the DOM parser refuses a document nested more deeply than `max_depth` and reports `DEPTH_ERROR`.
- **`doc/basics.md`** (On-Demand): what the depth limit does cover, namely the recursion the library does on your behalf, verified at every step under development checks, plus a separate paragraph noting that even without setting a parser-level limit you can avoid deep recursion in your own code with `current_depth()`.

Both sections recommend a value like **30**, which is generous for real-world JSON and keeps a recursive traversal to a few tens of kilobytes of stack.

Both also clarify a point that is easy to get wrong: the first argument of `allocate()` is a capacity to **reserve**, not a limit. `parser.allocate(0, 30)` sets the depth alone and lets the parser grow its buffers as usual, and `set_max_capacity()` is what actually caps the document size. Verified on both front-ends:

```
dom: allocate(1MiB,30) -> SUCCESS, capacity=1048576, max_capacity=4294967295
  parse 4MiB doc -> SUCCESS ; capacity now 4194307, max_depth still 30
ondemand with set_max_capacity(1MiB): iterate 4MiB doc -> CAPACITY
```

All code snippets in the new sections were compiled and run.

https://claude.ai/code/session_01FvxmYY8iXpAf3fi34G1vHX