### PR TITLE
ci: don't let the external corpus upload abort the fuzz job

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -131,6 +131,7 @@ jobs:
         path: corpus.tar
 
     - name: Store the corpus externally
+      continue-on-error: true
       run: |
         gzip --keep corpus.tar
         curl -F"filedata=@corpus.tar.gz" https://simdjson:${{ secrets.fuzzdatapassword }}@www.pauldreik.se/fuzzdata/index.php


### PR DESCRIPTION
`Store the corpus externally` in `fuzzers.yml` is a bare `curl` to `www.pauldreik.se` with no
failure handling, and it runs before the valgrind replay. When the host is unreachable the job
stops there and the valgrind replay and the corpus cache save are skipped.

Of the last 1000 runs on master, 14 failed; 10 of the 11 with step data failed at this step.
#2806 was the same outage.

`continue-on-error: true` lets the rest of the job finish. The step still shows as failed in the
run, and the corpus is already uploaded as a GitHub artifact one step earlier, so nothing is lost
while the mirror is down.

Type of change
- [ ] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [x] Other (please describe): CI reliability

Checklist before submitting
- [ ] I added/updated tests covering my change (if applicable)
- [ ] Code builds locally and passes my check
- [ ] Documentation / README updated if needed
- [x] Commits are atomic and messages are clear
- [ ] I linked the related issue (if applicable)
