### PR TITLE
Require POWER8 vector support for ppc64 SIMD code

### DIFF
--- a/include/simdjson/generic/builder/json_string_builder-inl.h
+++ b/include/simdjson/generic/builder/json_string_builder-inl.h
@@ -45,7 +45,7 @@
 #define SIMDJSON_EXPERIMENTAL_HAS_RVV 1
 #endif
 #endif
-#if (defined(__PPC64__) || defined(_M_PPC64)) && defined(__ALTIVEC__)
+#if (defined(__PPC64__) || defined(_M_PPC64)) && defined(__ALTIVEC__) && defined(__POWER8_VECTOR__)
 #ifndef SIMDJSON_EXPERIMENTAL_HAS_PPC64
 #define SIMDJSON_EXPERIMENTAL_HAS_PPC64 1
 #endif

--- a/include/simdjson/portability.h
+++ b/include/simdjson/portability.h
@@ -88,7 +88,7 @@ using std::size_t;
 #endif
 #elif defined(__PPC64__) || defined(_M_PPC64)
 #define SIMDJSON_IS_PPC64 1
-#if defined(__ALTIVEC__)
+#if defined(__ALTIVEC__) && defined(__POWER8_VECTOR__)
 #define SIMDJSON_IS_PPC64_VMX 1
 #endif // defined(__ALTIVEC__)
 #else


### PR DESCRIPTION
Short title (summary):
Require POWER8 vector support for ppc64 SIMD code

Description
The ppc64 kernel and the string builder SIMD path use VSX and POWER8
builtins (vec_vsx_ld, vec_vbpermq, 64-bit __vector types), but are
enabled whenever AltiVec is available. On targets whose baseline CPU
predates VSX (e.g. FreeBSD/powerpc64, which targets the 970), this
breaks the build:

error: use of 'long long' with '__vector' requires VSX support (available on POWER7 or later) to be enabled
error: use of undeclared identifier 'vec_vbpermq'

Gate both on __POWER8_VECTOR__ so such targets use the fallback paths,
while ppc64le (POWER8 baseline) and builds with -mcpu=power8 or newer
are unaffected.

Type of change
- [x] Bug fix
- [ ] Optimization
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation / tests
- [ ] Other (please describe):

How to verify / test
Build on powerpc64.
