### PR TITLE
Fix DOM at_path error propagation

### DIFF
--- a/include/simdjson/dom/array-inl.h
+++ b/include/simdjson/dom/array-inl.h
@@ -47,6 +47,7 @@ inline simdjson_result<dom::element> simdjson_result<dom::array>::at_pointer(std
 }
 
  inline simdjson_result<dom::element> simdjson_result<dom::array>::at_path(std::string_view json_path) const noexcept {
+  if (error()) { return error(); }
   auto json_pointer = json_path_to_pointer_conversion(json_path);
   if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
   return at_pointer(json_pointer);

--- a/include/simdjson/dom/element-inl.h
+++ b/include/simdjson/dom/element-inl.h
@@ -137,6 +137,7 @@ simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_
   return first.at_pointer(json_pointer);
 }
 simdjson_inline simdjson_result<dom::element> simdjson_result<dom::element>::at_path(const std::string_view json_path) const noexcept {
+  if (error()) { return error(); }
   auto json_pointer = json_path_to_pointer_conversion(json_path);
   if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
   return at_pointer(json_pointer);

--- a/include/simdjson/dom/object-inl.h
+++ b/include/simdjson/dom/object-inl.h
@@ -36,6 +36,7 @@ inline simdjson_result<dom::element> simdjson_result<dom::object>::at_pointer(st
   return first.at_pointer(json_pointer);
 }
 inline simdjson_result<dom::element> simdjson_result<dom::object>::at_path(std::string_view json_path) const noexcept {
+  if (error()) { return error(); }
   auto json_pointer = json_path_to_pointer_conversion(json_path);
   if (json_pointer == "-1") { return INVALID_JSON_POINTER; }
   return at_pointer(json_pointer);

--- a/tests/dom/json_path_tests.cpp
+++ b/tests/dom/json_path_tests.cpp
@@ -597,7 +597,7 @@ bool at_path_error_propagation() {
   auto doc = parser.parse(json);
   ASSERT_SUCCESS(doc.error());
 
-  // A failed lookup must retain its error even when the next path is invalid.
+  // Preserve the original error regardless of whether the next path is valid.
   for (std::string_view path : {"$.key", "$[0]", "invalid", "$["}) {
     ASSERT_ERROR(doc["missing"].at_path(path), NO_SUCH_FIELD);
     ASSERT_ERROR(doc["missing"].get_array().at_path(path), NO_SUCH_FIELD);

--- a/tests/dom/json_path_tests.cpp
+++ b/tests/dom/json_path_tests.cpp
@@ -590,9 +590,49 @@ bool modern_support() {
   return true;
 }
 
+bool at_path_error_propagation() {
+  TEST_START();
+  const auto json = R"({"array": [1], "object": {"key": 2}})"_padded;
+  dom::parser parser;
+  auto doc = parser.parse(json);
+  ASSERT_SUCCESS(doc.error());
+
+  // A failed lookup must retain its error even when the next path is invalid.
+  for (std::string_view path : {"$.key", "$[0]", "invalid", "$["}) {
+    ASSERT_ERROR(doc["missing"].at_path(path), NO_SUCH_FIELD);
+    ASSERT_ERROR(doc["missing"].get_array().at_path(path), NO_SUCH_FIELD);
+    ASSERT_ERROR(doc["missing"].get_object().at_path(path), NO_SUCH_FIELD);
+    ASSERT_ERROR(doc.get_array().at_path(path), INCORRECT_TYPE);
+    ASSERT_ERROR(doc["array"].get_object().at_path(path), INCORRECT_TYPE);
+    ASSERT_ERROR(doc["array"].at(1).at_path(path), INDEX_OUT_OF_BOUNDS);
+  }
+
+  // Successful results must still validate paths and return selected values.
+  ASSERT_ERROR(doc.at_path("invalid"), INVALID_JSON_POINTER);
+  ASSERT_ERROR(doc["array"].get_array().at_path("invalid"), INVALID_JSON_POINTER);
+  ASSERT_ERROR(doc["object"].get_object().at_path("invalid"), INVALID_JSON_POINTER);
+  int64_t value;
+  ASSERT_SUCCESS(doc.at_path("$.object.key").get_int64().get(value));
+  ASSERT_EQUAL(value, 2);
+  ASSERT_SUCCESS(doc["array"].get_array().at_path("$[0]").get_int64().get(value));
+  ASSERT_EQUAL(value, 1);
+  ASSERT_SUCCESS(doc["object"].get_object().at_path("$.key").get_int64().get(value));
+  ASSERT_EQUAL(value, 2);
+
+  const auto invalid_json = "["_padded;
+  auto invalid_doc = parser.parse(invalid_json);
+  const auto parse_error = invalid_doc.error();
+  ASSERT_TRUE(parse_error != SUCCESS);
+  ASSERT_ERROR(invalid_doc.at_path("invalid"), parse_error);
+  ASSERT_ERROR(invalid_doc.get_array().at_path("invalid"), parse_error);
+  ASSERT_ERROR(invalid_doc.get_object().at_path("invalid"), parse_error);
+  TEST_SUCCEED();
+}
+
 int main() {
   if (true && json_path_with_wildcard() && unterminated_bracket_quote_wildcard() &&
       json_path_malformed_deterministic_fuzz() && demo() && modern_support() &&
+      at_path_error_propagation() &&
       run_success_test(TEST_RFC_JSON, "$.foo", "[\"bar\",\"baz\"]") &&
       run_success_test(TEST_RFC_JSON, "$.foo[0]", "\"bar\"") &&
       run_success_test(TEST_RFC_JSON, "$.", "0") &&


### PR DESCRIPTION
This PR proposes preserving the original error when `at_path()` is called on a failed DOM result, consistent with the existing behavior of `at_pointer()` and the On-Demand `at_path()` wrappers.

For example, after parsing `{"array": [1], "object": {"key": 2}}`, `doc["missing"].at_path("invalid")` currently returns `INVALID_JSON_POINTER`, although the field lookup has already failed with `NO_SUCH_FIELD`. Checking the stored error before converting the path allows the original error to reach the caller.

The change adds an early error check to the `dom::element`, `dom::array`, and `dom::object` result wrappers. Regression tests cover missing fields, incorrect types, out-of-bounds indices, and parse failures, as well as path validation and successful queries. They also run with exceptions disabled.

Validation on Windows x64 with MSVC 19.44:

- The new regression test fails against the unmodified library with `INVALID_JSON_POINTER` instead of `NO_SUCH_FIELD`, and passes with the fix.
- Debug build: `ctest --test-dir build-contrib -C Debug -LE explicitonly --output-on-failure` — 112 tests passed.
- Release build with `SIMDJSON_EXCEPTIONS=OFF`: `ctest --test-dir build-contrib-noexcept -C Release -L dom --output-on-failure` — 21 tests passed.
- `git diff --check` and an ASCII check of all changed source files passed.

AI assistance was used to identify the issue and prepare the implementation, regression tests, and PR text.

Thank you for taking a look. Feedback on the error-handling behavior or test coverage would be very welcome.
